### PR TITLE
MudSelect: add Items which returns the MudSelectItems

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1025,5 +1025,18 @@ namespace MudBlazor.UnitTests.Components
             icons[5].Attributes["d"].Value.Should().Be(@checked);
             icons[7].Attributes["d"].Value.Should().Be(@unchecked);
         }
+
+        [Test]
+        public void Select_Item_Collection_Should_Match_Number_Of_Select_Options()
+        {
+            var comp = Context.RenderComponent<SelectTest1>();
+            var sut = comp.FindComponent<MudSelect<string>>();
+
+            var input = comp.Find("div.mud-input-control");
+            input.Click();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+
+            sut.Instance.Items.Should().HaveCountGreaterOrEqualTo(4);
+        }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -383,6 +383,11 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool MultiSelection { get; set; }
 
+        /// <summary>
+        /// The collection of items within this select
+        /// </summary>
+        public IReadOnlyList<MudSelectItem<T>> Items => _items;
+
         protected internal List<MudSelectItem<T>> _items = new();
         protected Dictionary<T, MudSelectItem<T>> _valueLookup = new();
         protected Dictionary<T, MudSelectItem<T>> _shadowLookup = new();


### PR DESCRIPTION
## Description
From the context of a `MudSelect<T>` object, there's no way to get the collection of child `MudSelectItem<T>`'s without relying on CSS selectors (which should be treated as an internal implementation detail).

This PR adds a getter to the `MudSelect<T>`'s component API to obtain a read-only collection of the `MudSelectItem<T>`'s contained within.

## How Has This Been Tested?
A unit test for this feature has been added to ensure that the number of options within the component match the test case.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
