### PR TITLE
Services/NumericField: Add KeyboardInterceptor service

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "MudBlazor.Docs.Server(Hosted wasm)": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "components/datepicker",
+      "launchUrl": "components/numericfield",
       "environmentVariables": {
         "APIBASE": "https://localhost:5001/",
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -340,16 +340,22 @@ namespace MudBlazor.UnitTests
             var numericField = comp.Instance;
             numericField.Value.Should().Be(1234.56);
             numericField.Text.Should().Be("1234.56");
-            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1235.56));
-            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false }));
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", }));
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", }));
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -457,46 +457,33 @@ namespace MudBlazor.UnitTests
         public async Task NumericFieldTestCultureFormat()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
-            // print the generated html
-            Console.WriteLine(comp.Markup);
-            // select elements needed for the test
-
             var inputs = comp.FindAll("input");
             var immediate = inputs.First();
             var notImmediate = inputs.Last();
-
             //german
             notImmediate.Change("1234");
             notImmediate.Blur();
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("1.234,00"));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(1234.0));
-
             notImmediate.Change("0");
             notImmediate.Blur();
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("0,00"));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(0.0));
-
             notImmediate.Change("");
             notImmediate.Blur();
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be(null));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(null));
-
             // English
             immediate.Input("1234");
             immediate.Blur();
-
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("1,234.00"));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(1234.0));
-
             immediate.Input("0");
             immediate.Blur();
-
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("0.00"));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(0.0));
-
             immediate.Input("");
             immediate.Blur();
-
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be(null));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(null));
         }
@@ -508,34 +495,49 @@ namespace MudBlazor.UnitTests
         public async Task NumericField_should_RemoveIllegalCharacters()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
-            // print the generated html
-            Console.WriteLine(comp.Markup);
-            // select elements needed for the test            
-
             //german
             comp.FindAll("input").Last().Change("abcd");
             comp.FindAll("input").Last().Blur();
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be(null));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(null));
-
             // English
             comp.FindAll("input").First().Input("abcd");
             comp.FindAll("input").First().Blur();
-
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be(null));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(null));
-
             // English
             comp.FindAll("input").First().Input("-12-34abc.56");
             comp.FindAll("input").First().Blur();
-
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("-1,234.56"));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(-1234.56));
-
             comp.FindAll("input").Last().Change("x+17,9y9z");
             comp.FindAll("input").Last().Blur();
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("17,99"));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(17.99));
+        }
+
+        [Test]
+        public async Task NumericField_should_ReformatTextOnBlur()
+        {
+            var comp = Context.RenderComponent<NumericFieldCultureTest>();
+            // english
+            comp.FindAll("input").First().Input("1,234.56");
+            comp.FindAll("input").First().Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("1,234.56"));
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(1234.56));
+            comp.FindAll("input").First().Input("1234.56");
+            comp.FindAll("input").First().Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("1,234.56"));
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(1234.56));
+            // german
+            comp.FindAll("input").Last().Change("7.000,99");
+            comp.FindAll("input").Last().Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("7.000,99"));
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(7000.99));
+            comp.FindAll("input").Last().Change("7000,99");
+            comp.FindAll("input").Last().Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("7.000,99"));
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(7000.99));
         }
 
         [TestCase((byte)5)]

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -150,11 +150,10 @@ namespace MudBlazor.UnitTests
         public void LabelShouldShrinkWhenPlaceholderIsSet()
         {
             //Arrange
-            using var ctx = new Bunit.TestContext();
             var label = Parameter(nameof(MudNumericField<int?>.Label), "label");
             var placeholder = Parameter(nameof(MudNumericField<int?>.Placeholder), "placeholder");
             //with no placeholder, label is not shrunk
-            var comp = ctx.RenderComponent<MudNumericField<int?>>(label);
+            var comp = Context.RenderComponent<MudNumericField<int?>>(label);
             comp.Markup.Should().NotContain("shrink");
             //with placeholder label is shrunk
             comp.SetParametersAndRender(placeholder);
@@ -341,20 +340,15 @@ namespace MudBlazor.UnitTests
             var numericField = comp.Instance;
             numericField.Value.Should().Be(1234.56);
             numericField.Text.Should().Be("1234.56");
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
+            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1235.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
+            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
+            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false }));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
+            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", }));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            await comp.InvokeAsync(()=>numericField.OnInputKeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", }));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
         }
 

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -397,8 +397,58 @@ namespace MudBlazor.UnitTests
             //MouseWheel down
             comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+
+            //MouseWheel without Shift doesn't do anything
+            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
+            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
         }
 
+        /// <summary>
+        /// MouseWheel actions should work on Firefox
+        /// </summary>
+        [Test]
+        public async Task NumericFieldTest_Wheel_Firefox()
+        {
+            var comp = Context.RenderComponent<MudNumericField<double>>();
+            comp.SetParam(x => x.Value, 1234.56);
+            var numericField = comp.Instance;
+
+            //MouseWheel up
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1235.56));
+
+            //MouseWheel down
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+
+            //Invert MouseWheel
+            numericField.InvertMouseWheel = true;
+
+            //MouseWheel up
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1233.56));
+
+            //MouseWheel down
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+
+            //Try with different step
+            numericField.Step = 0.5;
+
+            //MouseWheel up
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.06));
+
+            //MouseWheel down
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+
+            //MouseWheel without Shift doesn't do anything
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
+            comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
+        }
 
         /// <summary>
         /// NumericalField Formats input according to culture

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -35,6 +35,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
             ctx.Services.AddSingleton<IMenuService, MenuService>();
+            ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();
             ctx.Services.AddScoped(sp => new HttpClient());
         }
 

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddTransient<IEventListener, EventListener>();
-
+            ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();
             ctx.Services.AddOptions();
             ctx.Services.AddScoped(sp =>
                 new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });

--- a/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+#pragma warning disable CS1998
+#pragma warning disable CS0067
+    public class MockKeyInterceptorService : IKeyInterceptor
+    {
+        public void Dispose()
+        {
+            
+        }
+
+        public Task Connect(ElementReference element, KeyInterceptorOptions options)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task Disconnect()
+        {
+            return Task.CompletedTask;
+        }
+
+        public event KeyboardEvent KeyDown;
+        public event KeyboardEvent KeyUp;
+    }
+}

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -21,6 +21,7 @@
 	    <textarea class="@InputClassname"
                 @ref="_elementReference" 
                 rows="@Lines" 
+                @attributes="UserAttributes"
                 type="@InputTypeString"                  
                 placeholder="@Placeholder" 
                 disabled=@Disabled 

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -6,18 +6,43 @@
 <div class="@Classname" style="@Style">
 	@if (Adornment == Adornment.Start)
 	{
-	 <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
+	    <MudInputAdornment Class="@AdornmentClassname" 
+                Icon="@AdornmentIcon" 
+                Color="@AdornmentColor" 
+                Size="@IconSize" 
+                Text="@AdornmentText" 
+                Edge="@Edge.Start" 
+                AdornmentClick="@OnAdornmentClick" 
+        />
 	}
 
 	@if (Lines > 1)
 	{
-		@*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
-	    <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" inputmode="@InputMode.ToString()"
-			  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" @onpaste="@OnPaste" value="@Text" maxlength="@MaxLength"
-			  @onkeydown:preventDefault="@KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
-               @onmousewheel="@OnMouseWheel" 
-               @onwheel="@OnMouseWheel"
-              > @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
+	    <textarea class="@InputClassname"
+                @ref="_elementReference" 
+                rows="@Lines" 
+                type="@InputTypeString"                  
+                placeholder="@Placeholder" 
+                disabled=@Disabled 
+                readonly="@ReadOnly" 
+                inputmode="@InputMode.ToString()"
+			    @oninput="OnInput" 
+                @onchange="OnChange" 
+                @onblur="@OnBlurred" 
+                @onkeydown="@InvokeKeyDown" 
+                @onkeypress="@InvokeKeyPress" 
+                @onkeyup="@InvokeKeyUp" 
+                @onpaste="@OnPaste" 
+                value="@Text" 
+                maxlength="@MaxLength"
+			    @onkeydown:preventDefault="@KeyDownPreventDefault" 
+                @onkeypress:preventDefault="@KeyPressPreventDefault" 
+                @onkeyup:preventDefault="@KeyUpPreventDefault"
+                @onmousewheel="@OnMouseWheel" 
+                @onwheel="@OnMouseWheel"
+        > 
+            @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
+            @*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
             @Text       
         </textarea>
 	}
