### PR TITLE
Docs: Add a note in MessageBox page regarding its dependency on DialogService

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
@@ -6,6 +6,13 @@
     <DocsPageContent>
 
         <DocsPageSection>
+            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText>The MessageBox depends on <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline></MudText>
+            <MudText>Any global configuration done on the MudDialogProvider will affect all MessageBoxes in your application.</MudText>
+            <MudText>Check the Dialog <MudLink Href="/components/dialog#configuration">Configuration</MudLink> section for instructions on how to configure your dialogs globally.</MudText>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Message Box">
                 <Description>
                     The simplest way to show a message box is to use <CodeInline>IDialogService.ShowMessageBox</CodeInline>. It is a purely procedural way of showing a message box and awaiting the user's decision. 


### PR DESCRIPTION
Docs: Added a note in Message Box Page regarding its dependency on Dialog service and linked Dialog Configuration section.


## Description
Added a Note on Message Box dependency on Dialog Service. 
I have spent more than 3 hours wondering why my message box was too wide, I have checked my css files any div formatting without considering global configuration for MudDialog.
I was under the impression that Message Box and Dialog are separate components and have no relation with each other. I only figured it out after downloading MudBlazor and checking the code for Message Box component.
If the information was provided in the Message Box page it would have saved me a lot of time. 


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Document amendment.

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
