### PR TITLE
Dialog: Close on ESC

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -108,5 +108,36 @@
             <SectionSource Code="DialogInlineExample" GitHubFolderName="Dialog" ShowCode="false" />
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Inlining Dialog">
+                <Description>
+                    You can inline <CodeInline>MudDialog</CodeInline> directly in another component which, of course, makes most sense for small dialogs that are not re-used somewhere else.
+                    The advantage is that you can easily share code and data between dialog and owning component via bindings.
+                    <br />
+                    This example also shows how to override the dialog title with a render fragment. 
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <DialogInlineExample />
+            </SectionContent>
+            <SectionSource Code="DialogInlineExample" GitHubFolderName="Dialog" ShowCode="false" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Keyboard Navigation">
+                <Description>
+                    <MudText>MudDialog accepts keys to keyboard navigation.</MudText>
+                    <br />
+                    <MudText><CodeInline>Escape</CodeInline> key to close dialog. Closing a dialog by pressing escape has to be enabled by setting option <CodeInline>CloseOnEscapekey=true</CodeInline></MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <MudContainer>
+                    <DialogKeyboardNavigationExample />
+                </MudContainer>
+            </SectionContent>
+            <SectionSource Code="DialogKeyboardNavigationExample" GitHubFolderName="Dialog" ShowCode="false" />
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@inject IDialogService DialogService
+
+
+<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+    Open Dialog
+</MudButton>
+
+
+@code {
+
+    private void OpenDialog()
+    {    
+        DialogOptions closeOnEscapeKey = new DialogOptions() { CloseOnEscapeKey = true };
+
+        DialogService.Show<DialogKeyboardNavigationExample_Dialog>("Simple Dialog", closeOnEscapeKey);
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
@@ -1,0 +1,25 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField T="string" Label="Name"></MudTextField>
+        <MudSelect T="string" Label="Favorite Coffee" AnchorOrigin="Origin.BottomCenter">
+            <MudSelectItem Value="@("Cappuccino")" />
+            <MudSelectItem Value="@("Cafe Latte")" />
+            <MudSelectItem Value="@("Espresso")" />
+            <MudSelectItem Value="@("Irish Coffee")" />
+        </MudSelect>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+
+    void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    void Cancel() => MudDialog.Cancel();
+}

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/ManualMarkdown/MarkdownDialogParameters.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/ManualMarkdown/MarkdownDialogParameters.razor
@@ -10,6 +10,7 @@
     <span class="htmlAttributeName">DisableBackdropClick</span><span class="htmlOperator">=</span><span class="quot">"</span><span class="keyword">true</span><span class="quot">"</span>   <span class="comment">//If true, clicking the backdrop/overlay will not close the dialog</span>
     <span class="htmlAttributeName">NoHeader</span><span class="htmlOperator">=</span><span class="quot">"</span><span class="keyword">true</span><span class="quot">"</span>   <span class="comment">//If true disabled the dialog header</span>
     <span class="htmlAttributeName">Position</span><span class="htmlOperator">=</span><span class="quot">"</span><span class="enum">DialogPosition</span><span class="enumValue">.Center</span><span class="quot">"</span>  <span class="comment">//Sets the dialog postion</span>
+    <span class="htmlAttributeName">CloseOnEscapeKey</span><span class="htmlOperator">=</span><span class="quot">"</span><span class="keyword">true</span><span class="quot">"</span>   <span class="comment">//If true dialog is closable by pressing escape</span>
 <span class="htmlTagDelimiter">&lt;/</span>
 </pre>
     </div>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
@@ -11,7 +11,7 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter] public MudDialogInstance MudDialog { get; set; }
 
     void Submit() => MudDialog.Close(DialogResult.Ok(true));
     void Cancel() => MudDialog.Cancel();

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Dialog;
@@ -284,6 +285,30 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button")[1].Click();
             rv = await dialogReference.GetReturnValueAsync<string>();
             rv.Should().Be("Closed via OK");
+        }
+
+        [Test]
+        public async Task DialogKeyboardNavigation()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            //dialog with clickable backdrop
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { DisableBackdropClick = false }));
+            dialogReference.Should().NotBe(null);
+            var dialog1 = (DialogOkCancel)dialogReference.Dialog;
+            comp.Markup.Trim().Should().NotBeEmpty();
+            await comp.InvokeAsync(() => dialog1.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            comp.Markup.Trim().Should().BeEmpty();
+            //dialog with disabled backdrop click
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { DisableBackdropClick = true }));
+            dialogReference.Should().NotBe(null);
+            var dialog2 = (DialogOkCancel)dialogReference.Dialog;
+            comp.Markup.Trim().Should().NotBeEmpty();
+            await comp.InvokeAsync(() => dialog2.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            comp.Markup.Trim().Should().NotBeEmpty();
         }
     }
 

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -296,14 +296,14 @@ namespace MudBlazor.UnitTests.Components
             service.Should().NotBe(null);
             IDialogReference dialogReference = null;
             //dialog with clickable backdrop