@@ -25,41 +50,73 @@
 	{
 		@if (InputType == InputType.Hidden && ChildContent != null)
 		{
-		 <div class="@InputClassname">
-				@ChildContent
-		 </div>
+		    <div class="@InputClassname">
+		        @ChildContent
+		    </div>
 		}
 
-	    <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@_internalText" @oninput="OnInput" @onchange="OnChange"
-               placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" inputmode="@InputMode.ToString()" pattern="@Pattern"
-               @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" maxlength="@MaxLength"
-               @onkeydown:preventDefault="KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
-               @onmousewheel="@OnMouseWheel" 
-               @onwheel="@OnMouseWheel"
-        />
-	    @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
+	    <input class="@InputClassname"
+                @ref="_elementReference" 
+                @attributes="UserAttributes" 
+                type="@InputTypeString"                  
+                value="@_internalText" 
+                @oninput="OnInput" 
+                @onchange="OnChange"
+                placeholder="@Placeholder" 
+                disabled=@Disabled 
+                readonly="@ReadOnly" 
+                @onblur="@OnBlurred" 
+                inputmode="@InputMode.ToString()" 
+                pattern="@Pattern"
+                @onkeydown="@InvokeKeyDown" 
+                @onkeypress="@InvokeKeyPress" 
+                @onkeyup="@InvokeKeyUp" 
+                maxlength="@MaxLength"
+                @onkeydown:preventDefault="KeyDownPreventDefault" 
+                @onkeypress:preventDefault="@KeyPressPreventDefault" 
+                @onkeyup:preventDefault="@KeyUpPreventDefault"
+                @onmousewheel="@OnMouseWheel" 
+                @onwheel="@OnMouseWheel"
+         />
+	     @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
 	}
 
 	@if (_showClearable && !Disabled)
 	{
-	 <MudIconButton Color="@Color.Default" Icon="@ClearIcon" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="mud-icon-button-edge-end" />
+	    <MudIconButton Class="mud-icon-button-edge-end" 
+                Color="@Color.Default" 
+                Icon="@ClearIcon" 
+                Size="@Size.Small" 
+                OnClick="@ClearButtonClickHandlerAsync"
+        />
 	}
 
 	@if (Adornment == Adornment.End)
 	{
-	 <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
+	    <MudInputAdornment Class="@AdornmentClassname" 
+                Icon="@AdornmentIcon" 
+                Color="@AdornmentColor" 
+                Size="@IconSize" 
+                Text="@AdornmentText" 
+                Edge="@Edge.End" 
+                AdornmentClick="@OnAdornmentClick" 
+        />
 	}
 
 	@if (Variant == Variant.Outlined)
 	{
-	 <div class="mud-input-outlined-border"></div>
+	    <div class="mud-input-outlined-border"></div>
 	}
 
 	@if (!HideSpinButtons)
 	{
-	 <div class="mud-input-numeric-spin">
-	  <MudButton Variant="Variant.Text" @onclick="OnIncrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1"><MudIcon Icon="@NumericUpIcon" Size="@GetButtonSize()" /></MudButton>
-	  <MudButton Variant="Variant.Text" @onclick="OnDecrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1"><MudIcon Icon="@NumericDownIcon" Size="@GetButtonSize()" /></MudButton>
-	 </div>
+	    <div class="mud-input-numeric-spin">
+            <MudButton Variant="Variant.Text" @onclick="OnIncrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
+                <MudIcon Icon="@NumericUpIcon" Size="@GetButtonSize()" />
+            </MudButton>
+            <MudButton Variant="Variant.Text" @onclick="OnDecrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
+                <MudIcon Icon="@NumericDownIcon" Size="@GetButtonSize()" />
+            </MudButton>
+	    </div>
 	}
 </div>

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -12,9 +12,14 @@
 	@if (Lines > 1)
 	{
 		@*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
-	 <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" inputmode="@InputMode.ToString()"
+	    <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" inputmode="@InputMode.ToString()"
 			  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" @onpaste="@OnPaste" value="@Text" maxlength="@MaxLength"
-			  @onkeydown:preventDefault="@KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault">@Text</textarea>
+			  @onkeydown:preventDefault="@KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
+               @onmousewheel="@OnMouseWheel" 
+               @onwheel="@OnMouseWheel"
+              > @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
+            @Text       
+        </textarea>
 	}
 	else
 	{
@@ -25,11 +30,14 @@
 		 </div>
 		}
 
-	 <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@_internalText" @oninput="OnInput" @onchange="OnChange"
-		   placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" inputmode="@InputMode.ToString()" pattern="@Pattern"
-		   @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" maxlength="@MaxLength"
-		   @onkeydown:preventDefault="KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
-		   @onmousewheel="@OnMouseWheel" />
+	    <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@_internalText" @oninput="OnInput" @onchange="OnChange"
+               placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" inputmode="@InputMode.ToString()" pattern="@Pattern"
+               @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" maxlength="@MaxLength"
+               @onkeydown:preventDefault="KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault"
+               @onmousewheel="@OnMouseWheel" 
+               @onwheel="@OnMouseWheel"
+        />
+	    @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
 	}
 
 	@if (_showClearable && !Disabled)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -93,11 +93,6 @@ namespace MudBlazor
         [Parameter] public bool HideSpinButtons { get; set; } = true;
 
         /// <summary>
-        /// Revert up and down mouse wheel events.
-        /// </summary>
-        [Parameter] public bool InvertMouseWheel { get; set; } = false;
-
-        /// <summary>
         /// Show clear button.
         /// </summary>
         [Parameter] public bool Clearable { get; set; } = false;

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -6,39 +6,57 @@
 
 <CascadingValue Name="Standalone" Value="@Standalone" IsFixed="true">
     <div @ref="_self">
-        <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" CounterText="@GetCounterText()"
-                         Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
+        <MudInputControl 
+                    Label="@Label" 
+                    Variant="@Variant" 
+                    HelperText="@HelperText" 
+                    FullWidth="@FullWidth" 
+                    Class="@Classname"
+                    Error="@HasErrors" 
+                    ErrorText="@GetErrorText()" 
+                    Disabled="@Disabled" 
+                    Margin="@Margin" 
+                    Required="@Required"
+                    CounterText="@GetCounterText()"                    
+            >
             <InputContent>
-                <MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"
+                <MudInput T="string" 
+                          @ref="@_elementReference"
+                          @attributes="@UserAttributes" 
+                          InputType="@InputType.Text" 
+                          Style="@Style" 
+                          Variant="@Variant"
                           TextUpdateSuppression="@TextUpdateSuppression"
