### PR TITLE
Theme: Typography defaults and documentation

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/TypographyDefaultFontExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/TypographyDefaultFontExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+@code {
+    MudTheme MyCustomTheme = new MudTheme()
+    {
+        Typography = new Typography()
+        {
+            Default = new Default()
+            {
+                FontFamily = new[] { "Poppins", "Helvetica", "Arial", "sans-serif" }
+            }
+        }
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/TypographySettingsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/TypographySettingsExample.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.Docs.Examples
+@code {
+    MudTheme MyCustomTheme = new MudTheme()
+    {
+        Typography = new Typography()
+        {
+            H6 = new H6()
+            {
+                FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
+                FontSize = "1.25rem",
+                FontWeight = 500,
+                LineHeight = 1.6,
+                LetterSpacing = ".0075em"
+            }
+        }
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
@@ -20,7 +20,7 @@
             <ul class="docs-list mx-2">
                 <li><MudLink Href="/customization/theming/palette">Palette</MudLink></li>
                 <li><MudText Inline="true">Shadows</MudText></li>
-                <li><MudText Inline="true">Typography</MudText></li>
+                <li><MudLink Href="/customization/theming/typography">Typography</MudLink></li>
                 <li><MudText Inline="true">Layout Properties</MudText></li>
                 <li><MudLink Href="/customization/theming/z-index">z-index</MudLink></li>
             </ul>

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Typography.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Typography.razor
@@ -1,0 +1,62 @@
+﻿@page "/customization/theming/typography"
+
+<DocsPage>
+    <DocsPageHeader Title="Typography" SubTitle="Typography controls the text trough out the theme, like font-family, size, and other settings." DisableApiHeader="true" />
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="How it works">
+                <Description>
+                   <MudText>It's possible to change the following typography types in the theme and effects all text accross the library.</MudText>
+                </Description>
+            </SectionHeader>
+            <MudGrid>
+                <MudItem xs="6" sm="3">
+                    <ul class="mud-typography-body1">
+                        <li><CodeInline>Default</CodeInline></li>
+                        <li><CodeInline>Body1</CodeInline></li>
+                        <li><CodeInline>Body2</CodeInline></li>
+                        <li><CodeInline>Button</CodeInline></li>
+                    </ul>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <ul class="mud-typography-body1">
+                        <li><CodeInline>H1</CodeInline></li>
+                        <li><CodeInline>H2</CodeInline></li>
+                        <li><CodeInline>H3</CodeInline></li>
+                    </ul>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <ul class="mud-typography-body1">
+                        <li><CodeInline>H4</CodeInline></li>
+                        <li><CodeInline>H5</CodeInline></li>
+                        <li><CodeInline>H6</CodeInline></li>
+                    </ul>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <ul class="mud-typography-body1">
+                        <li><CodeInline>Caption</CodeInline></li>
+                        <li><CodeInline>Subtitle1</CodeInline></li>
+                        <li><CodeInline>Subtitle2</CodeInline></li>
+                    </ul>
+                </MudItem>
+            </MudGrid>
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Change Default Font">
+                <Description>
+                    To change the default font for all available typography change <CodeInline>FontFamily</CodeInline> for the <CodeInline>Default</CodeInline> typography.
+                </Description>
+            </SectionHeader>
+            <SectionSource Code="TypographyDefaultFontExample" NoToolbar="true" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Typography Settings">
+                <Description>
+                    Each typography can be configured with five different settings.
+                </Description>
+            </SectionHeader>
+            <SectionSource Code="TypographySettingsExample" NoToolbar="true" />
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>
+<Footer />

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -224,6 +224,7 @@ namespace MudBlazor.Docs.Services
             //new DocsLink{Title="Default theme", Href="customization/default-theme"},
             new DocsLink {Title = "Overview", Href = "customization/theming/overview"},
             new DocsLink {Title = "Palette", Href = "customization/theming/palette"},
+            new DocsLink {Title = "Typography", Href = "customization/theming/typography"},
             new DocsLink {Title = "z-index", Href = "customization/theming/z-index"},
         }.OrderBy(x => x.Title);
 

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -218,79 +218,79 @@ namespace MudBlazor
             theme.AppendLine($"--{Typography}-default-lineheight: {Theme.Typography.Default.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-default-letterspacing: {Theme.Typography.Default.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h1-family: '{string.Join("','", Theme.Typography.H1.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h1-family: '{string.Join("','", (Theme.Typography.H1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h1-size: {Theme.Typography.H1.FontSize};");
             theme.AppendLine($"--{Typography}-h1-weight: {Theme.Typography.H1.FontWeight};");
             theme.AppendLine($"--{Typography}-h1-lineheight: {Theme.Typography.H1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h1-letterspacing: {Theme.Typography.H1.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h2-family: '{string.Join("','", Theme.Typography.H2.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h2-family: '{string.Join("','", (Theme.Typography.H2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h2-size: {Theme.Typography.H2.FontSize};");
             theme.AppendLine($"--{Typography}-h2-weight: {Theme.Typography.H2.FontWeight};");
             theme.AppendLine($"--{Typography}-h2-lineheight: {Theme.Typography.H2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h2-letterspacing: {Theme.Typography.H2.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h3-family: '{string.Join("','", Theme.Typography.H3.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h3-family: '{string.Join("','", (Theme.Typography.H3.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H3.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h3-size: {Theme.Typography.H3.FontSize};");
             theme.AppendLine($"--{Typography}-h3-weight: {Theme.Typography.H3.FontWeight};");
             theme.AppendLine($"--{Typography}-h3-lineheight: {Theme.Typography.H3.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h3-letterspacing: {Theme.Typography.H3.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h4-family: '{string.Join("','", Theme.Typography.H4.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h4-family: '{string.Join("','", (Theme.Typography.H4.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H4.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h4-size: {Theme.Typography.H4.FontSize};");
             theme.AppendLine($"--{Typography}-h4-weight: {Theme.Typography.H4.FontWeight};");
             theme.AppendLine($"--{Typography}-h4-lineheight: {Theme.Typography.H4.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h4-letterspacing: {Theme.Typography.H4.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h5-family: '{string.Join("','", Theme.Typography.H5.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h5-family: '{string.Join("','", (Theme.Typography.H5.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H5.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h5-size: {Theme.Typography.H5.FontSize};");
             theme.AppendLine($"--{Typography}-h5-weight: {Theme.Typography.H5.FontWeight};");
             theme.AppendLine($"--{Typography}-h5-lineheight: {Theme.Typography.H5.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h5-letterspacing: {Theme.Typography.H5.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-h6-family: '{string.Join("','", Theme.Typography.H6.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-h6-family: '{string.Join("','", (Theme.Typography.H6.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H6.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h6-size: {Theme.Typography.H6.FontSize};");
             theme.AppendLine($"--{Typography}-h6-weight: {Theme.Typography.H6.FontWeight};");
             theme.AppendLine($"--{Typography}-h6-lineheight: {Theme.Typography.H6.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h6-letterspacing: {Theme.Typography.H6.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-subtitle1-family: '{string.Join("','", Theme.Typography.Subtitle1.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-subtitle1-family: '{string.Join("','", (Theme.Typography.Subtitle1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-subtitle1-size: {Theme.Typography.Subtitle1.FontSize};");
             theme.AppendLine($"--{Typography}-subtitle1-weight: {Theme.Typography.Subtitle1.FontWeight};");
             theme.AppendLine($"--{Typography}-subtitle1-lineheight: {Theme.Typography.Subtitle1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-subtitle1-letterspacing: {Theme.Typography.Subtitle1.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-subtitle2-family: '{string.Join("','", Theme.Typography.Subtitle2.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-subtitle2-family: '{string.Join("','", (Theme.Typography.Subtitle2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-subtitle2-size: {Theme.Typography.Subtitle2.FontSize};");
             theme.AppendLine($"--{Typography}-subtitle2-weight: {Theme.Typography.Subtitle2.FontWeight};");
             theme.AppendLine($"--{Typography}-subtitle2-lineheight: {Theme.Typography.Subtitle2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-subtitle2-letterspacing: {Theme.Typography.Subtitle2.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-body1-family: '{string.Join("','", Theme.Typography.Body1.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-body1-family: '{string.Join("','", (Theme.Typography.Body1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-body1-size: {Theme.Typography.Body1.FontSize};");
             theme.AppendLine($"--{Typography}-body1-weight: {Theme.Typography.Body1.FontWeight};");
             theme.AppendLine($"--{Typography}-body1-lineheight: {Theme.Typography.Body1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-body1-letterspacing: {Theme.Typography.Body1.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-body2-family: '{string.Join("','", Theme.Typography.Body2.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-body2-family: '{string.Join("','", (Theme.Typography.Body2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-body2-size: {Theme.Typography.Body2.FontSize};");
             theme.AppendLine($"--{Typography}-body2-weight: {Theme.Typography.Body2.FontWeight};");
             theme.AppendLine($"--{Typography}-body2-lineheight: {Theme.Typography.Body2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-body2-letterspacing: {Theme.Typography.Body2.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-button-family: '{string.Join("','", Theme.Typography.Button.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-button-family: '{string.Join("','", (Theme.Typography.Button.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Button.FontFamily))}';");
             theme.AppendLine($"--{Typography}-button-size: {Theme.Typography.Button.FontSize};");
             theme.AppendLine($"--{Typography}-button-weight: {Theme.Typography.Button.FontWeight};");
             theme.AppendLine($"--{Typography}-button-lineheight: {Theme.Typography.Button.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-button-letterspacing: {Theme.Typography.Button.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-caption-family: '{string.Join("','", Theme.Typography.Caption.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-caption-family: '{string.Join("','", (Theme.Typography.Caption.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Caption.FontFamily))}';");
             theme.AppendLine($"--{Typography}-caption-size: {Theme.Typography.Caption.FontSize};");
             theme.AppendLine($"--{Typography}-caption-weight: {Theme.Typography.Caption.FontWeight};");
             theme.AppendLine($"--{Typography}-caption-lineheight: {Theme.Typography.Caption.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-caption-letterspacing: {Theme.Typography.Caption.LetterSpacing};");
 
-            theme.AppendLine($"--{Typography}-overline-family: '{string.Join("','", Theme.Typography.Overline.FontFamily)}';");
+            theme.AppendLine($"--{Typography}-overline-family: '{string.Join("','", (Theme.Typography.Overline.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Overline.FontFamily))}';");
             theme.AppendLine($"--{Typography}-overline-size: {Theme.Typography.Overline.FontSize};");
             theme.AppendLine($"--{Typography}-overline-weight: {Theme.Typography.Overline.FontWeight};");
             theme.AppendLine($"--{Typography}-overline-lineheight: {Theme.Typography.Overline.LineHeight.ToString(CultureInfo.InvariantCulture)};");

--- a/src/MudBlazor/Themes/Models/Typography.cs
+++ b/src/MudBlazor/Themes/Models/Typography.cs
@@ -3,134 +3,163 @@ namespace MudBlazor
 {
     public class Typography
     {
-        public Default Default { get; set; } = new Default
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".875rem",
-            FontWeight = 400,
-            LineHeight = 1.43,
-            LetterSpacing = ".01071em"
-        };
-        public H1 H1 { get; set; } = new H1
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "6rem",
-            FontWeight = 300,
-            LineHeight = 1.167,
-            LetterSpacing = "-.01562em"
-        };
-        public H2 H2 { get; set; } = new H2
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "3.75rem",
-            FontWeight = 300,
-            LineHeight = 1.2,
-            LetterSpacing = "-.00833em"
-        };
-        public H3 H3 { get; set; } = new H3
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "3rem",
-            FontWeight = 400,
-            LineHeight = 1.167,
-            LetterSpacing = "0"
-        };
-        public H4 H4 { get; set; } = new H4
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "2.125rem",
-            FontWeight = 400,
-            LineHeight = 1.235,
-            LetterSpacing = ".00735em"
-        };
-        public H5 H5 { get; set; } = new H5
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "1.5rem",
-            FontWeight = 400,
-            LineHeight = 1.334,
-            LetterSpacing = "0"
-        };
-        public H6 H6 { get; set; } = new H6
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "1.25rem",
-            FontWeight = 500,
-            LineHeight = 1.6,
-            LetterSpacing = ".0075em"
-        };
-        public Subtitle1 Subtitle1 { get; set; } = new Subtitle1
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "1rem",
-            FontWeight = 400,
-            LineHeight = 1.75,
-            LetterSpacing = ".00938em"
-        };
-        public Subtitle2 Subtitle2 { get; set; } = new Subtitle2
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".875rem",
-            FontWeight = 500,
-            LineHeight = 1.57,
-            LetterSpacing = ".00714em"
-        };
-        public Body1 Body1 { get; set; } = new Body1
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = "1rem",
-            FontWeight = 400,
-            LineHeight = 1.5,
-            LetterSpacing = ".00938em"
-        };
-        public Body2 Body2 { get; set; } = new Body2
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".875rem",
-            FontWeight = 400,
-            LineHeight = 1.43,
-            LetterSpacing = ".01071em"
-        };
-        public Button Button { get; set; } = new Button
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".875rem",
-            FontWeight = 500,
-            LineHeight = 1.75,
-            LetterSpacing = ".02857em"
-        };
-        public Caption Caption { get; set; } = new Caption
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".75rem",
-            FontWeight = 400,
-            LineHeight = 1.66,
-            LetterSpacing = ".03333em"
-        };
-        public Overline Overline { get; set; } = new Overline
-        {
-            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" },
-            FontSize = ".75rem",
-            FontWeight = 400,
-            LineHeight = 2.66,
-            LetterSpacing = ".08333em"
-        };
+        public Default Default { get; set; } = new Default();
+        public H1 H1 { get; set; } = new H1();
+        public H2 H2 { get; set; } = new H2();
+        public H3 H3 { get; set; } = new H3();
+        public H4 H4 { get; set; } = new H4();
+        public H5 H5 { get; set; } = new H5();
+        public H6 H6 { get; set; } = new H6();
+        public Subtitle1 Subtitle1 { get; set; } = new Subtitle1();
+        public Subtitle2 Subtitle2 { get; set; } = new Subtitle2();
+        public Body1 Body1 { get; set; } = new Body1();
+        public Body2 Body2 { get; set; } = new Body2();
+        public Button Button { get; set; } = new Button();
+        public Caption Caption { get; set; } = new Caption();
+        public Overline Overline { get; set; } = new Overline();
     }
 
