### PR TITLE
Docs: Icon page implemented blazor virtualization hybrid

### DIFF
--- a/src/MudBlazor.Docs/Models/MudIcons.cs
+++ b/src/MudBlazor.Docs/Models/MudIcons.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Collections.Generic;
+
 namespace MudBlazor.Docs.Models
 {
     public class MudIcons
@@ -13,6 +15,16 @@ namespace MudBlazor.Docs.Models
             Name = name;
             Code = code;
             Category = category;
+        }
+    }
+
+    public class MudVirtualizedIcons
+    {
+        public List<MudIcons> RowIcons { get; set; }
+
+        public MudVirtualizedIcons(List<MudIcons> rowicons)
+        {
+            RowIcons = rowicons;
         }
     }
 }

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -17,7 +17,7 @@
                         <MudSelectItem Value="IconOrigin.Material">Material Icons</MudSelectItem>
                     </MudSelect>
                 </MudItem>
-                <MudItem xs="12">
+                <MudItem xs="12" Class="relative">
                     @if(SelectedIconOrigin == IconOrigin.Material)
                     {
                         <MudChipSet Filter="true" Mandatory="true">
@@ -41,11 +41,11 @@
             </MudGrid>
             
             <div class="relative" style="height:34000px;">
-                <div @ref="killZone" style="@($"height:65vh;width:100%;position:sticky;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
-                    <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(killZone)}-{ResizeObserver.GetHeight(killZone)}")</MudText>
+                <div class="absolute" style="top:0px;width:100%;">
+                    <div @ref="killZone" style="@GetKillZoneStyle(false)"></div>
                 </div>
                 <Virtualize Items="@SelectedIcons" ItemSize="@_iconCardHeight">
-                    <div class="d-flex mud-width-full">
+                    <div class="d-flex mud-width-full justify-center">
                         @foreach(var icon in context.RowIcons)
                         {
                             <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -39,19 +39,14 @@
                     }
                 </MudItem>
             </MudGrid>
-            <MudScrollToTop TopOffset="650" OnScroll="OnScroll" />
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:20px; left:20px; z-index:9999;">Scrolled Value: @_scrolledValue</MudText>
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:40px; left:20px; z-index:9999;">Scrolled Height: @_scrolledHeight</MudText>
-            <MudText Typo="Typo.h5" Color="Color.Error" Class="fixed" Style="top:60px; left:20px; z-index:9999;">Scrolled Diff: @_scrolledDiff</MudText>
+            
             <div class="relative" style="height:34000px;">
-                <div class="absolute mud-height-full mud-width-full" style="top:0px;"></div>
-                <div @ref="KillZone" style="@($"height:65vh;width:100%;position:absolute;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
-                    <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(KillZone)}-{ResizeObserver.GetHeight(KillZone)}")</MudText>
+                <div @ref="killZone" style="@($"height:65vh;width:100%;position:sticky;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;")">
+                    <MudText Color="Color.Error">@($"{ResizeObserver.GetWidth(killZone)}-{ResizeObserver.GetHeight(killZone)}")</MudText>
                 </div>
-                <div class="d-flex flex-wrap align-content-start justify-center" style="height:65vh;position:sticky;top:0px;">
-                    @if (DisplayedIcons != null)
-                    {
-                        @foreach (var icon in IconCardsTop)
+                <Virtualize Items="@SelectedIcons" ItemSize="@_iconCardHeight">
+                    <div class="d-flex mud-width-full">
+                        @foreach(var icon in context.RowIcons)
                         {
                             <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
                                 <MudIcon Icon="@icon.Code" Title="@icon.Name" />
@@ -60,30 +55,8 @@
                                 </MudText>
                             </button>
                         }
-                        @foreach (var icon in IconCardsCenter)
-                        {
-                            <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
-                                <MudIcon Icon="@icon.Code" Title="@icon.Name" />
-                                <MudText Typo="Typo.caption">
-                                    @icon.Name
-                                </MudText>
-                            </button>
-                        }
-                        @foreach (var icon in IconCardsBottom)
-                        {
-                            <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
-                                <MudIcon Icon="@icon.Code" Title="@icon.Name" />
-                                <MudText Typo="Typo.caption">
-                                    @icon.Name
-                                </MudText>
-                            </button>
-                        }
-                    }
-                    else
-                    {
-                        <MudText Typo="Typo.h5" Align="Align.Center">Loading...</MudText>
-                    }
-                </div>
+                    </div>
+                </Virtualize>
             </div>
         </DocsPageSection>
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
@@ -23,19 +23,12 @@ namespace MudBlazor.Docs.Pages.Features.Icons
         List<MudIcons> DisplayedIcons;
         private IconOrigin SelectedIconOrigin { get; set; } = IconOrigin.Material;
         private string SearchText { get; set; } = string.Empty;
