### PR TITLE
Tests: Fix user regional settings dependent unit tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MudThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MudThemeProviderTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("ar-ER")]
         public void DifferentCultures(string cultureString)
         {
-            var culture = new CultureInfo(cultureString);
+            var culture = new CultureInfo(cultureString, false);
 
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -181,13 +181,13 @@ namespace MudBlazor.UnitTests.Utilities
         public void DefaultConverterTestWithCustomFormat()
         {
             var float1 = new DefaultConverter<float>() { Format = "0.00" };
-            float1.Culture = new CultureInfo("en-US");
+            float1.Culture = new CultureInfo("en-US", false);
             float1.Set(1.7f).Should().Be("1.70");
             float1.Set(1.773f).Should().Be("1.77");
             float1.Get("1.773").Should().Be(1.773f);
             float1.Get("1.77").Should().Be(1.77f);
             float1.Get("1.7").Should().Be(1.7f);
-            float1.Culture = new CultureInfo("pt-BR");
+            float1.Culture = new CultureInfo("pt-BR", false);
             float1.Set(1.7f).Should().Be("1,70");
             float1.Set(1.773f).Should().Be("1,77");
             float1.Get("1,773").Should().Be(1.773f);
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Utilities
             float1.Get("1,7").Should().Be(1.7f);
 
             var float2 = new DefaultConverter<float?>() { Format = "0.00" };
-            float2.Culture = new CultureInfo("en-US");
+            float2.Culture = new CultureInfo("en-US", false);
             float2.Set(1.7f).Should().Be("1.70");
             float2.Set(1.773f).Should().Be("1.77");
             float2.Set(null).Should().Be(null);
@@ -203,7 +203,7 @@ namespace MudBlazor.UnitTests.Utilities
             float2.Get("1.77").Should().Be(1.77f);
             float2.Get("1.7").Should().Be(1.7f);
             float2.Get(null).Should().Be(null);
-            float2.Culture = new CultureInfo("pt-BR");
+            float2.Culture = new CultureInfo("pt-BR", false);
             float2.Set(1.7f).Should().Be("1,70");
             float2.Set(1.773f).Should().Be("1,77");
             float2.Get("1,773").Should().Be(1.773f);
@@ -211,13 +211,13 @@ namespace MudBlazor.UnitTests.Utilities
             float2.Get("1,7").Should().Be(1.7f);
 
             var dbl1 = new DefaultConverter<double>() { Format = "0.00" };
-            dbl1.Culture = new CultureInfo("en-US");
+            dbl1.Culture = new CultureInfo("en-US", false);
             dbl1.Set(1.7d).Should().Be("1.70");
             dbl1.Set(1.773d).Should().Be("1.77");
             dbl1.Get("1.773").Should().Be(1.773d);
             dbl1.Get("1.77").Should().Be(1.77d);
             dbl1.Get("1.7").Should().Be(1.7d);
-            dbl1.Culture = new CultureInfo("pt-BR");
+            dbl1.Culture = new CultureInfo("pt-BR", false);
             dbl1.Set(1.7d).Should().Be("1,70");
             dbl1.Set(1.773d).Should().Be("1,77");
             dbl1.Get("1,773").Should().Be(1.773d);
@@ -225,7 +225,7 @@ namespace MudBlazor.UnitTests.Utilities
             dbl1.Get("1,7").Should().Be(1.7d);
 
             var dbl2 = new DefaultConverter<double?>() { Format = "0.00" };
-            dbl2.Culture = new CultureInfo("en-US");
+            dbl2.Culture = new CultureInfo("en-US", false);
             dbl2.Set(1.7d).Should().Be("1.70");
             dbl2.Set(1.773d).Should().Be("1.77");
             dbl2.Set(null).Should().Be(null);
@@ -233,7 +233,7 @@ namespace MudBlazor.UnitTests.Utilities
             dbl2.Get("1.77").Should().Be(1.77d);
             dbl2.Get("1.7").Should().Be(1.7d);
             dbl2.Get(null).Should().Be(null);
-            dbl2.Culture = new CultureInfo("pt-BR");
+            dbl2.Culture = new CultureInfo("pt-BR", false);
             dbl2.Set(1.7d).Should().Be("1,70");
             dbl2.Set(1.773d).Should().Be("1,77");
             dbl2.Get("1,773").Should().Be(1.773d);
@@ -241,13 +241,13 @@ namespace MudBlazor.UnitTests.Utilities
             dbl2.Get("1,7").Should().Be(1.7d);
 
             var dec1 = new DefaultConverter<decimal>() { Format = "0.00" };
-            dec1.Culture = new CultureInfo("en-US");
+            dec1.Culture = new CultureInfo("en-US", false);
             dec1.Set(1.7m).Should().Be("1.70");
             dec1.Set(1.773m).Should().Be("1.77");
             dec1.Get("1.773").Should().Be(1.773m);
             dec1.Get("1.77").Should().Be(1.77m);
             dec1.Get("1.7").Should().Be(1.7m);
-            dec1.Culture = new CultureInfo("pt-BR");
+            dec1.Culture = new CultureInfo("pt-BR", false);
             dec1.Set(1.7m).Should().Be("1,70");
             dec1.Set(1.773m).Should().Be("1,77");
             dec1.Get("1,773").Should().Be(1.773m);
@@ -255,7 +255,7 @@ namespace MudBlazor.UnitTests.Utilities
             dec1.Get("1,7").Should().Be(1.7m);
 
             var dec2 = new DefaultConverter<decimal?>() { Format = "0.00" };
-            dec2.Culture = new CultureInfo("en-US");
+            dec2.Culture = new CultureInfo("en-US", false);
             dec2.Set(1.7m).Should().Be("1.70");
             dec2.Set(1.773m).Should().Be("1.77");
             dec2.Set(null).Should().Be(null);
@@ -263,7 +263,7 @@ namespace MudBlazor.UnitTests.Utilities
             dec2.Get("1.77").Should().Be(1.77m);
             dec2.Get("1.7").Should().Be(1.7m);
             dec2.Get(null).Should().Be(null);
-            dec2.Culture = new CultureInfo("pt-BR");
+            dec2.Culture = new CultureInfo("pt-BR", false);
             dec2.Set(1.7m).Should().Be("1,70");
             dec2.Set(1.773m).Should().Be("1,77");
             dec2.Get("1,773").Should().Be(1.773m);
@@ -271,21 +271,21 @@ namespace MudBlazor.UnitTests.Utilities
             dec2.Get("1,7").Should().Be(1.7m);
 
             var dt1 = new DefaultConverter<DateTime>() { Format = "MM/dd/yyyy" };
-            dt1.Culture = new CultureInfo("en-US");
+            dt1.Culture = new CultureInfo("en-US", false);
             dt1.Set(new DateTime(2020, 11, 03)).Should().Be("11/03/2020");
             dt1.Get("11/03/2020").Should().Be(new DateTime(2020, 11, 03));
-            dt1.Culture = new CultureInfo("pt-BR");
+            dt1.Culture = new CultureInfo("pt-BR", false);
             dt1.Format = "dd/MM/yyyy";
             dt1.Set(new DateTime(2020, 11, 03)).Should().Be("03/11/2020");
             dt1.Get("03/11/2020").Should().Be(new DateTime(2020, 11, 03));
 
             var dt2 = new DefaultConverter<DateTime?>() { Format = "MM/dd/yyyy" };
-            dt2.Culture = new CultureInfo("en-US");
+            dt2.Culture = new CultureInfo("en-US", false);
             dt2.Set(new DateTime(2020, 11, 03)).Should().Be("11/03/2020");
             dt2.Set(null).Should().Be(null);
             dt2.Get("11/03/2020").Should().Be(new DateTime(2020, 11, 03));
             dt2.Get(null).Should().Be(null);
-            dt2.Culture = new CultureInfo("pt-BR");
+            dt2.Culture = new CultureInfo("pt-BR", false);
             dt2.Format = "dd/MM/yyyy";
             dt2.Set(new DateTime(2020, 11, 03)).Should().Be("03/11/2020");
             dt2.Get("03/11/2020").Should().Be(new DateTime(2020, 11, 03));
@@ -295,22 +295,22 @@ namespace MudBlazor.UnitTests.Utilities
         public void DateTimeConvertersTest()
         {
             var dt1 = new DateConverter("dd/MM/yyyy");
-            dt1.Culture = new CultureInfo("pt-BR");
+            dt1.Culture = new CultureInfo("pt-BR", false);
             dt1.Set(new DateTime(2020, 11, 2)).Should().Be("02/11/2020");
             dt1.Get("02/11/2020").Should().Be(new DateTime(2020, 11, 2));
             var dt2 = new NullableDateConverter("dd/MM/yyyy");
-            dt2.Culture = new CultureInfo("pt-BR");
+            dt2.Culture = new CultureInfo("pt-BR", false);
             dt2.Set(new DateTime(2020, 11, 2)).Should().Be("02/11/2020");
             dt2.Get("02/11/2020").Should().Be(new DateTime(2020, 11, 2));
             dt2.Set(null).Should().Be(null);
             dt2.Get(null).Should().Be(null);
 
             var dt3 = new DateConverter("dd/MM/yyyy");
-            dt3.Culture = new CultureInfo("de-AT");
+            dt3.Culture = new CultureInfo("de-AT", false);
             dt3.Set(new DateTime(2020, 11, 2)).Should().Be("02.11.2020");
             dt3.Get("02/11/2020").Should().Be(new DateTime(2020, 11, 2));
             var dt4 = new NullableDateConverter("dd/MM/yyyy");
-            dt4.Culture = new CultureInfo("de-AT");
+            dt4.Culture = new CultureInfo("de-AT", false);
             dt4.Set(new DateTime(2020, 11, 2)).Should().Be("02.11.2020");
             dt4.Get("02/11/2020").Should().Be(new DateTime(2020, 11, 2));
             dt4.Set(null).Should().Be(null);

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("1abd", 17, 170, 187, 221)]
         public void FromString_Hex(string input, byte r, byte g, byte b, byte alpha)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -52,7 +52,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("rgb(255,255,255)", 255, 255, 255, 255)]
         public void FromString_RGB(string input, byte r, byte g, byte b, byte alpha)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -80,7 +80,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("rgba(255,255,255,1)", 255, 255, 255, 255)]
         public void FromString_RGBA(string input, byte r, byte g, byte b, byte alpha)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -436,7 +436,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase(71, 88, 99, 255, "rgb(71,88,99)")]
         public void ToRGB(byte r, byte g, byte b, byte a, string expectedValue)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -454,7 +454,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase(71, 88, 99, 204, "rgba(71,88,99,0.8)")]
         public void ToRGBA(byte r, byte g, byte b, byte a, string expectedValue)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -471,7 +471,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase(71, 88, 99, 255, "71,88,99")]
         public void ToColorRgbElements(byte r, byte g, byte b, byte a, string expectedValue)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -488,7 +488,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase(71, 88, 99, 204, "#475863")]
         public void ToHex(byte r, byte g, byte b, byte a, string expectedValue)
         {
-            var cultures = new[] { new CultureInfo("en"), new CultureInfo("se") };
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
 
             foreach (var item in cultures)
             {
@@ -610,7 +610,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("ar-ER")]
         public void CheckPaletteInDifferentCultures(string cultureString)
         {
-            var culture = new CultureInfo(cultureString);
+            var culture = new CultureInfo(cultureString, false);
 
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Due to the current CultureInfo() constructor usages, unit tests are prone to fail if a test-running-machine has custom regional settings. 
`float1.Culture = new CultureInfo("en-US");`

CultureInfo constructor has an optional **[useUserOverride](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.useuseroverride?view=net-5.0)** parameter which uses default culture settings of .net if false, and uses Windows user's custom regional settings if true. The problem is, it is **true** by default. So, all the tests with CultureInfo() constructors depend on potential custom user settings. 

### Solution
Always set 'useUserOverride' parameter to 'false' with CultureInfo constructors in unit test bodies in order to avoid the problem, and make tests more robust.
`float1.Culture = new CultureInfo("en-US", false);`

<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?

1. Change your regional settings on your local computer (e.g., Short Date format)
2. Re-run unit tests on your local computer
3. Observe that user regional settings dependent tests fail. (e.g., BindingConverterTests.DefaultConverterTestWithCustomFormat)
example of a failing test: `Expected dt1.Set(newDateTime(2020,11,03)) to be "11/03/2020", but "11-03-2020" differs near "-03" (index 2).`

![image](https://user-images.githubusercontent.com/1479777/138259280-9bb04d09-1209-481a-ab5e-cb0835dc6ade.png)
_Windows 10 - Regional settings screen (Use this screen to customise settings)_

<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
