### PR TITLE
Correct PickerVariant Elevation example typo

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerElevationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerElevationExample.razor
@@ -2,6 +2,6 @@
 
 <MudDatePicker PickerVariant="PickerVariant.Static" Rounded="true" Elevation="1" Date="@(DateTime.Today.AddDays(1))" />
 
-<MudDatePicker PickerVariant="PickerVariant.Static" Rounded="true" Elevation="12" Date="@(DateTime.Today.AddDays(1))" />
+<MudDatePicker PickerVariant="PickerVariant.Inline" Rounded="true" Elevation="12" Date="@(DateTime.Today.AddDays(1))" />
 
 


### PR DESCRIPTION
The example code says "You can change the elevation with the Elevation parameter. The default value is 0 for static and 8 for inline." but the code example has PickerVariant="PickerVariant.Static" for both examples.  Probably a cut and paste error. - Craig

Correction to the DatePicker documentation page.

## Description
Under the Elevation example for MudDatePicker the code example has PickerVariant="PickerVariant.Static" for both examples. The description describes that the example should show both PickerVariant.Static and PickerVariant.Inline.

## Motivation and Context
I wanted to see an inline example

## How Has This Been Tested?
This is a documentation bug

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in library)
