### PR TITLE
Docs: Add tooltips for enum types showing enum constants

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -76,7 +76,7 @@
                                 else
                                 {
                                     <MudText Typo="Typo.body2">@PresentDefaultValue(context.Default)</MudText>
-                                }                           
+                                }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -76,7 +76,7 @@
                                 else
                                 {
                                     <MudText Typo="Typo.body2">@PresentDefaultValue(context.Default)</MudText>
-                                }
+                                }                           
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
@@ -171,12 +171,12 @@
                 {
                     yield return new ApiProperty()
                     {
-                        PropertyInfo = info,
                         Name = info.Name,
-                        Type = info.PropertyType,
-                        IsTwoWay = CheckIsTwoWayEventCallback(info),
+                        PropertyInfo = info,
                         Default = string.Empty,
                         Description = GetDescription(Type, info),
+                        IsTwoWay = CheckIsTwoWayEventCallback(info),
+                        Type = info.PropertyType,
                     };
                 }
             }
@@ -226,12 +226,12 @@
                 {
                     yield return new ApiProperty()
                     {
-                        PropertyInfo = info,
                         Name = info.Name,
-                        Type = info.PropertyType,
-                        IsTwoWay = CheckIsTwoWayProperty(info),
+                        PropertyInfo = info,
                         Default = GetDefaultValue(info),
+                        IsTwoWay = CheckIsTwoWayProperty(info),
                         Description = GetDescription(Type, info),
+                        Type = info.PropertyType
                     };
                 }
             }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -45,16 +45,16 @@
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Type">
                                 <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
-                                    @if (context.PropertyInfo.PropertyType.IsEnum)
+                                    @if (context.Type.IsEnum)
                                     {
                                         <MudTooltip>
-                                            <ChildContent>@context.Type</ChildContent>
+                                            <ChildContent>@context.Type.ConvertToCSharpSource()</ChildContent>
                                             <TooltipContent>
                                                 enumeration type
                                                 <MudText Align="Align.Left" Typo="Typo.body2">
-                                                    @foreach (var name in Enum.GetNames(context.PropertyInfo.PropertyType))
+                                                    @foreach (var name in Enum.GetNames(context.Type))
                                                     {
-                                                        @(context.PropertyInfo.PropertyType.Name + "." + name)<br />
+                                                        @(context.Type.Name + "." + name)<br />
                                                     }
                                                 </MudText>
                                             </TooltipContent>
@@ -62,7 +62,7 @@
                                     }
                                     else
                                     {
-                                        @context.Type
+                                        @context.Type.ConvertToCSharpSource()
                                     }
                                     <DocsBinding IsTwoWay="@context.IsTwoWay" />
                                 </div>
@@ -98,7 +98,7 @@
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type</div></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type.ConvertToCSharpSource()</div></MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
                     </MudTable>
@@ -175,7 +175,7 @@
                         Default = string.Empty,
                         Description = GetDescription(Type, info),
                         IsTwoWay = CheckIsTwoWayEventCallback(info),
-                        Type = info.PropertyType.ConvertToCSharpSource(),
+                        Type = info.PropertyType,
                     };
                 }
             }
@@ -230,7 +230,7 @@
                         Default = GetDefaultValue(info),
                         IsTwoWay = CheckIsTwoWayProperty(info),
                         Description = GetDescription(Type, info),
-                        Type = info.PropertyType.ConvertToCSharpSource()
+                        Type = info.PropertyType,
                     };
                 }
             }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -43,7 +43,30 @@
                                     <MudChip Variant="Variant.Outlined" Color="Color.Secondary" Size="Size.Small">overridden</MudChip>
                                 }
                             </MudTd>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type<DocsBinding IsTwoWay="@context.IsTwoWay" /></div></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type">
