### PR TITLE
Thoughts on using snapshot testing to assert components?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,6 @@ src/MudBlazor/Styles/MudBlazor.css.map
 src/MudBlazor/Styles/.vscode/settings.json
 
 src/MudBlazor/wwwroot/MudBlazor.min.css.map
+
+
+*.received.*

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.00.verified.txt
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.00.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  Instance: {},
+  RenderCount: 1,
+  NodeCount: 40,
+  Bytes: 4,091
+}

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.01.verified.html
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.01.verified.html
@@ -1,0 +1,67 @@
+﻿
+<div class="mud-tabs mud-dynamic-tabs">
+  <div class="mud-tabs-toolbar">
+    <div class="mud-tabs-toolbar-inner" style="">
+      <div class="mud-tabs-toolbar-content" blazor:elementreference="">
+        <div class="mud-tabs-toolbar-wrapper" style="transform:translateX(-0px);">
+          <div class="mud-tooltip-root mud-tooltip-inline" blazor:onmouseenter="2" blazor:onmouseleave="3" blazor:onfocusout="4">
+            <div class="mud-tab mud-tab-active mud-ripple" style="" blazor:onclick="17" blazor:elementreference="">Tab A<div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                <button blazor:onclick="14" type="button" class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon my-close-icon-class" style="propertyA: 4px" blazor:onclick:stoppropagation="" blazor:elementreference="">
+                  <span class="mud-icon-button-label">
+                    <svg class="mud-icon-root mud-svg-icon mud-inherit-text mud-icon-size-medium" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path d="M19 4h-3.5l-1-1h-5l-1 1H5v2h14zM6 7v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zm8 7v4h-4v-4H8l4-4 4 4h-2z"></path>
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div id="popover-6b7e5a5f-6b2b-49a6-8cfc-e60a46f7d4f1" class="mud-popover-cascading-value"></div>
+          </div>
+          <div class="mud-tooltip-root mud-tooltip-inline" blazor:onmouseenter="6" blazor:onmouseleave="7" blazor:onfocusout="8">
+            <div class="mud-tab mud-ripple" style="" blazor:onclick="18" blazor:elementreference="">Tab B<div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                <button blazor:onclick="15" type="button" class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon my-close-icon-class" style="propertyA: 4px" blazor:onclick:stoppropagation="" blazor:elementreference="">
+                  <span class="mud-icon-button-label">
+                    <svg class="mud-icon-root mud-svg-icon mud-inherit-text mud-icon-size-medium" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path d="M19 4h-3.5l-1-1h-5l-1 1H5v2h14zM6 7v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zm8 7v4h-4v-4H8l4-4 4 4h-2z"></path>
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div id="popover-483cb404-b231-4f76-bfe5-08b2462092d7" class="mud-popover-cascading-value"></div>
+          </div>
+          <div class="mud-tooltip-root mud-tooltip-inline" blazor:onmouseenter="10" blazor:onmouseleave="11" blazor:onfocusout="12">
+            <div class="mud-tab mud-ripple" style="" blazor:onclick="19" blazor:elementreference="">Tab C<div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                <button blazor:onclick="16" type="button" class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon my-close-icon-class" style="propertyA: 4px" blazor:onclick:stoppropagation="" blazor:elementreference="">
+                  <span class="mud-icon-button-label">
+                    <svg class="mud-icon-root mud-svg-icon mud-inherit-text mud-icon-size-medium" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path d="M19 4h-3.5l-1-1h-5l-1 1H5v2h14zM6 7v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zm8 7v4h-4v-4H8l4-4 4 4h-2z"></path>
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div id="popover-71e38bbc-db8f-4be7-bfff-23890cff500e" class="mud-popover-cascading-value"></div>
+          </div>
+          <div class="mud-tab-slider mud-tab-slider-horizontal" style="width:250px;left:0px;transition:left .3s cubic-bezier(.64,.09,.08,1);;"></div>
+        </div>
+      </div>
+      <div class="mud-tabs-header mud-tabs-header-after">
+        <button blazor:onclick="1" type="button" class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon my-add-icon-class" style="propertyB: 6px" blazor:onclick:stoppropagation="" blazor:elementreference="">
+          <span class="mud-icon-button-label">
+            <svg class="mud-icon-root mud-svg-icon mud-inherit-text mud-icon-size-medium" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7zm1-11h-2v3H8v2h3v3h2v-3h3v-2h-3V9z"></path>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div class="mud-tabs-panels">
+    Content A
+  </div>
+</div>

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.01.verified.html
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.BasicParameters.01.verified.html
@@ -16,7 +16,7 @@
                 </button>
               </div>
             </div>
