### PR TITLE
Resize Observer: Remove sync Dispose

### DIFF
--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
@@ -9,7 +9,7 @@ namespace MudBlazor.Services
 
     public delegate void SizeChanged(IDictionary<ElementReference, BoundingClientRect> changes);
 
-    public interface IResizeObserver : IAsyncDisposable, IDisposable
+    public interface IResizeObserver : IAsyncDisposable
     {
         Task<BoundingClientRect> Observe(ElementReference element);
         Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
@@ -126,7 +126,7 @@ namespace MudBlazor.Services
             _cachedValueIds.Clear();
             _cachedValues.Clear();
 
-            // The JS call may timeout if the underlyinh JSRuntime is gone.
+            // The JS call may timeout if the underlying JSRuntime is gone.
             try { await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.cancelListener", _id); } catch (TaskCanceledException) { }
         }
     }


### PR DESCRIPTION
- We shouldnt create sync Dispose and discard the result of an async method.  That is what IAsyncDispose is for.
- Additionally because the try catch is surrounding a discard , any exception will not surface in this thread.

@henon