### PR TITLE
MudKeyInterceptor: improve compatibility with older browser

### DIFF
--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -67,10 +67,10 @@ class MudKeyInterceptor {
                 this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
             // remove whitespace and enforce lowercase
             var whitespace = new RegExp("\\s", "g");
-            keyOption.preventDown = (keyOption.preventDown || "none").replaceAll(whitespace, "").toLowerCase();
-            keyOption.preventUp = (keyOption.preventUp || "none").replaceAll(whitespace, "").toLowerCase();
-            keyOption.stopDown = (keyOption.stopDown || "none").replaceAll(whitespace, "").toLowerCase();
-            keyOption.stopUp = (keyOption.stopUp || "none").replaceAll(whitespace, "").toLowerCase();
+            keyOption.preventDown = (keyOption.preventDown || "none").replace(whitespace, "").toLowerCase();
+            keyOption.preventUp = (keyOption.preventUp || "none").replace(whitespace, "").toLowerCase();
+            keyOption.stopDown = (keyOption.stopDown || "none").replace(whitespace, "").toLowerCase();
+            keyOption.stopUp = (keyOption.stopUp || "none").replace(whitespace, "").toLowerCase();
         }
         this.logger('[MudBlazor | KeyInterceptor] key options: ', this._keyOptions);
         if (this._regexOptions.size > 0)


### PR DESCRIPTION
Changed javascript mudKeyInterceptor to use "replace" instead of "replaceAll" to improve compatibility with older browsers, that causes Blazor to crash.

The changes don't cause change of behaviour when the `pattern` parameter is a `RegExp`, like in this case.

## Description
Solves issue #3348

## How Has This Been Tested?
Tested running the application that was crashing using the new code, and running all existing tests.
 
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
