### PR TITLE
DateRangePicker: Added null safe access to value and _rangeText in the setter of RangeText

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
@@ -402,6 +403,30 @@ namespace MudBlazor.UnitTests.Components
             var comp = OpenPicker();
             comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == false);
+        }
+
+        [Test]
+        public void SetRangeTextFunc_NullInputNoError()
+        {
+            var comp = Context.RenderComponent<MudDateRangePicker>(parameters =>
+                parameters.Add(p => p.DateRange,
+                    new DateRange(new DateTime(2020, 12, 26),null))); 
+            comp.Find("input").Change("");
+            comp.Instance.DateRange.End.Should().BeNull();
+            comp.Instance.DateRange.Start.Should().BeNull();
+
+        }
+
+        [Test]
+        public void SetRangeTextFunc_NullRangeTextNoError()
+        {
+            var dateTime = new DateTime(2020, 12, 26);
+            var comp = Context.RenderComponent<MudDateRangePicker>(parameters =>
+                parameters.Add(p => p.DateRange, null)
+                    .Add(p=>p.Culture, CultureInfo.CurrentCulture));
+            comp.Find("input").Change(dateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern));
+            comp.Instance.DateRange.Start.Should().Be(dateTime);
+
         }
 
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -82,12 +82,12 @@ namespace MudBlazor
             get => _rangeText;
             set
             {
-                if (_rangeText.Equals(value))
+                if (_rangeText?.Equals(value) ?? value == null)
                     return;
 
                 Touched = true;
                 _rangeText = value;
-                SetDateRangeAsync(ParseDateRangeValue(value.Start, value.End), false).AndForget();
+                SetDateRangeAsync(ParseDateRangeValue(value?.Start, value?.End), false).AndForget();
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Using null-conditional access operator to access value and _rangeText in the setter of RangeText. This is necessary to not run into a Null Pointer Exception if Editable is set to true and the user manually deletes both dates or if the Clear() is called on the DateRangePicker and the user manually enters a new date.
Fixes #2915 

## How Has This Been Tested?
Manually checked that no Null Pointer Exception occurs anymore and added unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
