### PR TITLE
DatePicker: Obsolete AllowKeyboardInput parameter

### DIFF
--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -27,8 +27,8 @@ namespace MudBlazor
                 .AddClass($"mud-picker-static", PickerVariant == PickerVariant.Static)
                 .AddClass($"mud-rounded", PickerVariant == PickerVariant.Static && !_pickerSquare)
                 .AddClass($"mud-elevation-{_pickerElevation}", PickerVariant == PickerVariant.Static)
-                .AddClass($"mud-picker-input-button", !AllowKeyboardInput && PickerVariant != PickerVariant.Static)
-                .AddClass($"mud-picker-input-text", AllowKeyboardInput && PickerVariant != PickerVariant.Static)
+                .AddClass($"mud-picker-input-button", !Editable && PickerVariant != PickerVariant.Static)
+                .AddClass($"mud-picker-input-text", Editable && PickerVariant != PickerVariant.Static)
                 .AddClass($"mud-disabled", Disabled && PickerVariant != PickerVariant.Static)
                 .AddClass(Class)
             .Build();
@@ -235,8 +235,9 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Primary;
 
         /// <summary>
-        /// Allows text input from keyboard.
+        /// Changes the cursor appearance.
         /// </summary>
+        [Obsolete("This is enabled now by default when you use Editable=true. You can remove the parameter.", false)]
         [Parameter] public bool AllowKeyboardInput { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
In my opinion, the `AllowKeyboardInput` prop is not necessary. It just changes the appearance of the cursor. We can change the cursor based on `Editable`. See https://github.com/MudBlazor/MudBlazor/discussions/3447

Before:

![before](https://user-images.githubusercontent.com/62108893/144491524-7b0b16d2-be57-4f63-92e1-478bc188e5c2.gif)

After:

![after](https://user-images.githubusercontent.com/62108893/144491549-31984620-f7a2-4c19-a9ec-04a5591c52cf.gif)



## How Has This Been Tested?
visually

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
