### PR TITLE
DatePicker : add option to define CalendarWeekRule

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -777,7 +777,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(CalendarWeekRule.FirstDay, "1")]
         [TestCase(CalendarWeekRule.FirstFullWeek, "52")]
         [TestCase(CalendarWeekRule.FirstFourDayWeek, "53")]
-        public void Check_WeekNumber_CalendarWeekRule_FirstDay(CalendarWeekRule weekRule, string expectedWeekNumber)
+        public async Task Check_WeekNumber_CalendarWeekRule_FirstDay(CalendarWeekRule weekRule, string expectedWeekNumber)
         {
             // Define a date for comparison
             //2021, 1, 1 is a good sample as all option have a different value
@@ -787,11 +787,12 @@ namespace MudBlazor.UnitTests.Components
 
             //init picker
             var comp = Context.RenderComponent<MudDatePicker>();
-            var datepicker = comp.Instance;
-            datepicker.PickerMonth = dateSample;
+            comp.SetParam(p => p.ShowWeekNumbers, true);
+            comp.SetParam(p => p.CalendarWeekRule, weekRule);
+            comp.SetParam(p => p.PickerMonth, dateSample);
 
-            //Set week rule
-            datepicker.CalendarWeekRule = weekRule;
+            //Check method
+            var datepicker = comp.Instance;
 
             //Get week number
             var weekNumber = datepicker.GetWeekNumber(0, 0);

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -566,7 +566,7 @@ namespace MudBlazor.UnitTests.Components
             datePicker.Instance.Date.Should().Be(now);
 
             // Close the datepicker without submitting the date
-            // The date of the datepicker remains equal to now 
+            // The date of the datepicker remains equal to now
             await comp.InvokeAsync(() => datePicker.Instance.Close(false));
 
             // Change the value of autoclose
@@ -774,13 +774,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Check_WeekNumber_CalendarWeekRule_FirstDay()
+        [TestCase(CalendarWeekRule.FirstDay, "1")]
+        [TestCase(CalendarWeekRule.FirstFullWeek, "52")]
+        [TestCase(CalendarWeekRule.FirstFourDayWeek, "53")]
+        public void Check_WeekNumber_CalendarWeekRule_FirstDay(CalendarWeekRule weekRule, string expectedWeekNumber)
         {
             // Define a date for comparison
             //2021, 1, 1 is a good sample as all option have a different value
             var dateSample = new DateTime(2021, 1, 1);
             var cal = CultureInfo.CurrentCulture.Calendar;
-            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstDay, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
+            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, weekRule, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
 
             //init picker
             var comp = Context.RenderComponent<MudDatePicker>();
@@ -788,63 +791,13 @@ namespace MudBlazor.UnitTests.Components
             datepicker.PickerMonth = dateSample;
 
             //Set week rule
-            datepicker.CalendarWeekRule = CalendarWeekRule.FirstDay;
+            datepicker.CalendarWeekRule = weekRule;
 
             //Get week number
             var weekNumber = datepicker.GetWeekNumber(0, 0);
 
             //Assert
-            Assert.True(weekNumber == "1");
-            Assert.True(weekNumber == sampleWeekNumber);
-        }
-
-        [Test]
-        public void Check_WeekNumber_CalendarWeekRule_FirstFullWeek()
-        {
-            // Define a date for comparison
-            //2021, 1, 1 is a good sample as all option have a different value
-            var dateSample = new DateTime(2021, 1, 1);
-            var cal = CultureInfo.CurrentCulture.Calendar;
-            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstFullWeek, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
-
-            //init picker
-            var comp = Context.RenderComponent<MudDatePicker>();
-            var datepicker = comp.Instance;
-            datepicker.PickerMonth = dateSample;
-
-            //Set week rule
-            datepicker.CalendarWeekRule = CalendarWeekRule.FirstFullWeek;
-
-            //Get week number
-            var weekNumber = datepicker.GetWeekNumber(0, 0);
-
-            //Assert
-            Assert.True(weekNumber == "52");
-            Assert.True(weekNumber == sampleWeekNumber);
-        }
-
-        [Test]
-        public void Check_WeekNumber_CalendarWeekRule_FirstFourDayWeek()
-        {
-            // Define a date for comparison
-            //2021, 1, 1 is a good sample as all option have a different value
-            var dateSample = new DateTime(2021, 1, 1);
-            var cal = CultureInfo.CurrentCulture.Calendar;
-            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstFourDayWeek, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
-
-            //init picker
-            var comp = Context.RenderComponent<MudDatePicker>();
-            var datepicker = comp.Instance;
-            datepicker.PickerMonth = dateSample;
-
-            //Set week rule
-            datepicker.CalendarWeekRule = CalendarWeekRule.FirstFourDayWeek;
-
-            //Get week number
-            var weekNumber = datepicker.GetWeekNumber(0, 0);
-
-            //Assert
-            Assert.True(weekNumber == "53");
+            Assert.True(weekNumber == expectedWeekNumber);
             Assert.True(weekNumber == sampleWeekNumber);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -772,5 +772,80 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.ToggleState());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
         }
