### PR TITLE
TablePager: fix showing wrong info-text when filter returns no rows

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerInfoTextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagerInfoTextTest.razor
@@ -1,0 +1,59 @@
+﻿﻿@using System.ComponentModel
+@using System.Runtime.CompilerServices
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable  @ref="filteredTable" Items="states" Filter="new Func<string, bool>(FilterFunc)">
+    <ToolBarContent>
+        <MudText>Filtered Item Count: @FilteredItemCount</MudText>
+        <MudSpacer />
+        <MudTextField id="searchString"  @bind-Value="searchString" Placeholder="Search"></MudTextField>
+    </ToolBarContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "Info in pager should show '0-0 of 0' when filter did not match anything";
+
+    private string searchString;
+
+    private MudTable<string>
+    filteredTable;
+
+    private string FilteredItemCount
+    {
+        get { return filteredTable.GetFilteredItemsCount().ToString(); }
+    }
+
+    private bool FilterFunc(string state)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+            return true;
+        if (state.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        return false;
+    }
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1167,5 +1167,42 @@ namespace MudBlazor.UnitTests.Components
             var tr = comp.FindAll("tr").ToArray();
             tr.Length.Should().Be(5); // 1 table header + 4 group headers
         }
+
+        /// <summary>
+        /// Tests the correct output when filter does not return any matching elements
+        /// </summary>
+        /// <returns>The awaitable <see cref="Task"/></returns>
+        [Test]
+        public async Task TablePagerInfoTextTest()
+        {
+            // create the component
+            var tableComponent = Context.RenderComponent<TablePagerInfoTextTest>();
+ 
+            // print the generated html      
+            Console.WriteLine(tableComponent.Markup);
+
+            // assert correct info-text
+            tableComponent.Find("div.mud-table-page-number-information").Text().Should().Be("1-10 of 59", "No filter applied yet.");
+
+            // get the instance
+            var tableInstance = tableComponent.FindComponent<MudTable<string>>().Instance;
+ 
+            // get the search-string
+            var searchString = tableComponent.Find("#searchString");
+
+            // should return 3 items
+            searchString.Change("Ala");
+            tableInstance.GetFilteredItemsCount().Should().Be(3);
+            string.Join(",", tableInstance.FilteredItems).Should().Be("Alabama,Alaska,Palau");
+            tableComponent.FindAll("tr").Count.Should().Be(3);
+            tableComponent.Find("div.mud-table-page-number-information").Text().Should().Be("1-3 of 3", "'Ala' filter applied.");
+
+            // no matches
+            searchString.Change("ZZZ");
+            tableInstance.GetFilteredItemsCount().Should().Be(0);
+            tableInstance.FilteredItems.Count().Should().Be(0);
+            tableComponent.FindAll("tr").Count.Should().Be(0);
+            tableComponent.Find("div.mud-table-page-number-information").Text().Should().Be("0-0 of 0", "'ZZZ' filter applied.");
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -62,10 +62,21 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string InfoFormat { get; set; } = "{first_item}-{last_item} of {all_items}";
 
-        private string Info => Table == null ? "Table==null" : InfoFormat
-            .Replace("{first_item}", $"{Table?.CurrentPage * Table.RowsPerPage + 1}")
-            .Replace("{last_item}", $"{Math.Min((Table.CurrentPage + 1) * Table.RowsPerPage, Table.GetFilteredItemsCount())}")
-            .Replace("{all_items}", $"{Table.GetFilteredItemsCount()}");
+        private string Info
+        {
+            get
+            {
+                // fetch number of filtered items (once only)
+                var filteredItemsCount = Table?.GetFilteredItemsCount() ?? 0;
+
+                return Table == null
+                    ? "Table==null"
+                    : InfoFormat
+                        .Replace("{first_item}", $"{(filteredItemsCount == 0 ? 0 : Table?.CurrentPage * Table.RowsPerPage + 1)}")
+                        .Replace("{last_item}", $"{Math.Min((Table.CurrentPage + 1) * Table.RowsPerPage, filteredItemsCount)}")
+                        .Replace("{all_items}", $"{filteredItemsCount}");
+            }
+        }
 
         /// <summary>
         /// The localizable "Rows per page:" text.


### PR DESCRIPTION
* changed Info to show '0-0 of 0' instead of '1-0 of 0' when filter does not match anything
* added Viewer and bUnit-tests

As it can be tested here: https://dev.mudblazor.com/components/table#table-with-pagination-and-filtering
When filtering for something not matching anything, the info-label will show `1-0 of 0` which should be `0-0 of 0`.

![image](https://user-images.githubusercontent.com/14108019/133789585-67e2c8c3-63c6-4fda-b69e-57828d9b8d6f.png)