-                          Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="_inputConverter" Placeholder="@Placeholder"
-                          Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
-                          AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
-                          OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@(Immediate)" Margin="@Margin" MaxLength="@MaxLength"
-                          OnBlur="@OnBlurred" OnKeyDown="@InterceptKeydown" OnKeyUp="@InterceptKeyUp"
-                          KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="@KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
-                          OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons"
+                          Value="@Text" 
+                          ValueChanged="@OnInputValueChanged" 
+                          Converter="@_inputConverter" 
+                          Placeholder="@Placeholder"
+                          Disabled="@Disabled"
+                          DisableUnderLine="@DisableUnderLine" 
+                          ReadOnly="@ReadOnly" 
+                          Adornment="@Adornment"
+                          AdornmentText="@AdornmentText" 
+                          AdornmentIcon="@AdornmentIcon" 
+                          AdornmentColor="@AdornmentColor" 
+                          IconSize="@IconSize"
+                          Error="@Error" 
+                          Immediate="@(Immediate)" 
+                          Margin="@Margin"
+                          MaxLength="@MaxLength"
+                          HideSpinButtons="@HideSpinButtons"
                           min="@(_minHasValue ? FormatParam(_min) : null)"
                           max="@(_maxHasValue ? FormatParam(_max) : null)"
                           step="@(_stepHasValue ? FormatParam(_step) : null)"
-                          InputMode="InputMode"
+                          InputMode="@InputMode"
                           Pattern="@(Pattern+"*")"
+                          OnAdornmentClick="@OnAdornmentClick" 
+                          OnBlur="@OnBlurred" 
+                          OnKeyDown="@HandleKeydown" 
+                          OnKeyUp="@HandleKeyUp"
+                          OnIncrement="@Increment" 
+                          OnDecrement="@Decrement" 
                           OnMouseWheel="@OnMouseWheel"/>
             </InputContent>
         </MudInputControl>
     </div>
 </CascadingValue>
-
-@code{
-	//avoids the format to use scientific notation for large or small number in floating points types, while covering all options
-	//https://stackoverflow.com/questions/1546113/double-to-string-conversion-without-scientific-notation
-	private const string TagFormat = "0.###################################################################################################################################################################################################################################################################################################################################################";
-
-	private string FormatParam(T value)
-	{
-		if (value is IFormattable f)
-			return f.ToString(TagFormat, CultureInfo.InvariantCulture.NumberFormat);
-		else
-			return null;
-	}
-}

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -48,7 +48,7 @@
                           max="@(_maxHasValue ? FormatParam(_max) : null)"
                           step="@(_stepHasValue ? FormatParam(_step) : null)"
                           InputMode="@InputMode"
-                          Pattern="@(Pattern+"*")"
+                          Pattern="@((Pattern ?? "[0-9]").TrimEnd('*')+"*")"
                           OnAdornmentClick="@OnAdornmentClick" 
                           OnBlur="@OnBlurred" 
                           OnKeyDown="@HandleKeydown" 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -5,7 +5,7 @@
 @using System.Globalization;
 
 <CascadingValue Name="Standalone" Value="@Standalone" IsFixed="true">
-	<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" CounterText="@GetCounterText()"
+	<MudInputControl  @ref="_self" Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" CounterText="@GetCounterText()"
 					 Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
 		<InputContent>
             <MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -54,8 +54,9 @@
                           OnKeyDown="@HandleKeydown" 
                           OnKeyUp="@HandleKeyUp"
                           OnIncrement="@Increment" 
-                          OnDecrement="@Decrement" 
-                          OnMouseWheel="@OnMouseWheel"/>
+                          OnDecrement="@Decrement"  
+                          OnMouseWheel="@OnMouseWheel"
+                          />
             </InputContent>
         </MudInputControl>
     </div>

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -5,25 +5,28 @@
 @using System.Globalization;
 
 <CascadingValue Name="Standalone" Value="@Standalone" IsFixed="true">
-	<MudInputControl  @ref="_self" Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" CounterText="@GetCounterText()"
-					 Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
-		<InputContent>
-            <MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"
-                      TextUpdateSuppression="@TextUpdateSuppression"
-					  Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="_inputConverter" Placeholder="@Placeholder"
-					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
-					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
-					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@(Immediate)" Margin="@Margin" MaxLength="@MaxLength"
-					  OnBlur="@OnBlurred" OnKeyDown="@InterceptKeydown" OnKeyUp="@InterceptKeyUp" OnMouseWheel="@OnMouseWheel" @onwheel="@OnMouseWheel"
-					  KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="@KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
-                      OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" InvertMouseWheel="@InvertMouseWheel"
-					  min="@(_minHasValue ? FormatParam(_min) : null)"
-					  max="@(_maxHasValue ? FormatParam(_max): null)"
-					  step="@(_stepHasValue ? FormatParam(_step) : null)"
-					  InputMode="InputMode"
-					  Pattern="@Pattern"/>
-		</InputContent>
-	</MudInputControl>
+    <div @ref="_self">
+        <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname" CounterText="@GetCounterText()"
+                         Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
+            <InputContent>
+                <MudInput T="string" @ref="_elementReference" @key="_key" @attributes="UserAttributes" InputType="@InputType.Text" Style="@Style" Variant="@Variant"
+                          TextUpdateSuppression="@TextUpdateSuppression"
+                          Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="_inputConverter" Placeholder="@Placeholder"
+                          Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
+                          AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+                          OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@(Immediate)" Margin="@Margin" MaxLength="@MaxLength"
+                          OnBlur="@OnBlurred" OnKeyDown="@InterceptKeydown" OnKeyUp="@InterceptKeyUp"
+                          KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="@KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
+                          OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons"
+                          min="@(_minHasValue ? FormatParam(_min) : null)"
+                          max="@(_maxHasValue ? FormatParam(_max) : null)"
+                          step="@(_stepHasValue ? FormatParam(_step) : null)"
+                          InputMode="InputMode"
+                          Pattern="@(Pattern+"*")"
+                          OnMouseWheel="@OnMouseWheel"/>
+            </InputContent>
+        </MudInputControl>
+    </div>
 </CascadingValue>
 
 @code{

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -223,6 +223,7 @@ namespace MudBlazor
                     Keys = {
                         new KeyOptions { Key="ArrowUp", PreventDown = "key+none" }, // prevent scrolling page, instead increment
                         new KeyOptions { Key="ArrowDown", PreventDown = "key+none" }, // prevent scrolling page, instead decrement
+                        new KeyOptions { Key="Dead", PreventDown = "key+any" }, // prevent dead keys like ^ ` ´ etc
                         new KeyOptions { Key="/^(?!"+(Pattern ?? "[0-9]").TrimEnd('*')+").$/", PreventDown = "key+none|key+shift|key+alt" }, // prevent input of all other characters except allowed, like [0-9.,-+]
                     },
                 });

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -151,9 +151,10 @@ namespace MudBlazor
             return base.SetValueAsync(value, valueChanged || updateText);
         }
 
