### PR TITLE
Docs: Add render performance measurement in test environments

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -1,7 +1,7 @@
 ﻿<MudMainContent Class="mudblazor-main-content">
     <MudContainer MaxWidth="@MaxWidth">
         <div id="docspage" class="docs-page">
-            <CascadingValue Value="this" IsFixed="true">
+            <CascadingValue Value="this" IsFixed>
                 @ChildContent
             </CascadingValue>
         </div>

--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -4,10 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Docs.Models;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
 
 namespace MudBlazor.Docs.Components
@@ -19,6 +20,7 @@ namespace MudBlazor.Docs.Components
         private NavigationFooterLink _previous;
         private NavigationFooterLink _next;
         private NavigationSection? _section = null;
+        private Stopwatch _stopwatch = Stopwatch.StartNew();
 
         [Inject] NavigationManager NavigationManager { get; set; }
 
@@ -28,6 +30,7 @@ namespace MudBlazor.Docs.Components
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private bool _contentDrawerOpen = true;
+        public event Action<Stopwatch> Rendered;
 
         protected override void OnParametersSet()
         {
@@ -40,6 +43,7 @@ namespace MudBlazor.Docs.Components
         {
             if (firstRender)
             {
+                Rendered?.Invoke(_stopwatch);
                 await _contentNavigation.ScrollToSection(new Uri(NavigationManager.Uri));
             }
         }

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor
@@ -29,6 +29,7 @@
 <div class="docs-page-header mb-12">
     <MudText Typo="@Typo.h3">@Title</MudText>
     <MudText>@GetSubTitle() @Description</MudText>
+    <DocsRenderBenchmark />
 </div>
 <div id="mudads">
     @if (RenderAds)

--- a/src/MudBlazor.Docs/Components/DocsRenderBenchmark.razor
+++ b/src/MudBlazor.Docs/Components/DocsRenderBenchmark.razor
@@ -1,0 +1,32 @@
+﻿@using System.Diagnostics
+
+@if (IsTestEnvironment)
+{
+    <div class="mt-1" style="font-size:8px; color:silver;">
+        Rendered in @_renderMs ms
+    </div>
+}
+
+@code {
+
+    [Inject] public NavigationManager NavMan { get; set; }
+    [CascadingParameter] public DocsPage DocsPage { get; set; }
+
+    public bool IsTestEnvironment => NavMan.BaseUri.Contains("localhost") || NavMan.Uri.Contains("dev.mudblazor.com");
+
+    private double _renderMs;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        if (DocsPage != null)
+            DocsPage.Rendered += OnDocsPageRendered;
+    }
+
+    private void OnDocsPageRendered(Stopwatch stopwatch)
+    {
+        _renderMs = stopwatch.ElapsedMilliseconds;
+        Console.WriteLine($"### {NavMan.ToBaseRelativePath(NavMan.Uri)} rendered in {_renderMs}ms");
+        StateHasChanged();
+    }
+}


### PR DESCRIPTION
We have a way to measure docs page render times now:

This is the base line, showing WASM render times to be way too high, BSS times are acceptable:

```
BSS:
components/alert rendered in 80,573ms
components/appbar rendered in 58,1864ms
components/avatar rendered in 82,9861ms
components/badge rendered in 132,3375ms
components/breadcrumbs rendered in 52,4078ms

WASM:
components/alert rendered in 600ms
components/appbar rendered in 496ms
components/avatar rendered in 546ms
components/badge rendered in 571ms
components/breadcrumbs rendered in 515ms
```

Temporarily the measurement is shown right on the top of the page.
![image](https://user-images.githubusercontent.com/44090/141652315-cd72725e-a355-4c3a-971b-e5ac201619e0.png)

Note, to get a true measurement you need to do a warm-up. You need to click a few times between Alert and AppBar to get a representative measurement.

So far I found this: (the following measurements focus on WASM and only on the alert page)

```
baseline: ~600ms
w/o page nav menu: ~514ms (so the Menu on the right costs about 80ms)
w/o footer: ~495ms (footer costs about 20ms)
w/o any content: 11ms (the page content costs ~500ms)
```

I'll deal with menu and footer later, let's first get the page content loading times down

```
new baseline without nav and footer: ~500ms 
w/o API link: ~216ms (API link costs about 300ms)
w/o SEO tags: ~200ms (cheap)
w/o example source code: ~80ms (gains 120ms for alert)
```