+
+        [Test]
+        public void Check_WeekNumber_CalendarWeekRule_FirstDay()
+        {
+            // Define a date for comparison
+            //2021, 1, 1 is a good sample as all option have a different value
+            var dateSample = new DateTime(2021, 1, 1);
+            var cal = CultureInfo.CurrentCulture.Calendar;
+            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstDay, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
+
+            //init picker
+            var comp = Context.RenderComponent<MudDatePicker>();
+            var datepicker = comp.Instance;
+            datepicker.PickerMonth = dateSample;
+
+            //Set week rule
+            datepicker.CalendarWeekRule = CalendarWeekRule.FirstDay;
+
+            //Get week number
+            var weekNumber = datepicker.GetWeekNumber(0, 0);
+
+            //Assert
+            Assert.True(weekNumber == "1");
+            Assert.True(weekNumber == sampleWeekNumber);
+        }
+
+        [Test]
+        public void Check_WeekNumber_CalendarWeekRule_FirstFullWeek()
+        {
+            // Define a date for comparison
+            //2021, 1, 1 is a good sample as all option have a different value
+            var dateSample = new DateTime(2021, 1, 1);
+            var cal = CultureInfo.CurrentCulture.Calendar;
+            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstFullWeek, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
+
+            //init picker
+            var comp = Context.RenderComponent<MudDatePicker>();
+            var datepicker = comp.Instance;
+            datepicker.PickerMonth = dateSample;
+
+            //Set week rule
+            datepicker.CalendarWeekRule = CalendarWeekRule.FirstFullWeek;
+
+            //Get week number
+            var weekNumber = datepicker.GetWeekNumber(0, 0);
+
+            //Assert
+            Assert.True(weekNumber == "52");
+            Assert.True(weekNumber == sampleWeekNumber);
+        }
+
+        [Test]
+        public void Check_WeekNumber_CalendarWeekRule_FirstFourDayWeek()
+        {
+            // Define a date for comparison
+            //2021, 1, 1 is a good sample as all option have a different value
+            var dateSample = new DateTime(2021, 1, 1);
+            var cal = CultureInfo.CurrentCulture.Calendar;
+            var sampleWeekNumber = cal.GetWeekOfYear(dateSample.Date, CalendarWeekRule.FirstFourDayWeek, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek).ToString();
+
+            //init picker
+            var comp = Context.RenderComponent<MudDatePicker>();
+            var datepicker = comp.Instance;
+            datepicker.PickerMonth = dateSample;
+
+            //Set week rule
+            datepicker.CalendarWeekRule = CalendarWeekRule.FirstFourDayWeek;
+
+            //Get week number
+            var weekNumber = datepicker.GetWeekNumber(0, 0);
+
+            //Assert
+            Assert.True(weekNumber == "53");
+            Assert.True(weekNumber == sampleWeekNumber);
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -152,6 +152,12 @@ namespace MudBlazor
         public bool ShowWeekNumbers { get; set; }
 
         /// <summary>
+        /// Week rule to use when ShowWeekNumbers is set to true.  If no culture is defined, CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule will be used.
+        /// </summary>
+        [Parameter]
+        public CalendarWeekRule CalendarWeekRule { get; set; } = CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule;
+
+        /// <summary>
         /// Format of the selected date in the title. By default, this is "ddd, dd MMM" which abbreviates day and month names. 
         /// For instance, display the long names like this "dddd, dd. MMMM". 
         /// </summary>
@@ -275,7 +281,7 @@ namespace MudBlazor
                 yield return week_first.AddDays(i);
         }
 
-        private string GetWeekNumber(int month, int index)
+        public string GetWeekNumber(int month, int index)
         {
             if (index is < 0 or > 5)
                 throw new ArgumentException("Index must be between 0 and 5");
@@ -291,7 +297,7 @@ namespace MudBlazor
                 return "";
 
             return Culture.Calendar.GetWeekOfYear(week_first,
-                Culture.DateTimeFormat.CalendarWeekRule, FirstDayOfWeek ?? Culture.DateTimeFormat.FirstDayOfWeek).ToString();
+                CalendarWeekRule, FirstDayOfWeek ?? Culture.DateTimeFormat.FirstDayOfWeek).ToString();
         }
 
         protected virtual OpenTo? GetNextView()

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -84,7 +84,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Defines on which day the week starts. Depends on the value of Culture. 
+        /// Defines on which day the week starts. Depends on the value of Culture.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -138,7 +138,7 @@ namespace MudBlazor
         public int? MaxMonthColumns { get; set; }
 
         /// <summary>
-        /// Start month when opening the picker. 
+        /// Start month when opening the picker.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -155,11 +155,12 @@ namespace MudBlazor
         /// Week rule to use when ShowWeekNumbers is set to true.  If no culture is defined, CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule will be used.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public CalendarWeekRule CalendarWeekRule { get; set; } = CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule;
 
         /// <summary>
-        /// Format of the selected date in the title. By default, this is "ddd, dd MMM" which abbreviates day and month names. 
-        /// For instance, display the long names like this "dddd, dd. MMMM". 
+        /// Format of the selected date in the title. By default, this is "ddd, dd MMM" which abbreviates day and month names.
+        /// For instance, display the long names like this "dddd, dd. MMMM".
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -266,7 +267,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets the n-th week of the currently displayed month. 
+        /// Gets the n-th week of the currently displayed month.
         /// </summary>
         /// <param name="month">offset from _picker_month</param>
         /// <param name="index">between 0 and 4</param>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -282,7 +282,7 @@ namespace MudBlazor
                 yield return week_first.AddDays(i);
         }
 
-        public string GetWeekNumber(int month, int index)
+        internal string GetWeekNumber(int month, int index)
         {
             if (index is < 0 or > 5)
                 throw new ArgumentException("Index must be between 0 and 5");


### PR DESCRIPTION
DatePicker: Add option to define CalendarWeekRule (#3482) 


## Description
Add an option to allow users to set the CalendarWeekRule to get week numbers
Resolves #3482

## How Has This Been Tested?
unit 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

## Comment:
First PR on project, do not hesitate to comment if any issue. And thanks for the great job on MudBlazor !