+                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
+                                    @if (context.PropertyInfo.PropertyType.IsEnum)
+                                    {
+                                        <MudTooltip>
+                                            <ChildContent>@context.Type</ChildContent>
+                                            <TooltipContent>
+                                                enumeration type
+                                                <MudText Align="Align.Left" Typo="Typo.body2">
+                                                    @foreach (var name in Enum.GetNames(context.PropertyInfo.PropertyType))
+                                                    {
+                                                        @(context.PropertyInfo.PropertyType.Name + "." + name)<br />
+                                                    }
+                                                </MudText>
+                                            </TooltipContent>
+                                        </MudTooltip>
+                                    }
+                                    else
+                                    {
+                                        @context.Type
+                                    }
+                                    <DocsBinding IsTwoWay="@context.IsTwoWay" />
+                                </div>
+                            </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Default">
                                 @if (PresentDefaultValue(context.Default).Contains("<path"))
                                 {

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -170,12 +170,12 @@
                 {
                     yield return new ApiProperty()
                     {
-                        Name = info.Name,
                         PropertyInfo = info,
+                        Name = info.Name,
+                        Type = info.PropertyType,
+                        IsTwoWay = CheckIsTwoWayEventCallback(info),
                         Default = string.Empty,
                         Description = GetDescription(Type, info),
-                        IsTwoWay = CheckIsTwoWayEventCallback(info),
-                        Type = info.PropertyType,
                     };
                 }
             }
@@ -225,12 +225,12 @@
                 {
                     yield return new ApiProperty()
                     {
-                        Name = info.Name,
                         PropertyInfo = info,
-                        Default = GetDefaultValue(info),
-                        IsTwoWay = CheckIsTwoWayProperty(info),
-                        Description = GetDescription(Type, info),
+                        Name = info.Name,
                         Type = info.PropertyType,
+                        IsTwoWay = CheckIsTwoWayProperty(info),
+                        Default = GetDefaultValue(info),
+                        Description = GetDescription(Type, info),
                     };
                 }
             }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -45,16 +45,17 @@
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Type">
                                 <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
