### PR TITLE
RTL docs page added + new RTL css classes added

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesBorderRadiusExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesBorderRadiusExample.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<div class="mud-theme-primary py-4 px-6 mx-4 rounded-s-xl">
+    <MudText Align="Align.Center">.rounded-s-xl</MudText>
+</div>
+<div class="mud-theme-secondary py-4 px-6 mx-4 rounded-e-xl">
+    <MudText Align="Align.Center">.rounded-e-xl</MudText>
+</div>
+<div class="mud-theme-tertiary py-4 px-6 mx-4 rounded-ts-xl">
+    <MudText Align="Align.Center">.rounded-ts-xl</MudText>
+</div>
+<div class="mud-theme-info py-4 px-6 mx-4 rounded-te-xl">
+    <MudText Align="Align.Center">.rounded-te-xl</MudText>
+</div>
+<div class="mud-theme-warning py-4 px-6 mx-4 rounded-bs-xl">
+    <MudText Align="Align.Center">.rounded-bs-xl</MudText>
+</div>
+<div class="mud-theme-error py-4 px-6 mx-4 rounded-be-xl">
+    <MudText Align="Align.Center">.rounded-be-xl</MudText>
+</div>

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
@@ -1,0 +1,46 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudLayout RightToLeft="@_rightToLeft">
+    <MudCard Style="width: 400px">
+        <MudCardHeader>
+            <CardHeaderAvatar>
+                <MudAvatar Color="Color.Secondary">@Localizer("CardAvatarLetter")</MudAvatar>
+            </CardHeaderAvatar>
+            <CardHeaderContent>
+                <MudText Typo="Typo.body1">@Localizer("CardHeader")</MudText>
+                <MudText Typo="Typo.body2">@Localizer("CardSubHeader")</MudText>
+            </CardHeaderContent>
+            <CardHeaderActions>
+                <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" />
+            </CardHeaderActions>
+        </MudCardHeader>
+        <MudCardMedia Image="_content/MudBlazor.Docs/images/content-template-pilars.png" Height="250" />
+        <MudCardContent>
+            <MudText Typo="Typo.body2">@Localizer("CardDescription")</MudText>
+        </MudCardContent>
+        <MudCardActions>
+            <MudIconButton Icon="@Icons.Material.Filled.Favorite" Color="Color.Default" />
+            <MudIconButton Icon="@Icons.Material.Filled.Share" Color="Color.Default" />
+        </MudCardActions>
+    </MudCard>
+    <MudSwitch @bind-Checked="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" Class="mud-float-left mud-ltr"/>
+</MudLayout>
+
+@code {
+    private bool _rightToLeft = true;
+
+    //This translation is for demonstration purposes only. In a real application, you should use a IStringLocalizer etc.
+    private string Localizer(string key)
+    {
+        //This is just a google translation. If you have a better translation, feel free to share it with us  :)
+        if (key.Equals("CardAvatarLetter"))
+            return _rightToLeft ? "ا" : "I";
+        else if (key.Equals("CardHeader"))
+            return _rightToLeft ? "استريا كرواتيا" : "Istra Croatia";
+        else if (key.Equals("CardSubHeader"))
+            return _rightToLeft ? "شبه الجزيرة في أوروبا" : "Peninsula in Europe";
+        else if (key.Equals("CardDescription"))
+            return _rightToLeft ? "التقطت هذه الصورة في قرية صغيرة في استرا كرواتيا" : "This photo was taken in a small village in Istra Croatia.";
+        return "";
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
@@ -1,0 +1,62 @@
+﻿@page "/features/rtl-languages"
+
+<DocsPage>
+    <DocsPageHeader Title="RTL Languages" SubTitle="Right-to-Left (RTL) specific styling options" />
+    <DocsPageContent>
+        <DocsPageSection>
+
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="my-2">Note that RTL language support is still under development!</MudAlert>
+            <MudText Typo="Typo.h4" GutterBottom="true">Explanation</MudText>
+            <MudText>Right-to-Left script is used in languages like arabic and hebrew where writing starts from the right of the page and continues to the left. The ui has to be mirrored horizontally because of that.</MudText>
+            <MudText>
+                You can check out the docs in RTL styling by clicking on the
+                <MudTooltip Text="Toggle right-to-left/left-to-right">
+                    <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Primary" />
+                </MudTooltip>
+                icon on the top right in the appbar.
+            </MudText>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Setting the RightToLeft property in MudLayout</Title>
+                <Description>
+                    <MudText> Note that you should use <CodeInline>MudLayout</CodeInline> only once in your application.</MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" AutoMarginContent="false">
+                <RTLLanguagesLayoutExample />
+            </SectionContent>
+            <SectionSource Code="RTLLanguagesLayoutExample" ShowCode="false"/>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Border Radius</Title>
+                <Description>
+                    <MudText>
+                        If your application should support both left-to-right and right-to-left languages, make use of
+                        <CodeInline>start</CodeInline> and <CodeInline>end</CodeInline> border radiuses instead of <CodeInline>left</CodeInline> and <CodeInline>right</CodeInline>.
+                        Some other components like <MudLink Href="/components/drawer">MudDrawer</MudLink> also support <CodeInline>start</CodeInline> and <CodeInline>end</CodeInline> properties.
+                    </MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true">
+                <RTLLanguagesBorderRadiusExample />
+            </SectionContent>
+            <SectionSource Code="RTLLanguagesBorderRadiusExample" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Other useful css classes</Title>
+            </SectionHeader>
+            <ul class="mud-typography-body1">
+                <li><CodeInline>.mud-flip-x-rtl</CodeInline> - Flips the element horizontally when in <b>rtl mode</b> (Can be used for icons which should be flipped in <b>rtl mode</b>)</li>
+                <li><CodeInline>.mud-rtl</CodeInline> and <CodeInline>.mud-ltr</CodeInline> - Changes a specific element to use <b>left-to-right</b> or <b>right-to-left</b>  styling</li>
+                <li><CodeInline>.mud-float-start</CodeInline> and <CodeInline>.mud-float-end</CodeInline> - Places an element on the <b>start</b> or <b>end</b> side of its container</li>
+                <li><CodeInline>margin/padding</CodeInline> with <CodeInline>start/end</CodeInline> - See <MudLink Href="/features/spacing">Spacing</MudLink> for more information</li>
+            </ul>
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Pages/Features/Spacing/SpacingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Spacing/SpacingPage.razor
@@ -17,6 +17,8 @@
                 <li><CodeInline>b</CodeInline> - for <CodeInline>margin-bottom</CodeInline> or <CodeInline>padding-bottom</CodeInline></li>
                 <li><CodeInline>l</CodeInline> - for <CodeInline>margin-left</CodeInline> or <CodeInline>padding-left</CodeInline></li>
                 <li><CodeInline>r</CodeInline> - for <CodeInline>margin-right</CodeInline> or <CodeInline>padding-right</CodeInline></li>
+                <li><CodeInline>s</CodeInline> - for <CodeInline>margin-left/padding-left</CodeInline> <i>(in LTR mode)</i> and <CodeInline>margin-right/padding-right</CodeInline> <i>(in RTL mode)</i></li>
+                <li><CodeInline>e</CodeInline> - for <CodeInline>margin-right/padding-right</CodeInline> <i>(in LTR mode)</i> and <CodeInline>margin-left/padding-left</CodeInline> <i>(in RTL mode)</i></li>
                 <li><CodeInline>x</CodeInline> - for <CodeInline>margin-left/padding-left</CodeInline> and <CodeInline>margin-right/padding-right</CodeInline></li>
                 <li><CodeInline>y</CodeInline> - for <CodeInline>margin-top/padding-top</CodeInline> and <CodeInline>margin-bottom/padding-bottom</CodeInline></li>
                 <li><CodeInline>a</CodeInline> - for all 4 sides.</li>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -173,6 +173,7 @@ namespace MudBlazor.Docs.Services
                 new DocsLink {Title = "Flex", Href = "features/flex"},
                 new DocsLink {Title = "Icons", Href = "features/icons"},
                 new DocsLink {Title = "Spacing", Href = "features/spacing"},
+                new DocsLink {Title = "RTL Languages", Href = "features/rtl-languages"},
             }.OrderBy(x => x.Title);
 
 

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * MudBlazor (https://mudblazor.com/)
  * Copyright (c) 2020-2021 Jonny Larsson
  * Licensed under MIT (https://github.com/Garderoben/MudBlazor/blob/master/LICENSE)
@@ -77,6 +77,7 @@
 @import 'utilities/_scroll';
 @import 'utilities/_position';
 @import 'utilities/_visibility';
+@import 'utilities/_rtl';
 
 
 @import 'layout/_appbar';

--- a/src/MudBlazor/Styles/utilities/_borders.scss
+++ b/src/MudBlazor/Styles/utilities/_borders.scss
@@ -10,7 +10,7 @@
         border-top-right-radius: $value !important;
     }
 
-    .rounded-r-#{$size} {
+    .rounded-r-#{$size}, .rounded-e-#{$size} {
         border-top-right-radius: $value !important;
         border-bottom-right-radius: $value !important;
     }
@@ -20,26 +20,64 @@
         border-bottom-left-radius: $value !important;
     }
 
