### PR TITLE
Dialog: Fix Class, Style and Tag properties ignored in inline dialog

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
@@ -2,7 +2,7 @@
 
 <MudButton Variant="Variant.Filled" OnClick="()=>visible=true">Open</MudButton>
 
-<MudDialog @bind-IsVisible="visible" Options="inlineOptions">
+<MudDialog @bind-IsVisible="visible" Options="inlineOptions" Class="test-class" ClassContent="content-class" Style="color: red;" ContentStyle="color: blue;">
     <DialogContent>
         <MudText>Wabalabadubdub!</MudText>
     </DialogContent>

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -111,6 +111,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Based on bug report #3128
+        /// Dialog Class and Style parameters should be honored for inline dialog
+        /// </summary>
+        [Ignore("Sadly we can not get this test to work when it is run in bulk (local and CI). It passes when executed individually")]
+        [Test]
+        public async Task InlineDialogShouldHonorClassAndStyle()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            // open simple test dialog
+            await comp.InvokeAsync(() => dialogReference = service?.Show<TestInlineDialog>());
+            dialogReference.Should().NotBe(null);
+            comp.Find("button").Click();
+            comp.Find("div.mud-dialog").ClassList.Should().Contain("test-class");
+            comp.Find("div.mud-dialog").Attributes["style"].Value.Should().Be("color: red;");
+            comp.Find("div.mud-dialog-content").Attributes["style"].Value.Should().Be("color: blue;");
+            comp.Find("div.mud-dialog-content").ClassList.Should().NotContain("test-class");
+            comp.Find("div.mud-dialog-content").ClassList.Should().Contain("content-class");
+        }
+
+        /// <summary>
         /// Based on bug report by Porkopek:
         /// Updating values that are referenced in TitleContent render fragment won't result in an update of the dialog title
         /// when they change. This is solved by allowing the user to call ForceRender() on DialogInstance

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -76,13 +76,6 @@ namespace MudBlazor
                 if (_isVisible == value)
                     return;
                 _isVisible = value;
-                if (IsInline)
-                {
-                    if (_isVisible)
-                        Show();
-                    else
-                        Close();
-                }
                 IsVisibleChanged.InvokeAsync(value);
             }
         }
@@ -111,6 +104,9 @@ namespace MudBlazor
                 Close();
             var parameters = new DialogParameters()
             {
+                [nameof(Class)] = Class,
+                [nameof(Style)] = Style,
+                [nameof(Tag)] = Tag,
                 [nameof(TitleContent)] = TitleContent,
                 [nameof(DialogContent)] = DialogContent,
                 [nameof(DialogActions)] = DialogActions,
@@ -131,6 +127,13 @@ namespace MudBlazor
         {
             if (IsInline && _reference != null)
                 (_reference.Dialog as MudDialog)?.ForceUpdate(); // forward render update to instance
+            if (IsInline)
+            {
+                if (_isVisible)
+                    Show();
+                else
+                    Close();
+            }
             base.OnAfterRender(firstRender);
         }
 


### PR DESCRIPTION
## Description
Fixes #3128. Inline dialog should't be opened soon after setting IsVisible property because all other properties may not have been initialized yet, moved to OnAfterRender.
## How Has This Been Tested?
Added unit test. Currently it's ignored like InlineDialog_Should_UpdateIsVisibleOnClose, don't know if CI supports that.
## Checklist:
✔️ The PR is submitted to the correct branch (dev).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
