### PR TITLE
DatePicker: Add options to hide entire toolbar or year and date separately

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -95,7 +95,19 @@
             </SectionContent>
             <SectionSource Code="DatePickerFixedValuesExample" GitHubFolderName="DatePicker" ShowCode="false" />
         </DocsPageSection>
-
+        <DocsPageSection>
+            <SectionHeader Title="Toolbar options">
+                <Description>
+                    You can chose to hide the toolbar completly or to hide every combination of year, month and date.
+                    For this you canvas use the <CodeInline>HideToolbar</CodeInline>, <CodeInline>HideDateFromToolbar</CodeInline> and <CodeInline>HideYearFromToolbar</CodeInline> Parameters.
+                    This could especially be usefull in combination with fixed values, where you don't want the user to see parts of or the entire toolbar'.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <DatePickerToolbarOptionsExample />
+            </SectionContent>
+            <SectionSource Code="DatePickerToolbarOptionsExample" GitHubFolderName="DatePicker" ShowCode="true" />
+        </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Range Picker Usage">
                 <Description></Description>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerToolbarOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerToolbarOptionsExample.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.Docs.Examples
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudDatePicker HideToolbar Label="Datepicker with hidden Toolbar" @bind-Date="_date" OpenTo="OpenTo.Year" />
+        <MudText>@_date?.ToShortDateString()</MudText>
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudDatePicker HideYearInToolbar Label="Datepicker with hidden Year in toolbar" @bind-Date="_date" OpenTo="OpenTo.Year" />
+        <MudText>@_date?.ToShortDateString()</MudText>
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudDatePicker HideDateInToolbar Label="Datepicker with hidden Date in toolbar" @bind-Date="_date" OpenTo="OpenTo.Year" />
+        <MudText>@_date?.ToShortDateString()</MudText>
+    </MudItem>
+</MudGrid>
+
+@code { DateTime? _date;}

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerToolbarOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerToolbarOptionsExample.razor
@@ -14,4 +14,4 @@
     </MudItem>
 </MudGrid>
 
-@code { DateTime? _date;}
+@code { DateTime? _date = DateTime.UtcNow; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -17,8 +17,7 @@
                FixMonth="@FixMonth"
                FixYear="@FixYear"
                HideDateInToolbar="@HideDateInToolbar"
-               HideMonthInToolbar="@HideMonthInToolbar"
-               HideYearInToolbar="@HideDateInToolbar"
+               HideYearInToolbar="@HideYearInToolbar"
                HideToolbar="@HideToolbar"/> }
             else
             {
@@ -32,13 +31,12 @@
                FixMonth="@FixMonth"
                FixYear="@FixYear"
                HideDateInToolbar="@HideDateInToolbar"
-               HideMonthInToolbar="@HideMonthInToolbar"
-               HideYearInToolbar="@HideDateInToolbar"
+               HideYearInToolbar="@HideYearInToolbar"
                HideToolbar="@HideToolbar"
                />}
 @code { private MudDatePicker _picker;
-
-            public DateTime? Date { get; set; }
+            
+            [Parameter] public DateTime? Date { get; set; }
 
             private async Task HandleDateChanged(DateTime? input)
             {
@@ -56,7 +54,6 @@
             [Parameter] public int? FixYear { get; set; }
             [Parameter] public bool HideToolbar { get; set; }
             [Parameter] public bool HideYearInToolbar { get; set; }
-            [Parameter] public bool HideMonthInToolbar { get; set; }
             [Parameter] public bool HideDateInToolbar { get; set; }
 
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -15,7 +15,11 @@
                OpenTo="@OpenTo" 
                FixDay="@FixDay"
                FixMonth="@FixMonth"
-               FixYear="@FixYear"/> }
+               FixYear="@FixYear"
+               HideDateInToolbar="@HideDateInToolbar"
+               HideMonthInToolbar="@HideMonthInToolbar"
+               HideYearInToolbar="@HideDateInToolbar"
+               HideToolbar="@HideToolbar"/> }
             else
             {
 <MudDatePicker @ref="_picker"
@@ -26,7 +30,12 @@
                OpenTo="@OpenTo"
                FixDay="@FixDay"
                FixMonth="@FixMonth"
-               FixYear="@FixYear"/>}
+               FixYear="@FixYear"
+               HideDateInToolbar="@HideDateInToolbar"
+               HideMonthInToolbar="@HideMonthInToolbar"
+               HideYearInToolbar="@HideDateInToolbar"
+               HideToolbar="@HideToolbar"
+               />}
 @code { private MudDatePicker _picker;
 
             public DateTime? Date { get; set; }
@@ -45,6 +54,10 @@
             [Parameter] public int? FixDay { get; set; }
             [Parameter] public int? FixMonth { get; set; }
             [Parameter] public int? FixYear { get; set; }
+            [Parameter] public bool HideToolbar { get; set; }
+            [Parameter] public bool HideYearInToolbar { get; set; }
+            [Parameter] public bool HideMonthInToolbar { get; set; }
+            [Parameter] public bool HideDateInToolbar { get; set; }
 
 
             public async Task Open() => await InvokeAsync(() => _picker.Open());

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -361,7 +361,10 @@ namespace MudBlazor.UnitTests.Components
         public void Open_FixYear_Click2ndMonth_Click3_CheckDate()
         {
             var comp = OpenPicker(ComponentParameter.CreateParameter("FixYear", 2021));
-            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-year").Count.Should().Be(0);
+
+            comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
+            
+            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
             comp.Find("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[1].Click();
@@ -388,7 +391,10 @@ namespace MudBlazor.UnitTests.Components
         public void Open_FixMonth_ClickYear_Click3_CheckDate()
         {
             var comp = OpenPicker(ComponentParameter.CreateParameter("FixMonth", 1));
-            comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count().Should().Be(0);
+
+            Action act = () => comp.Find("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Click();
+            act.Should().Throw<MissingEventHandlerException>();
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(0);
             comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container > div.mud-picker-year")
@@ -404,7 +410,8 @@ namespace MudBlazor.UnitTests.Components
         public void Open_FixYear_FixMonth_Click3_CheckDate()
         {
             var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("FixMonth", 1), ComponentParameter.CreateParameter("FixYear", 2022) });
-            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-year").Count().Should().Be(0);
+            comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count().Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
             comp.FindAll("button.mud-picker-calendar-day")
@@ -428,7 +435,8 @@ namespace MudBlazor.UnitTests.Components
         public void Open_FixYear_FixDay_Click3rdMonth_CheckDate()
         {
             var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("OpenTo", OpenTo.Month), ComponentParameter.CreateParameter("FixYear", 2022), ComponentParameter.CreateParameter("FixDay", 1) });
-            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-year").Count().Should().Be(0);
+            comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(0);
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[2].Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, 3, 1));

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -363,8 +363,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = OpenPicker(ComponentParameter.CreateParameter("FixYear", 2021));
 
             comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
-            
-            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
+
             comp.Find("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[1].Click();
@@ -412,7 +411,6 @@ namespace MudBlazor.UnitTests.Components
             var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("FixMonth", 1), ComponentParameter.CreateParameter("FixYear", 2022) });
             comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(0);
