### PR TITLE
ExpansionPanels: Resolves infinite loop created by cascading StateHasChanged calls

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpandedMultipleWithoutMultipleExpansionSetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpandedMultipleWithoutMultipleExpansionSetTest.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudExpansionPanels>
+    <MudExpansionPanel Class="panel-one" Text="Panel One" IsExpanded>
+        Panel One Content
+    </MudExpansionPanel>
+    <MudExpansionPanel Class="panel-two" Text="Panel Two" IsExpanded>
+        Panel Two Content
+    </MudExpansionPanel>
+</MudExpansionPanels>
+

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -39,6 +39,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Multiple expanded expansion panels should not enter an infinite loop 
+        /// when MultiExpansionPanel is false
+        /// </summary>
+        [Test]
+        public void MudExpansionPanel_Without_MultiExpansion_Doesnt_Crash_With_Multiple_Expanded_Tabs()
+        {
+            var comp = Context.RenderComponent<ExpansionPanelExpandedMultipleWithoutMultipleExpansionSetTest>();
+
+            //click in the three headers
+            //foreach (var header in comp.FindAll(".mud-expand-panel-header"))
+            //{
+            //    header.Click();
+            //}
+
+            //Only one panel should be expanded
+            var allPanels = comp.FindAll(".mud-expand-panel").ToList();
+
+            var expandedPanels = comp.FindAll(".mud-panel-expanded").ToList();
+            expandedPanels.Count.Should().Be(1);
+            expandedPanels.First().Should().Be(allPanels.First());
+        }
+
+        /// <summary>
         /// MultiExpansion panel should not collapse other panels
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -66,6 +66,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<bool> IsExpandedChanged { get; set; }
 
+        internal event Action<MudExpansionPanel> NotifyIsExpandedChanged;
         /// <summary>
         /// Expansion state of the panel (two-way bindable)
         /// </summary>
@@ -78,11 +79,8 @@ namespace MudBlazor
                 if (_isExpanded == value)
                     return;
                 _isExpanded = value;
-                if (Parent?.MultiExpansion == true)
-                    Parent?.UpdateAll();
-                else
-                    Parent?.CloseAllExcept(this);
-                //InvokeAsync(StateHasChanged);
+
+                NotifyIsExpandedChanged?.Invoke(this);
                 IsExpandedChanged.InvokeAsync(_isExpanded);
             }
         }
@@ -111,7 +109,7 @@ namespace MudBlazor
                 if (_nextPanelExpanded == value)
                     return;
                 _nextPanelExpanded = value;
-                InvokeAsync(StateHasChanged);
+                //InvokeAsync(StateHasChanged);
             }
         }
 
@@ -119,14 +117,8 @@ namespace MudBlazor
         {
             if (Disabled)
                 return;
-            if (Parent?.MultiExpansion == true)
-            {
-                IsExpanded = !IsExpanded;
-            }
-            else
-            {
-                IsExpanded = !IsExpanded;
-            }
+
+            IsExpanded = !IsExpanded;
         }
 
         public void Expand(bool update_parent = true)
@@ -157,7 +149,8 @@ namespace MudBlazor
             //if (Parent == null)
             //    throw new ArgumentNullException(nameof(Parent), "ExpansionPanel must exist within a ExpansionPanels component");
             base.OnInitialized();
-            IsExpanded = IsInitiallyExpanded;
+            if (!IsExpanded && IsInitiallyExpanded)
+                _isExpanded = IsInitiallyExpanded;
             Parent?.AddPanel(this);
         }
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
@@ -52,18 +53,35 @@ namespace MudBlazor
 
         internal void AddPanel(MudExpansionPanel panel)
         {
+            if (MultiExpansion == false && _panels.Any(p => p.IsExpanded))
+            {
+                panel.Collapse(update_parent: false);
+            }
+
+            panel.NotifyIsExpandedChanged += UpdatePanelsOnPanelsChanged;
             _panels.Add(panel);
-            StateHasChanged();
         }
 
         public void RemovePanel(MudExpansionPanel panel)
         {
+            panel.NotifyIsExpandedChanged -= UpdatePanelsOnPanelsChanged;
             _panels.Remove(panel);
             try
             {
                 StateHasChanged();
             }
             catch (InvalidOperationException) { /* this happens on page reload, probably a Blazor bug */ }
+        }
+
+        internal void UpdatePanelsOnPanelsChanged(MudExpansionPanel panel)
+        {
+            if(MultiExpansion == false && panel.IsExpanded)
+            {
+                CloseAllExcept(panel);
+                return;
+            }
+
+            UpdateAll();
         }
 
         public void UpdateAll()
@@ -88,7 +106,5 @@ namespace MudBlazor
             }
             UpdateAll();
         }
-
-
     }
 }


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Resolves infinite loop created by cascading StateHasChanged calls. Removes parent logic from child ExpansionPanels and relocates it to the parent ExpansionPanel and removes unneeded state change in addPanels. Indirectly adds support internally for multicasting IsExpanded change events.
resolves  #2763

## How Has This Been Tested?
Test added to existing component test file utilizing a view that would otherwise cause the testing framework to enter the originally detected infinite loop.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
