### PR TITLE
Output ES6 compatible JavaScript to support older browsers

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -46,6 +46,7 @@
   <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" Condition="'$(CleanGeneratedFiles)' != 'false'">
     <ItemGroup>
       <FilesToClean Include="./TScripts/combined/MudBlazor.js" />
+      <FilesToClean Include="./TScripts/combined/MudBlazor.min.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.css" />
     </ItemGroup>
@@ -55,24 +56,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1.*" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Target Name="ToolRestore">
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
 
-  <!--combine js files-->
-  <Target Name="CombineJS">
-    <CreateItem Include="./TScripts/*.js">
-      <Output TaskParameter="Include" ItemName="jsFilesToCombine" />
-    </CreateItem>
-    <ReadLinesFromFile File="%(jsFilesToCombine.FullPath)">
-      <Output TaskParameter="Lines" ItemName="jsLines" />
-    </ReadLinesFromFile>
-    <WriteLinesToFile File="./TScripts/combined/MudBlazor.js" Lines="@(jsLines)" Overwrite="true" />
-  </Target>
-
-  <Target Name="WebCompiler" DependsOnTargets="ToolRestore;CombineJS">
+  <Target Name="WebCompiler" DependsOnTargets="ToolRestore">
     <!--compile and minify scss-->
     <Exec Command="dotnet webcompiler ./Styles/MudBlazor.scss -c excubowebcompiler.json" StandardOutputImportance="high" StandardErrorImportance="high" />
     <!--minify js-->

--- a/src/MudBlazor/tsconfig.json
+++ b/src/MudBlazor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "None",
+    "alwaysStrict": true,
+    "noEmitOnError": true,
+    "removeComments": true,
+    "allowJs": true,
+    "outFile": "TScripts/combined/MudBlazor.js"
+
+  },
+  "include": [ "TScripts/**/*" ],
+  "exclude": [ "wwwroot"]
+}

--- a/src/MudBlazor/tsconfig.json
+++ b/src/MudBlazor/tsconfig.json
@@ -9,6 +9,6 @@
     "outFile": "TScripts/combined/MudBlazor.js"
 
   },
-  "include": [ "TScripts/**/*" ],
-  "exclude": [ "wwwroot"]
+  "include": [ "TScripts/*.js" ],
+  "exclude": [ "wwwroot", "TScripts/combined" ]
 }


### PR DESCRIPTION
## Description

Fixes #3537

The project's build system has been modified to output **ES6 compatible JavaScript**, thus producing a reliable solution for the issue detailed in #3537 as well as defending against future possible issues stemming from usage of bleeding edge JavaScript features.

This allows you JavaScript Wizards to continue writing code the way you like it (with modern idioms) while offering an extra layer of protection against browsers with incomplete or absent coverage of your favorite features.

## How Has This Been Tested?

- [x] Unit tests
- [x] Visually

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
