### PR TITLE
Update to net6 rc.2

### DIFF
--- a/src/MudBlazor.Docs.Client/MudBlazor.Docs.Client.csproj
+++ b/src/MudBlazor.Docs.Client/MudBlazor.Docs.Client.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor-Analytics" Version="3.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0-rc.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0-rc.1.*" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0-rc.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0-rc.2.*" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0-rc.2.*" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
+++ b/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.12.0" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="6.0.0" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement.ServerPrerendering" Version="1.5.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.0-rc.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -89,8 +89,8 @@
   <!--Packages-->
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-rc.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-rc.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="6.0.0" />
   </ItemGroup>

--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0-rc.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0-rc.1.*" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0-rc.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0-rc.2.*" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0-rc.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -7,6 +7,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Services;
 using MudBlazor.UnitTests.TestComponents;
@@ -267,10 +268,10 @@ namespace MudBlazor.UnitTests.Components
 
             Mock<IJSRuntime> _jsruntimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()))
-                .ReturnsAsync(new object(), TimeSpan.FromMilliseconds(200)).Verifiable();
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListeners", It.IsAny<object[]>()))
-    .ReturnsAsync(new object());
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(200)).Verifiable();
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners", It.IsAny<object[]>()))
+    .ReturnsAsync(Mock.Of<IJSVoidResult>);
 
             BreakpointService service = new BreakpointService(_jsruntimeMock.Object, sizeMock.Object);
 

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.UnitTests.TestComponents.Popover;
 using NUnit.Framework;
@@ -191,14 +192,14 @@ namespace MudBlazor.UnitTests.Components
             RenderFragment renderFragement = (tree) => { };
             var mock = new Mock<IJSRuntime>();
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.connect",
-                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.disconnect",
-                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             var updateCounter = 0;
             Action updater = () => { updateCounter++; };
@@ -223,12 +224,12 @@ namespace MudBlazor.UnitTests.Components
             RenderFragment renderFragement = (tree) => { };
             var mock = new Mock<IJSRuntime>();
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.connect",
-                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.disconnect",
                 It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ThrowsAsync(new TaskCanceledException()).Verifiable();
 
@@ -252,12 +253,12 @@ namespace MudBlazor.UnitTests.Components
             RenderFragment renderFragement = (tree) => { };
             var mock = new Mock<IJSRuntime>();
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.connect",
-                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+                It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.disconnect",
                 It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ThrowsAsync(new InvalidOperationException()).Verifiable();
 
@@ -287,9 +288,9 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             {
                 var service = new MudPopoverService(mock.Object, null);
@@ -317,9 +318,9 @@ namespace MudBlazor.UnitTests.Components
             optionMock.SetupGet(x => x.Value).Returns(option);
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "my-custom-class" && (int)x[1] == 12))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "my-custom-class" && (int)x[1] == 12))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             var service = new MudPopoverService(mock.Object, optionMock.Object);
 
@@ -334,9 +335,9 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(new object(), TimeSpan.FromMilliseconds(300)).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(300)).Verifiable();
 
             Task[] tasks = new Task[5];
             var service = new MudPopoverService(mock.Object);
@@ -349,7 +350,7 @@ namespace MudBlazor.UnitTests.Components
             Task.WaitAll(tasks);
 
             mock.Verify(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0)), Times.Once());
         }
@@ -367,14 +368,14 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
             "mudPopover.dispose",
-            It.Is<object[]>(x => x.Length == 0))).ReturnsAsync(new object()).Verifiable();
+            It.Is<object[]>(x => x.Length == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             var service = new MudPopoverService(mock.Object);
             await service.InitializeIfNeeded();
@@ -390,12 +391,12 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
             "mudPopover.dispose",
             It.Is<object[]>(x => x.Length == 0))).ThrowsAsync(new TaskCanceledException()).Verifiable();
 
@@ -414,12 +415,12 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initilize",
-               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
             "mudPopover.dispose",
             It.Is<object[]>(x => x.Length == 0))).ThrowsAsync(new InvalidOperationException()).Verifiable();
 
@@ -504,14 +505,14 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
 
             mock.Setup(x =>
-           x.InvokeAsync<object>(
+           x.InvokeAsync<IJSVoidResult>(
                "mudPopover.connect",
-               It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+               It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
-            x.InvokeAsync<object>(
+            x.InvokeAsync<IJSVoidResult>(
            "mudPopover.disconnect",
-           It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(new object()).Verifiable();
+           It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
 
             var service = new MudPopoverService(mock.Object);

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -29,13 +29,13 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.2.49" />
+    <PackageReference Include="bunit" Version="1.3.30-preview" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="FluentValidation" Version="10.3.3" />
+    <PackageReference Include="FluentValidation" Version="10.3.3" /> 
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Services;
 using NUnit.Framework;
@@ -44,12 +45,12 @@ namespace MudBlazor.UnitTests.Services
                 expectedOptions.BreakpointDefinitions = BreakpointService.DefaultBreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
             }
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.listenForResize",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize",
                It.Is<object[]>(z =>
                    z[0] is DotNetObjectReference<BreakpointService> == true &&
                    (ResizeOptions)z[1] == expectedOptions &&
                    (Guid)z[2] != default
-               ))).ReturnsAsync(new object()).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
+               ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
                     (DotNetObjectReference<BreakpointService>)z[0],
                     (ResizeOptions)z[1], (Guid)z[2]
                    ))).Verifiable();
