### PR TITLE
MudThemeProvider: Add variable density as a theme parameter

### DIFF
--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -30,6 +30,7 @@
                         <MudMenuItem Link="https://opencollective.com/mudblazor" Target="_blank">Open Collective</MudMenuItem>
                     </MudMenu>
                     <MudDivider Vertical="true" FlexItem="true" DividerType="DividerType.Middle" Class="mx-4 my-3" />
+                    <MudNumericField @bind-Value="@_currentTheme.Density.Modifier" Immediate="true" Variant="Variant.Filled" Min="0" Step="0.25d" Max="10" Label="Theme Density"></MudNumericField>
                     @if (Wasm)
                     {
                         <MudTooltip Text="Switch to Blazor server-side">

--- a/src/MudBlazor.UnitTests/Components/MudThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MudThemeProviderTests.cs
@@ -222,6 +222,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-zindex-popover: 1200;",
                 "--mud-zindex-snackbar: 1500;",
                 "--mud-zindex-tooltip: 1600;",
+                "--mud-density-modifier: 1;",
                 "}"
             };
 

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -55,6 +55,7 @@ namespace MudBlazor
         private const string Typography = "mud-typography";
         private const string LayoutProperties = "mud";
         private const string Zindex = "mud-zindex";
+        private const string Density = "mud-density";
 
         protected virtual void GenerateTheme(StringBuilder theme)
         {
@@ -304,6 +305,9 @@ namespace MudBlazor
             theme.AppendLine($"--{Zindex}-popover: {Theme.ZIndex.Popover};");
             theme.AppendLine($"--{Zindex}-snackbar: {Theme.ZIndex.Snackbar};");
             theme.AppendLine($"--{Zindex}-tooltip: {Theme.ZIndex.Tooltip};");
+
+            //Density
+            theme.AppendLine($"--{Density}-modifier: {Theme.Density.Modifier};");
         }
     }
 }

--- a/src/MudBlazor/Styles/abstracts/_mixins.scss
+++ b/src/MudBlazor/Styles/abstracts/_mixins.scss
@@ -51,3 +51,13 @@
         @content
     }
 }
