### PR TITLE
Table: Fix for inner level grouping with paginated data

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingTest2.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 
-<MudTable Items="@Cars" Hover="true" @ref="tableInstance"
+<MudTable Items="@Cars" Hover="true" @ref="tableInstance" GroupBy="@groups"
           GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
           GroupFooterStyle="background-color:var(--mud-palette-background-grey)"
           MultiSelection="true">
@@ -17,15 +17,18 @@
     <GroupFooterTemplate>
         <MudTh Style="font-weight: 500;text-align: right;">Count: @context.Items.Count()</MudTh>
     </GroupFooterTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
 </MudTable>
 
 @code {
-    public MudTable<RacingCar> tableInstance;
-    private IEnumerable<RacingCar> Cars;
+    public MudTable<TableGroupingTest.RacingCar> tableInstance;
+    private IEnumerable<TableGroupingTest.RacingCar> Cars;
 
     protected override Task OnInitializedAsync()
     {
-        Cars = new List<RacingCar>()
+        Cars = new List<TableGroupingTest.RacingCar>()
     {
             new("919 Hybrid", "Porsche", "LMP1"),
             new("911 RSR", "Porsche", "GTE"),
@@ -34,28 +37,22 @@
             new("R8 LMS", "Audi", "GT3"),
             new ("F488", "Ferrari", "GTE"),
             new ("SF-1000", "Ferrari", "Formula 1"),
+            new ("MCL35M", "McLaren", "Formula 1"),
+            new ("720s", "McLaren", "GT3"),
             new ("Vantage", "Aston Martin", "GTE"),
             new ("AMR21", "Aston Martin", "Formula 1"),
         };
         return base.OnInitializedAsync();
     }
 
-    public class RacingCar
+    TableGroupDefinition<TableGroupingTest.RacingCar> groups = new()
     {
-        public RacingCar(string name, string brand, string category)
+        GroupName = "Category",
+        Selector = rc => rc.Category,
+        InnerGroup = new TableGroupDefinition<TableGroupingTest.RacingCar>()
         {
-            Name = name;
-            Brand = brand;
-            Category = category;
+            GroupName = "Brand",
+            Selector = rc => rc.Brand
         }
-
-        public string Name { get; set; }
-        public string Brand { get; set; }
-        public string Category { get; set; }
-
-        public override string ToString()
-        {
-            return $"({Category}) {Brand} {Name}";
-        }
-    }
+    };
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1148,6 +1148,52 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Tests the grouping behavior and ensure that it won't break anything else.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TableGroupingAndPaginationTest()
+        {
+            // without grouping, to ensure that anything was broken:
+            var comp = Context.RenderComponent<TableGroupingTest2>();
+            var table = comp.Instance.tableInstance;
+            table.Context.HeaderRows.Count.Should().Be(1);
+
+            // Page 01:
+            // [00] Porsche
+            //      [01] LMP1
+            //      [02] GTE
+            //      [03] GT3
+            // [04] Audi
+            //      [05] LMP1
+            //      [06] GT3
+            // [07] Ferrari
+            //      [08] Formula 1
+            // [09] McLaren
+            //      [10] Formula 1
+            //      [11] GT3
+            // [12] Aston Martin
+            //      [13] GTE
+            table.Context.GroupRows.Count.Should().Be(14);
+            table.Context.Rows.Count.Should().Be(10);
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(39); // 01 Table header + 14 Group Headers + 14 Group Footers + 10 Entries
+
+            // Navigating to page 2
+            table.NavigateTo(1);
+
+            // Page 02:
+            // [00] Aston Martin
+            //      [01] GTE
+            table.Context.GroupRows.Count.Should().Be(2);
+            table.Context.Rows.Count.Should().Be(1);
+            tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(6); // 01 Table header + 02 Group Headers + 02 Group Footers + 01 Entries
+
+        }
+
+
+        /// <summary>
         /// Tests the IsInitiallyExpanded grouping behavior.
         /// </summary>
         /// <returns></returns>

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31605.320
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor", "MudBlazor\MudBlazor.csproj", "{FE5531F3-55F6-403D-BF48-3C904089B91D}"
 EndProject

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -22,17 +22,26 @@ namespace MudBlazor
 
         [CascadingParameter] public TableContext Context { get; set; }
 
-        private IEnumerable<IGrouping<object, T>> _innerGroupItems;
+        private IEnumerable<IGrouping<object, T>> _innerGroupItems = null;
 
         /// <summary>
         /// The group definition for this grouping level. It's recursive.
         /// </summary>
         [Parameter] public TableGroupDefinition<T> GroupDefinition { get; set; }
 
+        IGrouping<object, T> _items = null;
         /// <summary>
         /// Inner Items List for the Group
         /// </summary>
-        [Parameter] public IGrouping<object, T> Items { get; set; }
+        [Parameter] public IGrouping<object, T> Items 
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                SyncInnerGroupItems();
+            }
+        }
 
         /// <summary>
         /// Defines Group Header Data Template
@@ -93,12 +102,17 @@ namespace MudBlazor
             {
                 IsExpanded = GroupDefinition.IsInitiallyExpanded;
                 ((TableContext<T>)Context)?.GroupRows.Add(this);
-                if (GroupDefinition.InnerGroup != null)
-                {
-                    _innerGroupItems = Table.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
-                }
+                SyncInnerGroupItems();
             }
             return base.OnInitializedAsync();
+        }
+
+        private void SyncInnerGroupItems()
+        {
+            if (GroupDefinition.InnerGroup != null)
+            {
+                _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
This is a fix for #2809 , when the inner level groups was statically displaying entries of the first page only, instead using the new ones from the current page.

This behavior can be observed here: https://try.mudblazor.com/snippet/GawPOXcwxFDtWOgi

## How Has This Been Tested?
Created a new test, counting the number of Group Rows and Data Rows, then, simulated navigation to the next page, and counting the rows again.

Visual tests were evaluated also.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
