### PR TITLE
Implemented homemade virtualization for icon page

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -40,13 +40,8 @@
                 </MudItem>
             </MudGrid>
             <MudScrollToTop TopOffset="650" OnScroll="OnScroll" />
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:20px; left:20px; z-index:9999;">Scrolled Value: @_scrolledValue</MudText>
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:40px; left:20px; z-index:9999;">Scrolled Height: @_scrolledHeight</MudText>
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:60px; left:20px; z-index:9999;">Scrolled Diff: @_scrolledDiff</MudText>
             <div class="relative" style="height:34000px;">
-                <div @ref="KillZone" style="@($"height:65vh;width:100%;position:absolute;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
-                    <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(KillZone)}-{ResizeObserver.GetHeight(KillZone)}")</MudText>
-                </div>
+                <div @ref="KillZone" style="@GetKillZoneStyle(false)"></div>
                 <div class="d-flex flex-wrap align-content-start justify-center" style="height:65vh;position:sticky;top:0px;">
                     @if (DisplayedIcons != null)
                     {

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -44,7 +44,6 @@
             <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:40px; left:20px; z-index:9999;">Scrolled Height: @_scrolledHeight</MudText>
             <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:60px; left:20px; z-index:9999;">Scrolled Diff: @_scrolledDiff</MudText>
             <div class="relative" style="height:34000px;">
-                <div class="absolute mud-height-full mud-width-full" style="top:0px;"></div>
                 <div @ref="KillZone" style="@($"height:65vh;width:100%;position:absolute;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
                     <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(KillZone)}-{ResizeObserver.GetHeight(KillZone)}")</MudText>
                 </div>

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -39,22 +39,51 @@
                     }
                 </MudItem>
             </MudGrid>
-            <div class="docs-icon-container">
-                @if (DisplayedIcons != null)
-                {
-                    <Virtualize Items="@SelectedIcons" ItemSize="128" OverscanCount="128">
-                        <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(context))">
-                            <MudIcon Icon="@context.Code" Title="@context.Name" />
-                            <MudText Typo="Typo.caption">
-                                @context.Name
-                            </MudText>
-                        </button>
-                    </Virtualize>
-                }
-                else
-                {
-                    <MudText Typo="Typo.h5" Align="Align.Center">Loading...</MudText>
-                }
+            <MudScrollToTop TopOffset="650" OnScroll="OnScroll" />
+            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:20px; left:20px; z-index:9999;">Scrolled Value: @_scrolledValue</MudText>
+            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:40px; left:20px; z-index:9999;">Scrolled Height: @_scrolledHeight</MudText>
+            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:60px; left:20px; z-index:9999;">Scrolled Diff: @_scrolledDiff</MudText>
+            <div class="relative" style="height:34000px;">
+                <div class="absolute mud-height-full mud-width-full" style="top:0px;"></div>
+                <div @ref="KillZone" style="@($"height:65vh;width:100%;position:absolute;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
+                    <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(KillZone)}-{ResizeObserver.GetHeight(KillZone)}")</MudText>
+                </div>
+                <div class="d-flex flex-wrap align-content-start justify-center" style="height:65vh;position:sticky;top:0px;">
+                    @if (DisplayedIcons != null)
+                    {
+                        @foreach (var icon in IconCardsTop)
+                        {
+                            <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
+                                <MudIcon Icon="@icon.Code" Title="@icon.Name" />
+                                <MudText Typo="Typo.caption">
+                                    @icon.Name
+                                </MudText>
+                            </button>
+                        }
+                        @foreach (var icon in IconCardsCenter)
+                        {
+                            <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
+                                <MudIcon Icon="@icon.Code" Title="@icon.Name" />
+                                <MudText Typo="Typo.caption">
+                                    @icon.Name
+                                </MudText>
+                            </button>
+                        }
+                        @foreach (var icon in IconCardsBottom)
+                        {
+                            <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
+                                <MudIcon Icon="@icon.Code" Title="@icon.Name" />
+                                <MudText Typo="Typo.caption">
+                                    @icon.Name
+                                </MudText>
+                            </button>
+                        }
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.h5" Align="Align.Center">Loading...</MudText>
+                    }
+                </div>
             </div>
         </DocsPageSection>
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
@@ -233,6 +233,7 @@ namespace MudBlazor.Docs.Pages.Features.Icons
                     DisplayedIcons = CustomUncategorized;
                     break;
             };
+            UpdateIconRange(false);
         }
 
         private void OnSelectedValue(IconOrigin origin)
@@ -273,6 +274,18 @@ namespace MudBlazor.Docs.Pages.Features.Icons
         {
             Custom,
             Material
+        }
+
+        private string GetKillZoneStyle(bool debugg)
+        {
+            if (debugg)
+            {
+                return $"height:65vh;width:100%;position:absolute;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;";
+            }
+            else
+            {
+                return $"height:65vh;width:100%;position:absolute;top:0px;";
+            }
         }
     }
 }

--- a/src/MudBlazor.Docs/Styles/components/_icons.scss
+++ b/src/MudBlazor.Docs/Styles/components/_icons.scss
@@ -1,18 +1,4 @@
 ﻿
-.docs-icon-container {
-    display: grid;
-    gap: 12px;
-    grid-template-rows: 1px minmax(128px, auto);
-    grid-template-columns: repeat(auto-fill,112px);
-
-    div:first-child:not(.docs-icon-panel) {
-        grid-column: 1 / -1;
-    }
-
-    div:last-child:not(.docs-icon-panel) {
-    }
-}
-
 .mud-icondrawer {
     .mud-typography-subtitle1 {
         font-weight: 500;
@@ -46,6 +32,7 @@
     height: 128px;
     width: 96px;
     padding: 0px 6px;
+    margin: 16px 12px;
     display: flex;
     text-align: center;
     align-items: center;
@@ -61,7 +48,7 @@
 
     &:focus-visible {
         background-color: var(--mud-palette-action-default-hover);
-        outline:none;
+        outline: none;
     }
 
     & .mud-svg-icon {


### PR DESCRIPTION
## Description
Blazor Virtualization is not really meant for grid like things but rather 1 item per row.
I made a hybrid between original Blazor one and this PR but it was still slower and was not as responsive.

But this implementation has some downsides as well, scrolling can sometimes feel like its not scrolling at all until the new icons popin, this can maybe/probably be fine tuned.

LoadTimes is slower than current dev in wasm where i get like 23ms contra this PR's ~70ms. But then again current dev does not function at all when scrolling.

I havent figured out how to make the ScrollUp function properly really could use some help here as well but overall my code is prob super shitty.

**PR of the year!**

I will cleanup my hybrid solution and PR that one as well as comparison. It has allot cleaner code.

## How Has This Been Tested?
Manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
