### PR TITLE
API documentation: Group properties by meaning - improvements

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -19,8 +19,8 @@
             <DocsPageSection>
                 <SectionHeader Title="Properties" />
                 <SectionContent Class="docs-content-api" FullWidth="true">
-                    <div style="float: right; margin-top: -10px; display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
-                        <MudText>Group by:&nbsp;</MudText>
+                    <div style="float: right; margin-top: -10px; display: flex; flex-flow: row wrap; gap: 7px; align-items: center; white-space: nowrap;">
+                        <MudText>Group by:</MudText>
                         <EnumSwitch T="Grouping" @bind-Value="@_propertiesGrouping" Color="Color.Primary" />
                     </div>
                     <MudTable Items="@Properties" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm" GroupBy="@PropertiesGroupDefinition">
@@ -31,7 +31,7 @@
                             <MudTh>Description</MudTh>
                         </HeaderContent>
                         <GroupHeaderTemplate>
-                            @if (_propertiesGrouping == Grouping.Class && (Type)context.Key != Type)
+                            @if (_propertiesGrouping == Grouping.Inheritance && (Type)context.Key != Type)
                             {
                                 <MudTh colspan="4">
                                     <MudText Typo="Typo.h6">@($"Inherited from {((Type)context.Key).ConvertToCSharpSource()}")</MudText>
@@ -47,7 +47,7 @@
                         <RowTemplate>
                             <MudTd Class="docs-content-api-cell" DataLabel="Name">
                                 <CodeInline>@context.Name</CodeInline>
-                                @if (_propertiesGrouping == Grouping.Class && IsOverridden(context.PropertyInfo))
+                                @if (_propertiesGrouping == Grouping.Inheritance && IsOverridden(context.PropertyInfo))
                                 {
                                     <MudChip Variant="Variant.Outlined" Color="Color.Secondary" Size="Size.Small">overridden</MudChip>
                                 }
@@ -211,7 +211,7 @@
             foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
                                      .OrderBy(x => _propertiesGrouping switch {
                                                         Grouping.Category => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
-                                                        Grouping.Class => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
+                                                        Grouping.Inheritance => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
                                                         _ => 0
                                                     })
                                      .ThenBy(x => x.Name))
@@ -354,18 +354,18 @@
 
     #region Grouping properties
 
-    private enum Grouping { Category, Class, None }
+    private enum Grouping { Category, Inheritance, None }
 
-    private Grouping _propertiesGrouping = Grouping.Class;
+    private Grouping _propertiesGrouping = Grouping.Inheritance;
 
     private TableGroupDefinition<ApiProperty> PropertiesGroupDefinition => _propertiesGrouping switch
     {
         Grouping.Category => new() { Selector = (p) => p.PropertyInfo.GetCustomAttribute<CategoryAttribute>()?.Name ?? "Misc" },
-        Grouping.Class => new() { Selector = (p) => BaseDefinitionClass(p.PropertyInfo) },
+        Grouping.Inheritance => new() { Selector = (p) => BaseDefinitionClass(p.PropertyInfo) },
         _ => null
     };
 
-    // -- Grouping properties by class ------------------------------------------------------------------------------------------
+    // -- Grouping properties by inheritance ------------------------------------------------------------------------------------------
 
     private static Type BaseDefinitionClass(MethodInfo m) => m.GetBaseDefinition().DeclaringType;
 

--- a/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Other
@@ -20,5 +23,75 @@ namespace MudBlazor.UnitTests.Other
                 }
             }
         }
