### PR TITLE
Table: Add default collapse option to basic table grouping

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
@@ -1,0 +1,69 @@
+@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<style>
+    .mud-table-cell-custom-group {
+        font-weight: 500;
+    }
+
+    .mud-table-cell-custom-group-footer {
+        padding-bottom: 50px;
+        text-align: right;
+    }
+</style>
+
+<MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
+          Items="@Elements"
+          GroupBy="@_groupDefinition"
+          GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
+          GroupFooterClass="mb-4"
+          Dense="true">
+    <ColGroup>
+        <col style="width: 60px;" />
+        <col />
+        <col />
+        <col />
+        <col />
+        <col />
+    </ColGroup>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <GroupHeaderTemplate>
+        <MudTh Class="mud-table-cell-custom-group" colspan="5">@($"{context.GroupName}: {context.Key}")</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd Style="text-align: right" DataLabel="Molar mass">@context.Molar"</MudTd>
+    </RowTemplate>
+    <GroupFooterTemplate>
+        <MudTh Class="mud-table-cell-custom-group mud-table-cell-custom-group-footer" colspan="5">Total Mass: @context.Items.Sum((e) => e.Molar)</MudTh>
+    </GroupFooterTemplate>
+</MudTable>
+
+@code { 
+    private TableGroupDefinition<Element> _groupDefinition = new()
+    {
+        GroupName = "Group",
+        Indentation = false,
+        Expandable = true,
+        IsInitiallyExpanded = false,
+        Selector = (e) => e.Group
+    };
+
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -199,6 +199,18 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Grouping (Basic) - Initially collapsed">
+                <Description>
+                    Displays items in a grouped way, but the groups are all collapsed as default.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableBasicGroupingInitiallyCollapsedExample />
+            </SectionContent>
+            <SectionSource Code="TableBasicGroupingInitiallyCollapsedExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Grouping (Multi Levels)">
                 <Description>
                     Displays items recursively grouped.

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1114,5 +1114,26 @@ namespace MudBlazor.UnitTests.Components
             tr = comp.FindAll("tr").ToArray();
             tr.Length.Should().Be(36);
         }
+
+        /// <summary>
+        /// Tests the IsInitiallyExpanded grouping behavior.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TableGroupIsInitiallyExpandedTest()
+        {
+            // group by Racing Category and collapse groups as default:
+            var comp = Context.RenderComponent<TableGroupingTest>();
+            var table = comp.Instance.tableInstance;
+            table.GroupBy = new TableGroupDefinition<TableGroupingTest.RacingCar>(rc => rc.Category, null) { 
+                GroupName = "Category",
+                Expandable = true,
+                IsInitiallyExpanded = false 
+            };
+            comp.Render();
+            table.Context.GroupRows.Count.Should().Be(4); // 4 categories
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(5); // 1 table header + 4 group headers
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -82,6 +82,7 @@ namespace MudBlazor
         {
             if (GroupDefinition != null)
             {
+                IsExpanded = GroupDefinition.IsInitiallyExpanded;
                 ((TableContext<T>)Context)?.GroupRows.Add(this);
                 if (GroupDefinition.InnerGroup != null)
                 {

--- a/src/MudBlazor/Components/Table/TableGroupDefinition.cs
+++ b/src/MudBlazor/Components/Table/TableGroupDefinition.cs
@@ -82,8 +82,22 @@ namespace MudBlazor
             {
                 _expandable = value;
                 if (_expandable == false)
-                    Context?.GroupRows.Where(gr => gr.GroupDefinition == this).ToList().ForEach(gr => gr.IsExpanded = true);
+                    Context?.GroupRows.Where(gr => gr.GroupDefinition == this).ToList().ForEach(gr => gr.IsExpanded = IsInitiallyExpanded);
             }
+        }
+
+        private bool _isInitiallyExpanded = true;
+        /// <summary>
+        /// Gets or Sets if expandable group header is collapsed or expanded on initialization.
+        /// </summary>
+        public bool IsInitiallyExpanded
+        {
+            get => _isInitiallyExpanded;
+            set
+            {
+                _isInitiallyExpanded = value;
+            }
+
         }
 
         internal bool IsParentExpandable


### PR DESCRIPTION
Tables using simple grouping can now have all groups collapsed by default. This helps users view only the information they want in large tables. 
![image](https://user-images.githubusercontent.com/14116459/132720411-d05801f7-7145-421b-b791-1daeafa9a17a.png)

fixes #2683
