### PR TITLE
API documentation: Add method descriptions on Wasm

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -164,7 +164,7 @@
                         Name = info.Name,
                         PropertyInfo = info,
                         Default = string.Empty,
-                        Description = GetDescription(Type, info),
+                        Description = DocStrings.GetMemberDescription(Type, info),
                         IsTwoWay = CheckIsTwoWayEventCallback(info),
                         Type = info.PropertyType,
                     };
@@ -195,7 +195,7 @@
                                 Return = info.ReturnParameter,
                                 Signature = info.GetSignature(),
                                 Parameters = info.GetParameters(),
-                                Documentation = info.GetDocumentation()
+                                Documentation = DocStrings.GetMemberDescription(Type, info)
                             };
                         }
                     }
@@ -224,7 +224,7 @@
                         PropertyInfo = info,
                         Default = GetDefaultValue(info),
                         IsTwoWay = CheckIsTwoWayProperty(info),
-                        Description = GetDescription(Type, info),
+                        Description = DocStrings.GetMemberDescription(Type, info),
                         Type = info.PropertyType
                     };
                 }
@@ -278,13 +278,6 @@
                eventCallbackInfo.PropertyType.Name.Contains("EventCallback") &&
                eventCallbackInfo.GetCustomAttribute<ParameterAttribute>() != null &&
                eventCallbackInfo.GetCustomAttribute<ObsoleteAttribute>() == null;
-    }
-
-    private string GetDescription(Type type, PropertyInfo info)
-    {
-        var doc = DocStrings.GetPropertyDescription(type, info.Name);
-        doc = Regex.Replace(doc??"", @"</?.+?>", "");
-        return doc;
     }
 
     // used for default value getting

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -7,15 +7,25 @@ namespace MudBlazor.Docs.Models
     // this is needed for the api docs 
     public static partial class DocStrings
     {
-        public static string GetPropertyDescription(Type t, string property)
+        // currently implemented only for properties
+        public static string GetMemberDescription(Type t, MemberInfo member)
         {
-            var name = $"{GetSaveTypename(t).Replace("<T>", "").TrimEnd('_')}_{property}";
+            var name = GetSaveTypename(t);
+
+            if (member is PropertyInfo property)
+                name += "_" + property.Name;
+            else if (member is MethodInfo method)
+                name += "_method_" + GetSaveMethodName(method);
+            else
+                throw new Exception("Implemented only for properties and methods.");
+
             var field = typeof(DocStrings).GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
             if (field == null)
                 return null;
             return (string)field.GetValue(null);
         }
 
-        public static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_");
+        private static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").TrimEnd('_');
+        private static string GetSaveMethodName(MethodInfo method) => Regex.Replace(method.ToString().Replace("MudBlazor.Docs.Models.T", "T"), "[^A-Za-z0-9_]", "_");  // method signature
     }
 }

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -7,7 +7,6 @@ namespace MudBlazor.Docs.Models
     // this is needed for the api docs 
     public static partial class DocStrings
     {
-        // currently implemented only for properties
         public static string GetMemberDescription(Type t, MemberInfo member)
         {
             var name = GetSaveTypename(t);
@@ -15,7 +14,7 @@ namespace MudBlazor.Docs.Models
             if (member is PropertyInfo property)
                 name += "_" + property.Name;
             else if (member is MethodInfo method)
-                name += "_method_" + GetSaveMethodName(method);
+                name += "_method_" + GetSaveMethodIdentifier(method);
             else
                 throw new Exception("Implemented only for properties and methods.");
 
@@ -26,6 +25,7 @@ namespace MudBlazor.Docs.Models
         }
 
         private static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").TrimEnd('_');
-        private static string GetSaveMethodName(MethodInfo method) => Regex.Replace(method.ToString().Replace("MudBlazor.Docs.Models.T", "T"), "[^A-Za-z0-9_]", "_");  // method signature
+
+        private static string GetSaveMethodIdentifier(MethodInfo method) => Regex.Replace(method.ToString().Replace("MudBlazor.Docs.Models.T", "T"), "[^A-Za-z0-9_]", "_");  // method signature
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

## Description

Fixes #3567. Descriptions of methods are now read from `DocsStrings.generated.cs` like descriptions of properties. The name of the method description field in the `DocsStrings.generated.cs` file is long and ugly, but it works.

## How Has This Been Tested?
I used Selenium to check that all pages in Wasm have the same content as currently in Blazor server side. The used test: https://github.com/MudBlazor/MudBlazor/discussions/3595.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