-                                    @if (context.Type.IsEnum)
+                                    @{ Type nonnullableType = Nullable.GetUnderlyingType(context.Type) ?? context.Type; }
+                                    @if (nonnullableType.IsEnum)
                                     {
                                         <MudTooltip>
                                             <ChildContent>@context.Type.ConvertToCSharpSource()</ChildContent>
                                             <TooltipContent>
                                                 enumeration type
                                                 <MudText Align="Align.Left" Typo="Typo.body2">
-                                                    @foreach (var name in Enum.GetNames(context.Type))
+                                                    @foreach (var name in Enum.GetNames(nonnullableType))
                                                     {
-                                                        @(context.Type.Name + "." + name)<br />
+                                                        @(nonnullableType.Name + "." + name)<br />
                                                     }
                                                 </MudText>
                                             </TooltipContent>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -45,26 +45,7 @@
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Type">
                                 <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
-                                    @{ Type nonnullableType = Nullable.GetUnderlyingType(context.Type) ?? context.Type; }
-                                    @if (nonnullableType.IsEnum)
-                                    {
-                                        <MudTooltip>
-                                            <ChildContent>@context.Type.ConvertToCSharpSource()</ChildContent>
-                                            <TooltipContent>
-                                                enumeration type
-                                                <MudText Align="Align.Left" Typo="Typo.body2">
-                                                    @foreach (var name in Enum.GetNames(nonnullableType))
-                                                    {
-                                                        @(nonnullableType.Name + "." + name)<br />
-                                                    }
-                                                </MudText>
-                                            </TooltipContent>
-                                        </MudTooltip>
-                                    }
-                                    else
-                                    {
-                                        @context.Type.ConvertToCSharpSource()
-                                    }
+                                    <DocsTypeInfo Type="@context.Type" />
                                     <DocsBinding IsTwoWay="@context.IsTwoWay" />
                                 </div>
                             </MudTd>

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -1,15 +1,13 @@
-﻿@{ Type nonnullableType = Nullable.GetUnderlyingType(Type) ?? Type; }
-
-@if (nonnullableType.IsEnum)
+﻿@if (NonnullableType.IsEnum)
 {
     <MudTooltip>
         <ChildContent>@Type.ConvertToCSharpSource()</ChildContent>
         <TooltipContent>
             enumeration type
             <MudText Align="Align.Left" Typo="Typo.body2">
-                @foreach (var name in Enum.GetNames(nonnullableType))
+                @foreach (var name in Enum.GetNames(NonnullableType))
                 {
-                    @(nonnullableType.Name + "." + name)<br />
+                    @(NonnullableType.Name + "." + name)<br />
                 }
             </MudText>
         </TooltipContent>
@@ -22,4 +20,6 @@ else
 
 @code {
     [Parameter] public Type Type { get; set; }
+
+    private Type NonnullableType => Nullable.GetUnderlyingType(Type) ?? Type;
 }

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -1,0 +1,25 @@
+﻿@{ Type nonnullableType = Nullable.GetUnderlyingType(Type) ?? Type; }
+
+@if (nonnullableType.IsEnum)
+{
+    <MudTooltip>
+        <ChildContent>@Type.ConvertToCSharpSource()</ChildContent>
+        <TooltipContent>
+            enumeration type
+            <MudText Align="Align.Left" Typo="Typo.body2">
+                @foreach (var name in Enum.GetNames(nonnullableType))
+                {
+                    @(nonnullableType.Name + "." + name)<br />
+                }
+            </MudText>
+        </TooltipContent>
+    </MudTooltip>
+}
+else
+{
+    @Type.ConvertToCSharpSource()
+}
+
+@code {
+    [Parameter] public Type Type { get; set; }
+}

--- a/src/MudBlazor.Docs/Models/ApiProperty.cs
+++ b/src/MudBlazor.Docs/Models/ApiProperty.cs
@@ -1,11 +1,12 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 namespace MudBlazor.Docs.Models
 {
     public class ApiProperty
     {
         public string Name { get; set; }
-        public string Type { get; set; }
+        public Type Type { get; set; }
         public PropertyInfo PropertyInfo { get; set; }
         public string Description { get; set; }
         public object Default { get; set; }

--- a/src/MudBlazor.Docs/Models/ApiProperty.cs
+++ b/src/MudBlazor.Docs/Models/ApiProperty.cs
@@ -5,12 +5,11 @@ namespace MudBlazor.Docs.Models
 {
     public class ApiProperty
     {
-        public PropertyInfo PropertyInfo { get; set; }
-
         public string Name { get; set; }
         public Type Type { get; set; }
-        public bool IsTwoWay { get; set; }
-        public object Default { get; set; }
+        public PropertyInfo PropertyInfo { get; set; }
         public string Description { get; set; }
+        public object Default { get; set; }
+        public bool IsTwoWay { get; set; }
     }
 }

--- a/src/MudBlazor.Docs/Models/ApiProperty.cs
+++ b/src/MudBlazor.Docs/Models/ApiProperty.cs
@@ -5,11 +5,12 @@ namespace MudBlazor.Docs.Models
 {
     public class ApiProperty
     {
+        public PropertyInfo PropertyInfo { get; set; }
+
         public string Name { get; set; }
         public Type Type { get; set; }
-        public PropertyInfo PropertyInfo { get; set; }
-        public string Description { get; set; }
-        public object Default { get; set; }
         public bool IsTwoWay { get; set; }
+        public object Default { get; set; }
+        public string Description { get; set; }
     }
 }


### PR DESCRIPTION
## Description
This commit adds a tooltip with the possible enum constants for enum type properties. It implements, at least in large part, point no. 3 of the https://github.com/MudBlazor/MudBlazor/issues/1020 issue.

## How Has This Been Tested?
I checked visually several properties. I checked it on: Blazor Server and WebAssembly, desktop and mobile.

The tooltip looks like this:

![Enum type tooltip](https://user-images.githubusercontent.com/8080496/139053772-ce79e842-e838-4472-b411-5dd48b9b4283.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.