### PR TITLE
NumericField MouseWheel function fix for Firefox

### DIFF
--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -13,7 +13,7 @@
 					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
 					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
 					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@(Immediate)" Margin="@Margin"
-					  OnBlur="@OnBlurred" OnKeyDown="@InterceptKeydown" OnKeyUp="@InterceptKeyUp" OnMouseWheel="@OnMouseWheel"
+					  OnBlur="@OnBlurred" OnKeyDown="@InterceptKeydown" OnKeyUp="@InterceptKeyUp" OnMouseWheel="@OnMouseWheel" @onwheel="@OnMouseWheel"
 					  KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="@KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
                       OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" InvertMouseWheel="@InvertMouseWheel"
 					  min="@(_minHasValue ? FormatParam(_min) : null)"


### PR DESCRIPTION
fix #2743.

As @Yomodo said. Mouse wheel function didn't worked on Firefox. It's my bad because i didn't try it with firefox. With a little research, i found that firefox didn't support onmousewheel event on new versions, it use "onwheel" event instead. So we simply add a additional event to work this function in firefox.