### PR TITLE
Unnecessary Declaration of selectedItems2.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -1,9 +1,9 @@
-﻿@using System.Net.Http.Json
+@using System.Net.Http.Json
 @using MudBlazor.Examples.Data.Models
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover">
+<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems" Hover="@hover">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -26,13 +26,11 @@
     </FooterContent>
 </MudTable>
 
-<MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
-<MudText Inline="true">Selected items: @(selectedItems2==null ? "" : string.Join(", ", selectedItems2.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
+<MudText Inline="true">Selected items: @(selectedItems==null ? "" : string.Join(", ", selectedItems.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
 
 @code {
     private bool hover = true;
-    private HashSet<Element> selectedItems1 = new HashSet<Element>();
-    private HashSet<Element> selectedItems2 = new HashSet<Element>();
+    private HashSet<Element> selectedItems = new HashSet<Element>();
 
     private IEnumerable<Element> Elements = new List<Element>();
 


### PR DESCRIPTION
I've removed any reference to "selectedItems2". It was not used in the example. "selectedItems1" has been renamed to "selectedItems".