### PR TITLE
adding pre panel rendering to tabs

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithPrePanelContent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithPrePanelContent.razor
@@ -1,0 +1,25 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudTabs @bind-ActivePanelIndex="SelectedIndex" Class="">
+	<ChildContent>
+		<MudTabPanel Text="Tab One">
+			<MudText class="my-text">Some Content</MudText>
+		</MudTabPanel>
+		<MudTabPanel Text="Tab Two">
+			<MudText class="my-text">Another content</MudText>
+		</MudTabPanel>
+	</ChildContent>
+	<PrePanelContent>
+		<MudText Class="pre-panel-content-custom">Selected: @context?.Text</MudText>
+	</PrePanelContent>
+</MudTabs>
+
+
+@code {
+
+	[Parameter]
+	public Int32 SelectedIndex { get; set; } = 0;
+
+}

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1035,6 +1035,30 @@ namespace MudBlazor.UnitTests.Components
             Assert.Throws<ElementNotFoundException>(() => comp.Find(".my-menu-item-1"));
         }
 
+        [Test]
+        public async Task PrePanelContent()
+        {
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = Context.RenderComponent<TabsWithPrePanelContent>(p => p.Add(x => x.SelectedIndex, 0));
+
+            var content =  comp.Find(".pre-panel-content-custom");
+
+            content.TextContent.Should().Be("Selected: Tab One");
+
+            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-toolbar");
+            content.NextElementSibling.ClassList.Should().Contain("mud-tabs-panels");
+
+            comp.SetParametersAndRender(p => p.Add(x => x.SelectedIndex, 1));
+
+            content = comp.Find(".pre-panel-content-custom");
+
+            content.TextContent.Should().Be("Selected: Tab Two");
+
+            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-toolbar");
+            content.NextElementSibling.ClassList.Should().Contain("mud-tabs-panels");
+        }
+
         #region Helper
 
         private static double GetSliderValue(IRenderedComponent<ScrollableTabsTest> comp, string attribute = "left")

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -75,6 +75,10 @@
                 }
             </div>
         </div>
+		@if(PrePanelContent != null)
+		{
+			@PrePanelContent(ActivePanel)
+		}
         <div class="@PanelsClassnames">
             @ChildContent
         </div>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -174,6 +174,15 @@ namespace MudBlazor
         public RenderFragment ChildContent { get; set; }
 
         /// <summary>
+        /// This fragment is placed between toolbar and panels. 
+        /// It can be used to display additional content like an address line in a browser.
+        /// The active tab will be the content of this RenderFragement
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Tabs.Behavior)]
+        public RenderFragment<MudTabPanel> PrePanelContent { get; set; }
+
+        /// <summary>
         /// Custom class/classes for TabPanel
         /// </summary>
         [Parameter]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Implementing a new render fragment is placed between the toolbar and panels. This is comparable to the address line in modern browsers where there is a space between tabs and the actual content.

![image](https://user-images.githubusercontent.com/51370361/144797718-00c3e15a-0d9f-4b6c-8a65-5c28beb5fb9f.png)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I've created a unit test to validate the base functionality and all other unit tests pass. Currently, there is no example for the docs, but the visual implications are zero, If the ``RenderFragment`` is not set, there is no change in the DOM for the existing tabs. 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