-        private double _scrolledValue { get; set; }
-        private double _scrolledHeight { get; set; }
-        private double _scrolledDiff { get; set; }
-        private double _scrolledVerticalMark { get; set; }
         private double _iconCardWidth = 136.88; // single icon card width includin margins
-        private double _iconCardHeight = 144; // single icon card height includin margins
-        private int _currentIconRange = 0;
+        private float _iconCardHeight = 144; // single icon card height includin margins
+        private int CardsPerRow = 0;
 
-        int CenterCardsCount = 100;
-        int CardsPerRow = 0;
-        int CardsToSwap = 0;
 
-        private ElementReference KillZone;
+        private ElementReference killZone;
 
         private List<MudIcons> CustomAll { get; set; } = new List<MudIcons>();
         private List<MudIcons> CustomBrands { get; set; } = new List<MudIcons>();
@@ -52,14 +45,33 @@ namespace MudBlazor.Docs.Pages.Features.Icons
         private string IconCodeOutput { get; set; }
         private Size PreviewIconSize { get; set; } = Size.Medium;
         private Color PreviewIconColor { get; set; } = Color.Dark;
+        private List<MudVirtualizedIcons> SelectedIcons => string.IsNullOrWhiteSpace(SearchText)
+            ? GetVirtualizedIcons(DisplayedIcons)
+            : GetVirtualizedIcons(DisplayedIcons.Where(m => m.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList());
 
-        private List<MudIcons> IconCardsTop { get; set; } = new List<MudIcons>();
-        private List<MudIcons> IconCardsCenter { get; set; } = new List<MudIcons>();
-        private List<MudIcons> IconCardsBottom { get; set; } = new List<MudIcons>();
+        private List<MudVirtualizedIcons> GetVirtualizedIcons(List<MudIcons> iconlist)
+        {
+            var virtualizedIcons = new List<MudVirtualizedIcons>();
+            var rowIcons = new List<MudIcons>();
+            int counter = 0;
 
-        private List<MudIcons> SelectedIcons => string.IsNullOrWhiteSpace(SearchText)
-            ? DisplayedIcons
-            : DisplayedIcons.Where(m => m.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+            foreach (var icon in iconlist)
+            {
+                if(CardsPerRow > counter)
+                {
+                    counter++;
+                    rowIcons.Add(icon);
+                }
+                else if(CardsPerRow == counter)
+                {
+                    rowIcons.Add(icon);
+                    virtualizedIcons.Add(new MudVirtualizedIcons(rowIcons));
+                    rowIcons = new List<MudIcons>();
+                    counter = 0;
+                }
+            }
+            return virtualizedIcons;
+        }
 
         private readonly IDictionary<string, object> IconTypes = new Dictionary<string, object>()
         {
@@ -91,11 +103,11 @@ namespace MudBlazor.Docs.Pages.Features.Icons
             if (firstRender)
             {
 
-                await ResizeObserver.Observe(KillZone);
+                await ResizeObserver.Observe(killZone);
 
                 ResizeObserver.OnResized += OnResized;
 
-                UpdateIconRange(false);
+                SetCardsPerRow();
                 StateHasChanged();
             }
         }
@@ -105,53 +117,9 @@ namespace MudBlazor.Docs.Pages.Features.Icons
             await InvokeAsync(StateHasChanged);
         }
 
-        private void OnScroll(ScrollEventArgs e)
+        private void SetCardsPerRow()
         {
-            CardsPerRow = Convert.ToInt32(ResizeObserver.GetWidth(KillZone) / _iconCardWidth);
-            CardsToSwap = CardsPerRow;
-            //CardsToSwap = (CardsPerRow) switch
-            //{
-            //    var x when x < 4 => 2 * CardsPerRow,
-            //    var x when x < 6 => 3 * CardsPerRow,
-            //    var x when x < 8 => 4 * CardsPerRow,
-            //    _=> 5 * CardsPerRow
-            //};
-
-            var oldvalue = _scrolledValue;
-
-            _scrolledValue = e.FirstChildBoundingClientRect.Top * -1;
-            _scrolledHeight += _scrolledValue;
-            _scrolledDiff += Math.Abs(_scrolledValue - oldvalue);
-
-            if (_scrolledDiff > _iconCardHeight && _scrolledValue > oldvalue)
-            {
-                _currentIconRange += CardsToSwap;
-                UpdateIconRange(false);
-            }
-            else if (_scrolledDiff > _iconCardHeight && _scrolledValue < oldvalue)
-            {
-                _currentIconRange += CardsToSwap;
-                UpdateIconRange(true);
-            }
-        }
-
-        private void UpdateIconRange(bool scrollUp)
-        {
-            CardsPerRow = Convert.ToInt32(ResizeObserver.GetWidth(KillZone) / _iconCardWidth);
-            CardsToSwap = CardsPerRow;
-
-            if (scrollUp)
-            {
-                IconCardsTop = SelectedIcons.GetRange(_currentIconRange - CardsToSwap, CardsToSwap).ToList();
-                IconCardsCenter = SelectedIcons.GetRange((_currentIconRange - CardsToSwap - CardsToSwap), CenterCardsCount).ToList();
-                IconCardsBottom = SelectedIcons.GetRange((_currentIconRange - CardsToSwap - CardsToSwap - CardsToSwap), CardsToSwap).ToList();
-            }
-            else
-            {
-                IconCardsTop = SelectedIcons.GetRange(_currentIconRange, CardsToSwap).ToList();
-                IconCardsCenter = SelectedIcons.GetRange((_currentIconRange + CardsToSwap), CenterCardsCount).ToList();
-                IconCardsBottom = SelectedIcons.GetRange((_currentIconRange + CardsToSwap + CardsToSwap), CardsToSwap).ToList();
-            }
+            CardsPerRow = Convert.ToInt32(ResizeObserver.GetWidth(killZone) / _iconCardWidth);
         }
 
         public async Task<List<MudIcons>> LoadMaterialIcons(string type)

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor.cs
@@ -57,12 +57,13 @@ namespace MudBlazor.Docs.Pages.Features.Icons
 
             foreach (var icon in iconlist)
             {
-                if(CardsPerRow > counter)
+                counter++;
+                if (CardsPerRow > counter)
                 {
-                    counter++;
+                    
                     rowIcons.Add(icon);
                 }
-                else if(CardsPerRow == counter)
+                else if(CardsPerRow <= counter)
                 {
                     rowIcons.Add(icon);
                     virtualizedIcons.Add(new MudVirtualizedIcons(rowIcons));
@@ -114,6 +115,7 @@ namespace MudBlazor.Docs.Pages.Features.Icons
 
         private async void OnResized(IDictionary<ElementReference, BoundingClientRect> changes)
         {
+            SetCardsPerRow();
             await InvokeAsync(StateHasChanged);
         }
 
@@ -241,6 +243,18 @@ namespace MudBlazor.Docs.Pages.Features.Icons
         {
             Custom,
             Material
+        }
+
+        private string GetKillZoneStyle(bool debugg)
+        {
+            if (debugg)
+            {
+                return $"height:65vh;width:100%;position:sticky;top:0px;border-color:#ff0000;border-style:dashed;border-width:4px;border-radius:8px;";
+            }
+            else
+            {
+                return $"height:65vh;width:100%;position:sticky;top:0px;";
+            }
         }
     }
 }

--- a/src/MudBlazor.Docs/Styles/components/_icons.scss
+++ b/src/MudBlazor.Docs/Styles/components/_icons.scss
@@ -30,7 +30,8 @@
 
 .docs-icon-panel {
     height: 128px;
-    width: 96px;
+    width: 100%;
+    max-width:112px;
     padding: 0px 6px;
     margin: 16px 12px;
     display: flex;
@@ -66,11 +67,5 @@
     &:hover {
         cursor: pointer;
         background-color: var(--mud-palette-action-default-hover);
-    }
-}
-
-@media screen and (min-width: 720px) {
-    .docs-icon-panel {
-        width: 112px;
     }
 }


### PR DESCRIPTION
## Description
Try scroll here fast, or in general jump with scrollbar: https://dev.mudblazor.com/features/icons#icons
i made two solutions this and this trash: https://github.com/MudBlazor/MudBlazor/pull/3371
But now i finally got the hybrid one working as it should and it just feels so much better.

Current dev one have like 20ms WASM benchmark but it does not work at all when it comes to scrolling, i got this one down to ~50ms so still pretty good.

One downside from this solution is that its not really a flex box / css grid, hence each row and its columns is not always 100% the same width, it can be seen when resizing but its a very minor issues.

fixes #3308

![IconStuff](https://user-images.githubusercontent.com/10367109/142026570-99add108-7c49-49fd-a9c3-4b7db6f38d0c.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
