### PR TITLE
TextField: White background deleted from label

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -205,7 +205,6 @@
         position: relative;
         box-sizing: content-box;
         letter-spacing: inherit;
-        -webkit-tap-highlight-color: transparent;
 
         @include inputplaceholder {
             color: currentColor;


### PR DESCRIPTION
## Description
Issue related #3486. 
After researching this issue, I found two great posts to read. I feel like they are related to this issue. 
[1](https://feedback.telerik.com/themes/1512311-blazor-the-floating-label-of-the-textarea-overlaps-the-text)
[2](https://docs.telerik.com/blazor-ui/knowledge-base/form-chrome-autofill)

I've decided to delete the white background from the input label(placeholder) box to make it looks a bit more polished for now, and also, I have a question: Is that issue can be a bug in Chromium? 

"When Chrome autofills the values in the fields in the form the `oninput` and `onfocus` events are not fired. This means that the browser does not notify the fields that their values have changed and thus the floating label remains inside."

## How Has This Been Tested?
none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
