### PR TITLE
DateRangePicker: Not updating validation-status

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
@@ -1,0 +1,32 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudForm @ref="_form" IsValidChanged="@(HandleFormValidChanged)">
+    <MudPaper>
+        @($"Status: {_submitStatus ?? "Not yet submitted/validated"}")
+    </MudPaper>
+    
+    <MudDateRangePicker @ref="@(_picker)" @bind-DateRange="@(_dateRange)" Label="Select Date Range" Required="true" RequiredError="This field is required!">
+        <PickerActions>
+            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
+            <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+            <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        </PickerActions>
+    </MudDateRangePicker>
+
+    <MudButton Class="mt-2" OnClick="@(() => _form.Validate())">Validate</MudButton>
+</MudForm>
+
+@code {
+    public static string __description__ = $"The {nameof(MudDateRangePicker)} should shown an error when clicking validate without any data but this should disappear when a value has been set.";
+
+    private MudForm _form;
+    private MudDateRangePicker _picker;
+    private string _submitStatus;
+    private DateRange _dateRange; // = new(DateTime.Now, DateTime.Now.AddDays(2));
+
+    private void HandleFormValidChanged(bool isValid)
+    {
+        _submitStatus = $"Form is {(isValid ? string.Empty : "in")}valid";
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -428,6 +429,48 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.DateRange.End.Should().NotBe(default);
             comp.Instance.DateRange.Start.Should().BeNull();
             comp.Instance.DateRange.End.Should().BeNull();
+        }
+
+        [Test]
+        public async Task DateRangePicker_RequiredValidation()
+        {
+            // define some "constant" values
+            var errorMessage = "A valid date has to be picked";
+            var startDate = DateTime.Now.Date;
+            var endDate = DateTime.Now.Date.AddDays(2);
+
+            // create the component
+            var dateRangePickerComponent = Context.RenderComponent<MudDateRangePicker>(Parameter(nameof(MudDateRangePicker.Required), true), Parameter(nameof(MudDateRangePicker.RequiredError), errorMessage));
+
+            // select the instance to work with
+            var dateRangePickerInstance = dateRangePickerComponent.Instance;
+
+            // assert default's
+            dateRangePickerInstance.Text.Should().BeNullOrEmpty();
+            dateRangePickerInstance.DateRange.Should().Be(null);
+
+            // validated the picker
+            await dateRangePickerComponent.InvokeAsync(()=> dateRangePickerInstance.Validate());
+            dateRangePickerInstance.Error.Should().BeTrue("Value is required and should be handled as invalid");
+            dateRangePickerInstance.ErrorText.Should().Be(errorMessage);
+
+            // set a value
+            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Text = RangeConverter<DateTime>.Join(startDate.ToShortDateString(), endDate.ToShortDateString()));
+            
+            // asert new values have been applied
+            dateRangePickerInstance.DateRange.Start.Should().Be(startDate);
+            dateRangePickerInstance.DateRange.End.Should().Be(endDate);
+            dateRangePickerInstance.Error.Should().BeFalse("Value has been set and should be handled as valid");
+            dateRangePickerInstance.ErrorText.Should().BeNullOrWhiteSpace();
+
+            // reset value
+            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Clear());
+
+            // assert values have benn nulled
+            dateRangePickerInstance.Text.Should().BeNullOrEmpty();
+            dateRangePickerInstance.DateRange.Should().Be(null);
+            dateRangePickerInstance.Error.Should().BeTrue("Value has been cleared and should be handled as invalid");
+            dateRangePickerInstance.ErrorText.Should().Be(errorMessage);
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -53,6 +53,7 @@ namespace MudBlazor
                 }
 
                 _dateRange = range;
+                _value = range?.End;
 
                 if (updateValue)
                 {


### PR DESCRIPTION
As described #1428 I've set the internal `_value` to the range's end-date so it fullfills the `Required` condition.

Maybe @henon can take care of this as he initially added the `Required`-feature for `DateRangePicker`s in the first place.