### PR TITLE
List: add SelectedValue which allows to pre-select list items via value

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListSelectionExample.razor
@@ -1,26 +1,26 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px">
-    <MudList Clickable="true" @bind-SelectedItem="selectedItem">
+    <MudList Clickable="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue">
         <MudListSubheader>
             Your drink:
             <MudChip Color="Color.Secondary">
-                @(selectedItem?.Text ?? "You are dry")
+                @(selectedItem?.Text ?? "You are dry") (@(selectedValue?.ToString() ?? "0"))
             </MudChip>
         </MudListSubheader>
-        <MudListItem Text="Sparkling Water" />
+        <MudListItem Text="Sparkling Water" Value="1"/>
         <MudListItem Text="Teas">
             <NestedList>
-                <MudListItem Text="Earl Grey" />
-                <MudListItem Text="Matcha" />
-                <MudListItem Text="Pu'er" />
+                <MudListItem Text="Earl Grey" Value="2" />
+                <MudListItem Text="Matcha"  Value="3"/>
+                <MudListItem Text="Pu'er"  Value="4"/>
             </NestedList>
         </MudListItem>
         <MudListItem Text="Coffees">
             <NestedList>
-                <MudListItem Text="Irish Coffee" />
-                <MudListItem Text="Double Espresso" />
-                <MudListItem Text="Cafe Latte" />
+                <MudListItem Text="Irish Coffee"  Value="5"/>
+                <MudListItem Text="Double Espresso"  Value="6"/>
+                <MudListItem Text="Cafe Latte"  Value="7"/>
             </NestedList>
         </MudListItem>
     </MudList>
@@ -30,4 +30,5 @@
 @code
 {
     MudListItem selectedItem;
+    object selectedValue = 1;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudList Clickable="true" @bind-SelectedItem="selectedItem">
+<MudList Clickable="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue">
     <MudListSubheader>
         Your drink:
         <MudChip Color="Color.Secondary">
@@ -26,6 +26,13 @@
 
 @code
 {
-    public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+    public static string __description__ = "Sparkling Water should be selected initially.";
     MudListItem selectedItem;
+    object selectedValue=1;
+
+    public void SetSelecedValue(object value)
+    {
+        selectedValue=value;
+        StateHasChanged();
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -15,6 +15,8 @@ namespace MudBlazor.UnitTests.Components
     {
         /// <summary>
         /// Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// 
+        /// In this test no item is selected to begin with
         /// </summary>
         [Test]
         public async Task ListSelectionTest()
@@ -41,6 +43,42 @@ namespace MudBlazor.UnitTests.Components
             list.SelectedItem.Text.Should().Be("Cafe Latte");
             comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
             comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
+        }
+
+        /// <summary>
+        /// Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// 
+        /// This test starts with a pre-selected item (by value)
+        /// </summary>
+        [Test]
+        public async Task ListWithPreSelectedValueTest()
+        {
+            var comp = Context.RenderComponent<ListSelectionInitialValueTest>();
+            Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudList>().Instance;
+            list.SelectedItem.Text.Should().Be("Sparkling Water");
+            // we have seven choices, 1 is active because of the initial value of SelectedValue
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            // set Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            await comp.InvokeAsync(()=>comp.Instance.SetSelecedValue(4));
+            list.SelectedItem.Text.Should().Be("Pu'er");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-selected-item");
+            // set Cafe Latte via changing SelectedValue
+            await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(7));
+            list.SelectedItem.Text.Should().Be("Cafe Latte");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
+            // set water
+            await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(1));
+            list.SelectedItem.Text.Should().Be("Sparkling Water");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-selected-item");
+            // set nothing
+            await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(null));
+            list.SelectedItem.Should().Be(null);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
         }
     }
 }

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -47,7 +47,7 @@ namespace MudBlazor
         [Parameter] public bool Disabled { get; set; }
 
         /// <summary>
-        /// The current selected list item. Bind this with a two-way binding to activate the lists exclusive selection behavior.
+        /// The current selected list item.
         /// Note: make the list Clickable for item selection to work.
         /// </summary>
         [Parameter]
@@ -58,7 +58,7 @@ namespace MudBlazor
             {
                 if (_selectedItem == value)
                     return;
-                SetSelectedItem(value, force: true);
+                SetSelectedValue(_selectedItem?.Value, force: true);
             }
         }
 