+
+@function density($values...) {
+    $result: ();
+
+    @each $value in $values {
+        $result: $result + calc( #{$value} * var(--mud-density-modifier));
+    }
+
+    @return unquote($result);
+}

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -71,7 +71,7 @@
 .mud-alert-icon {
     display: flex;
     opacity: 0.9;
-    padding: 7px 0;
+    padding: density(7px, 0px);
     font-size: 22px;
     margin-right: 12px;
     margin-inline-end: 12px;
@@ -91,7 +91,7 @@
 }
 
 .mud-alert-message {
-    padding: 9px 0;
+    align-self:center;
 }
 
 .mud-alert-position {

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -2,7 +2,7 @@
 
 .mud-alert {
     display: flex;
-    padding: 6px 16px;
+    padding: density(6px, 16px);
     border-radius: var(--mud-default-borderradius);
     background-color: transparent;
     transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -12,7 +12,7 @@
     }
 
     &.mud-dense {
-        padding: 0px 12px;
+       padding: density(0px, 12px);
     }
 }
 

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -32,7 +32,7 @@
 }
 
 .mud-button {
-    padding: 6px 16px;
+    padding: density(6px, 16px);
     font-family: var(--mud-typography-button-family);
     font-size: var(--mud-typography-button-size);
     font-weight: var(--mud-typography-button-weight);
@@ -58,7 +58,7 @@
 }
 
 .mud-button-text {
-    padding: 6px 8px;
+    padding: density(6px, 8px);
 
     &.mud-button-text-inherit {
         color: inherit;
@@ -78,7 +78,7 @@
 .mud-button-outlined {
     color: var(--mud-palette-text-primary);
     border: 1px solid var(--mud-palette-text-primary);
-    padding: 5px 15px;
+    padding: density(5px, 15px);
 
     &.mud-button-outlined-inherit {
         color: inherit;
@@ -174,17 +174,17 @@
 }
 
 .mud-button-text-size-small {
-    padding: 4px 5px;
+    padding: density(4px, 5px);
     font-size: 0.8125rem;
 }
 
 .mud-button-text-size-large {
-    padding: 8px 11px;
+    padding: density(8px, 11px);
     font-size: 0.9375rem;
 }
 
 .mud-button-outlined-size-small {
-    padding: 3px 9px;
+    padding: density(3px, 9px);
     font-size: 0.8125rem;
 
     &.mud-icon-button {
@@ -193,7 +193,7 @@
 }
 
 .mud-button-outlined-size-large {
-    padding: 7px 21px;
+    padding: density(7px, 21px);
     font-size: 0.9375rem;
 
     &.mud-icon-button {
@@ -202,7 +202,7 @@
 }
 
 .mud-button-filled-size-small {
-    padding: 4px 10px;
+    padding: density(4px, 10px);
     font-size: 0.8125rem;
 
     &.mud-icon-button {
@@ -211,7 +211,7 @@
 }
 
 .mud-button-filled-size-large {
-    padding: 8px 22px;
+    padding: density(8px, 22px);
     font-size: 0.9375rem;
 
     &.mud-icon-button {

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -73,7 +73,7 @@
 .mud-button-group-text {
     &.mud-button-group-override-styles {
         .mud-button-root {
-            padding: 6px 8px;
+            padding: density(6px, 8px);
         }
 
         &.mud-button-group-horizontal {
@@ -133,7 +133,7 @@
 .mud-button-group-outlined {
     &.mud-button-group-override-styles {
         .mud-button-root {
-            padding: 5px 15px;
+            padding: density(5px, 15px);
             border: 1px solid var(--mud-palette-text-primary);
         }
 
@@ -164,7 +164,7 @@
     &.mud-button-group-override-styles {
         .mud-button-root {
             background-color: var(--mud-palette-action-default-hover);
-            padding: 6px 16px;
+            padding: density(6px, 16px);
         }
 
         &.mud-button-group-horizontal {
@@ -228,7 +228,7 @@
 
 .mud-button-group-root {
     &.mud-button-group-text-size-small .mud-button-root {
-        padding: 4px 5px;
+        padding: density(4px, 5px);
         font-size: 0.8125rem;
 
         &.mud-icon-button .mud-icon-root {
@@ -237,7 +237,7 @@
     }
 
     &.mud-button-group-text-size-large .mud-button-root {
-        padding: 8px 11px;
+        padding: density(8px, 11px);
         font-size: 0.9375rem;
 
         &.mud-icon-button .mud-icon-root {
@@ -246,7 +246,7 @@
     }
 
     &.mud-button-group-outlined-size-small .mud-button-root {
-        padding: 3px 9px;
+        padding: density(3px, 9px);
         font-size: 0.8125rem;
 
         &.mud-icon-button {
@@ -259,7 +259,7 @@
     }
 
     &.mud-button-group-outlined-size-large .mud-button-root {
-        padding: 7px 21px;
+        padding: density(7px, 21px);
         font-size: 0.9375rem;
 
         &.mud-icon-button {
@@ -272,7 +272,7 @@
     }
 
     &.mud-button-group-filled-size-small .mud-button-root {
-        padding: 4px 10px;
+        padding: density(4px, 10px);
         font-size: 0.8125rem;
 
         &.mud-icon-button {
@@ -285,7 +285,7 @@
     }
 
     &.mud-button-group-filled-size-large .mud-button-root {
-        padding: 8px 22px;
+        padding: density(8px, 22px);
         font-size: 0.9375rem;
 
         &.mud-icon-button {

--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -4,15 +4,15 @@
 
 .mud-card-header {
     display: flex;
-    padding: 16px;
+    padding: density(16px);
     align-items: center;
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
 
     & .mud-card-header-avatar {
         flex: 0 0 auto;
-        margin-right: 16px;
-        margin-inline-end: 16px;
+        margin-right: density(16px);
+        margin-inline-end: density(16px);
         margin-inline-start: unset;
     }
 
@@ -27,9 +27,9 @@
     & .mud-card-header-actions {
         flex: 0 0 auto;
         align-self: flex-start;
-        margin-top: -8px;
-        margin-right: -8px;
-        margin-inline-end: -8px;
+        margin-top: density(-8px);
+        margin-right: density(-8px);
+        margin-inline-end: density(-8px);
         margin-inline-start: unset;
     }
 }
@@ -49,11 +49,11 @@
 }
 
 .mud-card-content {
-    padding: 16px;
+    padding: density(16px);
 }
 
 .mud-card-actions {
     display: flex;
-    padding: 8px;
+    padding: density(8px);
     align-items: center;
 }

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -199,7 +199,7 @@
         height: 1.1876em;
         margin: 0;
         display: block;
-        padding: 6px 0 7px;
+        padding: density(6px) 0px 7px;
         min-width: 0;
         background: none;
         position: relative;
@@ -241,11 +241,11 @@
         }
 
         &.mud-input-root-filled {
-            padding: 27px 12px 10px;
+            padding: calc(20px + (7px * var(--mud-density-modifier))) 12px density(10px);
 
             &.mud-input-root-margin-dense {
-                padding-top: 23px;
-                padding-bottom: 6px;
+                padding-top: calc(16px + (7px * var(--mud-density-modifier)));
+                padding-bottom: density(6px);
             }
 
             &:-webkit-autofill {
@@ -282,7 +282,7 @@
     }
 
     &.mud-input-root-outlined {
-        padding: 18.5px 14px;
+        padding: calc(8.5px + (10px * var(--mud-density-modifier))) 14px;
 
 
         &.mud-input-root:-webkit-autofill {
@@ -290,8 +290,8 @@
         }
 
         &.mud-input-root-margin-dense {
-            padding-top: 10.5px;
-            padding-bottom: 10.5px;
+            padding-top: calc(8.5px + (2px * var(--mud-density-modifier)));
+            padding-bottom: calc(8.5px + (2px * var(--mud-density-modifier)));
         }
 
         &.mud-input-root-adorned-start {

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -25,24 +25,24 @@
 
 .mud-input-label-filled {
     z-index: 1;
-    transform: translate(12px, 20px) scale(1);
+    transform: translate(12px, calc(12px + (9px * var(--mud-density-modifier)))) scale(1);
     pointer-events: none;
 
     &.mud-input-label-margin-dense {
-        transform: translate(12px, 17px) scale(1);
+        transform: translate(12px, calc(12px + (7px * var(--mud-density-modifier))))scale(1);
     }
 }
 
 
 .mud-input-label-outlined {
-    transform: translate(14px, 20px) scale(1);
+    transform: translate(14px,calc(12px + (9px * var(--mud-density-modifier)))) scale(1);
     pointer-events: none;
     background-color: var(--mud-palette-surface);
     padding: 0px 5px !important;
 
 
     &.mud-input-label-margin-dense {
-        transform: translate(14px, 12px) scale(1);
+        transform: translate(14px,calc(10px + (2px*var(--mud-density-modifier)))) scale(1);
     }
 }
 

--- a/src/MudBlazor/Styles/components/_list.scss
+++ b/src/MudBlazor/Styles/components/_list.scss
@@ -17,14 +17,14 @@
     box-sizing: border-box;
     text-align: start;
     align-items: center;
-    padding-top: 8px;
-    padding-bottom: 8px;
+    padding-top: density(8px);
+    padding-bottom: density(8px);
     justify-content: flex-start;
     text-decoration: none;
 
     &.mud-list-item-dense {
-        padding-top: 4px;
-        padding-bottom: 4px;
+        padding-top: density(4px);
+        padding-bottom: density(4px);
     }
 
     &.mud-list-item-disabled {
@@ -62,16 +62,16 @@
 }
 
 .mud-list-item-gutters {
-    padding-left: 16px;
-    padding-right: 16px;
+    padding-left: density(16px);
+    padding-right: density(16px);
 }
 
 
 .mud-list-item-text {
     flex: 1 1 auto;
     min-width: 0;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: density(4px);
+    margin-bottom: density(4px);
 }
 
 

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -27,8 +27,8 @@
     }
 
     & * .mud-navmenu .mud-nav-item .mud-nav-link {
-        padding-left: 36px;
-        padding-inline-start: 36px;
+        padding-left: density(36px);
+        padding-inline-start: density(36px);
         padding-inline-end: unset;
     }
 }
@@ -52,7 +52,7 @@
     width: 100%;
     white-space: pre;
     font-weight: 400;
-    padding: 8px 16px 8px 16px;
+    padding: density(8px, 16px, 8px, 16px);
     color: inherit;
     line-height: 1.75;
     display: inline-flex;
@@ -166,35 +166,35 @@
 
     .mud-nav-group {
         & * .mud-navmenu .mud-nav-item .mud-nav-link {
-            padding: 8px 16px 8px 16px;
+            padding: density(8px, 16px, 8px, 16px);
         }
     }
 
     .mud-nav-group * .mud-navmenu > .mud-nav-group {
         & .mud-nav-link {
-            padding: 8px 16px 8px 16px;
+            padding: density(8px, 16px, 8px, 16px);
         }
 
         & * .mud-navmenu .mud-nav-item .mud-nav-link {
-            padding: 8px 16px 8px 16px;
+            padding: density(8px, 16px, 8px, 16px);
         }
 
         & * .mud-navmenu > .mud-nav-group {
             & .mud-nav-link {
-                padding: 8px 16px 8px 16px;
+                padding: density(8px, 16px, 8px, 16px);
             }
 
             & * .mud-navmenu .mud-nav-item .mud-nav-link {
-                padding: 8px 16px 8px 16px;
+                padding: density(8px, 16px, 8px, 16px);
             }
 
             & * .mud-navmenu > .mud-nav-group {
                 & .mud-nav-link {
-                    padding: 8px 16px 8px 16px;
+                    padding: density(8px, 16px, 8px, 16px);
                 }
 
                 & * .mud-navmenu .mud-nav-item .mud-nav-link {
-                    padding: 8px 16px 8px 16px;
+                    padding: density(8px, 16px, 8px, 16px);
                 }
             }
         }

--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -23,7 +23,7 @@
 
             > td, th {
                 display: table-cell;
-                padding: 16px;
+                padding: density(16px);
                 font-size: 0.875rem;
                 text-align: start;
                 font-weight: 400;
@@ -52,7 +52,7 @@
 .mud-simple-table.mud-table-dense {
     & * tr {
         & td, th {
-            padding: 6px 24px 6px 16px;
+            padding: density(6px, 24px, 6px, 16px);
             padding-inline-start: 16px;
             padding-inline-end: 24px;
         }

--- a/src/MudBlazor/Styles/components/_snackbar.scss
+++ b/src/MudBlazor/Styles/components/_snackbar.scss
@@ -2,7 +2,7 @@
 .mud-snackbar {
     display: flex;
     flex-grow: initial;
-    padding: 6px 16px;
+    padding: density(6px, 16px);
     align-items: center;
     position: relative;
     pointer-events: auto;

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -99,7 +99,7 @@
 
 .mud-table-cell {
     display: table-cell;
-    padding: 16px;
+    padding: density(16px);
     font-size: 0.875rem;
     text-align: start;
     font-weight: 400;
@@ -122,7 +122,7 @@
 .mud-table-dense {
     & * .mud-table-row {
         & .mud-table-cell {
-            padding: 6px 24px 6px 16px;
+            padding: density(6px, 24px, 6px, 16px);
             padding-inline-start: 16px;
             padding-inline-end: 24px;
 

--- a/src/MudBlazor/Styles/components/_timeline.scss
+++ b/src/MudBlazor/Styles/components/_timeline.scss
@@ -19,7 +19,7 @@
     }
 
     .mud-timeline-item {
-        padding-bottom: 24px;
+        padding-bottom: density(24px);
 
         .mud-timeline-item-content {
             max-width: calc(50% - 48px);
@@ -50,8 +50,8 @@
     }
 
     .mud-timeline-item {
-        padding-left: 24px;
-        padding-right: 24px;
+        padding-left: density(24px);
+        padding-right: density(24px);
         width: 100%;
 
         .mud-timeline-item-content {

--- a/src/MudBlazor/Styles/components/_treeview.scss
+++ b/src/MudBlazor/Styles/components/_treeview.scss
@@ -53,7 +53,7 @@
 .mud-treeview-item-content {
     width: 100%;
     display: flex;
-    padding: 4px 8px;
+    padding: density(4px, 8px);
     align-items: center;
     transition: background-color 150ms cubic-bezier(.4,0,.2,1) 0ms;
 }
@@ -105,7 +105,7 @@
     }
 
     .mud-treeview-item-content {
-        padding: 1px 4px;
+        padding: density(1px, 4px);
     }
 
     .mud-treeview-item-arrow {

--- a/src/MudBlazor/Themes/Models/Density.cs
+++ b/src/MudBlazor/Themes/Models/Density.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudBlazor
+{
+    public class Density
+    {
+        public double Modifier { get; set; } = 1d;
+    }
+}

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -8,6 +8,7 @@
         public Typography Typography { get; set; }
         public LayoutProperties LayoutProperties { get; set; }
         public ZIndex ZIndex { get; set; }
+        public Density Density { get; set; }
 
         public MudTheme()
         {
@@ -16,6 +17,7 @@
             Typography = new Typography();
             LayoutProperties = new LayoutProperties();
             ZIndex = new ZIndex();
+            Density = new Density();
         }
     }
 }


### PR DESCRIPTION
## Description
Added a variable (double) into the theme to control the density of components. 0 = minimum padding, 1 = normal. 2 double padding.

Not all components have the effect applied as they are not necessarily relevant (i.e. grid spacing, icon buttons or skeletons).

**Please feel free to remove or move elsewhere the numeric input in the docs that changes the docs current density live. It does not look pretty, but I have little design skills to determine how it would suit this project best,**

## How Has This Been Tested?
Visually tested as these are purely cosmetic changes. Please help check in this fork and branch to check it looks right before merging. Care has been taken that default padding (1) is identical to existing. Extreme density values may have unintended side effects.






![Numeric Field - MudBlazor - Personal - Microsoft​ Edge Dev 27_10_2021 21_14_59](https://user-images.githubusercontent.com/21277696/139140660-8a466d52-1ee3-46ed-8d3d-2fe010b2def5.png)

![Numeric Field - MudBlazor - Personal - Microsoft​ Edge Dev 27_10_2021 21_15_08](https://user-images.githubusercontent.com/21277696/139140668-ba3ef4a9-0b3f-4fba-b23e-fd429e69f155.png)

![Numeric Field - MudBlazor - Personal - Microsoft​ Edge Dev 27_10_2021 21_15_18](https://user-images.githubusercontent.com/21277696/139140681-a165c427-4953-4610-b023-ca74065d24aa.png)


## Checklist:
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
❌ I've added relevant tests.
