### PR TITLE
RadioGroup: Enforce same generic type on child radios

### DIFF
--- a/src/MudBlazor/Components/Radio/IMudRadioGroup.cs
+++ b/src/MudBlazor/Components/Radio/IMudRadioGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace MudBlazor
+{
+    internal interface IMudRadioGroup
+    {
+        //This interface need to throw exception properly.
+        void CheckGenericTypeMatch(object select_item);
+    }
+}

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -5,7 +5,7 @@
 <label class="@Classname" style="@Style">
     <span class="@ButtonClassname">
         <span class="mud-radio-button">
-            <input @attributes="UserAttributes" aria-checked="@(Checked.ToString().ToLower())" aria-disabled="@(Disabled.ToString().ToLower())" role="radio" type="radio" class="mud-radio-input" name="@RadioGroup?.Name" disabled="@Disabled" @onclick="OnClick" />
+            <input @attributes="UserAttributes" aria-checked="@(Checked.ToString().ToLower())" aria-disabled="@(Disabled.ToString().ToLower())" role="radio" type="radio" class="mud-radio-input" name="@MudRadioGroup?.Name" disabled="@Disabled" @onclick="OnClick" />
             <span class="@RadioIconsClassNames">
                 <svg class="@IconClassName" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -8,8 +8,6 @@ namespace MudBlazor
 {
     public partial class MudRadio<T> : MudComponentBase, IDisposable
     {
-        [CascadingParameter] protected MudRadioGroup<T> RadioGroup { get; set; }
-
         [CascadingParameter] public bool RightToLeft { get; set; }
 
         protected string Classname =>
@@ -42,6 +40,27 @@ namespace MudBlazor
         new CssBuilder("mud-icon-root mud-svg-icon mud-radio-icon-checked")
             .AddClass($"mud-icon-size-{Size.ToDescriptionString()}")
             .Build();
+
+        private IMudRadioGroup _parent;
+
+        /// <summary>
+        /// The parent select component
+        /// </summary>
+        [CascadingParameter]
+        internal IMudRadioGroup IMudRadioGroup
+        {
+            get => _parent;
+            set
+            {
+                _parent = value;
+                if (_parent == null)
+                    return;
+                _parent.CheckGenericTypeMatch(this);
+                //MudRadioGroup<T>?.Add(this);
+            }
+        }
+
+        internal MudRadioGroup<T> MudRadioGroup => (MudRadioGroup<T>)IMudRadioGroup;
 
         private Placement ConvertPlacement(Placement placement)
         {
@@ -106,13 +125,13 @@ namespace MudBlazor
 
         public void Select()
         {
-            RadioGroup?.SetSelectedRadioAsync(this).AndForget();
+            MudRadioGroup?.SetSelectedRadioAsync(this).AndForget();
         }
 
         private Task OnClick()
         {
-            if (RadioGroup != null)
-                return RadioGroup.SetSelectedRadioAsync(this);
+            if (MudRadioGroup != null)
+                return MudRadioGroup.SetSelectedRadioAsync(this);
 
             return Task.CompletedTask;
         }
@@ -121,13 +140,13 @@ namespace MudBlazor
         {
             await base.OnInitializedAsync();
 
-            if (RadioGroup != null)
-                await RadioGroup.RegisterRadioAsync(this);
+            if (MudRadioGroup != null)
+                await MudRadioGroup.RegisterRadioAsync(this);
         }
 
         public void Dispose()
         {
-            RadioGroup?.UnregisterRadio(this);
+            MudRadioGroup?.UnregisterRadio(this);
         }
     }
 }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
         private IMudRadioGroup _parent;
 
         /// <summary>
-        /// The parent select component
+        /// The parent Radio Group
         /// </summary>
         [CascadingParameter]
         internal IMudRadioGroup IMudRadioGroup

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -2,7 +2,7 @@
 @typeparam T
 @inherits MudFormComponent<T, T>
 
-<CascadingValue Value="this" IsFixed="true">
+<CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
     <div role="radiogroup" @attributes="UserAttributes" class=@Class style="@Style">
         @ChildContent
     </div>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor
 {
-    public partial class MudRadioGroup<T> : MudFormComponent<T, T>
+    public partial class MudRadioGroup<T> : MudFormComponent<T, T>, IMudRadioGroup
     {
         public MudRadioGroup() : base(new Converter<T, T>()) { }
 
@@ -17,6 +18,13 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public string Name { get; set; } = Guid.NewGuid().ToString();
+
+        public void CheckGenericTypeMatch(object select_item)
+        {
+            var itemT = select_item.GetType().GenericTypeArguments[0];
+            if (itemT != typeof(T))
+                throw new GenericTypeMismatchException("MudRadioGroup", "MudRadio", typeof(T), itemT);
+        }
 
         [Parameter]
         public T SelectedOption


### PR DESCRIPTION
When MudRadioGroup and MudRadio types are different, there are no exception thrown, but the radios didn't work, so user may not understand what is the exact problem.

This PR solves this and use the same strategy which MudSelect has.

fix #1307