### PR TITLE
PopoverService:  may be initializing when browser is disconnected

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -304,6 +304,38 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MudPopoverService_Initialize_Catch_JSDisconnectedException()
+        {
+            var mock = new Mock<IJSRuntime>();
+
+            mock.Setup(x =>
+           x.InvokeAsync<IJSVoidResult>(
+               "mudPopover.initilize",
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ThrowsAsync(new JSDisconnectedException("JSDisconnectedException")).Verifiable();
+            {
+                var service = new MudPopoverService(mock.Object);
+                await service.InitializeIfNeeded();
+            }
+            mock.Verify();
+        }
+
+        [Test]
+        public async Task MudPopoverService_Initialize_Catch_TaskCancelledException()
+        {
+            var mock = new Mock<IJSRuntime>();
+
+            mock.Setup(x =>
+           x.InvokeAsync<IJSVoidResult>(
+               "mudPopover.initilize",
+               It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ThrowsAsync(new TaskCanceledException()).Verifiable();
+            {
+                var service = new MudPopoverService(mock.Object);
+                await service.InitializeIfNeeded();
+            }
+            mock.Verify();
+        }
+
+        [Test]
         public async Task MudPopoverService_Constructor_OptionWithCustomClass()
         {
             var mock = new Mock<IJSRuntime>();

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -120,6 +120,8 @@ namespace MudBlazor
                 await _jsRuntime.InvokeVoidAsync("mudPopover.initilize", _options.ContainerClass, _options.FlipMargin);
                 _isInitilized = true;
             }
+            catch (JSDisconnectedException) { }
+            catch (TaskCanceledException) { }
             finally
             {
                 _semaphoreSlim.Release();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
There is an exception in docs website logs that relates to `MudPopoverService` setup.
I think this is because `OnAfterRenderAsync` may continue to run after browser has disconnected
The exception is cosmetic because the browser connection is already closed.
However it is good to get it out of the logs so we can see real exceptions.

```
Microsoft.JSInterop.JSDisconnectedException:
   at Microsoft.AspNetCore.Components.Server.Circuits.RemoteJSRuntime.BeginInvokeJS (Microsoft.AspNetCore.Components.Server, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.JSInterop.JSRuntime.InvokeAsync (Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.JSInterop.JSRuntime+<InvokeAsync>d__16`1.MoveNext (Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Microsoft.JSInterop.JSRuntimeExtensions+<InvokeVoidAsync>d__0.MoveNext (Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at MudBlazor.MudPopoverService+<InitializeIfNeeded>d__11.MoveNext (MudBlazor, Version=5.2.0.0, Culture=neutral, PublicKeyToken=null: /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor/Components/Popover/MudPopoverService.cs:127)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at MudBlazor.MudPopover+<OnAfterRenderAsync>d__80.MoveNext (MudBlazor, Version=5.2.0.0, Culture=neutral, PublicKeyToken=null: /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor/Components/Popover/MudPopover.razor.cs:165)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer+<GetErrorHandledTask>d__66.MoveNext (Microsoft.AspNetCore.Components, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
```

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I haven't. this probably needs to go on the website to see if this resolves.


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️  I've added relevant tests.

@just-the-benno Please could you review.