### PR TITLE
Table: Fix expandable button overflow when table is dense

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -131,6 +131,10 @@
                     padding: 4px;
                 }
             }
+
+            .mud-table-row-expander {
+                padding: 4px;
+            }
         }
 
         & .mud-table-cell:last-child {


### PR DESCRIPTION
The fix was already applied to checkbox but needed to also be added for the expand option. 
Note: the button hover overflow was causing a whitespace at the end of the table as you can see bellow.

Before:
![image](https://user-images.githubusercontent.com/14116459/142938492-9a1b3153-69c0-480f-90ea-9a2d679b979a.png)

After:
![image](https://user-images.githubusercontent.com/14116459/142938637-af45130c-33f4-4df3-99c3-7cdd50ed149d.png)
