### PR TITLE
Docs: Fix missing API section on chips page

### DIFF
--- a/src/MudBlazor.Docs/Models/ApiLink.cs
+++ b/src/MudBlazor.Docs/Models/ApiLink.cs
@@ -9,20 +9,12 @@ namespace MudBlazor.Docs.Models
     {
         public static string GetApiLinkFor(Type type)
         {
-            if (!s_specialCaseComponents.TryGetValue(type, out var component))
-                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray()).ToLowerInvariant();
-            var href = $"api/{component}";
-            return href;
+            return $"api/{GetComponentName(type)}";
         }
 
         public static string GetComponentLinkFor(Type type)
         {
-            if (!s_specialCaseComponents.TryGetValue(type, out var component))
-                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray()).ToLowerInvariant();
-            if (s_componentLinkTranslation.ContainsKey(component))
-                component = s_componentLinkTranslation[component];
-            var href = $"components/{component}";
-            return href;
+            return $"components/{GetComponentName(type)}";
         }
 
         /// <summary>
@@ -63,6 +55,17 @@ namespace MudBlazor.Docs.Models
             return null;
         }
 
+        private static string GetComponentName(Type type)
+        {
+            if (!s_specialCaseComponents.TryGetValue(type, out var component))
+            {
+                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray())
+                    .ToLowerInvariant();
+            }
+
+            return component;
+        }
+
         private static Dictionary<Type, string> s_specialCaseComponents =
             new()
             {
@@ -75,18 +78,11 @@ namespace MudBlazor.Docs.Models
                 [typeof(Donut)] = "donutchart",
                 [typeof(Line)] = "linechart",
                 [typeof(Pie)] = "piechart",
+                [typeof(MudChip)] = "chips"
             };
 
         // this is the inversion of above lookup
         private static Dictionary<string, Type> s_inverseSpecialCase =
             s_specialCaseComponents.ToDictionary(pair => pair.Value, pair => pair.Key);
-
-        private static Dictionary<string, string> s_componentLinkTranslation =
-            new()
-            {
-                ["icon"] = "icons",
-                ["chip"] = "chips",
-            };
-
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
This is a fix for the API section of the chip documentation page. Each component documentation page has a section that displays the API links of the component and its related components. However, this is missing from the chip documentation page because of the way the links are generated.

Before:


![withoutApi](https://user-images.githubusercontent.com/69375025/135646991-7f66bbc9-42ac-4ba2-abe7-f9796360a71b.png)
After:
![withApi](https://user-images.githubusercontent.com/69375025/135647042-b5dcfdc7-342e-466a-801f-e0048c32e9bb.png)


<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
