### PR TITLE
MudChip - Added Variant.Text, SelectedColor option and updated docs.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
@@ -6,13 +6,31 @@
     </DocsPageHeader>
     <DocsPageContent>
         <DocsPageSection>
-            <SectionHeader Title="Basic Chips">
+            <SectionHeader Title="Filled Chips">
                 <Description>The Chips, when disabled, differ from other components. Instead of using the disabled color, the opacity is lowered.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" Class="mud-text-align-center">
                 <ChipBasicExample />
             </SectionContent>
             <SectionSource ShowCode="false" Code="ChipBasicExample" GitHubFolderName="Chip" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Text Chips">
+                <Description>Text Chips also differ from other components where it has transparent background instead of fully transparent.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ChipTextExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="ChipTextExample" GitHubFolderName="Chip" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Outlined Chips">
+                <Description>This looks and feels like outlined normaly do with a border and slightly transparent background on hover.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ChipOutlinedExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="ChipOutlinedExample" GitHubFolderName="Chip" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Closable">
@@ -39,14 +57,6 @@
                 <ChipLabelExample />
             </SectionContent>
             <SectionSource ShowCode="false" Code="ChipLabelExample" GitHubFolderName="Chip" />
-        </DocsPageSection>
-        <DocsPageSection>
-            <SectionHeader Title="Outlined">
-            </SectionHeader>
-            <SectionContent Outlined="true">
-                <ChipOutlinedExample />
-            </SectionContent>
-            <SectionSource ShowCode="false" Code="ChipOutlinedExample" GitHubFolderName="Chip" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Sizes">

--- a/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipBasicExample.razor
@@ -9,11 +9,11 @@
 <MudChip Color="Color.Error">Error</MudChip>
 <MudChip Color="Color.Dark">Dark</MudChip>
 <MudDivider />
-<MudChip Disabled="true">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Primary">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Secondary">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Info">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Success">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Warning">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Error">Disabled</MudChip>
-<MudChip Disabled="true" Color="Color.Dark">Disabled</MudChip>
+<MudChip Disabled="true">Default</MudChip>
+<MudChip Disabled="true" Color="Color.Primary">Primary</MudChip>
+<MudChip Disabled="true" Color="Color.Secondary">Secondary</MudChip>
+<MudChip Disabled="true" Color="Color.Info">Info</MudChip>
+<MudChip Disabled="true" Color="Color.Success">Success</MudChip>
+<MudChip Disabled="true" Color="Color.Warning">Warning</MudChip>
+<MudChip Disabled="true" Color="Color.Error">Error</MudChip>
+<MudChip Disabled="true" Color="Color.Dark">Dark</MudChip>

--- a/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipOutlinedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipOutlinedExample.razor
@@ -1,9 +1,19 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudChip Variant="Variant.Outlined">Default</MudChip>
-<MudChip Color="Color.Primary" Variant="Variant.Outlined">Primary</MudChip>
-<MudChip Color="Color.Secondary" Variant="Variant.Outlined">Secondary</MudChip>
-<MudChip Color="Color.Info" Variant="Variant.Outlined">Info</MudChip>
-<MudChip Icon="@Icons.Material.Filled.Storage" Label="true" Color="Color.Dark" Variant="Variant.Outlined">Server Storage</MudChip>
-<MudChip Icon="@Icons.Custom.Brands.Twitter" Label="true" Color="Color.Info" Variant="Variant.Outlined">New Tweets</MudChip>
-<MudChip Icon="@Icons.Custom.Uncategorized.Radioactive" Label="true" Color="Color.Warning" IconColor="Color.Dark" Variant="Variant.Outlined">Radioactive Areas</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Primary">Primary</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Secondary">Secondary</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Info">Info</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Success">Success</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Warning">Warning</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Error">Error</MudChip>
+<MudChip Variant="Variant.Outlined" Color="Color.Dark">Dark</MudChip>
+<MudDivider />
+<MudChip Disabled="true" Variant="Variant.Outlined">Default</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Primary">Primary</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Secondary">Secondary</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Info">Info</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Success">Success</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Warning">Warning</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Error">Error</MudChip>
+<MudChip Disabled="true" Variant="Variant.Outlined" Color="Color.Dark">Dark</MudChip>

--- a/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipTextExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/Examples/ChipTextExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudChip Variant="Variant.Text">Default</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Primary">Primary</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Secondary">Secondary</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Info">Info</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Success">Success</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Warning">Warning</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Error">Error</MudChip>
+<MudChip Variant="Variant.Text" Color="Color.Dark">Dark</MudChip>
+<MudDivider />
+<MudChip Disabled="true" Variant="Variant.Text">Default</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Primary">Primary</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Secondary">Secondary</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Info">Info</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Success">Success</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Warning">Warning</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Error">Error</MudChip>
+<MudChip Disabled="true" Variant="Variant.Text" Color="Color.Dark">Dark</MudChip>

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
@@ -39,7 +39,7 @@
             </SectionContent>
             <SectionSource ShowCode="false" Code="ChipSetAddRemoveExample" GitHubFolderName="ChipSet" />
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader Title="Default chips">
                 <Description>
