### PR TITLE
DatePicker: Fix setting culture not leading to DateFormat change (#2962)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -101,6 +101,47 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DatePicker_Should_ApplyCultureDateFormat()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+            // select elements needed for the test
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+
+            var customCulture = new CultureInfo("en-US");
+            customCulture.DateTimeFormat.ShortDatePattern.Should().Be("M/d/yyyy");
+            customCulture.DateTimeFormat.ShortDatePattern = "dd MM yyyy";
+            comp.SetParam(p => p.Culture, customCulture);
+
+            comp.SetParam(p => p.Text, "23 10 2020");
+            picker.Date.Should().Be(new DateTime(2020, 10, 23));
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
+            picker.Text.Should().Be("26 10 2020");
+
+            customCulture.DateTimeFormat.ShortDatePattern = "yyyy-MM-dd";
+            comp.SetParam(p => p.Text, "13 10 2020");
+            picker.Date.Should().Be(new DateTime(2020, 10, 13));
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 16));
+            picker.Text.Should().Be("16 10 2020");
+        }
+
+        [Test]
+        public async Task DatePicker_Should_DateFormatTakesPrecedenceOverCulture()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+            // select elements needed for the test
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+            comp.SetParam(p => p.DateFormat, "dd MM yyyy");
+            comp.SetParam(p => p.Culture, CultureInfo.InvariantCulture); // <-- this makes a huge difference!
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
+            picker.Date.Should().Be(new DateTime(2020, 10, 26));
+            picker.Text.Should().Be("26 10 2020");
+        }
+
+        [Test]
         public void Check_Intial_Date_Format()
         {
             DateTime? date = new DateTime(2021, 1, 13);

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -10,6 +10,8 @@ namespace MudBlazor
 {
     public abstract partial class MudBaseDatePicker : MudPicker<DateTime?>
     {
+        private bool _dateFormatTouched;
+
         protected MudBaseDatePicker() : base(new DefaultConverter<DateTime?>
         {
             Format = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
@@ -47,7 +49,10 @@ namespace MudBlazor
             set
             {
                 if (Converter is DefaultConverter<DateTime?> defaultConverter)
+                {
                     defaultConverter.Format = value;
+                    _dateFormatTouched = true;
+                }
                 DateFormatChanged(value);
             }
         }
@@ -58,6 +63,17 @@ namespace MudBlazor
         protected virtual Task DateFormatChanged(string newFormat)
         {
             return Task.CompletedTask;
+        }
+
+        protected override bool SetCulture(CultureInfo value)
+        {
+            if (!base.SetCulture(value))
+                return false;
+
+            if (!_dateFormatTouched && Converter is DefaultConverter<DateTime?> defaultConverter)
+                defaultConverter.Format = value.DateTimeFormat.ShortDatePattern;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
MudBaseDatePicker sets the Culture and Format on the default converter.
The CurrentCulture is used, and the CurrentCulture ShortDateFormat is used for the Format.

When DateFormat is set the converters Format is replaced.

When DateForamt is not set but Culture is set on the component this led to the unexpected behavior
of the CurrentCulture date format being used instead of the culture that was set (as reported in #2962).

With this change, setting the culture also leads to a Format change unless the DateFormat property has been set.

The Terminology “touched” is used for the private field to match the Touched property terminology.

Fixes #2962

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