-            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = true }));
             dialogReference.Should().NotBe(null);
             var dialog1 = (DialogOkCancel)dialogReference.Dialog;
             comp.Markup.Trim().Should().NotBeEmpty();
             await comp.InvokeAsync(() => dialog1.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().BeEmpty();
             //dialog with disabled backdrop click
-            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = true }));
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
             dialogReference.Should().NotBe(null);
             var dialog2 = (DialogOkCancel)dialogReference.Dialog;
             comp.Markup.Trim().Should().NotBeEmpty();

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -296,14 +296,14 @@ namespace MudBlazor.UnitTests.Components
             service.Should().NotBe(null);
             IDialogReference dialogReference = null;
             //dialog with clickable backdrop
-            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { DisableBackdropClick = false }));
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
             dialogReference.Should().NotBe(null);
             var dialog1 = (DialogOkCancel)dialogReference.Dialog;
             comp.Markup.Trim().Should().NotBeEmpty();
             await comp.InvokeAsync(() => dialog1.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().BeEmpty();
             //dialog with disabled backdrop click
-            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { DisableBackdropClick = true }));
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = true }));
             dialogReference.Should().NotBe(null);
             var dialog2 = (DialogOkCancel)dialogReference.Dialog;
             comp.Markup.Trim().Should().NotBeEmpty();

--- a/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
@@ -24,6 +24,11 @@ namespace MudBlazor.UnitTests.Mocks
             return Task.CompletedTask;
         }
 
+        public Task UpdateKey(KeyOptions option)
+        {
+            return Task.CompletedTask;
+        }
+
         public event KeyboardEvent KeyDown;
         public event KeyboardEvent KeyUp;
     }

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         public MaxWidth? MaxWidth { get; set; }
 
         public bool? DisableBackdropClick { get; set; }
+        public bool? CloseOnEscapeKey { get; set; }
         public bool? NoHeader { get; set; }
         public bool? CloseButton { get; set; }
         public bool? FullScreen { get; set; }

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="mud-dialog-container @Position">
+<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClick" Class="mud-overlay-dialog" DarkBackground="true" />
     <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style">
         @if (!NoHeader)

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -46,6 +46,7 @@ namespace MudBlazor
         private string Position { get; set; }
         private string DialogMaxWidth { get; set; }
         private bool DisableBackdropClick { get; set; }
+        private bool CloseOnEscapeKey { get; set; }
         private bool NoHeader { get; set; }
         private bool CloseButton { get; set; }
         private bool FullScreen { get; set; }
@@ -61,14 +62,18 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+                //Since CloseOnEscapeKey is the only thing to be handled, turn interceptor off
+                if (CloseOnEscapeKey)
                 {
-                    TargetClass = "mud-dialog",
-                    Keys = {
-                        new KeyOptions { Key="Escape", SubscribeDown = true },
-                    },
-                });
-                _keyInterceptor.KeyDown += HandleKeyDown;
+                    await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+                    {
+                        TargetClass = "mud-dialog",
+                        Keys = {
+                            new KeyOptions { Key="Escape", SubscribeDown = true },
+                        },
+                    });
+                    _keyInterceptor.KeyDown += HandleKeyDown;
+                }
             }
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -78,7 +83,7 @@ namespace MudBlazor
             switch (args.Key)
             {
                 case "Escape":
-                    if (!DisableBackdropClick)
+                    if (!CloseOnEscapeKey)
                     {
                         Cancel();
                     }
@@ -150,6 +155,7 @@ namespace MudBlazor
             FullWidth = SetFullWidth();
             FullScreen = SetFulScreen();
             DisableBackdropClick = SetDisableBackdropClick();
+            CloseOnEscapeKey = SetCloseOnEscapeKey();
         }
 
         private string SetPosition()
@@ -250,6 +256,17 @@ namespace MudBlazor
 
             if (GlobalDialogOptions.DisableBackdropClick.HasValue)
                 return GlobalDialogOptions.DisableBackdropClick.Value;
