### PR TITLE
Added capability to set alt property when Image is used in MudAvatar

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
@@ -32,7 +32,7 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Images">
-                <Description>Avatars can display images as well, specify a link to the image with <CodeInline>Image</CodeInline>.</Description>
+                <Description>Avatars can display images as well, specify a link to the image with <CodeInline>Image</CodeInline>.  If you specify an <CodeInline>Alt</CodeInline> prop, you can specify an alternative text description for the image to help with accessibility or if the image url isn't valid.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarImageExample />
@@ -70,13 +70,13 @@
         @*MudBadge needs fixing before showing this. Does not look good with avatars.*@
 
         @*<DocsPageSection>
-            <SectionHeader Title="Badges">
-                <Description></Description>
-            </SectionHeader>
-            <SectionContent Outlined="true" DisplayFlex="true">
-                <AvatarBadgeExample />
-            </SectionContent>
-            <SectionSource Code="AvatarBadgeExample" GitHubFolderName="Avatar" ShowCode="true" />
-        </DocsPageSection>*@
+                <SectionHeader Title="Badges">
+                    <Description></Description>
+                </SectionHeader>
+                <SectionContent Outlined="true" DisplayFlex="true">
+                    <AvatarBadgeExample />
+                </SectionContent>
+                <SectionSource Code="AvatarBadgeExample" GitHubFolderName="Avatar" ShowCode="true" />
+            </DocsPageSection>*@
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarImageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarImageExample.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudAvatar Image="_content/MudBlazor.Docs/images/mony.png" />
+<MudAvatar Image="_content/MudBlazor.Docs/images/mony.png" Alt="An image of the best dog ever!"/>
 <MudAvatar Image="_content/MudBlazor.Docs/images/toiletvisit.png" />

--- a/src/MudBlazor.UnitTests/Components/AvatarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class AvatarTests : BunitTest
+    {
+        /// <summary>
+        /// MudAvatar without Alt renders image without alt property
+        /// </summary>
+        [Test]
+        public void MudAvatarShouldRenderImageWithoutAltIfAltIsEmptyString()
+        {
+            var imageUrl = Parameter(nameof(MudAvatar.Image),
+                "https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+            var alt = Parameter(nameof(MudAvatar.Alt), "");
+
+            var comp = Context.RenderComponent<MudAvatar>(imageUrl, alt);
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+
+            var imageElement = comp.Find("img");
+            imageElement.ClassName.Should().Contain("mud-avatar-img");
+            imageElement.Attributes.GetNamedItem("src")?.Value.Should()
+                .Be("https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+            imageElement.Attributes.Should().NotContain(e => e.Name == "alt");
+        }
+
+        /// <summary>
+        /// MudAvatar without Alt renders image without alt property
+        /// </summary>
+        [Test]
+        public void MudAvatarShouldRenderImageWithoutAltIfAltIsNotSet()
+        {
+            var imageUrl = Parameter(nameof(MudAvatar.Image),
+                "https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+
+            var comp = Context.RenderComponent<MudAvatar>(imageUrl);
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+
+            var imageElement = comp.Find("img");
+            imageElement.ClassName.Should().Contain("mud-avatar-img");
+            imageElement.Attributes.GetNamedItem("src")?.Value.Should()
+                .Be("https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+            imageElement.Attributes.Should().NotContain(e => e.Name == "alt");
+        }
+
+        /// <summary>
+        /// MudAvatar with Alt renders image with alt property
+        /// </summary>
+        [Test]
+        public void MudAvatarShouldRenderImageWithAlt()
+        {
+            var imageUrl = Parameter(nameof(MudAvatar.Image),
+                "https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+            var alt = Parameter(nameof(MudAvatar.Alt), "Lady Avatar");
+
+            var comp = Context.RenderComponent<MudAvatar>(imageUrl, alt);
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+
+            var imageElement = comp.Find("img");
+            imageElement.ClassName.Should().Contain("mud-avatar-img");
+            imageElement.Attributes.GetNamedItem("src")?.Value.Should()
+                .Be("https://images.freeimages.com/images/small-previews/cd5/lady-avatar-1632969.jpg");
+            imageElement.Attributes.GetNamedItem("alt")?.Value.Should()
+                .Be("Lady Avatar");
+        }
+
+
+
+    }
+}
+
+
+

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor
@@ -6,7 +6,14 @@
     <div @attributes="UserAttributes" class="@Classname" style="@Stylesname">
         @if (!String.IsNullOrEmpty(Image))
         {
-            <img src="@Image" class="mud-avatar-img" />
+            if (!String.IsNullOrEmpty(Alt))
+            {
+                <img src="@Image" alt="@Alt" class="mud-avatar-img" />
+            }
+            else
+            {
+                <img src="@Image" class="mud-avatar-img" />
+            }
         }
         else
         {

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -47,6 +47,11 @@ namespace MudBlazor
         [Parameter] public string Image { get; set; }
 
         /// <summary>
+        /// If set (and Image is also set), will add an alt property to the img element
+        /// </summary>
+        [Parameter] public string Alt { get; set; }
+
+        /// <summary>
         /// The color of the component. It supports the theme colors.
         /// </summary>
         [Parameter] public Color Color { get; set; } = Color.Default;


### PR DESCRIPTION
## Description
Resolves #2893 
Added Alt property to MudAvatar so that when an Image is used, it is possible to set the alt property of the img element.

## Motivation and Context
Lighthouse accessibility test 

## How Has This Been Tested?
## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in library)