@@ -67,18 +67,35 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MudListItem> SelectedItemChanged { get; set; }
 
+        /// <summary>
+        /// The current selected value.
+        /// Note: make the list Clickable for item selection to work.
+        /// </summary>
+        [Parameter]
+        public object SelectedValue
+        {
+            get => _selectedValue;
+            set
+            {
+                SetSelectedValue(value, force: true);
+            }
+        }
+
+        /// <summary>
+        /// Called whenever the selection changed
+        /// </summary>
+        [Parameter] public EventCallback<object> SelectedValueChanged { get; set; }
+
         protected override void OnInitialized()
         {
             if (ParentList != null)
             {
                 ParentList.Register(this);
                 CanSelect = ParentList.CanSelect;
-                //OnListParametersChanged();
-                //ParentList.ParametersChanged += OnListParametersChanged;
             }
             else
             {
-                CanSelect = SelectedItemChanged.HasDelegate;
+                CanSelect = SelectedItemChanged.HasDelegate || SelectedValueChanged.HasDelegate || SelectedValue != null;
             }
         }
 
@@ -93,10 +110,17 @@ namespace MudBlazor
         private HashSet<MudListItem> _items = new();
         private HashSet<MudList> _childLists = new();
         private MudListItem _selectedItem;
+        private object _selectedValue;
 
         internal void Register(MudListItem item)
         {
             _items.Add(item);
+            if (CanSelect && SelectedValue!=null && object.Equals(item.Value, SelectedValue))
+            {
+                item.SetSelected(true);
+                _selectedItem = item;
+                SelectedItemChanged.InvokeAsync(item);
+            }
         }
 
         internal void Unregister(MudListItem item)
@@ -114,21 +138,30 @@ namespace MudBlazor
             _childLists.Remove(child);
         }
 
-        internal void SetSelectedItem(MudListItem item, bool force = false)
+        internal void SetSelectedValue(object value, bool force = false)
         {
             if ((!CanSelect || !Clickable) && !force)
                 return;
-            if (_selectedItem == item)
+            if (object.Equals(_selectedValue, value))
                 return;
-            _selectedItem = item;
-            _ = SelectedItemChanged.InvokeAsync(item);
+            _selectedValue = value;
+            SelectedValueChanged.InvokeAsync(value).AndForget();
+            _selectedItem = null; // <-- for now, we'll see which item matches the value below
             foreach (var listItem in _items.ToArray())
             {
-                listItem.SetSelected(item == listItem);
+                var isSelected = value!=null && object.Equals(value, listItem.Value);
+                listItem.SetSelected(isSelected);
+                if (isSelected)
+                    _selectedItem = listItem;
             }
             foreach (var childList in _childLists.ToArray())
-                childList.SetSelectedItem(item);
-            ParentList?.SetSelectedItem(item);
+            {
+                childList.SetSelectedValue(value);
+                if (childList.SelectedItem != null)
+                    _selectedItem= childList.SelectedItem;
+            }
+            SelectedItemChanged.InvokeAsync(_selectedItem).AndForget();
+            ParentList?.SetSelectedValue(value);
         }
 
         internal bool CanSelect { get; private set; }

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -28,6 +28,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string Text { get; set; }
 
+        [Parameter] public object Value { get; set; }
+
         /// <summary>
         /// Avatar to use if set.
         /// </summary>
@@ -173,13 +175,13 @@ namespace MudBlazor
             }
             else if (Href != null)
             {
-                MudList?.SetSelectedItem(this);
+                MudList?.SetSelectedValue(this.Value);
                 OnClick.InvokeAsync(ev);
                 UriHelper.NavigateTo(Href, ForceLoad);
             }
             else
             {
-                MudList?.SetSelectedItem(this);
+                MudList?.SetSelectedValue(this.Value);
                 OnClick.InvokeAsync(ev);
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {


### PR DESCRIPTION
Adds SelectedValue and allows to pre-select a value in the list by setting its value via a two-way binding.
`object SelectedValue` can be used to pre-select the initial list item and/or manipulate the selection from outside. MudListItem now has a parameter `object Value` for the selection value. All values have to be unique for now, so if you want to use the selection make sure to assign Value in the items.

kinda fixes #1295: Though generics are not what we want in MudList, we do it with type `object` instead. 
fixes #2553

fixes only partially #1779, so we'll not link this issue. It will stay open. will allow us to get #2758 done.