@@ -50,6 +50,30 @@
                 <ChipSetDefaultChipsExample />
             </SectionContent>
             <SectionSource ShowCode="false" Code="ChipSetDefaultChipsExample" GitHubFolderName="ChipSet" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Variants">
+                <Description>
+                    The chip's look different when selected depending on its initial <CodeInline>Variant</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" Class="mud-text-align-center">
+                <ChipSetVariantsExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="ChipSetVariantsExample" GitHubFolderName="ChipSet" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Selected Color">
+                <Description>
+                    The chip's selected color can be changed with the <CodeInline>SelectedColor</CodeInline> property, by default it has the same color as the chip.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" Class="mud-text-align-center">
+                <ChipSetSelectedColorExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="ChipSetSelectedColorExample" GitHubFolderName="ChipSet" />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetSelectedColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetSelectedColorExample.razor
@@ -1,30 +1,24 @@
 ﻿@namespace MudBlazor.Docs.Examples
 <MudChipSet MultiSelection="true" Filter="filter">
-    <MudChip Text="Brunsås" Variant="Variant.Text" SelectedColor="Color.Primary"></MudChip>
-    <MudChip Text="Milk" Variant="Variant.Text" SelectedColor="Color.Secondary"></MudChip>
-    <MudChip Text="Eggs" Variant="Variant.Text" SelectedColor="Color.Info"></MudChip>
-    <MudChip Text="Soap" Variant="Variant.Text" SelectedColor="Color.Success"></MudChip>
-    <MudChip Text="Cornflakes" Variant="Variant.Text" SelectedColor="Color.Warning"></MudChip>
-    <MudChip Text="Salad" Variant="Variant.Text" SelectedColor="Color.Error"></MudChip>
-    <MudChip Text="Apples" Variant="Variant.Text" SelectedColor="Color.Dark"></MudChip>
+    <MudChip Text="Brunsås" Variant="Variant.Text" Color="Color.Default" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Text" Color="Color.Primary" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Text" Color="Color.Dark" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Text" Color="Color.Info" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Text" Color="Color.Success" SelectedColor="Color.Error"></MudChip>
 </MudChipSet>
 <MudChipSet MultiSelection="true" Filter="filter">
-    <MudChip Text="Brunsås" Variant="Variant.Outlined" SelectedColor="Color.Primary"></MudChip>
-    <MudChip Text="Milk" Variant="Variant.Outlined" SelectedColor="Color.Secondary"></MudChip>
-    <MudChip Text="Eggs" Variant="Variant.Outlined" SelectedColor="Color.Info"></MudChip>
-    <MudChip Text="Soap" Variant="Variant.Outlined" SelectedColor="Color.Success"></MudChip>
-    <MudChip Text="Cornflakes" Variant="Variant.Outlined" SelectedColor="Color.Warning"></MudChip>
-    <MudChip Text="Salad" Variant="Variant.Outlined" SelectedColor="Color.Error"></MudChip>
-    <MudChip Text="Apples" Variant="Variant.Outlined" SelectedColor="Color.Dark"></MudChip>
+    <MudChip Text="Brunsås" Variant="Variant.Outlined" Color="Color.Default" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Outlined" Color="Color.Primary" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Outlined" Color="Color.Dark" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Outlined" Color="Color.Info" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Outlined" Color="Color.Success" SelectedColor="Color.Error"></MudChip>
 </MudChipSet>
 <MudChipSet MultiSelection="true" Filter="filter">