@@ -58,10 +59,10 @@ namespace MudBlazor.UnitTests.Services
 
         private void SetupJsMockForUnsubscription(Guid listenerId)
         {
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener",
                It.Is<object[]>(z =>
                    (Guid)z[0] == listenerId
-               ))).ReturnsAsync(new object()).Verifiable();
+               ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
         }
 
         private async Task CheckSubscriptionOptions(ResizeOptions expectedOptions, bool setBreakpoint)
@@ -404,11 +405,11 @@ namespace MudBlazor.UnitTests.Services
                  }
              };
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListeners",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners",
              It.Is<object[]>(z =>
                  z[0] is IEnumerable<Guid> &&
                  idChecker((IEnumerable<Guid>)z[0]) == true
-             ))).ReturnsAsync(new object()).Verifiable();
+             ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             await _service.DisposeAsync();
 

--- a/src/MudBlazor.UnitTests/Services/EventListenerTests.cs
+++ b/src/MudBlazor.UnitTests/Services/EventListenerTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using NUnit.Framework;
 
@@ -54,7 +55,7 @@ namespace MudBlazor.UnitTests.Services
              "button", "buttons", "ctrlKey", "shiftKey", "altKey", "metaKey", "type"
             };
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                     (string)z[0] == eventName &&
                     (string)z[1] == elementId &&
                     (string)z[2] == projectionName &&
@@ -62,13 +63,13 @@ namespace MudBlazor.UnitTests.Services
                     (Guid)z[4] != Guid.Empty &&
                     ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                     z[6] is DotNetObjectReference<EventListener>
-                ))).ReturnsAsync(true);
+                ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
             var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
             result.Should().NotBe(Guid.Empty);
 
-            _runtimeMock.Verify(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                 (Guid)z[4] == result
             )));
         }
@@ -111,7 +112,7 @@ namespace MudBlazor.UnitTests.Services
              "button", "buttons", "ctrlKey", "shiftKey", "altKey", "metaKey", "type"
             };
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                     (string)z[0] == eventName &&
                     (string)z[1] == elementId &&
                     (string)z[2] == projectionName &&
@@ -119,7 +120,7 @@ namespace MudBlazor.UnitTests.Services
                     (Guid)z[4] != Guid.Empty &&
                     ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                     z[6] is DotNetObjectReference<EventListener>
-                ))).ReturnsAsync(true);
+                ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
             var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
@@ -156,7 +157,7 @@ namespace MudBlazor.UnitTests.Services
              "button", "buttons", "ctrlKey", "shiftKey", "altKey", "metaKey", "type"
             };
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                     z.Length == 7 &&
                     (string)z[0] == eventName &&
                     (string)z[1] == elementId &&
@@ -165,15 +166,15 @@ namespace MudBlazor.UnitTests.Services
                     (Guid)z[4] != Guid.Empty &&
                     ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                     z[6] is DotNetObjectReference<EventListener>
-                ))).ReturnsAsync(true);
+                ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
 
             var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
                 z.Length == 1 &&
                 (Guid)z[0] == result
-            ))).ReturnsAsync(true);
+            ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
             result.Should().NotBe(Guid.Empty);
 
@@ -196,7 +197,7 @@ namespace MudBlazor.UnitTests.Services
              "button", "buttons", "ctrlKey", "shiftKey", "altKey", "metaKey", "type"
             };
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                     z.Length == 7 &&
                     (string)z[0] == eventName &&
                     (string)z[1] == elementId &&
@@ -205,12 +206,12 @@ namespace MudBlazor.UnitTests.Services
                     (Guid)z[4] != Guid.Empty &&
                     ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                     z[6] is DotNetObjectReference<EventListener>
-                ))).ReturnsAsync(true);
+                ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
 
             var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
-            _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
+            _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
                 z.Length == 1 &&
                 (Guid)z[0] == result
             ))).Throws(new InvalidOperationException("something went wrong! :("));
@@ -240,7 +241,7 @@ namespace MudBlazor.UnitTests.Services
             {
                 var elementId = $"my-customer-dom-element-{i}";
 
-                _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+                _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                         z.Length == 7 &&
                         (string)z[0] == eventName &&
                         (string)z[1] == elementId &&
@@ -249,12 +250,12 @@ namespace MudBlazor.UnitTests.Services
                         (Guid)z[4] != Guid.Empty &&
                         ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                         z[6] is DotNetObjectReference<EventListener>
-                    ))).ReturnsAsync(true);
+                    ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
 
                 var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
-                var flow = _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
+                var flow = _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
                         z.Length == 1 &&
                         (Guid)z[0] == result
                     )));
@@ -265,7 +266,7 @@ namespace MudBlazor.UnitTests.Services
                 }
                 else
                 {
-                    flow.ReturnsAsync(true);
+                    flow.ReturnsAsync(Mock.Of<IJSVoidResult>);
                 }
             }
 
