### PR TITLE
MudTable: added loading progress bar

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingText="@_loadingText" LoadingProgressColor="Color.Info">
+<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingProgressColor="Color.Info">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -26,7 +26,6 @@
 @code {
     private bool _hidePosition;
     private bool _loading;
-    private string _loadingText = "Loading in progress...";
     private IEnumerable<Element> Elements = new List<Element>();
 
     protected override async Task OnInitializedAsync()

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm">
+<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingText="@_loadingText" LoadingProgressColor="Color.Info">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -21,9 +21,12 @@
 </MudTable>
 
 <MudSwitch @bind-Checked="_hidePosition">Hide <b>position</b> when Breakpoint=Xs</MudSwitch>
+<MudSwitch @bind-Checked="_loading">Show Loading</MudSwitch>
 
 @code {
     private bool _hidePosition;
+    private bool _loading;
+    private string _loadingText = "Loading in progress...";
     private IEnumerable<Element> Elements = new List<Element>();
 
     protected override async Task OnInitializedAsync()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+</MudTable>
+
+<MudSwitch id="switch" @bind-Checked="_loading">Show Loading</MudSwitch>
+
+@code {
+    private bool _loading = false;
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override void OnInitialized()
+    {
+        Elements = new List<Element>()
+        {
+            new Element() { Molar = "A", Sign = "A", Name = "A", Number = "A", Position = "A"},
+            new Element() { Molar = "B", Sign = "B", Name = "B", Number = "B", Position = "B"},
+        };
+    }
+
+    public class Element
+    {
+        public string Number { get; set; }
+        public string Sign { get; set; }
+        public string Name { get; set; }
+        public string Position { get; set; }
+        public string Molar { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -51,6 +51,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Check if the loading parameter is adding a supplementary row.
+        /// </summary>
+        [Test]
+        public void TableLoadingTest()
+        {
+            var comp = ctx.RenderComponent<TableLoadingTest>();
+
+            // Count the number of rows
+            var trs = comp.FindAll("tr");
+
+            // It should be equal to 3 = two rows + header row
+            trs.Count.Should().Be(3);
+
+            // Find the loading switch
+            var switchElement = comp.Find("#switch");
+
+            // Click the loading switch
+            switchElement.Change(true); 
+
+            // Count the number of rows
+            trs = comp.FindAll("tr");
+
+            // It should be equal to 4 = two rows + header row + loading row
+            trs.Count.Should().Be(4);
+        }
+
+        /// <summary>
         /// should only be able to select one item and selecteditems.count should never exceed 1
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -48,31 +48,43 @@
                     </thead>
                 }
                 <tbody class="mud-table-body">
-                    @if (CurrentPageItems != null)
+                    @if (Loading)
                     {
-                        var rowIndex = 0;
-                        @foreach (var item in CurrentPageItems)
+                        <tr>
+                            <td colspan="1000">
+                                <MudProgressLinear Color="@LoadingProgressColor" Indeterminate="true" />
+                                <div style="display: flex; flex-direction: row; justify-content:center;" class="my-2">@LoadingText</div>
+                            </td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @if (CurrentPageItems != null)
                         {
-                            var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
-                            var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
-                                   IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
-                                @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
-                                { 
-                                    <CascadingValue Value="@Validator" IsFixed="true">
-                                        @RowEditingTemplate(item)
-                                    </CascadingValue>
-                                }
-                                else
-                                {
-                                    @RowTemplate(item)
-                                }
-                            </MudTr>
-                            @if (ChildRowContent != null)
+                            var rowIndex = 0;
+                            @foreach (var item in CurrentPageItems)
                             {
-                                @ChildRowContent(item)
+                                var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
+                                var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
+                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
+                                       IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                                    @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
+                                    { 
+                                        <CascadingValue Value="@Validator" IsFixed="true">
+                                            @RowEditingTemplate(item)
+                                        </CascadingValue>
+                                    }
+                                    else
+                                    {
+                                        @RowTemplate(item)
+                                    }
+                                </MudTr>
+                                @if (ChildRowContent != null)
+                                {
+                                    @ChildRowContent(item)
+                                }
+                                rowIndex++;
                             }
-                            rowIndex++;
                         }
                     }
                 </tbody>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -53,38 +53,34 @@
                         <tr>
                             <td colspan="1000">
                                 <MudProgressLinear Color="@LoadingProgressColor" Indeterminate="true" />
-                                <div style="display: flex; flex-direction: row; justify-content:center;" class="my-2">@LoadingText</div>
                             </td>
                         </tr>
                     }
-                    else
+                    @if (CurrentPageItems != null)
                     {
-                        @if (CurrentPageItems != null)
+                        var rowIndex = 0;
+                        @foreach (var item in CurrentPageItems)
                         {
-                            var rowIndex = 0;
-                            @foreach (var item in CurrentPageItems)
-                            {
-                                var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
-                                var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
-                                       IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
-                                    @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
-                                    { 
-                                        <CascadingValue Value="@Validator" IsFixed="true">
-                                            @RowEditingTemplate(item)
-                                        </CascadingValue>
-                                    }
-                                    else
-                                    {
-                                        @RowTemplate(item)
-                                    }
-                                </MudTr>
-                                @if (ChildRowContent != null)
-                                {
-                                    @ChildRowContent(item)
+                            var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
+                            var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
+                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
+                                    IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                                @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
+                                { 
+                                    <CascadingValue Value="@Validator" IsFixed="true">
+                                        @RowEditingTemplate(item)
+                                    </CascadingValue>
                                 }
-                                rowIndex++;
+                                else
+                                {
+                                    @RowTemplate(item)
+                                }
+                            </MudTr>
+                            @if (ChildRowContent != null)
+                            {
+                                @ChildRowContent(item)
                             }
+                            rowIndex++;
                         }
                     }
                 </tbody>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -148,14 +148,9 @@ namespace MudBlazor
         [Parameter] public bool Loading { get; set; }
 
         /// <summary>
-        /// Define the loading text.
-        /// </summary>
-        [Parameter] public string LoadingText { get; set; } = "Loading...";
-
-        /// <summary>
         /// The color of the loading progress if used. It supports the theme colors.
         /// </summary>
-        [Parameter] public Color LoadingProgressColor { get; set; } = Color.Default;
+        [Parameter] public Color LoadingProgressColor { get; set; } = Color.Info;
 
         /// <summary>
         /// Add MudTh cells here to define the table header. If <see cref="CustomHeader"/> is set, add one or more MudTHeadRow instead.

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -143,6 +143,21 @@ namespace MudBlazor
         [Parameter] public RenderFragment ToolBarContent { get; set; }
 
         /// <summary>
+        /// Show a loading animation, if true.
+        /// </summary>
+        [Parameter] public bool Loading { get; set; }
+
+        /// <summary>
+        /// Define the loading text.
+        /// </summary>
+        [Parameter] public string LoadingText { get; set; } = "Loading...";
+
+        /// <summary>
+        /// The color of the loading progress if used. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Color LoadingProgressColor { get; set; } = Color.Default;
+
+        /// <summary>
         /// Add MudTh cells here to define the table header. If <see cref="CustomHeader"/> is set, add one or more MudTHeadRow instead.
         /// </summary>
         [Parameter] public RenderFragment HeaderContent { get; set; }


### PR DESCRIPTION
Implementation of the [Loading State in Table](https://github.com/Garderoben/MudBlazor/issues/295) issue.

Three parameters are available : 

```
LoadingText = "Text"
Loading = true|false
LoadingProgressColor = "Color.Primary"
```

A demonstration of the _Loading_ properties is shown with a switch in the _Table_ documentation for the _Default Table_ example.