-            <div id="popover-6b7e5a5f-6b2b-49a6-8cfc-e60a46f7d4f1" class="mud-popover-cascading-value"></div>
+            <div id="popover-Guid_1" class="mud-popover-cascading-value"></div>
           </div>
           <div class="mud-tooltip-root mud-tooltip-inline" blazor:onmouseenter="6" blazor:onmouseleave="7" blazor:onfocusout="8">
             <div class="mud-tab mud-ripple" style="" blazor:onclick="18" blazor:elementreference="">Tab B<div class="mud-tabs-panel-header mud-tabs-panel-header-after">
@@ -30,7 +30,7 @@
                 </button>
               </div>
             </div>
-            <div id="popover-483cb404-b231-4f76-bfe5-08b2462092d7" class="mud-popover-cascading-value"></div>
+            <div id="popover-Guid_2" class="mud-popover-cascading-value"></div>
           </div>
           <div class="mud-tooltip-root mud-tooltip-inline" blazor:onmouseenter="10" blazor:onmouseleave="11" blazor:onfocusout="12">
             <div class="mud-tab mud-ripple" style="" blazor:onclick="19" blazor:elementreference="">Tab C<div class="mud-tabs-panel-header mud-tabs-panel-header-after">
@@ -44,7 +44,7 @@
                 </button>
               </div>
             </div>
-            <div id="popover-71e38bbc-db8f-4be7-bfff-23890cff500e" class="mud-popover-cascading-value"></div>
+            <div id="popover-Guid_3" class="mud-popover-cascading-value"></div>
           </div>
           <div class="mud-tab-slider mud-tab-slider-horizontal" style="width:250px;left:0px;transition:left .3s cubic-bezier(.64,.09,.08,1);;"></div>
         </div>

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.DefaultValues.00.verified.txt
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.DefaultValues.00.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  Instance: {
+    AddTabIcon: <g><rect fill="none" height="24" width="24"/></g><g><g><path d="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6V13z"/></g></g>,
+    CloseTabIcon: <path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>,
+    AddIconClass: ,
+    AddIconStyle: ,
+    CloseIconClass: ,
+    CloseIconStyle: ,
+    AddIconToolTip: ,
+    CloseIconToolTip: ,
+    PrevIcon: <path d="M0 0h24v24H0z" fill="none"/><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>,
+    NextIcon: <path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>,
+    Position: Top,
+    SliderColor: Inherit,
+    IconColor: Inherit,
+    ScrollIconColor: Inherit,
+    Header: {
+      Type: RenderFragment<MudTabs>,
+      Target: MudDynamicTabs,
+      Method: Microsoft.AspNetCore.Components.RenderFragment OnInitialized(MudBlazor.MudTabs)
+    },
+    TabPanelHeader: {
+      Type: RenderFragment<MudTabPanel>,
+      Target: MudDynamicTabs,
+      Method: Microsoft.AspNetCore.Components.RenderFragment OnInitialized(MudBlazor.MudTabPanel)
+    }
+  },
+  RenderCount: 1,
+  NodeCount: 16,
+  Bytes: 1,000
+}

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.DefaultValues.01.verified.html
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.DefaultValues.01.verified.html
@@ -1,0 +1,29 @@
+﻿
+<div class="mud-tabs mud-dynamic-tabs">
+  <div class="mud-tabs-toolbar">
+    <div class="mud-tabs-toolbar-inner" style="">
+      <div class="mud-tabs-toolbar-content" blazor:elementreference="">
+        <div class="mud-tabs-toolbar-wrapper" style="transform:translateX(-0px);">
+          <div class="mud-tab-slider mud-tab-slider-horizontal" style="width:0px;left:0px;transition:left .3s cubic-bezier(.64,.09,.08,1);;"></div>
+        </div>
+      </div>
+      <div class="mud-tabs-header mud-tabs-header-after">
+        <button blazor:onclick="1" type="button" class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon" style="" blazor:onclick:stoppropagation="" blazor:elementreference="">
+          <span class="mud-icon-button-label">
+            <svg class="mud-icon-root mud-svg-icon mud-inherit-text mud-icon-size-medium" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+              <g>
+                <rect fill="none" height="24" width="24"></rect>
+              </g>
+              <g>
+                <g>
+                  <path d="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6V13z"></path>
+                </g>
+              </g>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div class="mud-tabs-panels"></div>
+</div>

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -35,7 +35,8 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
-            await Verifier.Verify(comp);
+            await Verifier.Verify(comp)
+                .ScrubInlineGuids();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -13,6 +13,7 @@ using MudBlazor.Services;
 using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
