### PR TITLE
MudScollToTop: Fix data types in ScollEventArgs class (#3185)

### DIFF
--- a/src/MudBlazor/Services/Scroll/ScrollEventArgs.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollEventArgs.cs
@@ -14,12 +14,12 @@ namespace MudBlazor
         /// <summary>
         /// The ScrollTop property gets or sets the number of pixels that an element's content is scrolled vertically
         /// </summary>
-        public int ScrollTop { get; set; }
+        public double ScrollTop { get; set; }
 
         /// <summary>
         /// The ScrollLeft property gets or sets the number of pixels that an element's content is scrolled from its left edge.
         /// </summary>
-        public int ScrollLeft { get; set; }
+        public double ScrollLeft { get; set; }
 
         /// <summary>
         /// The ScrollHeight  property is a measurement of the height of an element's content, including content not visible on the screen due to overflow


### PR DESCRIPTION
## Description

Fixes #3185 by changing the type of the properties ScrollTop, ScrollLeft from int to double.
On systems using display scaling, scrollTop may give you a decimal value.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I'm going to add test for MudScrollOnTop component.


<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
❌ I've added relevant tests.