-    <MudChip Text="Brunsås" Variant="Variant.Filled" SelectedColor="Color.Primary"></MudChip>
-    <MudChip Text="Milk" Variant="Variant.Filled" SelectedColor="Color.Secondary"></MudChip>
-    <MudChip Text="Eggs" Variant="Variant.Filled" SelectedColor="Color.Info"></MudChip>
-    <MudChip Text="Soap" Variant="Variant.Filled" SelectedColor="Color.Success"></MudChip>
-    <MudChip Text="Cornflakes" Variant="Variant.Filled" SelectedColor="Color.Warning"></MudChip>
-    <MudChip Text="Salad" Variant="Variant.Filled" SelectedColor="Color.Error"></MudChip>
-    <MudChip Text="Apples" Variant="Variant.Filled" SelectedColor="Color.Dark"></MudChip>
+    <MudChip Text="Brunsås" Variant="Variant.Filled" Color="Color.Default" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Filled" Color="Color.Primary" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Filled" Color="Color.Dark" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Filled" Color="Color.Info" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Filled" Color="Color.Success" SelectedColor="Color.Error"></MudChip>
 </MudChipSet>
 <MudCheckBox @bind-Checked="filter">Filter</MudCheckBox>
 

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetSelectedColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetSelectedColorExample.razor
@@ -1,0 +1,36 @@
+﻿@namespace MudBlazor.Docs.Examples
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="Brunsås" Variant="Variant.Text" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Milk" Variant="Variant.Text" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Text" SelectedColor="Color.Info"></MudChip>
+    <MudChip Text="Soap" Variant="Variant.Text" SelectedColor="Color.Success"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Text" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Text" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Text" SelectedColor="Color.Dark"></MudChip>
+</MudChipSet>
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="Brunsås" Variant="Variant.Outlined" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Milk" Variant="Variant.Outlined" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Outlined" SelectedColor="Color.Info"></MudChip>
+    <MudChip Text="Soap" Variant="Variant.Outlined" SelectedColor="Color.Success"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Outlined" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Outlined" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Outlined" SelectedColor="Color.Dark"></MudChip>
+</MudChipSet>
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="Brunsås" Variant="Variant.Filled" SelectedColor="Color.Primary"></MudChip>
+    <MudChip Text="Milk" Variant="Variant.Filled" SelectedColor="Color.Secondary"></MudChip>
+    <MudChip Text="Eggs" Variant="Variant.Filled" SelectedColor="Color.Info"></MudChip>
+    <MudChip Text="Soap" Variant="Variant.Filled" SelectedColor="Color.Success"></MudChip>
+    <MudChip Text="Cornflakes" Variant="Variant.Filled" SelectedColor="Color.Warning"></MudChip>
+    <MudChip Text="Salad" Variant="Variant.Filled" SelectedColor="Color.Error"></MudChip>
+    <MudChip Text="Apples" Variant="Variant.Filled" SelectedColor="Color.Dark"></MudChip>
+</MudChipSet>
+<MudCheckBox @bind-Checked="filter">Filter</MudCheckBox>
+
+
+@code
+{
+    bool filter = true;
+}
+

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetVariantsExample.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor.Docs.Examples
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="grey" Variant="Variant.Text" Color="Color.Default">Default</MudChip>
+    <MudChip Text="purple" Variant="Variant.Text" Color="Color.Primary">Primary</MudChip>
+    <MudChip Text="pink" Variant="Variant.Text" Color="Color.Secondary">Secondary</MudChip>
+    <MudChip Text="blue" Variant="Variant.Text" Color="Color.Info">Info</MudChip>
+    <MudChip Text="green" Variant="Variant.Text" Color="Color.Success">Success</MudChip>
+    <MudChip Text="orange" Variant="Variant.Text" Color="Color.Warning">Warning</MudChip>
+    <MudChip Text="red" Variant="Variant.Text" Color="Color.Error">Error</MudChip>
+    <MudChip Text="black" Variant="Variant.Text" Color="Color.Dark">Dark</MudChip>
+</MudChipSet>
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="grey" Variant="Variant.Outlined" Color="Color.Default">Default</MudChip>
+    <MudChip Text="purple" Variant="Variant.Outlined" Color="Color.Primary">Primary</MudChip>
+    <MudChip Text="pink" Variant="Variant.Outlined" Color="Color.Secondary">Secondary</MudChip>
+    <MudChip Text="blue" Variant="Variant.Outlined" Color="Color.Info">Info</MudChip>
+    <MudChip Text="green" Variant="Variant.Outlined" Color="Color.Success">Success</MudChip>
+    <MudChip Text="orange" Variant="Variant.Outlined" Color="Color.Warning">Warning</MudChip>
+    <MudChip Text="red" Variant="Variant.Outlined" Color="Color.Error">Error</MudChip>
+    <MudChip Text="black" Variant="Variant.Outlined" Color="Color.Dark">Dark</MudChip>
+</MudChipSet>
+<MudChipSet MultiSelection="true" Filter="filter">
+    <MudChip Text="grey" Variant="Variant.Filled" Color="Color.Default">Default</MudChip>
+    <MudChip Text="purple" Variant="Variant.Filled" Color="Color.Primary">Primary</MudChip>
+    <MudChip Text="pink" Variant="Variant.Filled" Color="Color.Secondary">Secondary</MudChip>
+    <MudChip Text="blue" Variant="Variant.Filled" Color="Color.Info">Info</MudChip>
+    <MudChip Text="green" Variant="Variant.Filled" Color="Color.Success">Success</MudChip>
+    <MudChip Text="orange" Variant="Variant.Filled" Color="Color.Warning">Warning</MudChip>
+    <MudChip Text="red" Variant="Variant.Filled" Color="Color.Error">Error</MudChip>
+    <MudChip Text="black" Variant="Variant.Filled" Color="Color.Dark">Dark</MudChip>
+</MudChipSet>
+<MudCheckBox @bind-Checked="filter">Filter</MudCheckBox>
+
+
+@code
+{
+    bool filter = true;
+}
+

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -17,9 +17,9 @@ namespace MudBlazor
 
         protected string Classname =>
         new CssBuilder("mud-chip")
