### PR TITLE
TextField: add Clear() method which works even while focused

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -478,6 +478,33 @@ namespace MudBlazor.UnitTests.Components
         }
         #endregion
         #endregion
+
+        [Test]
+        public async Task TextField_ClearTest1()
+        {
+            var comp = Context.RenderComponent<MudTextField<int>>();
+            comp.SetParam("Text", "17");
+            var textfield = comp.Instance;
+            textfield.Value.Should().Be(17);
+            textfield.Text.Should().Be("17");
+            await comp.InvokeAsync(async ()=> await textfield.Clear());
+            textfield.Value.Should().Be(0);
+            textfield.Text.Should().Be(null);
+        }
+
+        [Test]
+        public async Task TextField_ClearTest2()
+        {
+            var comp = Context.RenderComponent<MudTextField<string>>();
+            comp.Find("input").Change("Viva la ignorancia");
+            var textfield = comp.Instance;
+            textfield.Value.Should().Be("Viva la ignorancia");
+            textfield.Text.Should().Be("Viva la ignorancia");
+            await comp.InvokeAsync(async () => await textfield.Clear());
+            textfield.Value.Should().Be(null);
+            textfield.Text.Should().Be(null);
+        }
+
     }
 
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -332,6 +332,7 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
+            UpdateTextPropertyAsync(false).AndForget();
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -106,6 +107,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public string Text { get; set; }
+
+        /// <summary>
+        /// When TextUpdateSuppression is true (which is default) the text can not be updated by bindings while the component is focused in BSS (not WASM).
+        /// This solves issue #1012: Textfield swallowing chars when typing rapidly
+        /// If you need to update the input's text while it is focused you can set this parameter to false.
+        /// Note: on WASM text update suppression is not active, so this parameter has no effect.
+        /// </summary>
+        [Parameter] public bool TextUpdateSuppression { get; set; } = true;
 
         /// <summary>
         ///  Hints at the type of data that might be entered by the user while editing the input
@@ -341,7 +350,10 @@ namespace MudBlazor
 
             if (_isFocused && !_forceTextUpdate)
             {
-                return;
+                // Text update suppression, only in BSS (not in WASM).
+                // This is a fix for #1012
+                if (RuntimeLocation.IsServerSide && TextUpdateSuppression)
+                    return;
             }
             _forceTextUpdate = false;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -9,7 +9,9 @@
             <InputContent>
                 <MudInput @ref="_elementReference" InputType="InputType.Text"
                           Class="mud-select-input" Margin="@Margin"
-                          Variant="@Variant" Value="@Text" DisableUnderLine="@DisableUnderLine"
+                          Variant="@Variant" 
+                          TextUpdateSuppression="@TextUpdateSuppression"
+                          Value="@Text" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -8,7 +8,8 @@
 	<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname"
 					 Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
 		<InputContent>
-			<MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"
+            <MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"
+                      TextUpdateSuppression="@TextUpdateSuppression"
 					  Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="_inputConverter" Placeholder="@Placeholder"
 					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
 					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -9,7 +9,9 @@
             <InputContent>
                 <MudInput @ref="_elementReference" InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
                           Class="mud-select-input" Margin="@Margin" Placeholder="@Placeholder"
-                          Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
+                          Variant="@Variant"
+                          TextUpdateSuppression="@TextUpdateSuppression"
+                          Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="true" Error="@Error"
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment"
                           AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -5,11 +5,12 @@
 <CascadingValue Name="Standalone" Value="@Standalone" IsFixed="true">
     <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
         <InputContent>
-            <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
-                      Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
-                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnInternalInputChanged="OnChange" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
+            <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" TextUpdateSuppression="@TextUpdateSuppression" Value="@Text" 
+                      ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
+                      Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" 
+                      Immediate="@Immediate" Margin="@Margin" OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnInternalInputChanged="OnChange" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
                       KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
-                      HideSpinButtons="true" Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick" />
+                      HideSpinButtons="true" Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"/>
         </InputContent>
     </MudInputControl>
 </CascadingValue>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
@@ -46,7 +47,17 @@ namespace MudBlazor
             return _elementReference.SelectRangeAsync(pos1, pos2);
         }
 
+        /// <summary>
+        /// Clear the text field, set Value to default(T) and Text to null
+        /// </summary>
+        /// <returns></returns>
+        public async Task Clear()
+        {
+            await _elementReference.SetText(null);
+        }
+
     }
 
+    [Obsolete]
     public class MudTextFieldString : MudTextField<string> { }
 }


### PR DESCRIPTION
fixes #2531
fixes #2701

- [x] TextField: add Clear() method which works even while focused
- [x] don't do the text-update-suppression on WASM at all
- [x] allow to disable the text-update-suppression which is on if the component has focus