+
+        [Test]
+        public void AllComponentPropertiesHaveCategories()
+        {
+
+            // Currently, these classes inheriting from MudComponentBase have uncategorized properties.
+            // If you want you can categorize them, and then remove from this list.
+            Type[] exceptions = {
+                typeof(MudDataGrid<>),  // TODO: remove it later
+                typeof(Column<>),
+                typeof(Row),
+                typeof(HeaderCell<>),
+                typeof(FooterCell<>),
+                typeof(Cell<>),
+                typeof(MudDataGridPager<>),
+
+                typeof(MudTHeadRow),
+                typeof(MudTFootRow),
+                typeof(MudTr),
+                typeof(MudTh),
+                typeof(MudTd),
+                typeof(MudTablePager),
+                typeof(MudTableSortLabel<>),
+                typeof(MudTableGroupRow<>),
+
+                typeof(MudInput<>),
+                typeof(MudInputControl),
+                typeof(MudInputLabel),
+                typeof(MudRangeInput<>),
+
+                typeof(MudCollapse),
+                typeof(MudPageContentNavigation),
+                typeof(MudSnackbarElement),
+                typeof(MudBlazor.Charts.Legend),
+                typeof(MudSparkLine),
+
+                typeof(MudRatingItem),  // TODO: remove it later; see also: https://github.com/MudBlazor/MudBlazor/discussions/3452
+                typeof(MudPicker<>),  // TODO: remove it later; see also: https://github.com/MudBlazor/MudBlazor/pull/3481
+            };
+
+            bool isTestOK = true;
+
+            IEnumerable<Type> components = typeof(MudElement).Assembly.GetTypes()
+                                                                      .Where(type => type.IsSubclassOf(typeof(MudComponentBase)))
+                                                                      .Except(exceptions);
+
+            foreach (Type component in components)
+            {
+                foreach (PropertyInfo property in component.GetProperties())
+                {
+                    if (GetBaseDefinitionClass(property) == component &&              // property isn't inherited
+                        !property.PropertyType.Name.Contains("EventCallback") &&      // property isn't an event callback
+                        property.GetCustomAttribute<ObsoleteAttribute>() == null &&   // property isn't obsolete
+                        property.GetCustomAttribute<ParameterAttribute>() != null &&  // property has the [Parameter] attribute
+                        property.GetCustomAttribute<CategoryAttribute>() == null)     // property doesn't have a category
+                    {
+                        isTestOK = false;
+                        Console.WriteLine($"{component}.{property.Name} property doesn't have a category");
+                    }
+                }
+            }
+
+            Assert.True(isTestOK, "Some component properties don't have categories.");
+        }
+
+        // Returns the class that declares the specified method.
+        private static Type GetBaseDefinitionClass(MethodInfo m) => m.GetBaseDefinition().DeclaringType;
+
+        // Returns the class that declares the specified property.
+        private static Type GetBaseDefinitionClass(PropertyInfo p) => GetBaseDefinitionClass(p.GetMethod ?? p.SetMethod);
     }
 }

--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -67,6 +67,10 @@ namespace MudBlazor
             ["Picker appearance"] = 405,
             ["Dot"] = 406,
 
+            // "Miscellaneous" category. In classes inheriting from MudComponentBase it can be used only exceptionally -
+            //  - only when the property can define behavior or appearance depending on value of the property.
+            ["Misc"] = int.MaxValue - 1,
+
             ["Common"] = int.MaxValue // general category
         };
     }
@@ -241,6 +245,7 @@ namespace MudBlazor
         {
             public const string Behavior = "Behavior";
             public const string Appearance = "Appearance";
+            public const string Misc = "Misc";
         }
 
         public static class Divider
@@ -253,6 +258,11 @@ namespace MudBlazor
         {
             public const string Behavior = "Behavior";
             public const string Appearance = "Appearance";
+        }
+
+        public static class Element
+        {
+            public const string Misc = "Misc";
         }
 
         public static class ExpansionPanel
@@ -326,6 +336,11 @@ namespace MudBlazor
             public const string Appearance = "Appearance";
         }
 