@@ -277,7 +278,7 @@ namespace MudBlazor.UnitTests.Services
             // a normal dispose shouldnt' change something
             _service.Dispose();
 
-            _runtimeMock.Verify(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                 true
             )), Times.Exactly(10));
         }
@@ -300,7 +301,7 @@ namespace MudBlazor.UnitTests.Services
             {
                 var elementId = $"my-customer-dom-element-{i}";
 
-                _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+                _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                         z.Length == 7 &&
                         (string)z[0] == eventName &&
                         (string)z[1] == elementId &&
@@ -309,12 +310,12 @@ namespace MudBlazor.UnitTests.Services
                         (Guid)z[4] != Guid.Empty &&
                         ContainsEqual((IEnumerable<string>)z[5], expectedProperties) == true &&
                         z[6] is DotNetObjectReference<EventListener>
-                    ))).ReturnsAsync(true);
+                    ))).ReturnsAsync(Mock.Of<IJSVoidResult>);
 
 
                 var result = await _service.Subscribe<MouseEventArgs>(eventName, elementId, projectionName, throttleInterval, callback);
 
-                var flow = _runtimeMock.Setup(x => x.InvokeAsync<Object>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
+                var flow = _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.unsubscribe", It.Is<object[]>(z =>
                         z.Length == 1 &&
                         (Guid)z[0] == result
                     )));
@@ -325,7 +326,7 @@ namespace MudBlazor.UnitTests.Services
                 }
                 else
                 {
-                    flow.ReturnsAsync(true);
+                    flow.ReturnsAsync(Mock.Of<IJSVoidResult>);
                 }
             }
 
@@ -334,7 +335,7 @@ namespace MudBlazor.UnitTests.Services
             // a second time shouldn't change something
             _service.Dispose();
 
-            _runtimeMock.Verify(x => x.InvokeAsync<Object>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
+            _runtimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudThrottledEventManager.subscribe", It.Is<object[]>(z =>
                 true
             )), Times.Exactly(10));
         }

--- a/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Services;
 using NUnit.Framework;
@@ -55,12 +56,12 @@ namespace MudBlazor.UnitTests.Services
         private void SetupJsMockForSubscription(ResizeOptions expectedOptions, Action<ListenForResizeCallbackInfo> callbackInfo = null)
         {
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.listenForResize",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize",
                It.Is<object[]>(z =>
                    z[0] is DotNetObjectReference<ResizeService> == true &&
                    (ResizeOptions)z[1] == expectedOptions &&
                    (Guid)z[2] != default
-               ))).ReturnsAsync(new object()).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
+               ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
                     (DotNetObjectReference<ResizeService>)z[0],
                     (ResizeOptions)z[1], (Guid)z[2]
                    ))).Verifiable();
@@ -69,10 +70,10 @@ namespace MudBlazor.UnitTests.Services
 
         private void SetupJsMockForUnsubscription(Guid listenerId)
         {
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener",
                It.Is<object[]>(z =>
                    (Guid)z[0] == listenerId
-               ))).ReturnsAsync(new object()).Verifiable();
+               ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
         }
 
         private async Task CheckSubscriptionOptions(ResizeOptions expectedOptions)
@@ -377,11 +378,11 @@ namespace MudBlazor.UnitTests.Services
                  }
              };
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListeners",
+            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners",
              It.Is<object[]>(z =>
                  z[0] is IEnumerable<Guid> &&
                  idChecker((IEnumerable<Guid>)z[0]) == true
-             ))).ReturnsAsync(new object()).Verifiable();
+             ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             await _service.DisposeAsync();
 
@@ -510,7 +511,7 @@ namespace MudBlazor.UnitTests.Services
 
             Task.WaitAll(tasksToExecute);
 
-            _jsruntimeMock.Verify((x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+            _jsruntimeMock.Verify((x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener",
                It.Is<object[]>(z =>
                    (Guid)z[0] == listenerId
                ))), Times.Once());

--- a/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Interop;
 using MudBlazor.Services;
@@ -171,13 +172,13 @@ namespace MudBlazor.UnitTests.Services
 
             foreach (var item in resolvedElements)
             {
-                _runtimeMock.Setup(x => x.InvokeAsync<Object>(
+                _runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>(
                 "mudResizeObserver.disconnect",
                 It.Is<object[]>(z =>
                     (Guid)z[0] == observerId &&
                     ids.Contains((Guid)z[1]) == true
                 )
-            )).ReturnsAsync(new Object()).Callback<String, Object[]>((x, y) => { ids.Remove((Guid)y[1]); }).Verifiable();
+            )).ReturnsAsync(Mock.Of<IJSVoidResult>).Callback<String, Object[]>((x, y) => { ids.Remove((Guid)y[1]); }).Verifiable();
             }
 
             await _service.Observe(resolvedElements.Keys);

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -53,8 +53,8 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-rc.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0-rc.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.2.*" />
   </ItemGroup>
 
   <Target Name="ToolRestore">


### PR DESCRIPTION
Seems updating to rc2 on the net6 branch causes MudPopover tests to fail. 
@just-the-benno @Garderoben 