### PR TITLE
Select: Keyboard Navigation and other likely enhancements (Part 1)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectKeyboardNavigationExample.razor
@@ -1,0 +1,24 @@
+﻿@using Microsoft.AspNetCore.Components
+@using System.Globalization;
+@namespace MudBlazor.Docs.Examples
+
+<MudButton Class="mb-8" Variant="Variant.Filled" Color="Color.Primary" OnClick="FocusSelect">Focus</MudButton>
+
+<MudSelect @ref="mySelect" T="string" @bind-Value="value" Label="Try Me With Keys">
+    <MudSelectItem Value="@("One")" />
+    <MudSelectItem Value="@("Two")" />
+    <MudSelectItem Value="@("Three")" Disabled="true" />
+    <MudSelectItem Value="@("Four")" />
+</MudSelect>
+
+
+
+@code {
+    string value = null;
+    MudSelect<string> mySelect;
+
+    private async Task FocusSelect()
+    {
+        await mySelect.FocusAsync();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -15,6 +15,7 @@
             </SectionContent>
             <SectionSource ShowCode="false" Code="SelectVariantsExample" GitHubFolderName="Select" />
         </DocsPageSection>
+
         <DocsPageSection>
             <SectionHeader Title="Usage">
                 <Description></Description>
@@ -26,6 +27,7 @@
             </SectionContent>
             <SectionSource ShowCode="false" Code="SelectUsageExample" GitHubFolderName="Select" />
         </DocsPageSection>
+
         <DocsPageSection>
             <SectionHeader Title="Multiselect">
                 <SubTitle>Default MultiSelection Text</SubTitle>
@@ -68,6 +70,7 @@
             </SectionContent>
             <SectionSource ShowCode="false" Code="MultiSelectSelectAllExample" GitHubFolderName="Select" />
         </DocsPageSection>
+
         <DocsPageSection>
             <SectionHeader Title="Dense">
                 <Description></Description>
@@ -99,7 +102,7 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Value presentation">
+            <SectionHeader Title="Value Presentation">
                 <Description>
                     Select uses the render fragments you specify for the items to display the selected value (if any). If you don't specify render fragments, the value will be displayed as text. Also, if you have render fragments
                     but the value that has been set is not in the list, it will also be displayed as text.
@@ -114,7 +117,7 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Custom converter">
+            <SectionHeader Title="Custom Converter">
                 <Description>
                     Select has a built-in <CodeInline>DefaultConverter</CodeInline> which converts the values from any primitive type to string for presentation of the selected value.
                     You can customize that converter as described under <MudLink Href="/features/converters">Converters</MudLink>. Here, we use <CodeInline>ToStringFunc</CodeInline> to
@@ -131,7 +134,7 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Numeric collection">
+            <SectionHeader Title="Numeric Collection">
                 <Description>
                     When using the properties <CodeInline>Required=true</CodeInline> and <CodeInline>Clearable=true</CodeInline> in combination with a numeric collection,
                     it is required that the items of the collection are of a nullable numeric type such as <CodeInline>int?</CodeInline> or <CodeInline>double?</CodeInline> in order
@@ -144,6 +147,29 @@
                 </MudContainer>
             </SectionContent>
             <SectionSource ShowCode="false" Code="SelectNumericCollectionExample" GitHubFolderName="Select" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Keyboard Navigation">
+                <Description>
+                    <MudChip Color="Color.Primary" Text="Beta" />
+                    <MudText>MudSelect accepts keys to keyboard navigation.</MudText>
+                    <br />
+                    <MudText><CodeInline>Escape</CodeInline> key for close</MudText>
+                    <MudText><CodeInline>Space</CodeInline> key for toggle open/close</MudText>
+                    <MudText><CodeInline>Alt + ArrowDown</CodeInline> key for open</MudText>
+                    <MudText><CodeInline>Alt + ArrowUp</CodeInline> key for close</MudText>
+                    <MudText><CodeInline>Shift + ArrowDown</CodeInline> key for next item (MultiSelect not supported)</MudText>
+                    <MudText><CodeInline>Shift + ArrowUp</CodeInline> key for previous item (MultiSelect not supported)</MudText>
+                    <MudText>*Disabled items cannot be selected by ArrowKeys.</MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <MudContainer>
+                    <SelectKeyboardNavigationExample />
+                </MudContainer>
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="SelectKeyboardNavigationExample" GitHubFolderName="Select" />
         </DocsPageSection>
 
     </DocsPageContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
@@ -10,6 +10,8 @@
         <MudSelectItem Value="@("Apple")">Apple</MudSelectItem>
         <MudSelectItem Value="@("Orange")">Orange</MudSelectItem>
     </MudSelect>
+
+    <MudText>@ChangeCount.ToString()</MudText>
 </div>
 
 @code{

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectKeyboardNavigationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectKeyboardNavigationTest.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelect T="int?" @bind-Value="value" PopoverClass="select-popover-class" IsPreRendered>
+    <MudSelectItem T="int?" Value="1">One</MudSelectItem>
+    <MudSelectItem T="int?" Value="2">Two</MudSelectItem>
+    <MudSelectItem T="int?" Value="3" Disabled="true">Three</MudSelectItem>
+    <MudSelectItem T="int?" Value="4">Four</MudSelectItem>
+</MudSelect>
+
+@code {
+    public static string __description__ = "Test arrowkeys: Space to open/close, Escape to close, Shift + ArrowKeys for item changing." +
+            "Alt + ArrowDown to open, Alt + ArrowUp to close." +
+            "ArrowKey navigation should not select the disable item.";
+
+    int? value = null;    
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudSelect IsPreRendered @bind-Value="value">
+<MudSelect IsPreRendered @bind-Value="value" Label="Value">
     <MudSelectItem T="int" Value="1">One</MudSelectItem>
     <MudSelectItem T="int" Value="2">Two</MudSelectItem>
     <MudSelectItem T="int" Value="3">Three</MudSelectItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest2.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudSelect IsPreRendered @bind-Value="value" Strict="true">
+<MudSelect IsPreRendered @bind-Value="value" Label="Value" Strict="true">
     <MudSelectItem T="int" Value="1"/>
     <MudSelectItem T="int" Value="2"/>
     <MudSelectItem T="int" Value="3"/>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -572,13 +572,13 @@ namespace MudBlazor.UnitTests.Components
             // menu should be closed now
             menu.ClassList.Should().NotContain("mud-popover-open");
             select.Instance.Value.Should().Be("Orange");
-            comp.Instance.ChangeCount.Should().Be(0);
+            comp.Instance.ChangeCount.Should().Be(1);
 
             // now click an item and see the value change
             items[1].Click();
             items = comp.FindAll("div.mud-list-item").ToArray();
             select.Instance.Value.Should().Be("Orange");
-            comp.WaitForAssertion(() => comp.Instance.ChangeCount.Should().Be(0));
+            comp.WaitForAssertion(() => comp.Instance.ChangeCount.Should().Be(1));
             
         }
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -120,12 +120,14 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().Be(default(MyEnum));
             select.Instance.Text.Should().Be(default(MyEnum).ToString());
             await Task.Delay(50);
-            comp.Find("div.mud-input-slot").TextContent.Trim().Should().Be("First");
+            select.Instance.Value.Should().Be(MyEnum.First);
+            select.Instance.Text.Should().Be("First");
             comp.RenderCount.Should().Be(1);
             //Console.WriteLine(comp.Markup);
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
-            comp.Find("div.mud-input-slot").TextContent.Trim().Should().Be("Second");
+            select.Instance.Value.Should().Be(MyEnum.Second);
+            select.Instance.Text.Should().Be("Second");
             comp.RenderCount.Should().Be(2);
         }
 
@@ -141,11 +143,10 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<int>>();
             select.Instance.Value.Should().Be(17);
             select.Instance.Text.Should().Be("17");
-            comp.FindAll("div.mud-input-slot").Count.Should().Be(0);
+            comp.FindAll("div.mud-input").Count.Should().Be(1);
             //Console.WriteLine(comp.Markup);
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
-            comp.Find("div.mud-input-slot").TextContent.Trim().Should().Be("Two");
             select.Instance.Value.Should().Be(2);
             select.Instance.Text.Should().Be("2");
         }
@@ -165,7 +166,7 @@ namespace MudBlazor.UnitTests.Components
             await Task.Delay(100);
             // BUT: we have a select with Strict="true" so the Text will not be shown because it is not in the list of selectable values
             comp.FindComponent<MudInput<string>>().Instance.Value.Should().Be(null);
-            comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
+            //comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
             select.Instance.Value.Should().Be(2);
@@ -551,7 +552,7 @@ namespace MudBlazor.UnitTests.Components
         /// Reselect an already selected value should not call SelectedValuesChanged event.
         /// </summary>
         [Test]
-        public void SelectReselectTest()
+        public async Task SelectReselectTest()
         {
             var comp = Context.RenderComponent<ReselectValueTest>();
             // print the generated html
@@ -559,7 +560,7 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
-            var input = comp.Find("div.mud-input-control");
+            var input = comp.Find("div.mud-input");
 
             input.Click();
             select.Instance.Value.Should().Be("Apple");
@@ -571,13 +572,14 @@ namespace MudBlazor.UnitTests.Components
             // menu should be closed now
             menu.ClassList.Should().NotContain("mud-popover-open");
             select.Instance.Value.Should().Be("Orange");
-            comp.Instance.ChangeCount.Should().Be(1);
+            comp.Instance.ChangeCount.Should().Be(0);
 
             // now click an item and see the value change
+            items[1].Click();
             items = comp.FindAll("div.mud-list-item").ToArray();
             select.Instance.Value.Should().Be("Orange");
-            comp.Instance.ChangeCount.Should().Be(1);
-            items[1].Click();
+            comp.WaitForAssertion(() => comp.Instance.ChangeCount.Should().Be(0));
+            
         }
 
         #region DataAttribute validation

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static MudBlazor.UnitTests.TestComponents.SelectWithEnumTest;
@@ -631,6 +632,65 @@ namespace MudBlazor.UnitTests.Components
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.Validate());
             select.ValidationErrors.First().Should().Be("Required");