+
+            return false;
+        }
+
+        private bool SetCloseOnEscapeKey()
+        {
+            if (Options.CloseOnEscapeKey.HasValue)
+                return Options.CloseOnEscapeKey.Value;
+
+            if (GlobalDialogOptions.CloseOnEscapeKey.HasValue)
+                return GlobalDialogOptions.CloseOnEscapeKey.Value;
 
             return false;
         }

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -80,10 +80,10 @@ namespace MudBlazor
 
         internal void HandleKeyDown(KeyboardEventArgs args)
         {
-            switch (args.Key)
+             switch (args.Key)
             {
                 case "Escape":
-                    if (!CloseOnEscapeKey)
+                    if (CloseOnEscapeKey)
                     {
                         Cancel();
                     }

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -22,6 +22,7 @@ namespace MudBlazor
         [Parameter] public bool? NoHeader { get; set; }
         [Parameter] public bool? CloseButton { get; set; }
         [Parameter] public bool? DisableBackdropClick { get; set; }
+        [Parameter] public bool? CloseOnEscapeKey { get; set; }
         [Parameter] public bool? FullWidth { get; set; }
         [Parameter] public DialogPosition? Position { get; set; }
         [Parameter] public MaxWidth? MaxWidth { get; set; }
@@ -36,6 +37,7 @@ namespace MudBlazor
             NavigationManager.LocationChanged += LocationChanged;
 
             _globalDialogOptions.DisableBackdropClick = DisableBackdropClick;
+            _globalDialogOptions.CloseOnEscapeKey = CloseOnEscapeKey;
             _globalDialogOptions.CloseButton = CloseButton;
             _globalDialogOptions.NoHeader = NoHeader;
             _globalDialogOptions.Position = Position;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -616,6 +616,7 @@ namespace MudBlazor
             StateHasChanged();
             await HilightSelectedValue();
 
+            //disable escape propagation: if selectmenu is open, only the select popover should close and underlying components should not handle escape key
             await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "Key+none" });
         }
 
@@ -631,6 +632,7 @@ namespace MudBlazor
                 StateHasChanged();
             }
 
+            //enable escape propagation: the select popover was closed, now underlying components are allowed to handle escape key
             await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "none" });
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -615,6 +615,8 @@ namespace MudBlazor
             UpdateIcon();
             StateHasChanged();
             await HilightSelectedValue();
+
+            await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "Key+none" });
         }
 
         public async Task CloseMenu(bool focusAgain = true)
@@ -628,6 +630,8 @@ namespace MudBlazor
                 _elementReference.FocusAsync().AndForget(TaskOption.Safe);
                 StateHasChanged();
             }
+
+            await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "none" });
         }
 
         private void UpdateIcon()
@@ -661,6 +665,7 @@ namespace MudBlazor
                         new KeyOptions { Key="ArrowDown", PreventDown = "key+none" }, // prevent scrolling page, instead hilight next item
                         new KeyOptions { Key="Home", PreventDown = "key+none" },
                         new KeyOptions { Key="End", PreventDown = "key+none" },
+                        new KeyOptions { Key="Escape" },
                         new KeyOptions { Key="Enter", PreventDown = "key+none" },
                         new KeyOptions { Key="NumpadEnter", PreventDown = "key+none" },
                         new KeyOptions { Key="a", PreventDown = "key+ctrl" }, // select all items instead of all page text

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
@@ -14,6 +14,7 @@ namespace MudBlazor.Services
     {
         Task Connect(string elementId, KeyInterceptorOptions options);
         Task Disconnect();
+        Task UpdateKey(KeyOptions option);
 
         event KeyboardEvent KeyDown;
         event KeyboardEvent KeyUp;

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -49,6 +49,11 @@ namespace MudBlazor.Services
             catch (TaskCanceledException) { }
         }
 
+        /// <summary>
+        /// Update behavior of a registered keyoption
+        /// The keystrike to update has to be monitored previously
+        /// </summary>
+        /// <param name="option">Define KeyOption to update</param>
         public async Task UpdateKey(KeyOptions option)
         {
             await _jsRuntime.InvokeVoidAsync($"mudKeyInterceptor.updatekey", _elementId, option);

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -49,6 +49,11 @@ namespace MudBlazor.Services
             catch (TaskCanceledException) { }
         }
 
+        public async Task UpdateKey(KeyOptions option)
+        {
+            await _jsRuntime.InvokeVoidAsync($"mudKeyInterceptor.updatekey", _elementId, option);
+        }
+
         /// <summary>
         /// Disconnect from the previously connected ancestor and its descendants
         /// </summary>

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -12,6 +12,13 @@
         element.mudKeyInterceptor.connect(element);
     }
 
