### PR TITLE
API documentation: huge performance increase on wasm

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -272,18 +272,12 @@
 
     private bool CheckIsTwoWayProperty(PropertyInfo propertyInfo)
     {
-        foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
-        {
-            if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && info.PropertyType.Name.Contains("EventCallback"))
-            {
-                if (info.Name == propertyInfo.Name + "Changed")
-                {
-                    return true;
-                }
-            }
-        }
+        PropertyInfo eventCallbackInfo = Type.GetProperty(propertyInfo.Name + "Changed");
 
-        return false;
+        return eventCallbackInfo != null &&
+               eventCallbackInfo.PropertyType.Name.Contains("EventCallback") &&
+               eventCallbackInfo.GetCustomAttribute<ParameterAttribute>() != null &&
+               eventCallbackInfo.GetCustomAttribute<ObsoleteAttribute>() == null;
     }
 
     private string GetDescription(Type type, PropertyInfo info)

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -11,8 +11,7 @@ namespace MudBlazor.Docs.Models
         public static string GetPropertyDescription(Type t, string property)
         {
             var name = $"{GetSaveTypename(t).Replace("<T>", "").TrimEnd('_')}_{property}";
-            var field = typeof(DocStrings).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField)
-                .FirstOrDefault(f => f.Name == name);
+            var field = typeof(DocStrings).GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
             if (field == null)
                 return null;
             return (string)field.GetValue(null);

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace MudBlazor.Docs.Models
 {
-    // this is needed for the api docs
+    // this is needed for the api docs 
     public static partial class DocStrings
     {
         public static string GetPropertyDescription(Type t, string property)

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
## Description

Reduces computational complexity of the `CheckIsTwoWayProperty()` and `GetPropertyDescription()` methods from O(n) to O(1), which speeds up all https://mudblazor.com/api/ pages both on Wasm and Blazor server side.

On my computer it reduces https://localhost/wasm/api/table time from about 3 seconds to well under a second.


## How Has This Been Tested?
 - visually
 - checked programmatically that the original and changed methods return the same result for each property of each MudBlazor class

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

Before - "Rendered in 1828 ms":
![image](https://user-images.githubusercontent.com/8080496/144728324-7f8f5682-5a65-45d4-9af5-1e72be38652e.png)

Now - "Rendered in 289 ms":
![image](https://user-images.githubusercontent.com/8080496/144728326-2aa92ba9-f5b1-42f6-90ce-80c1f1e5056e.png)

To see the rendered time I go to https://localhost:44399/wasm/components/table page and then click on a Table link in the "Pages" section, like on https://dev.mudblazor.com/.