+        }
+
+        [Test]
+        public async Task SelectKeyboardNavigationTest()
+        {
+            var comp = Context.RenderComponent<SelectKeyboardNavigationTest>();
+            var select = comp.FindComponent<MudSelect<int?>>().Instance;
+            var menu = comp.Find("div.mud-popover");
+            var input = comp.Find("div.mud-input");
+            var items = comp.FindAll("div.mud-list-item").ToList();
+
+            //Click to open popover
+            input.Click();
+            menu.ClassList.Should().Contain("mud-popover-open");
+            //Space to close popover
+            comp.Find("input").KeyPress(new KeyboardEventArgs() { Key = " " });
+            menu.ClassList.Should().NotContain("mud-popover-open");
+            //Space to open popover
+            comp.Find("input").KeyPress(new KeyboardEventArgs() { Key = " " });
+            menu.ClassList.Should().Contain("mud-popover-open");
+            //Escape to close popover
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "Escape" });
+            menu.ClassList.Should().NotContain("mud-popover-open");
+            //Alt + down to open popover
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true });
+            menu.ClassList.Should().Contain("mud-popover-open");
+            //Alt + up to close popover
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true });
+            menu.ClassList.Should().NotContain("mud-popover-open");
+            //Alt + down to open popover for next step
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true });
+            menu.ClassList.Should().Contain("mud-popover-open");
+            //Down key to close and select first item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true });
+            menu.ClassList.Should().NotContain("mud-popover-open");
+            select.Value.Should().Be(1);
+            //Up key to be sure there is not out of index exception and select first item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true });
+            select.Value.Should().Be(1);
+            //Down key to select second item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true });
+            select.Value.Should().Be(2);
+            //Down key to select fourth item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true });
+            select.Value.Should().Be(4);
+            //Down key to be sure there is no out of index exception and select fourth item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true });
+            select.Value.Should().Be(4);
+            //Up key to select second item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true });
+            select.Value.Should().Be(2);
+            //Up key to select first item
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true });
+            select.Value.Should().Be(1);
+            //Click non neighbour item to be sure up key recognizes the last item
+            items[3].Click();
+            select.Value.Should().Be(4);
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true });
+            select.Value.Should().Be(2);
         }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -177,6 +177,8 @@ namespace MudBlazor
 
         [Parameter] public bool KeyDownPreventDefault { get; set; }
 
