### PR TITLE
Dialog: improved the API for passing return values

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithReturnValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithReturnValue.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDialog>
+    <DialogContent>
+        <MudText>This Dialog returns a string as return value</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="() => MudDialog.Close(DialogResult.Cancel())">Cancel</MudButton>
+        <MudButton OnClick="@(() => MudDialog.Close("Closed via OK"))">OK</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -258,6 +258,32 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-overlay").Click();
             comp.WaitForAssertion(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
         }
+
+        /// <summary>
+        /// Getting return value from dialog
+        /// </summary>
+        [Test]
+        public async Task DialogShouldReturnTheReturnValue()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            // open dialog
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogWithReturnValue>());
+            dialogReference.Should().NotBe(null);
+            // close by click on cancel button
+            comp.FindAll("button")[0].Click();
+            var rv = await dialogReference.GetReturnValueAsync<string>();
+            rv.Should().BeNull();
+            // open dialog
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogWithReturnValue>());
+            // close by click on ok button
+            comp.FindAll("button")[1].Click();
+            rv = await dialogReference.GetReturnValueAsync<string>();
+            rv.Should().Be("Closed via OK");
+        }
     }
 
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -5,6 +5,7 @@
 // License: MIT
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -57,5 +58,20 @@ namespace MudBlazor
         {
             RenderFragment = rf;
         }
+
+        public async Task<T> GetReturnValueAsync<T>()
+        {
+            var result=await Result;
+            try
+            {
+                return (T)result.Data;
+            }
+            catch (InvalidCastException)
+            {
+                Debug.WriteLine($"Could not cast return value to {typeof(T)}, returning default.");
+                return default;
+            }
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -29,5 +29,7 @@ namespace MudBlazor
         void InjectRenderFragment(RenderFragment rf);
 
         void InjectDialog(object inst);
+
+        Task<T> GetReturnValueAsync<T>();
     }
 }

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -65,16 +65,42 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        /// <summary>
+        /// Close and return null. 
+        /// 
+        /// This is a shorthand of Close(DialogResult.Ok((object)null));
+        /// </summary>
         public void Close()
         {
             Close(DialogResult.Ok<object>(null));
         }
 
+        /// <summary>
+        /// Close with dialog result.
+        /// 
+        /// Usage: Close(DialogResult.Ok(returnValue))
+        /// </summary>
         public void Close(DialogResult dialogResult)
         {
             Parent.DismissInstance(Id, dialogResult);
         }
 
+        /// <summary>
+        /// Close and directly pass a return value. 
+        /// 
+        /// This is a shorthand for Close(DialogResult.Ok(returnValue))
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="returnValue"></param>
+        public void Close<T>(T returnValue)
+        {
+            var dialogResult = DialogResult.Ok<T>(returnValue);
+            Parent.DismissInstance(Id, dialogResult);
+        }
+
+        /// <summary>
+        /// Cancel the dialog. DialogResult.Cancelled will be set to true
+        /// </summary>
         public void Cancel()
         {
             Close(DialogResult.Cancel());
@@ -153,13 +179,13 @@ namespace MudBlazor
         }
 
         protected string Classname =>
-        new CssBuilder("mud-dialog")
-            .AddClass(DialogMaxWidth, !FullScreen)
-            .AddClass("mud-dialog-width-full", FullWidth && !FullScreen)
-            .AddClass("mud-dialog-fullscreen", FullScreen)
-            .AddClass("mud-dialog-rtl", RightToLeft)
-            .AddClass(Class)
-        .Build();
+            new CssBuilder("mud-dialog")
+                .AddClass(DialogMaxWidth, !FullScreen)
+                .AddClass("mud-dialog-width-full", FullWidth && !FullScreen)
+                .AddClass("mud-dialog-fullscreen", FullScreen)
+                .AddClass("mud-dialog-rtl", RightToLeft)
+                .AddClass(Class)
+            .Build();
 
         private bool SetHideHeader()
         {


### PR DESCRIPTION
Until now the API was quite un-intuitive, especially for getting the return value from the dialog reference. I added overloads and shorthand functions with which you can do it without needing to study the docs.

In the dialog, for returning data:

Until now: `MudDialogInstance.Close(DialogResult.Ok("Closed via OK"))`
Shorthand: `MudDialogInstance.Close("Closed via OK"))`

Outside for getting the return value:

Until now (ughhh):
```csharp
// note how Result looks like the blocking property of Task  *facepalm*
var result = await dialogReference.Result; 
var rv=result.Data as string;
```

Shorthand:
`var rv = await dialogReference.GetReturnValueAsync<string>();`

@Garderoben @mikes-gh You like?