+    updatekey(elementId, option) {
+        var element = document.getElementById(elementId);
+        if (!element || !element.mudKeyInterceptor)
+            return;
+        element.mudKeyInterceptor.updatekey(option);
+    }
+
     disconnect(elementId) {
         var element = document.getElementById(elementId);
         if (!element || !element.mudKeyInterceptor)
@@ -58,19 +65,7 @@ class MudKeyInterceptor {
                 this.logger('[MudBlazor | KeyInterceptor] got invalid key options: ', keyOption);
                 continue;
             }
-            if (keyOption.key.length > 2 && keyOption.key.startsWith('/') && keyOption.key.endsWith('/')) {
-                // JS regex key options such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
-                keyOption.regex = new RegExp(keyOption.key.substring(1, keyOption.key.length-1)); // strip the / from start and end
-                this._regexOptions.push(keyOption);
-            }
-            else
-                this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
-            // remove whitespace and enforce lowercase
-            var whitespace = new RegExp("\\s", "g");
-            keyOption.preventDown = (keyOption.preventDown || "none").replace(whitespace, "").toLowerCase();
-            keyOption.preventUp = (keyOption.preventUp || "none").replace(whitespace, "").toLowerCase();
-            keyOption.stopDown = (keyOption.stopDown || "none").replace(whitespace, "").toLowerCase();
-            keyOption.stopUp = (keyOption.stopUp || "none").replace(whitespace, "").toLowerCase();
+            this.setKeyOption(keyOption)
         }
         this.logger('[MudBlazor | KeyInterceptor] key options: ', this._keyOptions);
         if (this._regexOptions.size > 0)
@@ -79,6 +74,29 @@ class MudKeyInterceptor {
         for (const child of this._element.getElementsByClassName(targetClass)) {
             this.attachHandlers(child);
         }
+    }
+
+    setKeyOption(keyOption) {
+        if (keyOption.key.length > 2 && keyOption.key.startsWith('/') && keyOption.key.endsWith('/')) {
+            // JS regex key options such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
+            keyOption.regex = new RegExp(keyOption.key.substring(1, keyOption.key.length - 1)); // strip the / from start and end
+            this._regexOptions.push(keyOption);
+        }
+        else
+            this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
+        // remove whitespace and enforce lowercase
+        var whitespace = new RegExp("\\s", "g");
+        keyOption.preventDown = (keyOption.preventDown || "none").replace(whitespace, "").toLowerCase();
+        keyOption.preventUp = (keyOption.preventUp || "none").replace(whitespace, "").toLowerCase();
+        keyOption.stopDown = (keyOption.stopDown || "none").replace(whitespace, "").toLowerCase();
+        keyOption.stopUp = (keyOption.stopUp || "none").replace(whitespace, "").toLowerCase();
+    }
+
+    updatekey(updatedOption) {        
+        var option = this._keyOptions[updatedOption.key.toLowerCase()];
+        option || this.logger('[MudBlazor | KeyInterceptor] updating option failed: key not registered');
+        this.setKeyOption(updatedOption);
+        this.logger('[MudBlazor | KeyInterceptor] updated option ', { option, updatedOption });
     }
 
     disconnect() {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This PR improves MudDialog: Pressing ESC closes MudDialog, if close by backdrop click is possible. (closes #3379)

I noticed a difficulty or a bad ux: If there is a component with popover within a dialog and its popover is also closeable by ESC (like MudSelect, Picker), pressing escape does not close the popover, instead the dialog closes. 
To prevent this I had to extend the mudkeyinterceptor with a possibility to update a keyoption:
Example-situation:
- Focused a MudSelect nested in MudDialog, the popover opens (and sets StopDown to ` StopDown = "Key+none"` to stop propagation, otherwise the dialog would close)
- Pressing ESC should now close only the Popover (and sets StopDown to ` StopDown = "none"`)
- Pressing ESC a second time should now close the dialog

There are other components which react on ESC press and have to be investigated:
- [x] MudSelect
- [ ] MudAutocomplete
- [ ] MudCheckBox
- [ ] MudPicker
- [ ] MudSwitch

## How Has This Been Tested?
See test in 3aee5fd96d2cc042c322733653449feedfd190c2
Checks whether dialog is closed by ESC and whether dialog is not closed, if backdropclick is disabled


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->




<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