-    .rounded-l-#{$size} {
+    .rounded-l-#{$size}, .rounded-s-#{$size} {
         border-top-left-radius: $value !important;
         border-bottom-left-radius: $value !important;
     }
 
-    .rounded-tl-#{$size} {
+    .rounded-tl-#{$size}, .rounded-ts-#{$size} {
         border-top-left-radius: $value !important;
     }
 
-    .rounded-tr-#{$size} {
+    .rounded-tr-#{$size}, .rounded-te-#{$size} {
         border-top-right-radius: $value !important;
     }
 
-    .rounded-br-#{$size} {
+    .rounded-br-#{$size}, .rounded-be-#{$size} {
         border-bottom-right-radius: $value !important;
     }
 
-    .rounded-bl-#{$size} {
+    .rounded-bl-#{$size}, .rounded-bs-#{$size} {
         border-bottom-left-radius: $value !important;
     }
+
+    //--------------------------- rtl styles ---------------------------
+    .mud-application-layout-rtl {
+        .rounded-s-#{$size} {
+            border-top-right-radius: $value !important;
+            border-bottom-right-radius: $value !important;
+            border-top-left-radius: 0 !important;
+            border-bottom-left-radius: 0 !important;
+        }
+
+        .rounded-e-#{$size} {
+            border-top-left-radius: $value !important;
+            border-bottom-left-radius: $value !important;
+            border-top-right-radius: 0 !important;
+            border-bottom-right-radius: 0 !important;
+        }
+
+        .rounded-ts-#{$size} {
+            border-top-right-radius: $value !important;
+            border-top-left-radius: 0 !important;
+        }
+
+        .rounded-te-#{$size} {
+            border-top-left-radius: $value !important;
+            border-top-right-radius: 0 !important;
+        }
+
+        .rounded-bs-#{$size} {
+            border-bottom-right-radius: $value !important;
+            border-bottom-left-radius: 0 !important;
+        }
+
+        .rounded-be-#{$size} {
+            border-bottom-left-radius: $value !important;
+            border-bottom-right-radius: 0 !important;
+        }
+    }
+    //------------------------------------------------------------------
 }
 
 .rounded {
@@ -51,7 +89,7 @@
     border-top-right-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-r {
+.rounded-r, .rounded-e {
     border-top-right-radius: var(--mud-default-borderradius) !important;
     border-bottom-right-radius: var(--mud-default-borderradius) !important;
 }
@@ -61,26 +99,65 @@
     border-bottom-left-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-l {
+.rounded-l, .rounded-s {
     border-top-left-radius: var(--mud-default-borderradius) !important;
     border-bottom-left-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-tl {
+.rounded-tl, .rounded-ts {
     border-top-left-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-tr {
+.rounded-tr, .rounded-te {
     border-top-right-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-br {
+.rounded-br, .rounded-be {
     border-bottom-right-radius: var(--mud-default-borderradius) !important;
 }
 
-.rounded-bl {
+.rounded-bl, .rounded-bs {
     border-bottom-left-radius: var(--mud-default-borderradius) !important;
 }
+
+//--------------------------- rtl styles ---------------------------
+.mud-application-layout-rtl {
+    .rounded-s {
+        border-top-right-radius: var(--mud-default-borderradius) !important;
+        border-bottom-right-radius: var(--mud-default-borderradius) !important;
+        border-top-left-radius: 0 !important;
+        border-bottom-left-radius: 0 !important;
+    }
+
+    .rounded-e {
+        border-top-left-radius: var(--mud-default-borderradius) !important;
+        border-bottom-left-radius: var(--mud-default-borderradius) !important;
+        border-top-right-radius: 0 !important;
+        border-bottom-right-radius: 0 !important;
+    }
+
+    .rounded-ts {
+        border-top-right-radius: var(--mud-default-borderradius) !important;
+        border-top-left-radius: 0 !important;
+    }
+
+    .rounded-te {
+        border-top-left-radius: var(--mud-default-borderradius) !important;
+        border-top-right-radius: 0 !important;
+    }
+
+    .rounded-bs {
+        border-bottom-right-radius: var(--mud-default-borderradius) !important;
+        border-bottom-left-radius: 0 !important;
+    }
+
+    .rounded-be {
+        border-bottom-left-radius: var(--mud-default-borderradius) !important;
+        border-bottom-right-radius: 0 !important;
+    }
+}
+//------------------------------------------------------------------
+
 
 .rounded-circle {
     border-radius: 50% !important;

--- a/src/MudBlazor/Styles/utilities/_float.scss
+++ b/src/MudBlazor/Styles/utilities/_float.scss
@@ -5,3 +5,23 @@
 .mud-float-right {
     float: right;
 }
+
+//--------------------------- rtl styles ---------------------------
+.mud-float-start {
+    float: left;
+}
+
+.mud-float-end {
+    float: right;
+}
+
+.mud-application-layout-rtl {
+    .mud-float-start {
+        float: right;
+    }
+
+    .mud-float-end {
+        float: left;
+    }
+}
+//------------------------------------------------------------------

--- a/src/MudBlazor/Styles/utilities/_rtl.scss
+++ b/src/MudBlazor/Styles/utilities/_rtl.scss
@@ -1,0 +1,13 @@
+﻿.mud-rtl {
+    direction: rtl !important;
+}
+
+.mud-ltr {
+    direction: ltr !important;
+}
+
+.mud-application-layout-rtl {
+    .mud-flip-x-rtl {
+        transform: scaleX(-1);
+    }
+}

--- a/src/MudBlazor/Styles/utilities/_spacing.scss
+++ b/src/MudBlazor/Styles/utilities/_spacing.scss
@@ -26,11 +26,20 @@ $spacing-negative-values: ( "n1": -4px, "n2": -8px, "n3": -12px, "n4": -16px, "n
                 #{$prop}-bottom: $value !important;
             }
 
+            .#{$abbrev}s-#{$breakpoint}#{$name} {
+                #{$prop}-inline-start: $value !important;
+            }
+
+            .#{$abbrev}e-#{$breakpoint}#{$name} {
+                #{$prop}-inline-end: $value !important;
+            }
+
             .#{$abbrev}a-#{$breakpoint}#{$name} {
                 #{$prop}: $value !important;
             }
         }
     }
+
     @each $prop, $abbrev in (margin: m) {
         @each $name, $value in $spacing-negative-values {
             .#{$abbrev}t-#{$breakpoint}#{$name},
@@ -51,6 +60,14 @@ $spacing-negative-values: ( "n1": -4px, "n2": -8px, "n3": -12px, "n4": -16px, "n
             .#{$abbrev}b-#{$breakpoint}#{$name},
             .#{$abbrev}y-#{$breakpoint}#{$name} {
                 #{$prop}-bottom: $value !important;
+            }
+
+            .#{$abbrev}s-#{$breakpoint}#{$name} {
+                #{$prop}-inline-start: $value !important;
+            }
+
+            .#{$abbrev}e-#{$breakpoint}#{$name} {
+                #{$prop}-inline-end: $value !important;
             }
 
             .#{$abbrev}a-#{$breakpoint}#{$name} {


### PR DESCRIPTION
This PR adds a `RTL Languages` section under `Features`.
This also introduces new RTL css classes:
- `margin/padding` with `start/end` as mentioned in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-723676431
- `border radius` with `start/end`
- other css classes like: `mud-float-start`, `mud-float-end`, `mud-rtl`, `mud-ltr`, `mud-flip-x-rtl`

![docs](https://user-images.githubusercontent.com/62108893/120527814-14412580-c3db-11eb-98d6-7aee8bfa895b.png)
![grafik](https://user-images.githubusercontent.com/62108893/120527859-20c57e00-c3db-11eb-837e-7a9bef985ac8.png)
![grafik](https://user-images.githubusercontent.com/62108893/120527899-2a4ee600-c3db-11eb-83d5-bae7abf3230a.png)