-          .AddClass($"mud-chip-{Variant.ToDescriptionString()}")
+          .AddClass($"mud-chip-{GetVariant().ToDescriptionString()}")
           .AddClass($"mud-chip-size-{Size.ToDescriptionString()}")
-          .AddClass($"mud-chip-color-{Color.ToDescriptionString()}")
+          .AddClass($"mud-chip-color-{GetColor().ToDescriptionString()}")
           .AddClass("mud-clickable", (OnClick.HasDelegate || ChipSet != null))
           .AddClass($"mud-ripple", !DisableRipple && (OnClick.HasDelegate || ChipSet != null))
           .AddClass("mud-chip-label", Label)
@@ -27,6 +27,33 @@ namespace MudBlazor
           .AddClass("mud-chip-selected", IsSelected)
           .AddClass(Class)
         .Build();
+
+        private Variant GetVariant()
+        {
+            return Variant switch
+            {
+                Variant.Text => IsSelected ? Variant.Filled : Variant.Text,
+                Variant.Filled => IsSelected ? Variant.Text : Variant.Filled,
+                Variant.Outlined => Variant.Outlined,
+                _ => Variant
+            };
+        }
+
+        private Color GetColor()
+        {
+            if (IsSelected && SelectedColor != Color.Inherit)
+            {
+                return SelectedColor;
+            }
+            else if(IsSelected && SelectedColor == Color.Inherit)
+            {
+                return Color;
+            }
+            else
+            {
+                return Color;
+            }
+        }
 
         [CascadingParameter] MudChipSet ChipSet { get; set; }
 
@@ -44,6 +71,11 @@ namespace MudBlazor
         /// The variant to use.
         /// </summary>
         [Parameter] public Variant Variant { get; set; } = Variant.Filled;
+
+        /// <summary>
+        /// The selected color to use when selected, only works togheter with ChipSet, Color.Inherit for default value.
+        /// </summary>
+        [Parameter] public Color SelectedColor { get; set; } = Color.Inherit;
 
         /// <summary>
         /// Avatar Icon, Overrides the regular Icon if set.

--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -102,11 +102,6 @@
             &:hover {
                 background-color: var(--mud-palette-#{$color}-darken);
             }
-
-            &.mud-chip-selected {
-                color: var(--mud-palette-#{$color});
-                background-color: var(--mud-palette-#{$color}-hover) !important;
-            }
         }
     }
 }
@@ -126,11 +121,33 @@
             &:hover {
                 background-color: var(--mud-palette-#{$color}-hover);
             }
+
+            &.mud-chip-selected {
+                background-color: var(--mud-palette-#{$color}-hover);
+
+                &:hover {
+                    background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+                }
+            }
         }
     }
 }
+.mud-chip-text {
+    color: var(--mud-palette-text-primary);
+    background-color: var(--mud-palette-action-default-hover);
 
-.mud-chip-selected {
-    color: var(--mud-palette-primary);
-    background-color: var(--mud-palette-primary-hover) !important;
+    &:hover {
+        background-color: var(--mud-palette-action-disabled-background);
+    }
+
+    @each $color in $mud-palette-colors {
+        &.mud-chip-color-#{$color} {
+            color: var(--mud-palette-#{$color});
+            background-color: var(--mud-palette-#{$color}-hover);
+
+            &:hover {
+                background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+            }
+        }
+    }
 }


### PR DESCRIPTION
MudChip and MudChipSet
Variant.Text did nothing and "broke" the component when used.

Added variant.text css, removed most selected css and instead swap between Filled and Text variant if they are used.
Added the possibility to set the SelectedColor only affects the MudChip is its used with a ChipSet
Updated both Chips and ChipSet pages.

![image](https://user-images.githubusercontent.com/10367109/132990889-c5107e55-f1b1-424c-b6c0-d9ebbff9bb3b.png)
![VariantsHover](https://user-images.githubusercontent.com/10367109/132991080-9e5ee8ea-6c0c-478c-952a-0e10b8b0b541.gif)
![ColorAndSelectedColor](https://user-images.githubusercontent.com/10367109/132991247-7490a0c2-0bfa-4436-bc95-67f5c1137867.gif)