-    public class Default : BaseTypography { }
-    public class H1 : BaseTypography { }
-    public class H2 : BaseTypography { }
-    public class H3 : BaseTypography { }
-    public class H4 : BaseTypography { }
-    public class H5 : BaseTypography { }
-    public class H6 : BaseTypography { }
-    public class Subtitle1 : BaseTypography { }
-    public class Subtitle2 : BaseTypography { }
-    public class Body1 : BaseTypography { }
-    public class Body2 : BaseTypography { }
-    public class Button : BaseTypography { }
-    public class Caption : BaseTypography { }
-    public class Overline : BaseTypography { }
+    public class Default : BaseTypography
+    { 
+        public Default()
+        {
+            FontFamily = new[] { "Roboto", "Helvetica", "Arial", "sans-serif" };
+            FontSize = ".875rem";
+            FontWeight = 400;
+            LineHeight = 1.43;
+            LetterSpacing = ".01071em";
+        }
+    }
+    public class H1 : BaseTypography
+    {
+        public H1()
+        {
+            FontSize = "6rem";
+            FontWeight = 300;
+            LineHeight = 1.167;
+            LetterSpacing = "-.01562em";
+        }
+    }
+    public class H2 : BaseTypography
+    {
+        public H2()
+        {
+            FontSize = "3.75rem";
+            FontWeight = 300;
+            LineHeight = 1.2;
+            LetterSpacing = "-.00833em";
+        }
+    }
+    public class H3 : BaseTypography
+    {
+        public H3()
+        {
+            FontSize = "3rem";
+            FontWeight = 400;
+            LineHeight = 1.167;
+            LetterSpacing = "0";
+        }
+    }
+    public class H4 : BaseTypography
+    {
+        public H4()
+        {
+            FontSize = "2.125rem";
+            FontWeight = 400;
+            LineHeight = 1.235;
+            LetterSpacing = ".00735em";
+        }
+    }
+    public class H5 : BaseTypography
+    {
+        public H5()
+        {
+            FontSize = "1.5rem";
+            FontWeight = 400;
+            LineHeight = 1.334;
+            LetterSpacing = "0";
+        }
+    }
+    public class H6 : BaseTypography
+    {
+        public H6()
+        {
+            FontSize = "1.25rem";
+            FontWeight = 500;
+            LineHeight = 1.6;
+            LetterSpacing = ".0075em";
+        }
+    }
+    public class Subtitle1 : BaseTypography
+    {
+        public Subtitle1()
+        {
+            FontSize = "1rem";
+            FontWeight = 400;
+            LineHeight = 1.75;
+            LetterSpacing = ".00938em";
+        }
+    }
+    public class Subtitle2 : BaseTypography
+    {
+        public Subtitle2()
+        {
+            FontSize = ".875rem";
+            FontWeight = 500;
+            LineHeight = 1.57;
+            LetterSpacing = ".00714em";
+        }
+    }
+    public class Body1 : BaseTypography
+    {
+        public Body1()
+        {
+            FontSize = "1rem";
+            FontWeight = 400;
+            LineHeight = 1.5;
+            LetterSpacing = ".00938em";
+        }
+    }
+    public class Body2 : BaseTypography
+    {
+        public Body2()
+        {
+            FontSize = ".875rem";
+            FontWeight = 400;
+            LineHeight = 1.43;
+            LetterSpacing = ".01071em";
+        }
+    }
+    public class Button : BaseTypography
+    {
+        public Button()
+        {
+            FontSize = ".875rem";
+            FontWeight = 500;
+            LineHeight = 1.75;
+            LetterSpacing = ".02857em";
+        }
+    }
+    public class Caption : BaseTypography
+    {
+        public Caption()
+        {
+            FontSize = ".75rem";
+            FontWeight = 400;
+            LineHeight = 1.66;
+            LetterSpacing = ".03333em";
+        }
+    }
+    public class Overline : BaseTypography
+    {
+        public Overline()
+        {
+            FontSize = ".75rem";
+            FontWeight = 400;
+            LineHeight = 2.66;
+            LetterSpacing = ".08333em";
+        }
+    }
 
     public class BaseTypography
     {


### PR DESCRIPTION
## Description
Before when changing the default theme's typography you had to specify all property's even if you only wanted to change one of them.
Before example:
```
Typography = new Typography()
{
    Default = new Default()
    {
        FontFamily = new[] { "Robot", "Helvetica", "Arial", "sans-serif" },
        FontSize = ".875rem",
        FontWeight = 400,
        LineHeight = 1.43,
        LetterSpacing = ".01071em"
    },
    H1 =.....
```

And if you wanted the change the font from `Robot` to something else you had to do it for all types `Default`, `H1`, `H2` etc..
Now its possible to only change the one you actually want to change, and all typos use the `Default` typos FontFamily unless specified, this way you don't have to change it on all 14.
```
Typography = new Typography()
{
    Default = new Default()
    {
        FontFamily = new[] { "Poppins", "Helvetica", "Arial", "sans-serif" }
    }
```

I also added some basic documentation on how to change the theme's typography in the customization/theming section of docs.

I implemented this so it would not break current behavior or break any user code even if they have custom theming fonts already.

resolves #2234
fixes #2787

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
