### PR TITLE
CheckBox: Default Cursor when readonly

### DIFF
--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -10,6 +10,7 @@ namespace MudBlazor
         protected string Classname =>
         new CssBuilder("mud-checkbox")
             .AddClass($"mud-disabled", Disabled)
+            .AddClass($"mud-readonly", ReadOnly)
           .AddClass(Class)
         .Build();
 
@@ -19,6 +20,7 @@ namespace MudBlazor
             .AddClass($"mud-checkbox-dense", Dense)
             .AddClass($"mud-ripple mud-ripple-checkbox", !DisableRipple)
             .AddClass($"mud-disabled", Disabled)
+            .AddClass($"mud-readonly", ReadOnly)
         .Build();
 
         /// <summary>

--- a/src/MudBlazor/Styles/components/_checkbox.scss
+++ b/src/MudBlazor/Styles/components/_checkbox.scss
@@ -17,6 +17,10 @@
         }
     }
 
+    &.mud-readonly, .mud-readonly:hover {
+        cursor: default;
+    }
+
     & .mud-checkbox-dense {
         padding: 4px;
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
fix #2899.
We change the CheckBox cursor from pointer to default when it is readonly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
