### PR TITLE
MudForm: Add bool parameter override for ResetForm 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsTouchedNestedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsTouchedNestedTest.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudForm ValidationDelay="0">
+    <MudTextField T="string" Required="true" RequiredError="Enter a rock star"></MudTextField>
+    <MudDatePicker @bind-Date="Date"></MudDatePicker>
+
+    <MudForm ValidationDelay="0">
+        <MudTextField T="string" Required="true" RequiredError="Enter a rock star"></MudTextField>
+        <MudDatePicker @bind-Date="Date"></MudDatePicker>
+    </MudForm>
+</MudForm>
+
+@code {
+    public static string __description__ = "Changing any of the fields, required or not, should set the forms IsTouched property to true";
+    private DateTime? Date { get; set; } = new DateTime(2021, 05, 15);
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -146,6 +146,90 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.ResetValidation());
             form.IsTouched.Should().Be(true);
         }
+        
+        /// <summary>
+        /// Changing the nested form fields value should set IsTouched 
+        /// </summary>
+        [Test]
+        public async Task FormIsTouchedAndNestedFormIsNotTouchedWhenParentFormFieldIsTouchedTest()
+        {
+            var comp = Context.RenderComponent<FormIsTouchedNestedTest>();
+            Console.WriteLine(comp.Markup);
+            var formsComp = comp.FindComponents<MudForm>();
+            var textCompFields = comp.FindComponents<MudTextField<string>>();
+            var dateCompFields = comp.FindComponents<MudDatePicker>();
+            var form = formsComp[0].Instance;
+            var textField = textCompFields[0].Instance;
+            var dateField = dateCompFields[0].Instance;
+            var nestedForm = formsComp[1].Instance;
+            var nestedFormTextField = textCompFields[1].Instance;
+            var nestedFormDateField = dateCompFields[1].Instance;
+
+            // check initial state: form should not be touched 
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(false);
+            // input a date, istouched should be true
+            textCompFields[0].Find("input").Change("2001-01-31");
+            form.IsTouched.Should().Be(true);
+            nestedForm.IsTouched.Should().Be(false);
+
+            //reset should set touched to false
+            await comp.InvokeAsync(() => form.Reset());
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(false);
+
+            // clear value to null
+            textCompFields[0].Find("input").Change("value is changed");
+            form.IsTouched.Should().Be(true);
+            nestedForm.IsTouched.Should().Be(false);
+
+            //reset validation should not reset touched state
+            await comp.InvokeAsync(() => form.ResetValidation());
+            form.IsTouched.Should().Be(true);
+            nestedForm.IsTouched.Should().Be(false);
+        }
+
+        /// <summary>
+        /// Changing the nested form fields value should set IsTouched to true on parent form
+        /// </summary>
+        [Test]
+        public async Task FormIsUnTouchedWhenNestedFormTouchedTest()
+        {
+            var comp = Context.RenderComponent<FormIsTouchedNestedTest>();
+            Console.WriteLine(comp.Markup);
+            var formsComp = comp.FindComponents<MudForm>();
+            var textCompFields = comp.FindComponents<MudTextField<string>>();
+            var dateCompFields = comp.FindComponents<MudDatePicker>();
+            var form = formsComp[0].Instance;
+            var textField = textCompFields[0].Instance;
+            var dateField = dateCompFields[0].Instance;
+            var nestedForm = formsComp[1].Instance;
+            var nestedFormTextField = textCompFields[1].Instance;
+            var nestedFormDateField = dateCompFields[1].Instance;
+
+            // check initial state: form should not be touched 
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(false);
+            // input a date, istouched should be true
+            textCompFields[1].Find("input").Change("2001-01-31");
+            form.IsTouched.Should().Be(true);
+            nestedForm.IsTouched.Should().Be(true);
+
+            //reset should set touched to false
+            await comp.InvokeAsync(() => form.Reset());
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(false);
+
+            // clear value to null
+            textCompFields[3].Find("input").Change("value is changed");
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(true);
+
+            //reset validation should not reset touched state
+            await comp.InvokeAsync(() => nestedFormDateField.ResetValidation());
+            form.IsTouched.Should().Be(false);
+            nestedForm.IsTouched.Should().Be(true);
+        }
 
         /// <summary>
         /// Custom validation func should be called to determine whether or not a form value is good
@@ -741,8 +825,8 @@ namespace MudBlazor.UnitTests.Components
             textfields[7].Instance.ErrorText.Should().NotBeNullOrEmpty();
             numericFields[1].Instance.HasErrors.Should().BeTrue();
             numericFields[1].Instance.ErrorText.Should().NotBeNullOrEmpty();
-        }
-
+        } 
+        
         /// <summary>
         /// Testing the functionality of the MudForm example from the docs.
         /// Root MudForm is invalid and nested MudForm is valid


### PR DESCRIPTION
MudForm: Add bool parameter override for ResetForm to not call EvaluateForm if user chooses

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Regression fix for forcing validation on MudForm.Reset() introduced between Version="5.1.5" to Version="6.0.2" was the forcing of validation on MudForm.Reset(). Now with the MudForm.Reset(bool evaluateForm = true) a user can choose the behavior with the default behavior being to EvaluateForm

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tested

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Regression Fix

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
