### PR TITLE
Fix MudSelect comparer

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -96,9 +96,9 @@ namespace MudBlazor
             set
             {
                 var set = value ?? new HashSet<T>();
-                if (SelectedValues.Count == set.Count && SelectedValues.All(x => set.Contains(x)))
+                if (SelectedValues.Count == set.Count && SelectedValues.All(x => set.Contains(x)) && _selectedValues.Comparer == set.Comparer)
                     return;
-                _selectedValues = new HashSet<T>(set);
+                _selectedValues = new HashSet<T>(set, set.Comparer);
                 SelectionChangedFromOutside?.Invoke(_selectedValues);
                 if (!MultiSelection)
                     SetValueAsync(_selectedValues.FirstOrDefault()).AndForget();
@@ -116,7 +116,7 @@ namespace MudBlazor
                         SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x)))).AndForget();
                     }
                 }
-                SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues));
+                SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, SelectedValues.Comparer));
             }
         }
 


### PR DESCRIPTION
## Description

Fix for issue https://github.com/MudBlazor/MudBlazor/issues/2824

The fix is implemented by using the Comparer of the outside SelectedValues HashSet for the creation of internal _selectedValues HashSet.

## Motivation and Context

When using the MudSelect component with HashSets with a custom Comparer, the comparer will not be used in the internal MudSelect _selectedValues HashSet.

This breaks sysnchronization of check marks in the popover list.

## How Has This Been Tested?

No unit test provided yet. Will be added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in library)
