### PR TITLE
Table: Optional checkbox selection on RowClick

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover">
+<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover" ToggleSelectionOnRowClick="@selectionOnRowClick">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -28,9 +28,11 @@
 
 <MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
 <MudText Inline="true">Selected items: @(selectedItems2==null ? "" : string.Join(", ", selectedItems2.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
+<MudSwitch @bind-Checked="selectionOnRowClick" Color="Color.Info">Enable selection on Row Click</MudSwitch>
 
 @code {
     private bool hover = true;
+    private bool selectionOnRowClick = true;
     private HashSet<Element> selectedItems1 = new HashSet<Element>();
     private HashSet<Element> selectedItems2 = new HashSet<Element>();
 

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -85,7 +85,7 @@
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" 
-                                      IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                                      ToggleSelectionOnRowClick="ToggleSelectionOnRowClick" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                                    @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                                    {
@@ -190,7 +190,7 @@
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, ! string.IsNullOrEmpty("mud-table-row-group-indented-1")).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
                 <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
-                        IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                        ToggleSelectionOnRowClick="ToggleSelectionOnRowClick" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                     {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -239,6 +239,11 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Defines if table row clicks should trigger selection (if MultiSelection is set to true).
+        /// </summary>
+        [Parameter] public bool ToggleSelectionOnRowClick { get; set; } = true;
+
+        /// <summary>
         /// Callback is called whenever items are selected or deselected in multi selection mode.
         /// </summary>
         [Parameter] public EventCallback<HashSet<T>> SelectedItemsChanged { get; set; }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -36,12 +36,12 @@ namespace MudBlazor
 
         [Parameter] public bool IsFooter { get; set; }
 
-        [Parameter]
-        public EventCallback<bool> IsCheckedChanged { get; set; }
+        [Parameter] public bool ToggleSelectionOnRowClick { get; set; }
+
+        [Parameter] public EventCallback<bool> IsCheckedChanged { get; set; }
 
         private bool _checked;
-        [Parameter]
-        public bool IsChecked
+        [Parameter] public bool IsChecked
         {
             get => _checked;
             set
@@ -84,7 +84,7 @@ namespace MudBlazor
 
             Context?.Table.SetEditingItem(Item);
 
-            if (Context?.Table.MultiSelection == true && !IsHeader)
+            if (Context?.Table.MultiSelection == true && ToggleSelectionOnRowClick && !IsHeader)
             {
                 IsChecked = !IsChecked;
             }


### PR DESCRIPTION
This PR introduces a property (ToggleSelectionOnRowClick) to control if the row-click should toggle the MultiSelection checkbox. This is useful when you want to have the row click performing other actions, like turning inline-edit, showing context menus, etc..., without toggling the checkboxes.
I set the default to true to preserve compatibility.