### PR TITLE
Docs, Carousel: Replace "Delimiters" with "Bullets"

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Carousel/CarouselPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/CarouselPage.razor
@@ -52,7 +52,7 @@
 	<DocsPageContent>
 		<DocsPageSection>
 			<SectionHeader Title="Elements Templates">
-				<Description>Custom arrows or delimiters templates:</Description>
+				<Description>Custom arrows or bullets templates:</Description>
 			</SectionHeader>
 			<SectionContent Outlined="true" FullWidth="true" Class="demo-alert">
 				<MudBlazor.Docs.Examples.CarouselTemplatesExample />

--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCarousel @ref="_carousel" ItemsSource="@_source" @bind-SelectedIndex="selectedIndex" Style="height:200px;" ShowArrows="@_arrows" ShowDelimiters="@_delimiters" AutoCycle="@_autocycle">
+<MudCarousel @ref="_carousel" ItemsSource="@_source" @bind-SelectedIndex="selectedIndex" Style="height:200px;" ShowArrows="@_arrows" ShowBullets="@_bullets" AutoCycle="@_autocycle">
 	<ItemTemplate>
 		<div class="d-flex flex-column flex-column justify-center" style="height:100%">
 			<MudIcon Class="mx-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />
@@ -9,7 +9,7 @@
 	</ItemTemplate>
 </MudCarousel>
 <MudSwitch @bind-Checked="@_arrows" Color="Color.Primary">Show Arrows</MudSwitch>
-<MudSwitch @bind-Checked="@_delimiters" Color="Color.Primary">Show Delimiters</MudSwitch>
+<MudSwitch @bind-Checked="@_bullets" Color="Color.Primary">Show Bullets</MudSwitch>
 <MudSwitch @bind-Checked="@_autocycle" Color="Color.Primary">Auto Cycle (Default: 5 secs)</MudSwitch>
 <br />
 <MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddAsync">Add</MudButton>
@@ -28,7 +28,7 @@
 @code {
 	private MudCarousel<string> _carousel;
 	private bool _arrows = true;
-	private bool _delimiters = true;
+	private bool _bullets = true;
 	private bool _autocycle = true;
 	private IList<string> _source = new List<string>() { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
 	private int selectedIndex = 2;

--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCarousel Style="height:200px;" ShowArrows="@arrows" ShowDelimiters="@delimiters" AutoCycle="@autocycle" TData="object">
+<MudCarousel Style="height:200px;" ShowArrows="@arrows" ShowBullets="@bullets" AutoCycle="@autocycle" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
         <div class="d-flex" style="height:100%">
             <MudIcon Class="mx-auto my-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />
@@ -23,12 +23,12 @@
     <MudSelectItem Value="@Transition.None">None</MudSelectItem>
 </MudSelect>
 <MudSwitch @bind-Checked="@arrows" Color="Color.Primary">Show Arrows</MudSwitch>
-<MudSwitch @bind-Checked="@delimiters" Color="Color.Primary">Show Delimiters</MudSwitch>
+<MudSwitch @bind-Checked="@bullets" Color="Color.Primary">Show Bullets</MudSwitch>
 <MudSwitch @bind-Checked="@autocycle" Color="Color.Primary">Auto Cycle (Default: 5 secs)</MudSwitch>
 
 @code{ 
     private bool arrows = true;
-    private bool delimiters = true;
+    private bool bullets = true;
     private bool autocycle = true;
     private Transition transition = Transition.Slide;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselTemplatesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselTemplatesExample.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudCarousel Style="height:200px;" AutoCycle="false" TData="object">
-    <DelimiterTemplate Context="selected">
+    <BulletTemplate Context="selected">
         <div Class="mud-button-root mud-icon-button mud-icon-button-color-inherit mud-ripple mud-ripple-icon">
             <span class="mud-icon-button-label">
                 <MudIcon Icon="@(selected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Circle)" Color="@Color.Inherit" />
             </span>
         </div>
-    </DelimiterTemplate>
+    </BulletTemplate>
     <PreviousButtonTemplate>
         <div Class="mud-button-root mud-icon-button mud-icon-button-color-inherit mud-ripple mud-ripple-icon">
             <span class="mud-icon-button-label">

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor
@@ -49,14 +49,14 @@
                         @for (int i = 0; i < Items.Count; i++)
                         {
                             int current = i;
-                            if (BulletsTemplate == null)
+                            if (BulletTemplate == null)
                             {
                                 <MudIconButton tabindex="@(i+3)" aria-label="@(i+1)" Class="@BulletsButtonsClassName" Style="z-index:3;opacity:0.75" Icon="@(current == SelectedIndex ? CheckedIcon : UncheckedIcon)" OnClick="(() => MoveTo(current))" Color="Color.Inherit" />
                             }
                             else
                             {
                                 <div @onclick="() => MoveTo(current)" class="@BulletsButtonsClassName" style="z-index:3">
-                                    @BulletsTemplate(current == SelectedIndex)
+                                    @BulletTemplate(current == SelectedIndex)
                                 </div>
                             }
                         }

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -214,16 +214,16 @@ namespace MudBlazor
         /// Gets or Sets the Template for Bullets
         /// </summary>
         [Category(CategoryTypes.Carousel.Appearance)]
-        [Parameter] public RenderFragment<bool> BulletsTemplate { get; set; }
+        [Parameter] public RenderFragment<bool> BulletTemplate { get; set; }
 
         /// <summary>
         /// Gets or Sets the Template for Delimiters.
         /// Deprecated, use BulletsTemplate instead.
         /// </summary>
         [Category(CategoryTypes.Carousel.Appearance)]
-        [Obsolete($"Use {nameof(BulletsTemplate)} instead", false)]
+        [Obsolete($"Use {nameof(BulletTemplate)} instead", false)]
         [ExcludeFromCodeCoverage]
-        [Parameter] public RenderFragment<bool> DelimiterTemplate { get => BulletsTemplate; set => BulletsTemplate = value; }
+        [Parameter] public RenderFragment<bool> DelimiterTemplate { get => BulletTemplate; set => BulletTemplate = value; }
 
 
         /// <summary>


### PR DESCRIPTION
## Description
In the previous pull request #3463 we deprecated the term "Delimiter" in favour of "Bullet".
I replaced the tests but not the docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
