### PR TITLE
Table: Fix conflicts between MultiSelection callbacks and invalid selection when row enters in edit mode

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -713,8 +713,9 @@ namespace MudBlazor.UnitTests.Components
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var inputs = comp.FindAll("input").ToArray();
             table.SelectedItems.Count.Should().Be(0); // selected items should be empty
-            inputs[1].Click(); // A single checkbox click adds 5 items through the callback method
-            table.SelectedItems.Count.Should().Be(6);
+            Action onclick = () => inputs[1].Click(); // OnRowClick is not called anymore, neither .GotClicked<>(), so selectedItems didn't add any element.
+            onclick.Should().Throw<Bunit.MissingEventHandlerException>().WithMessage("The element does not have an event handler for the event 'onclick'. It does however have event handlers for these events, 'onchange', 'onclick:stoppropagation'.");
+            table.SelectedItems.Count.Should().Be(0);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -703,21 +703,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Checkbox click must not bubble up.
-        /// </summary>
-        [Test]
-        public void TableMultiSelection_Checkbox_Executes_Callback()
-        {
-            var comp = Context.RenderComponent<TableMultiSelectionCheckboxExecutesCallback>();
-
-            var table = comp.FindComponent<MudTable<int>>().Instance;
-            var inputs = comp.FindAll("input").ToArray();
-            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
-            inputs[1].Click(); // A single checkbox click adds 5 items through the callback method
-            table.SelectedItems.Count.Should().Be(6);
-        }
-
-        /// <summary>
         /// Setting items delayed should work well and update pager also
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -703,6 +703,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Checkbox click must not bubble up.
+        /// </summary>
+        [Test]
+        public void TableMultiSelection_Checkbox_Executes_Callback()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionCheckboxExecutesCallback>();
+
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var inputs = comp.FindAll("input").ToArray();
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+            inputs[1].Click(); // A single checkbox click adds 5 items through the callback method
+            table.SelectedItems.Count.Should().Be(6);
+        }
+
+        /// <summary>
         /// Setting items delayed should work well and update pager also
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -9,7 +9,7 @@
             <div class="d-flex" style="@ActionsStylename">
                 @if (IsCheckable)
                 {
-                    <MudCheckBox @bind-Checked="IsChecked" StopClickPropagation="false" Class="mud-table-cell-checkbox"></MudCheckBox>
+                    <MudCheckBox @bind-Checked="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
                 }
             </div>
         </MudElement>

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -90,7 +90,7 @@ namespace MudBlazor
                 Context?.Table.SetEditingItem(Item);
             }
 
-            if (Context?.Table.MultiSelection == true && !IsHeader)
+            if (Context?.Table.MultiSelection == true && !IsHeader && !(Context?.Table.IsEditable == true))
             {
                 IsChecked = !IsChecked;
             }


### PR DESCRIPTION
It's a small change based on #3627 , adding a stop propagation to selection CheckBox, and avoiding selection when row is clicked and the table is editable.

![#3627](https://user-images.githubusercontent.com/15158923/147621108-10b0f916-2e10-43e9-b8b7-b21a540823b2.gif)

Any review is appreciated.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. (Visual tests only)
