### PR TITLE
Support concurrent async validations

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -265,7 +265,8 @@ namespace MudBlazor
         {
             base.OnInitialized();
 
-            // Initialize Text property according to initial value and converter
+            // Because the way the Value setter is built, it won't cause an update if the incoming Value is
+            // equal to the initial value. This is why we force an update to the Text property here.
             UpdateTextProperty(); 
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
@@ -28,12 +29,11 @@ namespace MudBlazor
             get => _value;
             set
             {
-                if (object.Equals(value, _value))
-                    return;
-                _value = value;
-                CheckedChanged.InvokeAsync(value);
-                _=ValidateValue(value);
-                EditFormValidate();
+                if (!EqualityComparer<T>.Default.Equals(_value, value))
+                {
+                    _value = value;
+                    BeginValidateAfter(CheckedChanged.InvokeAsync(value));
+                }
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -92,22 +92,50 @@ namespace MudBlazor
         /// </summary>
         protected T _value;
 
+        // These are the call-and-forget methods to launch an async validation process.
+        // After each async step, we make sure the current Value of the component has not changed while
+        // async code was executed to avoid race condition which could lead to incorrect validation results.
+        protected async void BeginValidateAfter(Task task)
+        {
+            var value = _value;
+
+            await task;
+
+            if (EqualityComparer<T>.Default.Equals(value, _value))
+            {
+                BeginValidate();
+            }
+        }
+
+        protected async void BeginValidate()
+        {
+            var value = _value;
+
+            await Validate();
+
+            if (EqualityComparer<T>.Default.Equals(value, _value))
+            {
+                EditFormValidate();
+            }
+        }
+
         /// <summary>
         /// Causes this component to validate its value
         /// </summary>
-        public async Task Validate() => await ValidateValue(_value);
+        public Task Validate() => ValidateValue();
 
-        internal async virtual Task ValidateValue(T value)
+        internal async virtual Task ValidateValue()
         {
-            ValidationErrors = new List<string>();
+            var changed = false;
+            var errors = new List<string>();
             try
             {
-                var hasValue = HasValue(value);
+                var hasValue = HasValue(_value);
                 if (Required)
                 {
                     if (!hasValue)
                     {
-                        ValidationErrors.Add(RequiredError);
+                        errors.Add(RequiredError);
                         return; // no need to call validation funcs if required value doesn't exist. we already have a required error.
                     }
                     // we have a required value, proceed to the validation funcs
@@ -118,130 +146,136 @@ namespace MudBlazor
                         return; // if nothing has been entered, we return OK without calling validation funcs
                     // proceed to the validation funcs
                 }
+
                 if (Validation is ValidationAttribute)
-                    ValidateWithAttribute(Validation as ValidationAttribute, value);
+                    ValidateWithAttribute(Validation as ValidationAttribute, _value, errors);
                 else if (Validation is Func<T, bool>)
-                    ValidateWithFunc(Validation as Func<T, bool>, value);
+                    ValidateWithFunc(Validation as Func<T, bool>, _value, errors);
                 else if (Validation is Func<T, string>)
-                    ValidateWithFunc(Validation as Func<T, string>, value);
+                    ValidateWithFunc(Validation as Func<T, string>, _value, errors);
                 else if (Validation is Func<T, IEnumerable<string>>)
-                    ValidateWithFunc(Validation as Func<T, IEnumerable<string>>, value);
-                else if (Validation is Func<T, Task<bool>>)
-                    await ValidateWithFunc(Validation as Func<T, Task<bool>>, value);
-                else if (Validation is Func<T, Task<string>>)
-                    await ValidateWithFunc(Validation as Func<T, Task<string>>, value);
-                else if (Validation is Func<T, Task<IEnumerable<string>>>)
-                    await ValidateWithFunc(Validation as Func<T, Task<IEnumerable<string>>>, value);
+                    ValidateWithFunc(Validation as Func<T, IEnumerable<string>>, _value, errors);
+                else
+                {
+                    var value = _value;
+
+                    if (Validation is Func<T, Task<bool>>)
+                        await ValidateWithFunc(Validation as Func<T, Task<bool>>, _value, errors);
+                    else if (Validation is Func<T, Task<string>>)
+                        await ValidateWithFunc(Validation as Func<T, Task<string>>, _value, errors);
+                    else if (Validation is Func<T, Task<IEnumerable<string>>>)
+                        await ValidateWithFunc(Validation as Func<T, Task<IEnumerable<string>>>, _value, errors);
+
+                    changed = !EqualityComparer<T>.Default.Equals(value, _value);
+                }
             }
             finally
             {
-                // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
-                // if Error and ErrorText are set by the user, setting them here will have no effect. 
-                Error = ValidationErrors.Count > 0;
-                ErrorText = ValidationErrors.FirstOrDefault();
-                Form?.Update(this);
-                StateHasChanged();
+                // If Value has changed while we were validating it, ignore results and exit
+                if (!changed)
+                {
+                    // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
+                    // if Error and ErrorText are set by the user, setting them here will have no effect. 
+                    ValidationErrors = errors;
+                    Error = errors.Count > 0;
+                    ErrorText = errors.FirstOrDefault();
+                    Form?.Update(this);
+                    StateHasChanged();
+                }
             }
         }
 
         protected virtual bool HasValue(T value)
         {
-            var hasValue = true;
             if (typeof(T) == typeof(string))
-                hasValue = !string.IsNullOrWhiteSpace((string)(object)value);
-            else if (value == null)
-                hasValue = false;
-            return hasValue;
+                return !string.IsNullOrWhiteSpace((string)(object)value);
+
+            return value != null;
         }
 
-        protected virtual void ValidateWithAttribute(ValidationAttribute attr, T value)
+        protected virtual void ValidateWithAttribute(ValidationAttribute attr, T value, List<string> errors)
         {
-            if (attr.IsValid(value))
-                return;
-            ValidationErrors.Add(attr.ErrorMessage);
+            if (!attr.IsValid(value))
+                errors.Add(attr.ErrorMessage);
         }
 
-        protected virtual void ValidateWithFunc(Func<T, bool> func, T value)
+        protected virtual void ValidateWithFunc(Func<T, bool> func, T value, List<string> errors)
         {
             try
             {
-                if (func(value))
-                    return;
-                ValidationErrors.Add("Invalid");
+                if (!func(value))
+                    errors.Add("Invalid");
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
-        protected virtual void ValidateWithFunc(Func<T, string> func, T value)
+        protected virtual void ValidateWithFunc(Func<T, string> func, T value, List<string> errors)
         {
             try
             {
                 var error = func(value);
-                if (error == null)
-                    return;
-                ValidationErrors.Add(error);
+                if (error != null)
+                    errors.Add(error);
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
-        protected virtual void ValidateWithFunc(Func<T, IEnumerable<string>> func, T value)
+        protected virtual void ValidateWithFunc(Func<T, IEnumerable<string>> func, T value, List<string> errors)
         {
             try
             {
                 foreach (var error in func(value))
-                    ValidationErrors.Add(error);
+                    errors.Add(error);
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
-        protected async virtual Task ValidateWithFunc(Func<T, Task<bool>> func, T value)
+        protected async virtual Task ValidateWithFunc(Func<T, Task<bool>> func, T value, List<string> errors)
         {
             try
             {
-                if (await func(value))
-                    return;
-                ValidationErrors.Add("Invalid");
+                if (!await func(value))
+                    errors.Add("Invalid");
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
-        protected async virtual Task ValidateWithFunc(Func<T, Task<string>> func, T value)
+        protected async virtual Task ValidateWithFunc(Func<T, Task<string>> func, T value, List<string> errors)
         {
             try
             {
                 var error = await func(value);
-                if (error == null)
-                    return;
-                ValidationErrors.Add(error);
+                if (error != null)
+                    errors.Add(error);
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
-        protected async virtual Task ValidateWithFunc(Func<T, Task<IEnumerable<string>>> func, T value)
+        protected async virtual Task ValidateWithFunc(Func<T, Task<IEnumerable<string>>> func, T value, List<string> errors)
         {
             try
             {
                 foreach (var error in await func(value))
-                    ValidationErrors.Add(error);
+                    errors.Add(error);
             }
             catch (Exception e)
             {
-                ValidationErrors.Add("Error in validation func: " + e.Message);
+                errors.Add("Error in validation func: " + e.Message);
             }
         }
 
@@ -280,11 +314,10 @@ namespace MudBlazor
         /// </summary>
         internal void EditFormValidate()
         {
-            if (_fieldIdentifier.FieldName == null)
+            if (_fieldIdentifier.FieldName != null)
             {
-                return;
+                EditContext?.NotifyFieldChanged(_fieldIdentifier);
             }
-            EditContext?.NotifyFieldChanged(_fieldIdentifier);
         }
 
         /// <summary>
@@ -298,12 +331,13 @@ namespace MudBlazor
 
         private void OnValidationStateChanged(object sender, ValidationStateChangedEventArgs e)
         {
-            if (EditContext == null)
-                return;
-            var error_msgs = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
-            Error = error_msgs.Length > 0;
-            ErrorText = (Error ? error_msgs[0] : null);
-            StateHasChanged();
+            if (EditContext != null)
+            {
+                var error_msgs = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
+                Error = error_msgs.Length > 0;
+                ErrorText = (Error ? error_msgs[0] : null);
+                StateHasChanged();
+            }
         }
 
         /// <summary>
@@ -327,30 +361,27 @@ namespace MudBlazor
 
         protected override void OnParametersSet()
         {
-            if (EditContext == null)
-                return;
-            if (For == null)
-                return;
-            if (For != _currentFor)
+            if (EditContext != null && For != null)
             {
-                _fieldIdentifier = FieldIdentifier.Create(For);
-                _currentFor = For;
-            }
+                if (For != _currentFor)
+                {
+                    _fieldIdentifier = FieldIdentifier.Create(For);
+                    _currentFor = For;
+                }
 
-            if (EditContext != _currentEditContext)
-            {
-                DetachValidationStateChangedListener();
-                EditContext.OnValidationStateChanged += OnValidationStateChanged;
-                _currentEditContext = EditContext;
+                if (EditContext != _currentEditContext)
+                {
+                    DetachValidationStateChangedListener();
+                    EditContext.OnValidationStateChanged += OnValidationStateChanged;
+                    _currentEditContext = EditContext;
+                }
             }
         }
 
         private void DetachValidationStateChangedListener()
         {
             if (_currentEditContext != null)
-            {
                 _currentEditContext.OnValidationStateChanged -= OnValidationStateChanged;
-            }
         }
 
         #endregion

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -172,13 +172,13 @@ namespace MudBlazor
         private T[] _items;
         private int _selectedListItemIndex = 0;
 
-        protected override void UpdateTextProperty()
+        protected override void UpdateTextProperty(bool updateValue)
         {
-            base.UpdateTextProperty();
+            base.UpdateTextProperty(updateValue);
             _timer?.Dispose();
         }
 
-        protected override void UpdateValueProperty()
+        protected override void UpdateValueProperty(bool updateText)
         {
             if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 Value = default(T);

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -127,7 +127,7 @@ namespace MudBlazor
             _timer?.Dispose();
             IsOpen = false;
             UpdateIcon();
-            _ = ValidateValue(Value);
+            BeginValidate();
             StateHasChanged();
         }
 
@@ -172,15 +172,15 @@ namespace MudBlazor
         private T[] _items;
         private int _selectedListItemIndex = 0;
 
-        protected override void GenericValueChanged(T value)
+        protected override void UpdateTextProperty()
         {
-            base.GenericValueChanged(value);
+            base.UpdateTextProperty();
             _timer?.Dispose();
         }
 
-        protected override void StringValueChanged(string text)
+        protected override void UpdateValueProperty()
         {
-            if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(text))
+            if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 Value = default(T);
             _timer?.Dispose();
             _timer = new Timer(OnTimerComplete, null, DebounceInterval, Timeout.Infinite);

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -21,13 +21,13 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
 
-        protected override void StringValueChanged(string text)
+        protected override void UpdateValueProperty()
         {
             //setting the Text property
 
             if (DebounceInterval == 0)
             {
-                base.StringValueChanged(text);
+                base.UpdateValueProperty();
                 return;
             }
             //stops previous timer
@@ -46,7 +46,7 @@ namespace MudBlazor
         
         private void OnTimerCompleteGuiThread()
         {
-            base.StringValueChanged(Text);
+            base.UpdateValueProperty();
             OnDebounceIntervalElapsed.InvokeAsync(Text);
         }
 

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -21,20 +21,26 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
 
-        protected override void UpdateValueProperty()
+        private bool _updateTextOnTimerComplete;
+
+        protected override void UpdateValueProperty(bool updateText)
         {
-            //setting the Text property
+            // This method is called when Value property needs to be refreshed from the current Text property, so typically because Text property has changed.
+            // If a debounce interval is defined, we want to delay the update of Value property.
 
             if (DebounceInterval == 0)
             {
-                base.UpdateValueProperty();
-                return;
+                base.UpdateValueProperty(updateText);
             }
-            //stops previous timer
-            _timer.Stop();
+            else
+            {
+                // store the value to use when timer will complete
+                _updateTextOnTimerComplete = updateText;
 
-            //starts the timer while user is typing
-            _timer.Start();
+                // restart the timer while user is typing
+                _timer.Stop();
+                _timer.Start();
+            }
         }
 
         /// <summary>
@@ -46,7 +52,7 @@ namespace MudBlazor
         
         private void OnTimerCompleteGuiThread()
         {
-            base.UpdateValueProperty();
+            base.UpdateValueProperty(_updateTextOnTimerComplete);
             OnDebounceIntervalElapsed.InvokeAsync(Text);
         }
 
@@ -81,9 +87,5 @@ namespace MudBlazor
             _timer.Elapsed -= OnTimerComplete;
             _timer.Dispose();
         }
-
-
     }
-
-
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -141,18 +141,17 @@ namespace MudBlazor
             return selected_item.ChildContent;
         }
 
-        protected override void UpdateValueProperty()
+        protected override void UpdateValueProperty(bool updateText)
         {
             // Select does not support updating the value through the Text property at all!
-            //base.StringValueChanged();
         }
 
-        protected override void UpdateTextProperty()
+        protected override void UpdateTextProperty(bool updateValue)
         {
             // when multiselection is true, we don't update the text when the value changes. 
             // instead the Text will be set with a comma separated list of selected values
             if (!MultiSelection)
-                base.UpdateTextProperty();
+                base.UpdateTextProperty(updateValue);
         }
 
         internal event Action<HashSet<T>> SelectionChangedFromOutside;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -141,19 +141,18 @@ namespace MudBlazor
             return selected_item.ChildContent;
         }
 
-        protected override void StringValueChanged(string text)
+        protected override void UpdateValueProperty()
         {
             // Select does not support updating the value through the Text property at all!
-            //base.StringValueChanged(text);
+            //base.StringValueChanged();
         }
 
-        protected override void GenericValueChanged(T value)
+        protected override void UpdateTextProperty()
         {
             // when multiselection is true, we don't update the text when the value changes. 
             // instead the Text will be set with a comma separated list of selected values
-            if (MultiSelection)
-                return;
-            base.GenericValueChanged(value);
+            if (!MultiSelection)
+                base.UpdateTextProperty();
         }
 
         internal event Action<HashSet<T>> SelectionChangedFromOutside;

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -22,26 +22,21 @@ namespace MudBlazor
         {
             try
             {
+                // string
+                if (typeof(T) == typeof(string))
+                    return (T)(object)value;
+
                 // this is important, or otherwise all the TryParse down there might fail.
                 if (string.IsNullOrEmpty(value))
                     return default(T);
-                // string
-                if (typeof(T) == typeof(string))
-                {
-                    return (T)(object)value;
-                }
                 // char
                 else if (typeof(T) == typeof(char) || typeof(T) == typeof(char?))
                 {
-                    if (string.IsNullOrEmpty(value))
-                        return default(T);
                     return (T)(object)value[0];
                 }
                 // bool
                 else if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
                 {
-                    if (string.IsNullOrEmpty(value))
-                        return default(T);
                     var lowerValue = value.ToLowerInvariant();
                     if ( lowerValue=="true")
                         return (T)(object)true;


### PR DESCRIPTION
As discusses in #403, here's an implementation of an internal call-and-forget async validation process, which will manage concurrent calls with unordered result returns.