-        protected override void OnBlurred(FocusEventArgs obj)
+        protected override async void OnBlurred(FocusEventArgs obj)
         {
             base.OnBlurred(obj);
+            await UpdateTextPropertyAsync(false);
         }
 
         protected async Task<bool> ValidateInput(T value)

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -213,7 +213,7 @@ namespace MudBlazor
             {
                 await _keyInterceptor.Connect(_self, new KeyInterceptorOptions()
                 {
-                    EnableLogging = true,
+                    //EnableLogging = true,
                     TargetClass = "mud-input-slot",
                     Keys = {
                         new KeyOptions { Key="ArrowUp", PreventDown = "key+none" }, // prevent scrolling page, instead increment

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -218,7 +218,7 @@ namespace MudBlazor
                     Keys = {
                         new KeyOptions { Key="ArrowUp", PreventDown = "key+none" }, // prevent scrolling page, instead increment
                         new KeyOptions { Key="ArrowDown", PreventDown = "key+none" }, // prevent scrolling page, instead decrement
-                        new KeyOptions { Key="/^(?!"+Pattern+").$/", PreventDown = "key+none|key+shift|key+alt" }, // prevent input of all other characters except allowed, like [0-9.,-+]
+                        new KeyOptions { Key="/^(?!"+(Pattern ?? "[0-9]").TrimEnd('*')+").$/", PreventDown = "key+none|key+shift|key+alt" }, // prevent input of all other characters except allowed, like [0-9.,-+]
                     },
                 });
             }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -125,16 +126,19 @@ namespace MudBlazor
 
         private Converter<string> _inputConverter;
 
+        [ExcludeFromCodeCoverage]
         public override ValueTask FocusAsync()
         {
             return _elementReference.FocusAsync();
         }
 
+        [ExcludeFromCodeCoverage]
         public override ValueTask SelectAsync()
         {
             return _elementReference.SelectAsync();
         }
 
+        [ExcludeFromCodeCoverage]
         public override ValueTask SelectRangeAsync(int pos1, int pos2)
         {
             return _elementReference.SelectRangeAsync(pos1, pos2);

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -222,7 +222,7 @@ namespace MudBlazor
             {
                 await _keyInterceptor.Connect(_self, new KeyInterceptorOptions()
                 {
-                    EnableLogging = true,
+                    //EnableLogging = true,
                     TargetClass = "mud-input-slot",
                     Keys = {
                         new KeyOptions { Key="ArrowUp", SubscribeDown=true, PreventDown = "key+none" }, // prevent scrolling page, instead increment
@@ -235,7 +235,7 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        private async void OnInputKeyDown(KeyboardEventArgs args)
+        internal async void OnInputKeyDown(KeyboardEventArgs args)
         {
             if (Disabled || ReadOnly)
                 return;
@@ -250,86 +250,10 @@ namespace MudBlazor
             }
         }
 
-        /// <summary>
-        /// Overrides KeyDown event, intercepts Arrow Up/Down and uses them to add/substract the value manually by the step value.
-        /// Relying on the browser mean the steps are each integer multiple from <see cref="Min"/> up until <see cref="Max"/>.
-        /// This aligns the behaviour with the spinner buttons.
-        /// </summary>
-        /// <remarks>https://try.mudblazor.com/snippet/QamlkdvmBtrsuEtb</remarks>
         protected Task InterceptKeydown(KeyboardEventArgs obj)
         {
             if (Disabled || ReadOnly)
                 return Task.CompletedTask;
-            /*
-            //Server side and WASM have different (opposite) behaviour. We need to set initial value false on BSS and true on WASM
-            if (RuntimeLocation.IsClientSide)
-            {
-                _keyDownPreventDefault = false;
-            }
-            if (obj.Type == "keydown") //KeyDown or repeat, blazor never fires InvokeKeyPress
-            {
-                switch (obj.Key)
-                {
-                    case "ArrowUp":
-                        _key++;
-                        await Task.Delay(1);
-                        await Increment();
-                        await Task.Delay(1);
-                        await _elementReference.FocusAsync();
-                        break;
-
-                    case "ArrowDown":
-                        _key++;
-                        await Task.Delay(1);
-                        await Decrement();
-                        await Task.Delay(1);
-                        await _elementReference.FocusAsync();
-                        break;
-
-                    case "ArrowLeft":
-                    case "ArrowRight":
-                    case "Tab":
-                    case "Backspace":
-                    case "Delete":
-                    case "Enter":
-                    case "NumpadEnter":
-                    case "Home":
-                    case "End":
-                        break;
-
-                    //copy/paste
-                    case "v":
-                    case "c":
-                    case "a":
-                        if (obj.CtrlKey is false)
-                        {
-                            _keyDownPreventDefault = true;
-                            _key++;
-                            StateHasChanged();
-                            await Task.Delay(1);
-                            await _elementReference.FocusAsync();
-                        }
-                        break;
-
-                    default:
-                        //Check the shift key for AZERTY keyboard support 'Shift' and copy, paste, select all execution for 'Ctrl'.
-                        if (obj.Key != "Shift" && obj.Key != "Control")
-                        {
-                            var acceptableKeyTypes = new Regex("^[0-9,.-]$");
-                            var isMatch = acceptableKeyTypes.Match(obj.Key).Success;
-                            if (isMatch is false)
-                            {
-                                _keyDownPreventDefault = true;
-                                _key++;
-                                StateHasChanged();
-                                await Task.Delay(1);
-                                await _elementReference.FocusAsync();
-                            }
-                        }
-                        break;
-                }
-            }
-            */
             OnKeyDown.InvokeAsync(obj).AndForget();
             return Task.CompletedTask;
         }
@@ -338,17 +262,6 @@ namespace MudBlazor
         {
             if (Disabled || ReadOnly)
                 return Task.CompletedTask;
-            /*
-            //Look at InterceptKeyDown method comment for details.
-            if (RuntimeLocation.IsClientSide)
-            {
-                _keyDownPreventDefault = true;
-            }
-            else
-            {
-                _keyDownPreventDefault = false;
-            }
-            */
             OnKeyUp.InvokeAsync(obj).AndForget();
             return Task.CompletedTask;
         }

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using MudBlazor.Interop;
 
 namespace MudBlazor
 {
+    [ExcludeFromCodeCoverage]
     public static class ElementReferenceExtensions
     {
         private static readonly PropertyInfo jsRuntimeProperty =

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\content\Nuget.png" Pack="true" Visible="false" PackagePath="" />
-    <None Include="compilerconfig.json" />
   </ItemGroup>
 
   <!--Is this a rebuild - Dont clean generated files as this breaks rebuild behaviour-->

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\content\Nuget.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="compilerconfig.json" />
   </ItemGroup>
 
   <!--Is this a rebuild - Dont clean generated files as this breaks rebuild behaviour-->

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+
+    public delegate void KeyboardEvent(KeyboardEventArgs args);
+
+    public interface IKeyInterceptor : IDisposable
+    {
+        Task Connect(ElementReference element, KeyInterceptorOptions options);
+        Task Disconnect();
+
+        event KeyboardEvent KeyDown;
+        event KeyboardEvent KeyUp;
+
+    }
+
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+    public class KeyInterceptor : IKeyInterceptor, IDisposable
+    {
+        private bool _isDisposed = false;
+
+        private readonly DotNetObjectReference<KeyInterceptor> _dotNetRef;
+        private readonly IJSRuntime _jsRuntime;
+        private bool _isObserving;
+        private ElementReference _element;
+
+        public KeyInterceptor(IJSRuntime jsRuntime)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            _jsRuntime = jsRuntime;
+
+        }
+
+        public async Task Connect(ElementReference element, KeyInterceptorOptions options)
+        {
+            if (_isObserving)
+                return;
+            _element = element;
+            try
+            {
+                await _jsRuntime.InvokeAsync<IEnumerable<BoundingClientRect>>("mudKeyInterceptor.connect", _dotNetRef, element, options);
+                _isObserving = true;
+            }
+            catch (TaskCanceledException) { /*ignore*/ }
+        }
+
+        public async Task Disconnect()
+        {
+            try
+            {
+                var task=_jsRuntime.InvokeVoidAsync($"mudKeyInterceptor.disconnect", _element);
+                if (!_isDisposed)
+                    await task;
+            } catch (Exception) {  /*ignore*/ }
+            _isObserving = false;
+        }
+
+        [JSInvokable]
+        public void OnKeyDown(KeyboardEventArgs args)
+        {
+            KeyDown?.Invoke( args);
+        }
+
+        [JSInvokable]
+        public void OnKeyUp(KeyboardEventArgs args)
+        {
+            KeyUp?.Invoke( args);
+        }
+
+        public event KeyboardEvent KeyDown;
+        public event KeyboardEvent KeyUp;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || _isDisposed)
+                return;
+            _isDisposed = true;
+            _=Disconnect();
+            _dotNetRef.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+    }
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -36,15 +36,13 @@ namespace MudBlazor.Services
     ///          PreventDown=null or PreventDown="none"
     ///  * Prevent key down of unmodified keystrokes such as "Tab":
     ///          PreventDown="key+none"
-    ///  * Prevent key down of "Tab" and "Ctrl+Tab"
+    ///  * Prevent key down of Tab and Ctrl+Tab
     ///          PreventDown="key+none|key+ctrl"
-    ///  * Prevent key down of just "Ctrl+Tab"
+    ///  * Prevent key down of just Ctrl+Tab
     ///          PreventDown="key+ctrl"
-    ///  * Prevent key down of "Ctrl+Tab" and "Shift+Tab" but not "Shift+Ctrl+Tab":
-    ///          PreventDown="key+ctrl"
-    ///  * Prevent key down of "Ctrl+Tab" and "Shift+Tab" but not "Shift+Ctrl+Tab":
+    ///  * Prevent key down of Ctrl+Tab and Shift+Tab but not Shift+Ctrl+Tab:
     ///          PreventDown="key+shift|key+ctrl"
-    ///  * Prevent key down of "Shift+Ctrl+Tab" and "Ctrl+Tab" but not "Shift+Tab":
+    ///  * Prevent key down of Shift+Ctrl+Tab and Ctrl+Tab but not Shift+Tab:
     ///          PreventDown="key+shift+ctrl|key+ctrl"
     ///  * Prevent any combination of key and modifiers, but not the unmodified key:
     ///          PreventDown="key+any"
@@ -57,14 +55,10 @@ namespace MudBlazor.Services
         /// Javascript keyboard event.key
         ///
         /// Examples: " " for space, "Tab" for tab, "a" for lowercase A-key.
-        /// Also allowed (if IsRegex is true): JS regex  such as "[a-z]" or "a|b" but NOT /[a-z]/ or /[a-z]/i
+        /// Also allowed: JS regex such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
+        ///      regex must be inclosed in two forward slashes!
         /// </summary>
         public string Key { get; set; }
-
-        /// <summary>
-        /// Set to true to interpret Key as a JS regex. 
-        /// </summary>
-        public bool IsRegex { get; set; }
 
         /// <summary>
         /// Subscribe down key and invoke event KeyDown on c# side

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -56,7 +56,7 @@ namespace MudBlazor.Services
         ///
         /// Examples: " " for space, "Tab" for tab, "a" for lowercase A-key.
         /// Also allowed: JS regex such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
-        ///      regex must be inclosed in two forward slashes!
+        ///      regex must be enclosed in two forward slashes!
         /// </summary>
         public string Key { get; set; }
 

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -75,7 +75,4 @@ namespace MudBlazor.Services
         public string StopDown { get; set; } = "none";
         public string StopUp { get; set; } = "none";
     }
-
-
-
 }

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+
+namespace MudBlazor.Services
+{
+    public class KeyInterceptorOptions
+    {
+        /// <summary>
+        /// Class of the target node which should be observed for keyboard events
+        ///
+        /// Note: this must be a single class
+        /// </summary>
+        public string TargetClass { get; set; }
+
+        /// <summary>
+        /// Report resize events in the browser's console.
+        /// </summary>
+        public bool EnableLogging { get; set; } = false;
+
+        /// <summary>
+        /// Intercept configuration for keys of interest
+        /// </summary>
+        public List<KeyOptions> Keys { get; set; } = new List<KeyOptions>();
+    }
+
+    /// <summary>
+    /// Configuration for preventDefault() and stopPropagation() control
+    ///
+    /// For PreventDown, PreventUp, StopDown and StopUp the configuration which key combinations should match
+    /// is a Javascript boolean expression.
+    ///
+    /// Examples:
+    /// For the examples, let's assume the Tab key was pressed.
+    /// Note: for combinations of more than one modifier the following order of modifiers must be followed strictly: shift+ctrl+alt+meta
+    /// 
+    ///  * Don't prevent key down:
+    ///          PreventDown=null or PreventDown="none"
+    ///  * Prevent key down of unmodified keystrokes such as "Tab":
+    ///          PreventDown="key+none"
+    ///  * Prevent key down of "Tab" and "Ctrl+Tab"
+    ///          PreventDown="key+none|key+ctrl"
+    ///  * Prevent key down of just "Ctrl+Tab"
+    ///          PreventDown="key+ctrl"
+    ///  * Prevent key down of "Ctrl+Tab" and "Shift+Tab" but not "Shift+Ctrl+Tab":
+    ///          PreventDown="key+ctrl"
+    ///  * Prevent key down of "Ctrl+Tab" and "Shift+Tab" but not "Shift+Ctrl+Tab":
+    ///          PreventDown="key+shift|key+ctrl"
+    ///  * Prevent key down of "Shift+Ctrl+Tab" and "Ctrl+Tab" but not "Shift+Tab":
+    ///          PreventDown="key+shift+ctrl|key+ctrl"
+    ///  * Prevent any combination of key and modifiers, but not the unmodified key:
+    ///          PreventDown="key+any"
+    ///  * Prevent any combination of key and modifiers, even the unmodified key:
+    ///          PreventDown="any"
+    /// </summary>
+    public class KeyOptions
+    {
+        /// <summary>
+        /// Javascript keyboard event.key
+        ///
+        /// Examples: " " for space, "Tab" for tab, "a" for lowercase A-key.
+        /// Also allowed (if IsRegex is true): JS regex  such as "[a-z]" or "a|b" but NOT /[a-z]/ or /[a-z]/i
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Set to true to interpret Key as a JS regex. 
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
+        /// Subscribe down key and invoke event KeyDown on c# side
+        /// </summary>
+        public bool SubscribeDown { get; set; }
+
+        /// <summary>
+        /// Subscribe up key and invoke event KeyUp on c# side
+        /// </summary>
+        public bool SubscribeUp { get; set; }
+
+        public string PreventDown { get; set; } = "none";
+        public string PreventUp { get; set; } = "none";
+        public string StopDown { get; set; } = "none";
+        public string StopUp { get; set; } = "none";
+    }
+
+
+
+}

--- a/src/MudBlazor/Services/Scroll/ScrollManagerException.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManagerException.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {
+
+    [ExcludeFromCodeCoverage]
     [Serializable]
     public class ScrollManagerException : Exception
     {

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -121,6 +121,17 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        /// Adds IKeyInterceptor as a Transient instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorKeyInterceptor(this IServiceCollection services)
+        {
+            services.TryAddTransient<IKeyInterceptor, KeyInterceptor>();
+            return services;
+        }
+
+        /// <summary>
         /// Adds ScrollManager as a transient instance.
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -200,6 +211,7 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeListener(configuration.ResizeOptions)
                 .AddMudBlazorResizeObserver(configuration.ResizeObserverOptions)
                 .AddMudBlazorResizeObserverFactory()
+                .AddMudBlazorKeyInterceptor()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
                 .AddMudBlazorJsApi()
@@ -226,6 +238,7 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeListener(options.ResizeOptions)
                 .AddMudBlazorResizeObserver(options.ResizeObserverOptions)
                 .AddMudBlazorResizeObserverFactory()
+                .AddMudBlazorKeyInterceptor()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
                 .AddMudBlazorJsApi()

--- a/src/MudBlazor/Services/ServiceConfiguration.cs
+++ b/src/MudBlazor/Services/ServiceConfiguration.cs
@@ -10,5 +10,6 @@
         public SnackbarConfiguration SnackbarConfiguration { get; set; } = new SnackbarConfiguration();
         public ResizeOptions ResizeOptions { get; set; } = new ResizeOptions();
         public ResizeObserverOptions ResizeObserverOptions { get; set; } = new ResizeObserverOptions();
+
     }
 }

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -87,7 +87,7 @@ class MudKeyInterceptor {
     attachHandlers(child) {
         this.logger('[MudBlazor | KeyInterceptor] attaching handlers ', { child });
         if (this._observedChildren.indexOf(child) > -1) {
-            console.log("... already attached");
+            //console.log("... already attached");
             return;
         }
         child.mudKeyInterceptor = this;

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -49,7 +49,6 @@ class MudKeyInterceptor {
         // transform key options into a key lookup
         this._keyOptions = {};
         this._regexOptions = [];
-            /*
         for (const keyOption of this._options.keys) {
             if (!keyOption || !keyOption.key) {
                 this.logger('[MudBlazor | KeyInterceptor] got invalid key options: ', keyOption);
@@ -63,10 +62,10 @@ class MudKeyInterceptor {
             else
                 this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
             // remove whitespace and enforce lowercase
-            keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(/\s/g, "").toLowerCase();
-            keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(/\s/g, "").toLowerCase();
-            keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(/\s/g, "").toLowerCase();
-            keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(/\s/g, "").toLowerCase();
+            //keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(/\s/g, "").toLowerCase();
+            //keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(/\s/g, "").toLowerCase();
+            //keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(/\s/g, "").toLowerCase();
+            //keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(/\s/g, "").toLowerCase();
         }
         this.logger('[MudBlazor | KeyInterceptor] key options: ', this._keyOptions);
         if (this._regexOptions.size > 0)
@@ -75,7 +74,6 @@ class MudKeyInterceptor {
         for (const child of this._element.getElementsByClassName(targetClass)) {
             this.attachHandlers(child);
         }
-            */
     }
 
     disconnect() {

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -27,6 +27,7 @@ class MudKeyInterceptor {
         this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
     }
 
+    /*
     connect(element) {
         if (!this._options)
             return;
@@ -74,7 +75,7 @@ class MudKeyInterceptor {
             this.attachHandlers(child);
         }
     }
-
+    */
     disconnect() {
         if (!this._observer)
             return;

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -62,7 +62,7 @@ class MudKeyInterceptor {
             else
                 this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
             // remove whitespace and enforce lowercase
-            var whitespace = new RegExp("\\s");
+            var whitespace = new RegExp("\\s", "g");
             keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(whitespace, "").toLowerCase();
             keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(whitespace, "").toLowerCase();
             keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(whitespace, "").toLowerCase();

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -1,0 +1,225 @@
+﻿class MudKeyInterceptorFactory {
+
+    connect(dotNetRef, element, options) {
+        //console.log('[MudBlazor | MudKeyInterceptorFactory] connect ', { dotNetRef, element, options });
+        if (!element.mudKeyInterceptor)
+            element.mudKeyInterceptor = new MudKeyInterceptor(dotNetRef, options);
+        element.mudKeyInterceptor.connect(element);
+    }
+
+    disconnect(element) {
+        if (!element.mudKeyInterceptor)
+            return;
+        element.mudKeyInterceptor.disconnect();
+    }
+}
+window.mudKeyInterceptor = new MudKeyInterceptorFactory();
+
+class MudKeyInterceptor {
+
+    constructor(dotNetRef, options) {
+        this._dotNetRef = dotNetRef;
+        this._options = options;
+        this.logger = options.enableLogging ? console.log : (message) => { };
+        this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
+    }
+
+    connect(element) {
+        if (!this._options)
+            return;
+        if (!this._options.keys) 
+            throw "_options.keys: array of KeyOptions expected";
+        if (!this._options.targetClass)
+            throw "_options.targetClass: css class name expected";
+        if (this._observer) {
+            // don't do double registration
+            return;
+        }
+        var targetClass = this._options.targetClass;
+        this.logger('[MudBlazor | KeyInterceptor] Start observing DOM of element for changes to child with class ', { element, targetClass});
+        this._element = element;
+        this._observer = new MutationObserver(this.onDomChanged);
+        this._observer.mudKeyInterceptor = this;
+        this._observer.observe(this._element, { attributes: false, childList: true, subtree: true });
+        this._observedChildren = [];
+        // transform key options into a key lookup
+        this._keyOptions = {};
+        this._regexOptions = [];
+        for (const keyOption of this._options.keys) {
+            if (!keyOption || !keyOption.key) {
+                this.logger('[MudBlazor | KeyInterceptor] got invalid key options: ', keyOption);
+                continue;
+            }
+            if (keyOption.isRegex) {
+                // JS regex key options such as "[a-z]" or "a|b", NOT allowed: /[a-z]/ or /[a-z]/i
+                keyOption.regex = new RegExp(keyOption.key);
+                this._regexOptions.push(keyOption);
+            }
+            else
+                this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
+            // remove whitespace and enforce lowercase
+            keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(/\s/g, "").toLowerCase();
+            keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(/\s/g, "").toLowerCase();
+            keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(/\s/g, "").toLowerCase();
+            keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(/\s/g, "").toLowerCase();
+        }
+        this.logger('[MudBlazor | KeyInterceptor] key options: ', this._keyOptions);
+        if (this._regexOptions.size > 0)
+            this.logger('[MudBlazor | KeyInterceptor] regex options: ', this._regexOptions);
+        // register handlers
+        for (const child of this._element.getElementsByClassName(targetClass)) {
+            this.attachHandlers(child);
+        }
+    }
+
+    disconnect() {
+        if (!this._observer)
+            return;
+        this.logger('[MudBlazor | KeyInterceptor] disconnect mutation observer and event handlers');
+        this._observer.disconnect();
+        this._observer = null;
+        for (const child of this._observedChildren)
+            this.detachHandlers(child);
+    }
+
+    attachHandlers(child) {
+        this.logger('[MudBlazor | KeyInterceptor] attaching handlers ', { child });
+        if (this._observedChildren.indexOf(child) > -1) {
+            console.log("... already attached");
+            return;
+        }
+        child.mudKeyInterceptor = this;
+        child.addEventListener('keydown', this.onKeyDown);
+        child.addEventListener('keyup', this.onKeyUp);
+        this._observedChildren.push(child);
+    }
+
+    detachHandlers(child) {
+        this.logger('[MudBlazor | KeyInterceptor] detaching handlers ', { child });
+        child.removeEventListener('keydown', this.onKeyDown);
+        child.removeEventListener('keyup', this.onKeyUp);
+        this._observedChildren = this._observedChildren.filter(x=>x!==child);
+    }
+
+    onDomChanged(mutationsList, observer) {
+        var self = this.mudKeyInterceptor; // func is invoked with this == _observer
+        //self.logger('[MudBlazor | KeyInterceptor] onDomChanged: ', { self });
+        var targetClass = self._options.targetClass;
+        for (const mutation of mutationsList) {
+            //self.logger('[MudBlazor | KeyInterceptor] Subtree mutation: ', { mutation });
+            for (const element of mutation.addedNodes) {
+                if (element.classList && element.classList.contains(targetClass))
+                    self.attachHandlers(element);
+            }
+            for (const element of mutation.removedNodes) {
+                if (element.classList && element.classList.contains(targetClass))
+                    self.detachHandlers(element);
+            }
+        }
+    }
+
+    matchesKeyCombination(option, args) {
+        if (!option || option=== "none")
+            return false;
+        if (option === "any")
+            return true;
+        var shift = args.shiftKey;
+        var ctrl = args.ctrlKey;
+        var alt = args.altKey;
+        var meta = args.metaKey;
+        var any = shift || ctrl || alt || meta;
+        if (any && option === "key+any")
+            return true;
+        if (!any && option.includes("key+none"))
+            return true;
+        if (!any)
+            return false;
+        var combi = `key${shift ? "+shift" : ""}${ctrl ? "+ctrl" : ""}${alt ? "+alt" : ""}${meta ? "+meta" : ""}`;
+        return option.includes(combi);
+    }
+
+    onKeyDown(args) {
+        var self = this.mudKeyInterceptor; // func is invoked with this == child
+        var key = args.key.toLowerCase();
+        self.logger('[MudBlazor | KeyInterceptor] down "' + key + '"', args);
+        var invoke = false;
+        if (self._keyOptions.hasOwnProperty(key)) {
+            var keyOptions = self._keyOptions[key];
+            self.logger('[MudBlazor | KeyInterceptor] options for "' + key + '"', keyOptions);
+            self.processKeyDown(args, keyOptions);
+            if (keyOptions.subscribeDown)
+                invoke = true;
+        }
+        for (const keyOptions of self._regexOptions) {
+            if (keyOptions.regex.matches(key)) {
+                self.logger('[MudBlazor | KeyInterceptor] regex options for "' + key + '"', keyOptions);
+                self.processKeyDown(args, keyOptions);
+                if (keyOptions.subscribeDown)
+                    invoke = true;
+            }
+        }
+        if (invoke) {
+            var eventArgs = self.toKeyboardEventArgs(args);
+            eventArgs.Type = "keydown";
+            // we'd like to pass a reference to the child element back to dotnet but we can't
+            // https://github.com/dotnet/aspnetcore/issues/16110
+            // if we ever need it we'll pass the id up and users need to id the observed elements
+            self._dotNetRef.invokeMethodAsync('OnKeyDown', eventArgs);
+        }
+    }
+
+    processKeyDown(args, keyOptions) {
+        if (this.matchesKeyCombination(keyOptions.preventDown, args))
+            args.preventDefault();
+        if (this.matchesKeyCombination(keyOptions.stopDown, args))
+            args.stopPropagation();
+    }
+
+    onKeyUp(args) {
+        var self = this.mudKeyInterceptor; // func is invoked with this == child
+        var key = args.key.toLowerCase();
+        self.logger('[MudBlazor | KeyInterceptor] up "' + key + '"', args);
+        var invoke = false;
+        if (self._keyOptions.hasOwnProperty(key)) {
+            var keyOptions = self._keyOptions[key];
+            self.processKeyUp(args, keyOptions);
+            if (keyOptions.subscribeUp)
+                invoke = true;
+        }
+        for (const keyOptions of self._regexOptions) {
+            if (keyOptions.regex.matches(key)) {
+                self.processKeyUp(args, keyOptions);
+                if (keyOptions.subscribeUp)
+                    invoke = true;
+            }
+        }
+        if (invoke) {
+            var eventArgs = self.toKeyboardEventArgs(args);
+            eventArgs.Type = "keyup";
+            // we'd like to pass a reference to the child element back to dotnet but we can't
+            // https://github.com/dotnet/aspnetcore/issues/16110
+            // if we ever need it we'll pass the id up and users need to id the observed elements
+            self._dotNetRef.invokeMethodAsync('OnKeyUp', eventArgs);
+        }
+    }
+
+    processKeyUp(args, keyOptions) {
+        if (this.matchesKeyCombination(keyOptions.preventUp, args))
+            args.preventDefault();
+        if (this.matchesKeyCombination(keyOptions.stopUp, args))
+            args.stopPropagation();
+    }
+
+    toKeyboardEventArgs(args) {
+        const Key = args.key;
+        const Code = args.code;
+        const Location = args.location;
+        const Repeat = args.repeat;
+        const CtrlKey = args.ctrlKey;
+        const ShiftKey = args.shiftKey;
+        const AltKey = args.altKey;
+        const MetaKey = args.metaKey;
+        return { Key, Code, Location, Repeat, CtrlKey, ShiftKey, AltKey, MetaKey };
+    }
+
+}

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -17,7 +17,7 @@
 }
 window.mudKeyInterceptor = new MudKeyInterceptorFactory();
 
-/*
+
 class MudKeyInterceptor {
 
     constructor(dotNetRef, options) {
@@ -26,7 +26,7 @@ class MudKeyInterceptor {
         this.logger = options.enableLogging ? console.log : (message) => { };
         this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
     }
-
+/*
     connect(element) {
         if (!this._options)
             return;
@@ -225,5 +225,6 @@ class MudKeyInterceptor {
             MetaKey: args.metaKey
         };
     }
+    */
 }
-*/
+

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -121,7 +121,7 @@ class MudKeyInterceptor {
             }
         }
     }
-    /*
+
     matchesKeyCombination(option, args) {
         if (!option || option=== "none")
             return false;
@@ -226,6 +226,6 @@ class MudKeyInterceptor {
             MetaKey: args.metaKey
         };
     }
-    */
+
 }
 

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -62,10 +62,11 @@ class MudKeyInterceptor {
             else
                 this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
             // remove whitespace and enforce lowercase
-            //keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(/\s/g, "").toLowerCase();
-            //keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(/\s/g, "").toLowerCase();
-            //keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(/\s/g, "").toLowerCase();
-            //keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(/\s/g, "").toLowerCase();
+            var whitespace = new RegExp("\\s");
+            keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(whitespace, "").toLowerCase();
+            keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(whitespace, "").toLowerCase();
+            keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(whitespace, "").toLowerCase();
+            keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(whitespace, "").toLowerCase();
         }
         this.logger('[MudBlazor | KeyInterceptor] key options: ', this._keyOptions);
         if (this._regexOptions.size > 0)

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -17,6 +17,7 @@
 }
 window.mudKeyInterceptor = new MudKeyInterceptorFactory();
 
+/*
 class MudKeyInterceptor {
 
     constructor(dotNetRef, options) {
@@ -225,3 +226,4 @@ class MudKeyInterceptor {
         };
     }
 }
+*/

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -213,15 +213,15 @@ class MudKeyInterceptor {
     }
 
     toKeyboardEventArgs(args) {
-        const Key = args.key;
-        const Code = args.code;
-        const Location = args.location;
-        const Repeat = args.repeat;
-        const CtrlKey = args.ctrlKey;
-        const ShiftKey = args.shiftKey;
-        const AltKey = args.altKey;
-        const MetaKey = args.metaKey;
-        return { Key, Code, Location, Repeat, CtrlKey, ShiftKey, AltKey, MetaKey };
+        return {
+            Key: args.key,
+            Code: args.code,
+            Location: args.location,
+            Repeat: args.repeat,
+            CtrlKey: args.ctrlKey,
+            ShiftKey: args.shiftKey,
+            AltKey: args.shiftKey,
+            MetaKey: args.metaKey
+        };
     }
-
 }

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -27,7 +27,7 @@ class MudKeyInterceptor {
         this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
     }
 
-    /*
+    
     connect(element) {
         if (!this._options)
             return;
@@ -49,6 +49,7 @@ class MudKeyInterceptor {
         // transform key options into a key lookup
         this._keyOptions = {};
         this._regexOptions = [];
+            /*
         for (const keyOption of this._options.keys) {
             if (!keyOption || !keyOption.key) {
                 this.logger('[MudBlazor | KeyInterceptor] got invalid key options: ', keyOption);
@@ -74,8 +75,9 @@ class MudKeyInterceptor {
         for (const child of this._element.getElementsByClassName(targetClass)) {
             this.attachHandlers(child);
         }
+            */
     }
