### PR TITLE
MudBadge: Add Visible parameter (#2796)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/BadgeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BadgeTests.cs
@@ -1,0 +1,42 @@
+﻿
+#pragma warning disable CS1998 // async without await
+
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class BadgeTests : BunitTest
+    {
+        [Test]
+        public async Task Badge_Renders_Using_Default_Values()
+        {
+            var comp = Context.RenderComponent<MudBadge>();
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("span").Should().HaveCount(3, "Default behavior of badge is to render 3 spans");
+        }
+
+        [Test]
+        public async Task Badge_Renders_When_VisibleIsTrue()
+        {
+            var comp = Context.RenderComponent<MudBadge>();
+            comp.SetParam("Visible", true);
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("span").Should().HaveCount(3, "Visible badge renders 3 spans");
+        }
+
+        [Test]
+        public async Task Badge_Does_Not_Render_When_VisibleIsFalse()
+        {
+            var comp = Context.RenderComponent<MudBadge>();
+            comp.SetParam("Visible", false);
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("span").Should().HaveCount(1, "Hidden badge renders 1 span");
+        }
+    }
+}

--- a/src/MudBlazor/Components/Badge/MudBadge.razor
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor
@@ -3,19 +3,22 @@
 
 <span @attributes="UserAttributes" class="@Classname" style="@Style">
     @ChildContent
-    <span class="mud-badge-wrapper">
-        <span class="@BadgeClass" @onclick="HandleBadgeClick">
-            @if (!Dot)
-            {
-                @if (!String.IsNullOrEmpty(Icon))
-                {
-                    <MudIcon Icon="@Icon" Class="mud-icon-badge" />
-                }
-                else
-                {
-                    @_content
-                }
-            }
-        </span>
-    </span>
+	@if (Visible)
+	{
+		<span class="mud-badge-wrapper">
+			<span class="@BadgeClass" @onclick="HandleBadgeClick">
+				@if (!Dot)
+				{
+					@if (!String.IsNullOrEmpty(Icon))
+					{
+						<MudIcon Icon="@Icon" Class="mud-icon-badge" />
+					}
+					else
+					{
+						@_content
+					}
+				}
+			</span>
+		</span>
+	}
 </span>

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -30,6 +30,11 @@ namespace MudBlazor
         [CascadingParameter] public bool RightToLeft { get; set; }
 
         /// <summary>
+        /// The visibility of the badge.
+        /// </summary>
+        [Parameter] public bool Visible { get; set; } = true;
+
+        /// <summary>
         /// The color of the badge.
         /// </summary>
         [Parameter] public Color Color { get; set; } = Color.Default;


### PR DESCRIPTION
This is basically offering and easy option to hide the badge based on a new Visible parameter.
Before 
![image](https://user-images.githubusercontent.com/90164955/134092363-d56faa92-7bed-4d64-9cd4-9ceb6a763f9f.png)
After
![image](https://user-images.githubusercontent.com/90164955/134092387-3e3ee5e2-c9a4-4e34-9fd5-426e2f7595eb.png)

Also added tests checking the number of span created. 
3 spans when visible (default behavior) vs 1 span when hidden.

resolves #2796 