### PR TITLE
Drawer: Fixed mini mode drawer's z-index when "closed"

### DIFF
--- a/src/MudBlazor/Styles/layout/_drawer.scss
+++ b/src/MudBlazor/Styles/layout/_drawer.scss
@@ -29,7 +29,7 @@
     }
 
     @each $breakpoint in map-keys($breakpoints) {
-        &.mud-drawer-mini.mud-drawer-#{$breakpoint}, &.mud-drawer-responsive.mud-drawer-#{$breakpoint} {
+        &.mud-drawer-mini.mud-drawer-#{$breakpoint}:not(.mud-drawer--closed), &.mud-drawer-responsive.mud-drawer-#{$breakpoint} {
             @media (max-width: map-get($breakpoints, $breakpoint) - 1px) {
                 z-index: calc(var(--mud-zindex-appbar) + 2);
 


### PR DESCRIPTION
## Description
The Mini mode drawer when "closed" or in mini mode, it still received the higher z-index even when it should not. resulting in overlapping content. I changed so it only applies the z-index change if the mini drawer is "open".

**Issue can be seen here:**
![TheDrawerIssue](https://user-images.githubusercontent.com/10367109/139531552-6c345d12-a4b1-430c-9012-ec960cd7f097.gif)

## How Has This Been Tested?
Manual/Visual testing.


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->




<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