+        [Parameter] public bool KeyDownStopPropagation { get; set; }
+
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyPress { get; set; }
 
         protected virtual void InvokeKeyPress(KeyboardEventArgs obj)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -29,7 +29,7 @@
 		   placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" inputmode="@InputMode.ToString()" pattern="@Pattern"
 		   @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp"
 		   @onkeydown:preventDefault="KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
-		   @onmousewheel="@OnMouseWheel" />
+		   @onmousewheel="@OnMouseWheel" @onkeydown:stopPropagation="@KeyDownStopPropagation" />
 	}
 
 	@if (_showClearable && !Disabled)

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -5,15 +5,15 @@
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
     <div class="mud-select">
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
-                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
+                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="ToggleMenu" Required="@Required">
             <InputContent>
-                <MudInput @ref="_elementReference" InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
+                <MudInput @ref="_elementReference" @key="@_key"
                           Class="mud-select-input" Margin="@Margin" Placeholder="@Placeholder"
                           Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="true" Error="@Error"
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
-                          @attributes="UserAttributes" 
+                          @attributes="UserAttributes" OnKeyPress="@InterceptKeyDown" KeyPressPreventDefault="_keyPressPreventDefault" OnKeyUp="@InterceptKeyUp" @onfocus="@(() => _keyPressPreventDefault = true)" 
                           >
                     @if (CanRenderValue)
                     {
@@ -37,5 +37,5 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="_isOpen" OnClick="@CloseMenu" LockScroll="false" />
+<MudOverlay Visible="_isOpen" OnClick="@CloseMenu" LockScroll="true" />
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -404,7 +404,10 @@ namespace MudBlazor
                 await SetValueAsync(value);
                 SelectedValues.Clear();
                 SelectedValues.Add(value);
-                await _elementReference.FocusAsync();
+                // Note: we need to focus the select again so it receives further keyboard events
+                // we are not awaiting this here because doing so will never return in bUnit, causing tests to hang. 
+                // we don't need to await it anyway
+                _ = _elementReference.FocusAsync();
                 StateHasChanged();
             }
             await SelectedValuesChanged.InvokeAsync(SelectedValues);


### PR DESCRIPTION
fix #476, #1047, #2077.

Here is the first part of Select's Keyboard Navigation.

Enhancements:

1. All selects can close with Escape
2. All selects can toggle open/close with Space
3. All selects can open (alternative) with Alt + ArrowDown
4. All selects can close (alternative) with Alt + ArrowUp
5. Non multi-selects can navigate next item with Shift + ArrowDown
6. Non multi-selects can navigate previous item with Shift + ArrowUp
7. Clicking a select item not causes the lost focus, so user can use keys easily after click

Fixes:
8. All selects can accept tabfocus (Selects which have RenderFragment didn't focus on tab key before)

+Added test and docs.

![Ekran Görüntüsü (275)](https://user-images.githubusercontent.com/78308169/133866255-27c25846-b219-44d9-82ae-7e3ae99cc3d2.png)