-            comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count().Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("3")).First().Click();
@@ -441,6 +439,33 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[2].Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, 3, 1));
         }
+
+        [Test]
+        public void Hide_Entire_Toolbar()
+        {
+            //entire toolbar
+            var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("HideToolbar", true) });
+            comp.FindAll("div.mud-picker-datepicker-toolbar").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void Hide_Year_In_Toolbar()
+        {
+            var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("HideYearInToolbar", true), ComponentParameter.CreateParameter("Date", DateTime.UtcNow) });
+            comp.FindAll("div.mud-picker-datepicker-toolbar").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-date").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-year").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void Hide_Date_In_Toolbar()
+        {
+            var comp = OpenPicker(new ComponentParameter[] { ComponentParameter.CreateParameter("HideDateInToolbar", true), ComponentParameter.CreateParameter("Date", DateTime.UtcNow) });
+            comp.FindAll("div.mud-picker-datepicker-toolbar").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-year").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-datepicker-toolbar > button.mud-button-date").Count.Should().Be(0);
+        }
+
 
         [Test]
         public async Task Open_Programmatically_CheckOpen_Close_Programmatically_CheckClosed()

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -9,15 +9,19 @@
 
     protected override RenderFragment PickerContent =>
     @<CascadingValue Value="@this" IsFixed="true">
-        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
-            @if (!FixYear.HasValue)
-            {
-                <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
-            }
-            @* Is shown even with fix day, button click does not change to that day -> if it would this would need to be changed *@
-            <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
-           
-        </MudPickerToolbar>
+        @if (!HideToolbar)
+        {
+                <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
+                    @if (!HideYearInToolbar)
+                    {
+                        <MudButton ReadOnly="@FixYear.HasValue" Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
+                    }
+                    @if (!HideDateInToolbar)
+                    {
+                        <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
+                    }
+            </MudPickerToolbar>
+        }
         <MudPickerContent>
             <div class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
                 @{
@@ -85,7 +89,7 @@
                                             <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
                                         </button>
                                         <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" /> }
-                                    else { <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>}
+                                    else { <MudText Class="mud-picker-calendar-header-transition mud-button-month" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText> }
                                 </div>
                                 <div class="mud-picker-calendar-header-day">
                                     @if (ShowWeekNumbers)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -449,6 +449,7 @@ namespace MudBlazor
 
         private void OnYearClick()
         {
+            if (FixYear.HasValue) return;
             CurrentView = OpenTo.Year;
             StateHasChanged();
             _scrollToYearAfterRender = true;

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -206,6 +206,24 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int? FixDay { get; set; }
+        /// <summary>
+        /// Hides the year button in the toolbar
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerAppearance)]
+        public bool HideYearInToolbar { get; set; }
+        /// <summary>
+        /// Hides the date display in the toolbar
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerAppearance)]
+        public bool HideDateInToolbar { get; set; }
+        /// <summary>
+        /// Hide the toolbar
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerAppearance)]
+        public bool HideToolbar { get; set; }
 
         protected virtual bool IsRange { get; } = false;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Resolves comment of @Garderoben  in PR #2722 
Splits the toolbar hiding logic from the fixed-value parameters.
Adds new Parameters "HideToolbar" "HideYearInToolbar" and "HideDateInToolbar" 

## How Has This Been Tested?
Unit - Tests: Changed Fixed Values Tests for DatePicker to reflect the changes and added new tests
Tested example manually
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It is not yet breaking, because the orignal PR is only on dev at the moment and not released.

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
Here sime screenshots: No Toolbar at all, hidden year and hidden date
![image](https://user-images.githubusercontent.com/25527000/144764250-7e846893-dc6d-4cf0-9a68-cf61b9f43483.png)
![image](https://user-images.githubusercontent.com/25527000/144764258-4c90499b-6356-4d19-9fa0-f85e9aa85f6c.png)
![image](https://user-images.githubusercontent.com/25527000/144764266-07af55b0-9744-40ef-bf90-11e95b7cfbbf.png)



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