+        public static class MainContent
+        {
+            public const string Behavior = "Behavior";
+        }
+
         public static class Menu
         {
             public const string Behavior = "Behavior";
@@ -396,6 +411,11 @@ namespace MudBlazor
             public const string Data = "Data";
             public const string Behavior = "Behavior";
             public const string Appearance = "Appearance";
+        }
+
+        public static class RTLProvider
+        {
+            public const string Behavior = "Behavior";
         }
 
         public static class ScrollToTop

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -29,6 +29,7 @@ namespace MudBlazor
         /// The currently selected range (two-way bindable). If null, then nothing was selected.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.FormComponent.Data)]
         public DateRange DateRange
         {
             get => _dateRange;

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -48,8 +48,9 @@ namespace MudBlazor
         /// Default options to pass to Show(), if none are explicitly provided.
         /// Typically useful on inline dialogs.
         /// </summary>
-        // "Misc" category (Behavior and Appearance)
-        [Parameter] public DialogOptions Options { get; set; }
+        [Parameter]
+        [Category(CategoryTypes.Dialog.Misc)]  // Behavior and Appearance
+        public DialogOptions Options { get; set; }
 
         /// <summary>
         /// No padding at the sides

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -21,8 +21,8 @@ namespace MudBlazor
         [CascadingParameter] private MudDialogProvider Parent { get; set; }
         [CascadingParameter] private DialogOptions GlobalDialogOptions { get; set; } = new DialogOptions();
 
-        // "Misc" category (Behavior and Appearance)
         [Parameter]
+        [Category(CategoryTypes.Dialog.Misc)]  // Behavior and Appearance
         public DialogOptions Options
         {
             get

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -13,20 +13,23 @@ namespace MudBlazor
         /// <summary>
         /// Child content
         /// </summary>
-        // "Misc" category
-        [Parameter] public RenderFragment ChildContent { get; set; }
+        [Parameter]
+        [Category(CategoryTypes.Element.Misc)]
+        public RenderFragment ChildContent { get; set; }
 
         /// <summary>
         /// The HTML element that will be rendered in the root by the component
         /// </summary>
-        // "Misc" category
-        [Parameter] public string HtmlTag { get; set; } = "span";
+        [Parameter]
+        [Category(CategoryTypes.Element.Misc)]
+        public string HtmlTag { get; set; } = "span";
         /// <summary>
         /// The ElementReference to bind to.
         /// Use like @bind-Ref="myRef"
         /// </summary>
-        // "Misc" category
-        [Parameter] public ElementReference? Ref { get; set; }
+        [Parameter]
+        [Category(CategoryTypes.Element.Misc)]
+        public ElementReference? Ref { get; set; }
 
         [Parameter] public EventCallback<ElementReference> RefChanged { get; set; }
 

--- a/src/MudBlazor/Components/Main/MudMainContent.razor
+++ b/src/MudBlazor/Components/Main/MudMainContent.razor
@@ -13,5 +13,7 @@
         .AddClass(Class)
      .Build();
 
-    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter]
+    [Category(CategoryTypes.MainContent.Behavior)]
+    public RenderFragment ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -169,7 +169,9 @@ namespace MudBlazor
         /// <summary>
         /// Show clear button.
         /// </summary>
-        [Parameter] public bool Clearable { get; set; } = false;
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public bool Clearable { get; set; } = false;
 
         /// <summary>
         /// Decrements or increments depending on factor

--- a/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
+++ b/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
         /// If true, changes the layout to RightToLeft.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.RTLProvider.Behavior)]
         public bool RightToLeft
         {
             get => _rtl;
@@ -34,6 +35,7 @@ namespace MudBlazor
         /// Child content of the component.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.RTLProvider.Behavior)]
         public RenderFragment ChildContent { get; set; }
     }
 }


### PR DESCRIPTION
## Description
The PR contains the following improvements to the https://github.com/MudBlazor/MudBlazor/pull/3413:
 1. Adds a test that checks if all component properties have the category attribute.
 2. Adds missing categories for properties of: MudDialog, MudDialogInstance, MudElement, MudMainContent, MudRTLProvider, MudDateRangePicker, and NumericField.
 3. Changes the displayed name from "Group by class" to "Group by inheritance" in a "button switch".

## How Has This Been Tested?
visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Screenshot of the changed label on desktop:
![image](https://user-images.githubusercontent.com/8080496/144612537-8f17c449-52d9-4d7f-8199-2fe008fab74f.png)

Screenshot of the changed label on mobile:

![image](https://user-images.githubusercontent.com/8080496/144612566-3dd0e12e-fbe1-4743-8288-8e72afc41a6a.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