-    */
+
     disconnect() {
         if (!this._observer)
             return;

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -26,7 +26,7 @@ class MudKeyInterceptor {
         this.logger = options.enableLogging ? console.log : (message) => { };
         this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
     }
-/*
+
     connect(element) {
         if (!this._options)
             return;
@@ -84,7 +84,7 @@ class MudKeyInterceptor {
         for (const child of this._observedChildren)
             this.detachHandlers(child);
     }
-
+    
     attachHandlers(child) {
         this.logger('[MudBlazor | KeyInterceptor] attaching handlers ', { child });
         if (this._observedChildren.indexOf(child) > -1) {
@@ -120,7 +120,7 @@ class MudKeyInterceptor {
             }
         }
     }
-
+    /*
     matchesKeyCombination(option, args) {
         if (!option || option=== "none")
             return false;

--- a/src/MudBlazor/Utilities/Exceptions/GenericTypeMismatchException.cs
+++ b/src/MudBlazor/Utilities/Exceptions/GenericTypeMismatchException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor.Utilities.Exceptions
 {
+    [ExcludeFromCodeCoverage]
     public class GenericTypeMismatchException : Exception
     {
         public GenericTypeMismatchException(string parent, string child, Type t1, Type t2) : base($"{parent}<{t1.Name}> has a child {child}<{t2}> with mismatching generic type.")

--- a/src/MudBlazor/Utilities/RuntimeLocation.cs
+++ b/src/MudBlazor/Utilities/RuntimeLocation.cs
@@ -1,7 +1,9 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace MudBlazor.Utilities
 {
+    [ExcludeFromCodeCoverage]
     public class RuntimeLocation
     {
         public static bool IsClientSide => RuntimeInformation.OSDescription == "Browser"; // WASM


### PR DESCRIPTION
KeyboardInterceptor allows to preventDefault specific key strokes directly on the javascript side.

The service significantly improves NumericField which needed some very complex key-handlers to work (and even then it worked only so-so. Before forbidden characters (like [a-z]) were added briefly visible in the text box before being removed by the cleanup logic. With this new interceptor service the keys are prevented and will never show up. 

fixes #2592

**Using the new KeyboardInterceptor**

The interceptor service binds itself against an element reference of the component (in this example `_self`). That means you need a ref to a top-level div of the component you want the interceptor to work on. It attaches a mutation observer to that DOM node to check for re-arrangements of the elements it attaches key event listeners to. These elements need to be marked with a css class so the interceptor can find them.

Connecting the interceptor to the component:
```c#
        protected override async Task OnAfterRenderAsync(bool firstRender)
        {
            if (firstRender)
            {
                await _keyInterceptor.Connect(_self, new KeyInterceptorOptions()
                {
                    //EnableLogging = true,
                    TargetClass = "mud-input-slot",
                    Keys = {
                        new KeyOptions { Key="ArrowUp", PreventDown = "key+none" }, // prevent scrolling page, instead increment
                        new KeyOptions { Key="ArrowDown", PreventDown = "key+none" }, // prevent scrolling page, instead decrement
                        new KeyOptions { Key="/^(?!"+Pattern+").$/", PreventDown = "key+none|key+shift|key+alt" }, // prevent input of all other characters except allowed, like [0-9.,-+]
                    },
                });
            }
            await base.OnAfterRenderAsync(firstRender);
        }
```

Above we see how it is attached to `_self` which is the top-level div of numeric field (which I had to add). We also see that the TargetClass is set to `mud-input-slot` which is one of the css classes of  the `<input>` we want to intercept key events from.

The `Keys` configure which individual key combinations to subscribe/preventDefault/stopPropagate.  Here we only apply preventDefault. We prevent the default action of the arrow keys which would scroll the page. And (using a negative lookahead expression) we prevent all single character input keys except `[0-9,.\-]` (defined in the `Pattern` property). This means that by changing `Pattern` the user can define which keys to allow and which to prevent. For instance, we had an issue where a user wanted to prevent input of the minus character. He could just change `Pattern` to `"[0-9],."`. 

**general info on how to match different key combinations**

```
 Configuration for preventDefault() and stopPropagation() control

 For PreventDown, PreventUp, StopDown and StopUp the configuration which key combinations should match
 is a Javascript boolean expression.

 Examples:
 For the examples, let's assume the Tab key was pressed.
 Note: for combinations of more than one modifier the following order of modifiers must be followed strictly: shift+ctrl+alt+meta
 
  * Don't prevent key down:
          PreventDown=null or PreventDown="none"
  * Prevent key down of unmodified keystrokes such as "Tab":
          PreventDown="key+none"
  * Prevent key down of Tab and Ctrl+Tab
          PreventDown="key+none|key+ctrl"
  * Prevent key down of just Ctrl+Tab
          PreventDown="key+ctrl"
  * Prevent key down of Ctrl+Tab and Shift+Tab but not Shift+Ctrl+Tab:
          PreventDown="key+shift|key+ctrl"
  * Prevent key down of Shift+Ctrl+Tab and Ctrl+Tab but not Shift+Tab:
          PreventDown="key+shift+ctrl|key+ctrl"
  * Prevent any combination of key and modifiers, but not the unmodified key:
          PreventDown="key+any"
  * Prevent any combination of key and modifiers, even the unmodified key:
          PreventDown="any"
```

**key matching**

For matching keys you can either use the key representation or a java regex. 

```
Examples: " " for space, "Tab" for tab, "a" for lowercase A-key.
Also allowed: JS regex such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
              regex must be inclosed in two forward slashes!
```

**subscribing matched key events**
In this PR we are using the normal keyup and keydown events via Blazor. But you can get selective events via the KeyInterceptor by setting `SubscribeUp` or `SubscribeDown`. Then you can attach handlers like so:

```c#
_keyinterceptor.KeyDown+=OnKeyDown;
_keyinterceptor.KeyUp+=OnKeyUp;
```

Of course only matching keys with SubscribeDown or -Up will fire the events.

