### PR TITLE
Table: Add option for location of PagerContent

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginatePositionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginatePositionExample.razor
@@ -1,0 +1,47 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable Items="@Elements" PagerPosition="@_tablePagerPosition">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+		<MudTablePager HorizontalAlignment="HorizontalAlignment.Center" />
+    </PagerContent>
+</MudTable>
+
+<div class="d-flex flex-wrap mt-4">
+	<MudSelect T="Enums.TablePagerPosition" Label="Pager position options" @bind-Value="_tablePagerPosition">
+		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Bottom">Bottom</MudSelectItem>
+		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Top">Top</MudSelectItem>
+		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.TopAndBottom">TopAndBottom</MudSelectItem>
+	</MudSelect>
+</div>
+
+@code {
+
+	private Enums.TablePagerPosition _tablePagerPosition = Enums.TablePagerPosition.Bottom;
+
+	private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginatePositionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginatePositionExample.razor
@@ -27,11 +27,11 @@
 </MudTable>
 
 <div class="d-flex flex-wrap mt-4">
-	<MudSelect T="Enums.TablePagerPosition" Label="Pager position options" @bind-Value="_tablePagerPosition">
-		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Bottom">Bottom</MudSelectItem>
-		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Top">Top</MudSelectItem>
-		<MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.TopAndBottom">TopAndBottom</MudSelectItem>
-	</MudSelect>
+    <MudSelect T="Enums.TablePagerPosition" Label="Pager position options" @bind-Value="_tablePagerPosition">
+        <MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Bottom">Bottom</MudSelectItem>
+        <MudSelectItem T=Enums.TablePagerPosition Value="Enums.TablePagerPosition.Top">Top</MudSelectItem>
+        <MudSelectItem T=Enums.TablePagerPosition Value="(Enums.TablePagerPosition.Top | Enums.TablePagerPosition.Bottom)">Top & Bottom</MudSelectItem>
+    </MudSelect>
 </div>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -45,7 +45,7 @@
             <SectionSource Code="TableExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
 
-		<DocsPageSection>
+        <DocsPageSection>
             <SectionHeader Title="Table pagination position">
                 <Description>
                     The location of the pager can be customize by setting the <CodeInline>PagerPosition</CodeInline> property.                    

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -45,6 +45,18 @@
             <SectionSource Code="TableExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
 
+		<DocsPageSection>
+            <SectionHeader Title="Table pagination position">
+                <Description>
+                    The location of the pager can be customize by setting the <CodeInline>PagerPosition</CodeInline> property.                    
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableServerSidePaginatePositionExample />
+            </SectionContent>
+            <SectionSource Code="TabPagerLocationExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
         <DocsPageSection>
             <SectionHeader Title="TabPager Customization">
                 <Description>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingLocationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingLocationTest.razor
@@ -1,0 +1,36 @@
+﻿@using System.ComponentModel
+@using System.Runtime.CompilerServices
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPaper>
+	<MudTable InlineEdit="false"
+			  Items="states"
+			  PagerPosition=@PagerPosition>
+		<RowTemplate>
+			<MudTd>@context</MudTd>
+		</RowTemplate>
+		<PagerContent>
+			<MudTablePager />
+		</PagerContent>
+	</MudTable>
+</MudPaper>
+
+@code {
+	private string[] states =
+	{
+		"Alabama", "Alaska", "American Samoa", "Arizona",
+		"Arkansas", "California", "Colorado", "Connecticut",
+		"Delaware", "District of Columbia", "Federated States of Micronesia",
+		"Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+		"Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+		"Louisiana", "Maine", "Marshall Islands", "Maryland",
+		"Massachusetts", "Michigan", "Minnesota", "Mississippi",
+		"Missouri", "Montana", "Nebraska", "Nevada",
+		"New Hampshire", "New Jersey", "New Mexico", "New York",
+		"North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+		"Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+		"Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+		"Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+		"Washington", "West Virginia", "Wisconsin", "Wyoming",
+	};
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingLocationTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingLocationTest.razor.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Enums;
+
+namespace MudBlazor.UnitTests.TestComponents
+{
+    public partial class TablePagingLocationTest
+    {
+        public static string __description__ = "Test table pager layout.";
+
+        private TablePagerPosition _pagerPosition;
+
+        [Parameter]
+        public TablePagerPosition PagerPosition
+        {
+            get => _pagerPosition;
+            set
+            {
+                if (_pagerPosition == value)
+                    return;
+                _pagerPosition = value;
+                PagerPositionChanged.InvokeAsync(value);
+            }
+        }
+
+        [Parameter]
+        public EventCallback<TablePagerPosition> PagerPositionChanged { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.Enums;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -403,6 +404,41 @@ namespace MudBlazor.UnitTests.Components
             searchString.Change(string.Empty);
             comp.FindAll("tr").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+        }
+
+        /// <summary>
+        /// Test checks that the table pager can be positioned top, bottom or top and bottom
+        /// </summary>
+        [Test]
+        [TestCase(Enums.TablePagerPosition.Top, true, false)]
+        [TestCase(Enums.TablePagerPosition.Bottom, false, true)]
+        [TestCase(Enums.TablePagerPosition.TopAndBottom, true, true)]
+        public async Task TablePagerPosition(
+            TablePagerPosition pagerPosition,
+            bool topPagerShouldExist,
+            bool bottomPagerShouldExist)
+        {
+            var comp = Context.RenderComponent<TablePagingLocationTest>(parameters =>
+                parameters.Add(p => p.PagerPosition, pagerPosition));
+            // print the generated html      
+            Console.WriteLine(comp.Markup);
+
+            if (topPagerShouldExist && bottomPagerShouldExist)
+                comp.FindAll(".mud-table-pagination").Should().HaveCount(2);
+            else
+                comp.FindAll(".mud-table-pagination").Should().HaveCount(1);
+
+            comp
+                .FindAll(".mud-table-container")
+                .Previous(".mud-table-pagination")
+                .Should()
+                .HaveCount(topPagerShouldExist ? 1 : 0);
+
+            comp
+                .FindAll(".mud-table-container")
+                .Next(".mud-table-pagination")
+                .Should()
+                .HaveCount(bottomPagerShouldExist ? 1 : 0);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -412,7 +412,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         [TestCase(Enums.TablePagerPosition.Top, true, false)]
         [TestCase(Enums.TablePagerPosition.Bottom, false, true)]
-        [TestCase(Enums.TablePagerPosition.TopAndBottom, true, true)]
+        [TestCase((Enums.TablePagerPosition.Top | Enums.TablePagerPosition.Bottom), true, true)]
         public async Task TablePagerPosition(
             TablePagerPosition pagerPosition,
             bool topPagerShouldExist,
@@ -420,7 +420,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TablePagingLocationTest>(parameters =>
                 parameters.Add(p => p.PagerPosition, pagerPosition));
-            // print the generated html      
+            // print the generated html
             Console.WriteLine(comp.Markup);
 
             if (topPagerShouldExist && bottomPagerShouldExist)

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -24,7 +24,7 @@
             </div>
 
         }
-		@if (PagerContent != null && (PagerPosition == Enums.TablePagerPosition.Top || PagerPosition == Enums.TablePagerPosition.TopAndBottom))
+		@if (PagerContent != null && PagerPosition.HasFlag(Enums.TablePagerPosition.Top))
 		{
 			<div class="mud-table-pagination">
 				@PagerContent
@@ -176,7 +176,7 @@
                 }
             </table>
         </div>
-		@if (PagerContent != null && (PagerPosition == Enums.TablePagerPosition.Bottom || PagerPosition == Enums.TablePagerPosition.TopAndBottom))	        
+        @if (PagerContent != null && PagerPosition.HasFlag(Enums.TablePagerPosition.Bottom))
         {
             <div class="mud-table-pagination">
                 @PagerContent

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -24,6 +24,12 @@
             </div>
 
         }
+		@if (PagerContent != null && (PagerPosition == Enums.TablePagerPosition.Top || PagerPosition == Enums.TablePagerPosition.TopAndBottom))
+		{
+			<div class="mud-table-pagination">
+				@PagerContent
+			</div>
+		}
         <div class="mud-table-container" style="@TableStyle @(GetHorizontalScrollbarStyle())">
             <table class="mud-table-root">
                 @if (ColGroup != null)
@@ -170,7 +176,7 @@
                 }
             </table>
         </div>
-        @if (PagerContent != null)
+		@if (PagerContent != null && (PagerPosition == Enums.TablePagerPosition.Bottom || PagerPosition == Enums.TablePagerPosition.TopAndBottom))	        
         {
             <div class="mud-table-pagination">
                 @PagerContent

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Enums;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -311,6 +312,11 @@ namespace MudBlazor
         /// If true, the results are displayed in a Virtualize component, allowing a boost in rendering speed.
         /// </summary>
         [Parameter] public bool Virtualize { get; set; }
+
+        /// <summary>
+        /// Sets the location of the table pager.
+        /// </summary>
+        [Parameter] public TablePagerPosition PagerPosition { get; set; }
 
         #region --> Obsolete Forwarders for Backwards-Compatiblilty
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -316,7 +316,7 @@ namespace MudBlazor
         /// <summary>
         /// Sets the location of the table pager.
         /// </summary>
-        [Parameter] public TablePagerPosition PagerPosition { get; set; }
+        [Parameter] public TablePagerPosition PagerPosition { get; set; } = TablePagerPosition.Bottom;
 
         #region --> Obsolete Forwarders for Backwards-Compatiblilty
         /// <summary>

--- a/src/MudBlazor/Enums/TablePagerPosition.cs
+++ b/src/MudBlazor/Enums/TablePagerPosition.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace MudBlazor.Enums
+{
+    public enum TablePagerPosition
+    {
+        [Description("bottom")]
+        Bottom,
+        [Description("top")]
+        Top,
+        [Description("top-and-bottom")]
+        TopAndBottom
+    }
+}

--- a/src/MudBlazor/Enums/TablePagerPosition.cs
+++ b/src/MudBlazor/Enums/TablePagerPosition.cs
@@ -2,17 +2,17 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel;
 
 namespace MudBlazor.Enums
 {
+    [Flags]
     public enum TablePagerPosition
     {
         [Description("bottom")]
-        Bottom,
+        Bottom = 1,
         [Description("top")]
-        Top,
-        [Description("top-and-bottom")]
-        TopAndBottom
+        Top = 2
     }
 }


### PR DESCRIPTION
## Description
The location of the Table pager is configurable. Options are (Bottom | Top | Top and Bottom).

## How Has This Been Tested?
### Unit test
Unit tests have been implemented testing the three options: see test: TablePagerPosition()
### Visually
![image](https://user-images.githubusercontent.com/595313/138768270-5828c9ac-05e1-450f-bb50-47c7bf2725a2.png)






## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
