### PR TITLE
Picker: Add 'context' parameter to 'PickerActions' to simplify creation of actions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
@@ -14,11 +14,11 @@
         <MudTimePicker Label="24 hours (editable)" Editable="true" />
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudTimePicker @ref="_picker" Label="With action buttons" AutoClose="@autoClose">
+        <MudTimePicker Label="With action buttons" AutoClose="@autoClose">
             <PickerActions>
-                <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-                <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-                <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+                <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton>
+                <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton>
             </PickerActions>
         </MudTimePicker>
         <MudSwitch @bind-Checked="@autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
@@ -26,7 +26,6 @@
 </MudGrid>
 
 @code{
-    MudTimePicker _picker;
     TimeSpan? time = new TimeSpan(00, 45, 00);
     private bool autoClose;
     private bool readOnly;

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerKeyboardNavigationExample.razor
@@ -13,11 +13,11 @@
         <MudTimePicker Label="24 hours (editable)" Editable="true" />
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudTimePicker @ref="_picker" Label="With action buttons" AutoClose="@autoClose">
+        <MudTimePicker Label="With action buttons" AutoClose="@autoClose">
             <PickerActions>
-                <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-                <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-                <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+                <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton>
+                <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton>
             </PickerActions>
         </MudTimePicker>
         <MudSwitch @bind-Checked="@autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
@@ -25,7 +25,6 @@
 </MudGrid>
 
 @code{
-    MudTimePicker _picker;
     TimeSpan? time = new TimeSpan(00, 45, 00);
     private bool autoClose;
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/AutoCompleteTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/AutoCompleteTimePickerTest.razor
@@ -1,14 +1,13 @@
 ﻿<MudPopoverProvider></MudPopoverProvider>
 
-<MudTimePicker @ref="_picker" Label="With action buttons" @bind-Time="time">
+<MudTimePicker Label="With action buttons" @bind-Time="time">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Id="theCloseButton" Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton>
+        <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton>
+        <MudButton Id="theCloseButton" Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton>
     </PickerActions>
 </MudTimePicker>
 
 @code{
-    MudTimePicker _picker;
     TimeSpan? time = new TimeSpan(00, 45, 00);
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -39,7 +39,7 @@
 							@if (PickerActions != null)
 							{
 								<div class="@ActionClass">
-									@PickerActions
+									@PickerActions(this)
 								</div>
 							}
 					   </MudPaper>
@@ -57,7 +57,7 @@
                     @if (PickerActions != null)
                     {
                         <div class="@ActionClass">
-                            @PickerActions
+                            @PickerActions(this)
                         </div>
                     }
                </MudPaper>
@@ -74,7 +74,7 @@
                         @if (PickerActions != null)
                         {
                             <div class="@ActionClass">
-                                @PickerActions
+                                @PickerActions(this)
                             </div>
                         }
                    </MudPaper>

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -269,7 +269,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
-        public RenderFragment PickerActions { get; set; }
+        public RenderFragment<MudPicker<T>> PickerActions { get; set; }
 
         /// <summary>
         ///  Will adjust vertical spacing.


### PR DESCRIPTION
## Description
Added a `context` parameter to `PickerActions` to simplify creation of action buttons for pickers without the need to reference the picker itself.

## How Has This Been Tested?
All standard tests apply.

## Types of changes
This is how `PickerActions` was used before this PR:
```html
<MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date" AutoClose="@autoClose"> // note the usage of @ref
    <PickerActions>
        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton> // @ref needed here
        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton> // @ref needed here
        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton> // @ref needed here
    </PickerActions>
</MudDatePicker>
```
After this PR:
```html
<MudDatePicker Label="With action buttons" @bind-Date="date" AutoClose="@autoClose"> // note the absence of @ref
    <PickerActions>
        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton> // @ref replaced with `context`
        <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton> // @ref replaced with `context`
        <MudButton Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton> // @ref replaced with `context`
    </PickerActions>
</MudDatePicker>
```
There is now no need to define a separate property for a `MudDatePicker` (or any other `Picker`) to use it's methods inside `PickerActions`.
Sample code take from [stock demo](https://mudblazor.com/wasm/components/datepicker#basic-usage).
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.