### PR TITLE
MudExpansionPanel: Let Changed handler run before actually expanding.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelAsyncExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelAsyncExample.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudExpansionPanels>
+    <MudExpansionPanel Text="Panel with async loaded contents" MaxHeight="1000" IsExpandedChanged="ExpandedChanged">
+        @_panelContent
+    </MudExpansionPanel>
+</MudExpansionPanels>
+
+@code {
+    private RenderFragment _panelContent;
+
+    private async Task ExpandedChanged(bool newVal)
+    {
+        if (newVal)
+        {
+            await Task.Delay(600);
+            _panelContent = _bigAsyncContent;
+        }
+        else
+        {
+            // Reset after a while to prevent sudden collapse.
+            Task.Delay(350).ContinueWith(t => _panelContent = null).AndForget(); 
+        }
+    }
+
+    private RenderFragment _bigAsyncContent = __builder =>
+    {
+        <div>The expansion of the</div>
+        <div>inner panel is done after</div>
+        <div>IsExpandedChanged</div>
+        <div>has completed to allow for</div>
+        <div>smooth opening of async data</div>
+        <div>of initially unknown height.</div>
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
@@ -15,12 +15,22 @@
 
         <DocsPageSection>
             <SectionHeader Title="Multiple Expanded Panels">
-                <Description></Description>
+                <Description>Multiple expansion panels can be opened at the same time by setting <CodeInline>MultiExpansion</CodeInline>.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelMultiExample />
             </SectionContent>
             <SectionSource Code="ExpansionPanelMultiExample" GitHubFolderName="ExpansionPanel" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Async loading of data">
+                <Description>The panels inner collapsible won't expand until IsExpandedChanged has completed, enabling smooth opening of expansion panels even if the data is not loaded when the header is clicked.'</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <ExpansionPanelAsyncExample />
+            </SectionContent>
+            <SectionSource Code="ExpansionPanelAsyncExample" ShowCode="false" GitHubFolderName="ExpansionPanel" />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
@@ -25,7 +25,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Async loading of data">
-                <Description>The panels inner collapsible won't expand until IsExpandedChanged has completed, enabling smooth opening of expansion panels even if the data is not loaded when the header is clicked.'</Description>
+                <Description>The panels inner collapsible won't expand until IsExpandedChanged has completed, enabling smooth opening of expansion panels even if the data is not loaded when the header is clicked.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelAsyncExample />

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
@@ -65,14 +66,14 @@ namespace MudBlazor.UnitTests.Components
         /// MultiExpansion panel should not collapse other panels
         /// </summary>
         [Test]
-        public void MudExpansionPanel_MultiExpansion_Doesnt_Collapse_Others()
+        public async Task MudExpansionPanel_MultiExpansion_Doesnt_Collapse_Others()
         {
             var comp = Context.RenderComponent<ExpansionPanelMultiExpansionTest>();
 
             //click in the three headers
             foreach (var header in comp.FindAll(".mud-expand-panel-header"))
             {
-                header.Click();
+                await comp.InvokeAsync(() => header.Click());
             }
 
             //the three panels must be expanded
@@ -104,7 +105,7 @@ namespace MudBlazor.UnitTests.Components
         /// Start expanded should work with multi expansion
         /// </summary>
         [Test]
-        public void MudExpansionPanel_IsInitiallyExpanded_Works_With_Multi_Expanded()
+        public async Task MudExpansionPanel_IsInitiallyExpanded_Works_With_Multi_Expanded()
         {
             var comp = Context.RenderComponent<ExpansionPanelStartExpandedMultipleTest>();
 
@@ -115,7 +116,7 @@ namespace MudBlazor.UnitTests.Components
             //click in the three headers
             foreach (var header in comp.FindAll(".mud-expand-panel-header"))
             {
-                header.Click();
+                await comp.InvokeAsync(() => header.Click());
             }
 
             //we could close them all

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -50,18 +50,19 @@ namespace MudBlazor
             {
                 if (_expanded == value)
                     return;
-
                 _expanded = value;
+
                 if (_isRendered)
                 {
                     _state = _expanded ? CollapseState.Entering : CollapseState.Exiting;
                     _ = UpdateHeight();
-                    _updateHeight = _height == 0;
+                    _updateHeight = true;
                 }
                 else if (_expanded)
                 {
                     _state = CollapseState.Entered;
                 }
+
                 _ = ExpandedChanged.InvokeAsync(_expanded);
             }
         }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-    <div class="mud-expand-panel-header" @onclick=@( () => ToggleExpansion())>
+    <div class="mud-expand-panel-header" @onclick="ToggleExpansion">
         <div class="mud-expand-panel-text">
             @if (TitleContent != null)
             {
@@ -18,7 +18,7 @@
             <MudIcon Icon="@Icon" class="@(IsExpanded? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
         }
     </div>
-    <MudCollapse Expanded="@IsExpanded" MaxHeight="@MaxHeight">
+    <MudCollapse Expanded="@_collapseIsExpanded" MaxHeight="@MaxHeight">
         <div class="@PanelContentClassname">
             @ChildContent
         </div>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -8,6 +8,8 @@ namespace MudBlazor
     {
         private bool _nextPanelExpanded;
         private bool _isExpanded;
+        private bool _collapseIsExpanded;
+
         [CascadingParameter] private MudExpansionPanels Parent { get; set; }
 
         protected string Classname =>
@@ -81,7 +83,14 @@ namespace MudBlazor
                 _isExpanded = value;
 
                 NotifyIsExpandedChanged?.Invoke(this);
-                IsExpandedChanged.InvokeAsync(_isExpanded);
+                IsExpandedChanged.InvokeAsync(_isExpanded).ContinueWith(t =>
+                {
+                    if (_collapseIsExpanded != _isExpanded)
+                    {
+                        _collapseIsExpanded = _isExpanded;
+                        InvokeAsync(() => StateHasChanged());
+                    }
+                });
             }
         }
 
@@ -116,7 +125,9 @@ namespace MudBlazor
         public void ToggleExpansion()
         {
             if (Disabled)
+            {
                 return;
+            }
 
             IsExpanded = !IsExpanded;
         }
@@ -128,6 +139,7 @@ namespace MudBlazor
             else
             {
                 _isExpanded = true;
+                _collapseIsExpanded = true;
                 IsExpandedChanged.InvokeAsync(_isExpanded);
             }
         }
@@ -139,6 +151,7 @@ namespace MudBlazor
             else
             {
                 _isExpanded = false;
+                _collapseIsExpanded = false;
                 IsExpandedChanged.InvokeAsync(_isExpanded);
             }
         }
@@ -150,7 +163,11 @@ namespace MudBlazor
             //    throw new ArgumentNullException(nameof(Parent), "ExpansionPanel must exist within a ExpansionPanels component");
             base.OnInitialized();
             if (!IsExpanded && IsInitiallyExpanded)
-                _isExpanded = IsInitiallyExpanded;
+            {
+                _isExpanded = true;
+                _collapseIsExpanded = true;
+            }
+
             Parent?.AddPanel(this);
         }
 


### PR DESCRIPTION
## Description
If the main body of a MudExpansionPanel is async loaded as a result of the panel being expanded, the opening animation won't work correctly. This PR fixes that.

## How Has This Been Tested?
Visually, as a part of updated documentation.

## Types of changes
- [x] New feature ish (non-breaking change which adds functionality)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
