### PR TITLE
Menu: prevent browser's context menu in WASM on right click menus

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -34,7 +34,7 @@
         <MudIconButton Variant="@Variant" Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
     @* The portal has to include  the cascading values inside, because it's not able to teletransport the cascade *@
-    <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+    <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? "return false;" : null)" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
         <CascadingValue Value="@this">
             <MudList Clickable="@(_isOpen==false?false:true)" Dense="@Dense"  
               @onmouseenter="@PopoverMouseEnter"


### PR DESCRIPTION
fix #1571.

While on working we need to decide another thing. In current or previous versions, user may have right click on their context menu and browser's context menu opens over their context menu. I think it is unnecessary, should we disable all to make sure menu works clear?