### PR TITLE
Table: prevent changing sort while row editing

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditSortTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditSortTest.razor
@@ -1,0 +1,48 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+
+<MudTable @ref="MudTableRef" Items="items" T="Element" @bind-SelectedItem="selectedItem"
+ RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues" CanCancelEdit="true">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Value)">#</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Value</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField T="string" id="@context.Id" @bind-Value="@context.Value"></MudTextField>
+        </MudTd>
+    </RowEditingTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "editing a sorted column should not shift position while open";
+    
+    private Element elementBeforeEditing = new();
+    private Element selectedItem = null;
+    public MudTable<Element> MudTableRef { get; private set; }
+
+    IEnumerable<Element> items = new List<Element> 
+    { 
+        new Element { Value = "B", Id = "Id1" }, 
+        new Element { Value = "A", Id = "Id2" }, 
+        new Element { Value = "C", Id = "Id3" }, 
+    };
+    
+    private void BackupItem(object element)
+    {
+        elementBeforeEditing.Value = ((Element)element).Value;
+    }
+
+    private void ResetItemToOriginalValues(object element)
+    {
+        ((Element)element).Value = elementBeforeEditing.Value;
+    }
+    
+    public class Element
+    {
+        public string Id { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -889,6 +889,51 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// This test validates the edit row maintains position on changing sort key for an inline editing table.
+        /// </summary>
+        [Test]
+        public async Task TableInlineEditSortTest()
+        {
+            var comp = Context.RenderComponent<TableInlineEditSortTest>();
+
+            // Count the number of rows including header
+            comp.FindAll("tr").Count.Should().Be(4); // Three rows + header row
+            
+            // Check the values of rows
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("B");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("A");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("C");
+            
+            // Access to the table
+            var table = comp.FindComponent<MudTable<TableInlineEditSortTest.Element>>();
+
+            // Get the mudtablesortlabels associated to the table
+            var mudTableSortLabels = table.Instance.Context.SortLabels;
+
+            // Sort the first column
+            await table.InvokeAsync(() => mudTableSortLabels[0].ToggleSortDirection());
+
+            // Check the values of rows
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("A");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("C");
+            
+            // Click on the second row
+            var trs = comp.FindAll("tr");
+            trs[2].Click();
+            
+            // Change row two data
+            var input = comp.Find(("#Id1"));
+            input.Change("D");
+            
+            // Check row two is still in position 2 of the data rows
+            var trs2 = comp.FindAll("tr");
+            trs2[1].InnerHtml.Contains("input").Should().BeFalse();
+            trs2[2].InnerHtml.Contains("input").Should().BeTrue();
+            trs2[3].InnerHtml.Contains("input").Should().BeFalse();
+        }
+
+        /// <summary>
         /// This test validates the processing of the Commit and Cancel buttons for an inline editing table.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -289,16 +289,28 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
 
+        private IEnumerable<T> _preEditSort { get; set; } = null;
+        private bool _hasPreEditSort => _preEditSort != null;
+
         public IEnumerable<T> FilteredItems
         {
             get
             {
+                if (_isEditing && _hasPreEditSort)
+                    return _preEditSort;
                 if (ServerData != null)
-                    return _server_data.Items;
+                {
+                    _preEditSort = _server_data.Items.ToList();
+                    return _preEditSort;
+                }
 
                 if (Filter == null)
-                    return Context.Sort(Items);
-                return Context.Sort(Items.Where(Filter));
+                {
+                    _preEditSort = Context.Sort(Items).ToList();
+                    return _preEditSort;
+                }
+                _preEditSort = Context.Sort(Items.Where(Filter)).ToList();
+                return _preEditSort;
             }
         }
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -12,6 +12,7 @@ namespace MudBlazor
     public abstract class MudTableBase : MudComponentBase
     {
         internal object _editingItem = null;
+        internal bool _isEditing => _editingItem != null;
 
         private int _currentPage = 0;
         private int? _rowsPerPage;


### PR DESCRIPTION
## Description
Makes a copy of the sorted table data for use when the table enters editing mode. To keep the sort action from occurring while editing with a `RowEditingTemplate`.
Resolves #1575

## Motivation and Context
Prior to this change, when using an edit row template and changing the column that is currently sorted, the row can move even as far as not being on this page.

## How Has This Been Tested?
### New UnitTest
TableInlineEditSortTest - TDD unit test fails on DEV but successful on this branch

### Manual testing
1. Navigate to /components/table#inline-edit-mode
2. Click on a row (such as the third row which contains Argon)
3. Edit the Name field which is sorted by default (such as changing it to "bbbArgon" which currently moves it down below Barium)
4. Notice that the position is maintained until the row is committed

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in library)
https://www.loom.com/share/187d46194efb4e318016f175bfb32202