### PR TITLE
AutoComplete: New Feature - Loading Indicator & CancellationToken

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCancellation.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCancellation.razor
@@ -1,0 +1,53 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+<MudAutocomplete T="string" Label="US States" 
+                 @bind-Value="value1"
+                 SearchFuncWithCancel="@Search1"
+                 ShowLoading="true"
+                 DebounceInterval="400"
+                 MinHeight="100"
+                 PopoverClass="autocomplete-popover-class"
+                 LoadingSize="Size.Small"
+                 LoadingColor="Color.Success"/>
+
+@code { public static string __description__ = "Initial value should be shown and popup should not open.";
+
+    private string value1 = "Alabama";
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken cancellationToken)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(1500);
+
+
+        if (!cancellationToken.IsCancellationRequested)
+        {
+            // if text is null or empty, show complete list
+            if (string.IsNullOrEmpty(value))
+                return states;
+            return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+        }
+        else
+        {
+            throw new TaskCanceledException();
+        }
+
+    } }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -23,38 +23,43 @@
                           InputMode="@InputMode" Pattern="@Pattern"
                           T="string" />
                 <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@_anchorOrigin" TransformOrigin="@_transformOrigin" Class="@PopoverClass" RelativeWidth="true">
-                    @if (_items != null && _items.Length != 0)
-                    {
-                        <MudList Clickable="true" Dense="@Dense">
-                            @for (var index = 0; index < _items.Length; index++)
+                    
+                   
+                    <div style="@($"min-height: {MinHeight}px;")">
+                        @if (ShowLoading && IsLoading)
                             {
-                                var item = _items[index];
-                                bool is_selected = index == _selectedListItemIndex;
-                                bool is_disabled = !_enabledItemIndices.Contains(index);
-                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
-                                    @if (ItemTemplate == null)
-                                    {
-                                        @GetItemString(item)
-                                    }
-                                    else if (is_disabled && ItemDisabledTemplate != null)
-                                    {
-                                        @ItemDisabledTemplate(item)
-                                    }
-                                    else if (is_selected)
-                                    {
-                                        @if (ItemSelectedTemplate == null)
-                                            @ItemTemplate(item)
-                                        else
-                                            @ItemSelectedTemplate(item)
-                                    }
-                                    else
-                                    {
-                                        @ItemTemplate(item)
-                                    }
-                                </MudListItem>
-                            }
-                        </MudList>
-                    }
+                        <div style="height: 100%; position: absolute; background-color: transparent;  width: 100%;">
+                            <div style="position: absolute; top: 45%; left:50%; height: 50px; width: 50px; -ms-transform: translateY(-50%); transform: translateY(-50%); -ms-transform: translateX(-50%); transform: translateX(-50%);">
+                                <MudProgressCircular Color="@LoadingColor" Indeterminate="true" Size="@LoadingSize" />
+                            </div>
+                        </div>}
+                        @if (_items != null && _items.Length != 0)
+                        {
+                    <MudList Clickable="true" Dense="@Dense">
+                        @for (var index = 0; index < _items.Length; index++)
+                        {
+                            var item = _items[index];
+                            bool is_selected = index == _selectedListItemIndex;
+                            bool is_disabled = !_enabledItemIndices.Contains(index);
+                    <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                        @if (ItemTemplate == null)
+                        {
+                    @GetItemString(item) }
+                else if (is_disabled && ItemDisabledTemplate != null)
+                {
+                    @ItemDisabledTemplate(item) }
+                else if (is_selected)
+                {
+                    @if (ItemSelectedTemplate == null)
+                    @ItemTemplate(item) else
+                    @ItemSelectedTemplate(item) }
+                else
+                {
+                    @ItemTemplate(item)}
+                    </MudListItem>}
+                    </MudList>}
+                    </div>
+                  
                 </MudPopover>
             </InputContent>
         </MudInputControl>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -87,7 +87,7 @@ namespace MudBlazor
         /// <summary>
         /// The minimum height of the Autocomplete when it is open. 
         /// </summary>
-        [Parameter] public int MinHeight { get; set; } = 0;
+        [Parameter] public int MinHeight { get; set; }
 
 
         private Func<T, string> _toStringFunc;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description

Adds the following parameters to support  a visual indicator for loading/progress while the MudAutoComplete component is awaiting the results of the SearchFunc Task.

- `[Parameter] public bool ShowLoading { get; set; }`
- `[Parameter] public Size LoadingSize { get; set; } = Size.Medium;`
- `[Parameter] public Color LoadingColor { get; set; } = Color.Default;`
- `[Parameter] public int MinHeight {get; set;}`

Adds a `[Parameter] public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFuncWithCancel { get; set; }` parameter which can be used instead of ` [Parameter] public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; }`.
This allows a `CancellationToken` to be be passed into the SearchFunc by the MudAutoComplete component.  The token is cancelled when the following methods are called:

- `Task OnSearchAsync()`
- `Task SelectOption(T value)`

This allows for expensive asynchronous work to be cancelled before the result is returned, and can then more quickly process the next search (if the user changed the search value).

## How Has This Been Tested?

- All existing Unit Tests for AutoComplete ran successfully.  
- Created AutocompleteTestCancellation.razor in MudBlazor.UnitTests.Viewer->TestComponents->Autocomplete to test the Loading and Cancellation functionality.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


![autocomplete_cancellation](https://user-images.githubusercontent.com/15041155/137949335-384706ea-2c08-40bb-9cc7-18b1be520bfe.gif)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
