### PR TITLE
Table: Fixed incorrect async code path for label sorting

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<span id="counter">@reloadCounter</span>
+<button id="reseter" @onclick="() => reloadCounter = 0">Reset</button>
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="No." InitialDirection="SortDirection.Descending" T="int">Nr</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+#pragma warning disable CS1998 // async without await
+    public static string __description__ = "The server-side load callback should be called only once per operations.";
+
+    private int totalItems;
+    private int reloadCounter;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<int>> ServerReload(TableState state)
+    {
+        //if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
+        //    throw new ArgumentException("SortDirection is set but SortLabel is not");
+
+        ++reloadCounter;
+        StateHasChanged();
+
+        var p = state.Page*3;
+        IEnumerable<int> data = new List<int>() { 1 + p, 2 + p, 3 + p };
+        totalItems = 99;
+        var sortedData = state.SortDirection == SortDirection.Descending ? data.Reverse() : data;
+        return new TableData<int>() { TotalItems = totalItems, Items = sortedData };
+    }
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
@@ -27,8 +27,6 @@
     /// </summary>
     private async Task<TableData<int>> ServerReload(TableState state)
     {
-        //if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
-        //    throw new ArgumentException("SortDirection is set but SortLabel is not");
 
         ++reloadCounter;
         StateHasChanged();

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -834,6 +834,86 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The server-side load callback should be called only once per page change
+        /// </summary>
+        [Test]
+        public async Task TableServerSideDataTest5()
+        {
+            var comp = Context.RenderComponent<TableServerSideDataTest5>();
+            comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("2");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("3");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("4");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("5");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("6");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("7");
+
+            comp.Find("#reseter").Click(); //reset counter and test again
+            comp.Find("#counter").TextContent.Should().Be("0");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("1");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("2");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
+            comp.Find("#counter").TextContent.Should().Be("3");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("4");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("5");
+
+            comp.FindAll("div.mud-table-pagination-actions button")[1].Click(); // < previous
+            comp.Find("#counter").TextContent.Should().Be("6");
+        }
+
+        /// <summary>
+        /// The server-side load callback should be called only once per sort change
+        /// </summary>
+        [Test]
+        public async Task TableServerSideDataTest6()
+        {
+            var comp = Context.RenderComponent<TableServerSideDataTest5>();
+            comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("2");
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("3");
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("4");
+
+            comp.Find("#reseter").Click(); //reset counter and test again
+            comp.Find("#counter").TextContent.Should().Be("0");
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("1");
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("2");
+
+            comp.Find("span.mud-button-root.mud-table-sort-label").Click(); // sort
+            comp.Find("#counter").TextContent.Should().Be("3");
+        }
+
+        /// <summary>
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -56,7 +56,7 @@ namespace MudBlazor
         private Task UpdateSortDirectionAsync(SortDirection sortDirection)
         {
             SortDirection = sortDirection;
-            return Context.SetSortFunc(this);
+            return Context?.SetSortFunc(this);
         }
 
         [Parameter]

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -56,11 +56,7 @@ namespace MudBlazor
         private Task UpdateSortDirectionAsync(SortDirection sortDirection)
         {
             SortDirection = sortDirection;
-
-            if (SortBy != null || Table.HasServerData)
-                Context?.SetSortFunc(this);
-
-            return Table.InvokeServerLoadFunc();
+            return Context.SetSortFunc(this);
         }
 
         [Parameter]

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MudBlazor.Extensions;
 
 namespace MudBlazor
@@ -111,7 +112,7 @@ namespace MudBlazor
         public Func<T, object> SortBy { get; protected set; }
         public MudTableSortLabel<T> CurrentSortLabel { get; protected set; }
 
-        public void SetSortFunc(MudTableSortLabel<T> label, bool override_direction_none = false)
+        public async Task SetSortFunc(MudTableSortLabel<T> label, bool override_direction_none = false)
         {
             CurrentSortLabel = label;
             if (label.SortDirection == SortDirection.None && override_direction_none)
@@ -119,8 +120,10 @@ namespace MudBlazor
             SortDirection = label.SortDirection;
             SortBy = label.SortBy;
             UpdateSortLabels(label);
+
             if (Table.HasServerData)
-                Table.InvokeServerLoadFunc();
+                await Table.InvokeServerLoadFunc();
+
             TableStateHasChanged();
         }
 


### PR DESCRIPTION
## Description
This PR fixes incorrect usage of async code path when clicking `MudTable` labels to sort data.
Also fixed double callback for `ServerData` in the same case.

## How Has This Been Tested?
All standard tests apply and passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.

This PR was created based on 5.2.0 tag.