### PR TITLE
Table: call a function with the items displayed in the table

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSimpleWrapper.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSimpleWrapper.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable Items="@Items"
+          ServerData="@ServerData"
+          Filter="@Filter"
+          CurrentPageItemsChanged="@PagedChanged">
+    <HeaderContent>
+        <MudTh>Field</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Field">@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    [Parameter] public IEnumerable<string> Items { get; set; }
+    [Parameter] public Func<TableState, Task<TableData<string>>> ServerData { get; set; }
+    [Parameter] public Func<string, bool> Filter { get; set; }
+    [Parameter] public Action<IEnumerable<string>> PagedChanged { get; set; }
+    
+    
+    public static readonly string[] states = { "Alabama", "Alaska", "American Samoa", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware", "District of Columbia", "Federated States of Micronesia", "Florida", "Georgia", "Guam", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Marshall Islands", "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio", "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virgin Island", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming", };
+}

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -58,10 +58,12 @@
                     </thead>
                 }
                 <tbody class="mud-table-body">
+                    @* Avoid re-executing CurrentPageItems getter on every read bellow. *@
+                    @{var currentPageItems = CurrentPageItems;}
                     @if (Loading)
                     {
                         <tr>
-                            <td colspan="1000" class="@(CurrentPageItems.Count() > 0 || LoadingContent != null ? "mud-table-loading" : "")">
+                            <td colspan="1000" class="@(currentPageItems.Count() > 0 || LoadingContent != null ? "mud-table-loading" : "")">
                                 <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                             </td>
                         </tr>
@@ -78,10 +80,10 @@
                     }
                     else
                     {
-                        @if (CurrentPageItems != null && CurrentPageItems.Count() > 0)
+                        @if (currentPageItems != null && currentPageItems.Count() > 0)
                         {
                             var rowIndex = 0;
-                            <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" Context="item">
+                            <MudVirtualize IsEnabled="@Virtualize" Items="@currentPageItems?.ToList()" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" 
@@ -124,7 +126,7 @@
                             </MudVirtualize>
                         }
                     }
-                    @if(!(CurrentPageItems != null && CurrentPageItems.Count() > 0)
+                    @if(!(currentPageItems != null && currentPageItems.Count() > 0)
                         && (Loading ? LoadingContent != null : NoRecordsContent != null)
                     )
                     {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -163,6 +163,14 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Action is called when items displayed in the tables changed. This can be useful to dispose row states persistent accross updates of the table.
+        /// Only triggered when using <see cref="Items"/>.
+        /// </summary>
+        [Category(CategoryTypes.Table.Data)]
+        [Parameter]
+        public Action<IEnumerable<T>> CurrentPageItemsChanged { get; set; }
+
+        /// <summary>
         /// A function that returns whether or not an item should be displayed in the table. You can use this to implement your own search function.
         /// </summary>
         [Parameter]
@@ -354,8 +362,11 @@ namespace MudBlazor
         {
             get
             {
-                if (@PagerContent == null)
-                    return FilteredItems; // we have no pagination
+                if (@PagerContent == null) // we have no pagination
+                {
+                    CurrentPageItemsChanged?.Invoke(FilteredItems);
+                    return FilteredItems;
+                }
                 if (ServerData == null)
                 {
                     var filteredItemCount = GetFilteredItemsCount();
@@ -367,7 +378,9 @@ namespace MudBlazor
                     CurrentPage = lastPageNo < CurrentPage ? lastPageNo : CurrentPage;
                 }
 
-                return GetItemsOfPage(CurrentPage, RowsPerPage);
+                var paginated = GetItemsOfPage(CurrentPage, RowsPerPage);
+                CurrentPageItemsChanged?.Invoke(paginated);
+                return paginated;
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Add a parameter of type `Action<IEnumerable<T>>` triggered when currently displayed items change. This might be used to dispose states of displayed rows stored in a parent component, that should survive redraw of the row.

> Note that this might also induce performance improvements, since `CurrentPageItems` was used via its geter 5 times per redraw in simple scenarios, and this function might be a bit expensive depending on the case. I've assigned to a view variable to run the getter once. 
> https://github.com/MudBlazor/MudBlazor/blob/0df8e34c4c753adc69793db4b6c28bc0e5a1a74c/src/MudBlazor/Components/Table/MudTable.razor.cs#L353-L372
> I'm not sure about that though, because I don't know how rendering behavior & change detection works deep down. But in unit tests, the function was originally called 5 times.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tested by asserting the calls of a mocked Action parameter

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