+using VerifyNUnit;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -25,29 +26,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = Context.RenderComponent<MudDynamicTabs>();
-            var tabs = comp.Instance;
-
-            tabs.Header.Should().NotBeNull();
-            tabs.TabPanelHeader.Should().NotBeNull();
-
-            tabs.HeaderPosition.Should().Be(TabHeaderPosition.After);
-            tabs.TabPanelHeaderPosition.Should().Be(TabHeaderPosition.After);
-
-            tabs.AddTabIcon.Should().Be(Icons.Material.Filled.Add);
-            tabs.CloseTabIcon.Should().Be(Icons.Material.Filled.Close);
-
-            tabs.AddIconClass.Should().BeNullOrEmpty();
-            tabs.AddIconStyle.Should().BeNullOrEmpty();
-            tabs.AddIconToolTip.Should().BeNullOrEmpty();
-
-            tabs.CloseIconClass.Should().BeNullOrEmpty();
-            tabs.CloseIconStyle.Should().BeNullOrEmpty();
-            tabs.CloseIconToolTip.Should().BeNullOrEmpty();
-
-            comp.Nodes.Should().ContainSingle();
-            comp.Nodes[0].Should().BeAssignableTo<IHtmlDivElement>();
-
-            ((IHtmlDivElement)comp.Nodes[0]).ClassList.Should().BeEquivalentTo("mud-tabs", "mud-dynamic-tabs");
+            await Verifier.Verify(comp);
         }
 
         [Test]
@@ -56,37 +35,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
-            Console.WriteLine(comp.Markup);
-
-            // three panels three close icons;
-            var closeButtons = comp.FindAll(".my-close-icon-class");
-            closeButtons.Should().HaveCount(3);
-
-            foreach (var item in closeButtons)
-            {
-                item.GetAttribute("style").Should().Be("propertyA: 4px");
-                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
-
-                var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
-                var expected = XElement.Parse($"<test>{Icons.Material.Filled.RestoreFromTrash}</test>");
-
-                actual.Should().BeEquivalentTo(expected);
-            }
-
-            var addButtons = comp.FindAll(".my-add-icon-class");
-
-            addButtons.Should().HaveCount(1);
-            foreach (var item in addButtons)
-            {
-                item.GetAttribute("style").Should().Be("propertyB: 6px");
-                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
-
-                var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
-                var expected = XElement.Parse($"<test>{Icons.Material.Filled.AddAlarm}</test>");
-
-                actual.Should().BeEquivalentTo(expected);
-
-            }
+            await Verifier.Verify(comp);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -35,8 +35,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
-            await Verifier.Verify(comp)
-                .ScrubInlineGuids();
+            await Verifier.Verify(comp);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/ModuleInitializer.cs
+++ b/src/MudBlazor.UnitTests/ModuleInitializer.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+using Verify.AngleSharp;
+using VerifyTests;
+
+public static class ModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        // remove some noise from the html snapshot
+        
+        VerifyBunit.Initialize();
+        VerifierSettings.ScrubEmptyLines();
+        VerifierSettings.ScrubLinesWithReplace(s => s.Replace("<!--!-->", ""));
+        HtmlPrettyPrint.All();
+        VerifierSettings.ScrubLinesContaining("<script src=\"_framework/dotnet.");
+    }
+}

--- a/src/MudBlazor.UnitTests/ModuleInitializer.cs
+++ b/src/MudBlazor.UnitTests/ModuleInitializer.cs
@@ -11,6 +11,7 @@ public static class ModuleInitializer
         
         VerifyBunit.Initialize();
         VerifierSettings.ScrubEmptyLines();
+        VerifierSettings.ScrubInlineGuids();
         VerifierSettings.ScrubLinesWithReplace(s => s.Replace("<!--!-->", ""));
         HtmlPrettyPrint.All();
         VerifierSettings.ScrubLinesContaining("<script src=\"_framework/dotnet.");

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -42,6 +42,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="Verify.Bunit" Version="7.1.1" />
+    <PackageReference Include="Verify.NUnit" Version="13.1.0" />
+    <PackageReference Include="Verify.AngleSharp" Version="2.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -42,9 +42,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="Verify.Bunit" Version="7.1.1" />
+    <PackageReference Include="Verify.Bunit" Version="7.1.2" />
     <PackageReference Include="Verify.NUnit" Version="13.1.0" />
-    <PackageReference Include="Verify.AngleSharp" Version="2.7.2" />
+    <PackageReference Include="Verify.AngleSharp" Version="2.7.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I converted two tests over to using snapshot testing via [Verify](https://github.com/VerifyTests/Verify).

 * `DynamicTabsTests.BasicParameters`
 * `DynamicTabsTests.DefaultValues`

Since the majority of code in those tests is assertions, all thos cade get replaced with a single call to Verify. The result is two files for each test: a Json serialized representation of the component model, and the rendered html. This means changes can be visualized in the model/html. those snapshot file get checked in, and future changes are compared against those for correctness.

When change a change effect many snapshots, causing many tests to fail, Verify support bulk approval. See [Snapshot Management](https://github.com/VerifyTests/Verify#snapshot-management)

Thoughts? Is this something you would find useful?