### PR TITLE
NavMenu: Added color, border, rounded, margin, dense options

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuBorderedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuBorderedExample.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Elevation="0" Class="py-3">
+    <MudNavMenu Bordered="true">
+        <MudNavLink Href="/dashboard">Dashboard</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="/components/navmenu">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Expanded="true">
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuColorExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Elevation="0" Class="py-3">
+    <MudNavMenu Color="Color.Info">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="/components/navmenu" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Expanded="true">
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>
+<MudPaper Width="250px" Elevation="0" Class="py-3">
+    <MudNavMenu Color="Color.Success" Bordered="true">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="/components/navmenu" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Expanded="true">
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuDenseExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Class="py-3" Elevation="0">
+    <MudNavMenu Dense="true" Color="Color.Info">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+            <MudNavLink Href="/components/navmenu" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+            <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+            <MudNavGroup Title="Settings" Expanded="true">
+                <MudNavLink Href="/users">Users</MudNavLink>
+                <MudNavLink Href="/security">Security</MudNavLink>
+            </MudNavGroup>
+            <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>
+<MudPaper Width="250px" Class="py-3" Elevation="0">
+    <MudNavMenu Dense="true" Rounded="true" Margin="Margin.Dense" Color="Color.Secondary" Class="pa-2">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="/components/navmenu" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Expanded="true">
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuMarginExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuMarginExample.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Elevation="0" Class="py-1">
+    <MudNavMenu Margin="Margin.Dense" Color="Color.Warning">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="/components/navmenu" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/thelab" Icon="@Icons.Filled.Science">The Lab</MudNavLink>
+    </MudNavMenu>
+</MudPaper>
+<MudPaper Width="250px" Elevation="0" Class="py-1">
+    <MudNavMenu Margin="Margin.Normal" Color="Color.Error">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="/components/navmenu" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/thelab" Icon="@Icons.Filled.Science">The Lab</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuRoundedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuRoundedExample.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Elevation="0">
+    <MudNavMenu Rounded="true" Margin="Margin.Dense" Color="Color.Primary" Class="pa-2">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="/components/navmenu" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/thelab" Icon="@Icons.Filled.Science">The Lab</MudNavLink>
+    </MudNavMenu>
+</MudPaper>
+<MudPaper Width="250px" Elevation="0">
+    <MudNavMenu Rounded="true" Margin="Margin.Normal" Color="Color.Tertiary" Class="pa-2">
+        <MudNavLink Href="/dashboard" Icon="@Icons.Filled.Dashboard">Dashboard</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="/components/navmenu" Icon="@Icons.Filled.Storage">Servers</MudNavLink>
+        <MudNavLink Href="/thelab" Icon="@Icons.Filled.Science">The Lab</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -3,42 +3,97 @@
 <DocsPage>
     <DocsPageHeader Title="Navigation Menu" />
     <DocsPageContent>
+        
         <DocsPageSection>
             <SectionHeader Title="Basic Usage">
                 <Description></Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true">
-                <NavMenuExample />
+                <NavMenuExample/>
             </SectionContent>
-            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu" ShowCode="false" />
+            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu" ShowCode="false"/>
         </DocsPageSection>
+        
         <DocsPageSection>
             <SectionHeader Title="Two Way Bind">
                 <Description>MudNavGroup allows two-way binding in the <CodeInline>Expanded</CodeInline> property, so you can control what happens when expanded and collapsed.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true">
-                <NavMenuTwoWayBindableExample />
+                <NavMenuTwoWayBindableExample/>
             </SectionContent>
-            <SectionSource Code="NavMenuTwoWayBindableExample" GitHubFolderName="NavMenu" ShowCode="false" />
+            <SectionSource Code="NavMenuTwoWayBindableExample" GitHubFolderName="NavMenu" ShowCode="false"/>
         </DocsPageSection>
+        
         <DocsPageSection>
             <SectionHeader Title="Sub Groups">
                 <Description>NavMenu can have up to <CodeInline>4</CodeInline> sub groups within <CodeInline>MudNavMenu</CodeInline> itself.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true">
-                <NavMenuSubGroupExample />
+                <NavMenuSubGroupExample/>
             </SectionContent>
-            <SectionSource Code="NavMenuSubGroupExample" GitHubFolderName="NavMenu" ShowCode="false" />
+            <SectionSource Code="NavMenuSubGroupExample" GitHubFolderName="NavMenu" ShowCode="false"/>
         </DocsPageSection>
+        
         <DocsPageSection>
             <SectionHeader Title="Icons">
                 <Description>You can use both the icons that come with MudBlazor or font icons. <MudLink Href="/components/icons">Read more about icons here.</MudLink></Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true">
                 <link href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" rel="stylesheet">
-                <NavMenuIconExample />
+                <NavMenuIconExample/>
             </SectionContent>
-            <SectionSource Code="NavMenuIconExample" GitHubFolderName="NavMenu" ShowCode="false" />
+            <SectionSource Code="NavMenuIconExample" GitHubFolderName="NavMenu" ShowCode="false"/>
         </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Bordered">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuBorderedExample/>
+            </SectionContent>
+            <SectionSource Code="NavMenuBorderedExample" GitHubFolderName="NavMenu" ShowCode="false"/>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuColorExample/>
+            </SectionContent>
+            <SectionSource Code="NavMenuColorExample" GitHubFolderName="NavMenu" ShowCode="false"/>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Margin">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuMarginExample/>
+            </SectionContent>
+            <SectionSource Code="NavMenuMarginExample" GitHubFolderName="NavMenu" ShowCode="false"/>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Rounded">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuRoundedExample/>
+            </SectionContent>
+            <SectionSource Code="NavMenuRoundedExample" GitHubFolderName="NavMenu" ShowCode="false"/>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Dense">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuDenseExample/>
+            </SectionContent>
+            <SectionSource Code="NavMenuDenseExample" GitHubFolderName="NavMenu" ShowCode="false"/>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -1,4 +1,5 @@
 ﻿
+using System;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
@@ -7,13 +8,61 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    public class NavMenuTexts : BunitTest
+    public class NavMenuTests : BunitTest
     {
+        
+        [Test]
+        /// <summary>
+        /// Change all styling parameters so that all default values have the correct classes.
+        /// </summary>
+        public void NavMenuTests_DefaultValues()
+        {
+            var comp = Context.RenderComponent<MudNavMenu>();
+            Console.WriteLine(comp.Markup);
+
+            comp.Instance.Bordered.Should().Be(false);
+            comp.Instance.Color.Should().Be(Color.Default);
+            comp.Instance.Dense.Should().Be(false);
+            comp.Instance.Margin.Should().Be(Margin.None);
+            comp.Instance.Rounded.Should().Be(false);
+            
+            comp.FindAll("mud-navmenu-bordered").Count.Should().Be(0);
+            comp.FindAll("mud-navmenu-success").Count.Should().Be(0);
+            comp.FindAll("mud-navmenu-dense").Count.Should().Be(0);
+            comp.FindAll("mud-navmenu-margin-dense").Count.Should().Be(0);
+            comp.FindAll("mud-navmenu-rounded").Count.Should().Be(0);
+        }
+        
+        [Test]
+        /// <summary>
+        /// Change all styling parameters from its default values and check that the correct classes are added.
+        /// </summary>
+        public void NavMenuTests_CheckAllStyling()
+        {
+            var comp = Context.RenderComponent<MudNavMenu>(x =>
+            {
+                x.Add(p => p.Bordered, true);
+                x.Add(p => p.Color, Color.Success);
+                x.Add(p => p.Dense, true);
+                x.Add(p => p.Margin, Margin.Dense);
+                x.Add(p => p.Rounded, true);
+            });
+            
+            Console.WriteLine(comp.Markup);
+
+            comp.Markup.Should().Contain("mud-navmenu-bordered");
+            comp.Markup.Should().Contain("mud-navmenu-success");
+            comp.Markup.Should().Contain("mud-navmenu-dense");
+            comp.Markup.Should().Contain("mud-navmenu-margin-dense");
+            comp.Markup.Should().Contain("mud-navmenu-rounded");
+        }
+
+        
+        [Test]
         /// <summary>
         /// This component is initially Expanded with the property Expand set to imutable true <c>Expand=true</c>
         /// And even so, he changes when clicked
         /// </summary>
-        [Test]
         public void One_Way_Bindable()
         {
             var comp = Context.RenderComponent<NavMenuOneWay>();

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 
 using MudBlazor.Utilities;
+using MudBlazor.Extensions;
 
 namespace MudBlazor
 {
@@ -8,10 +9,51 @@ namespace MudBlazor
     {
         protected string Classname =>
         new CssBuilder("mud-navmenu")
-          .AddClass(Class)
+            .AddClass($"mud-navmenu-{Color.ToDescriptionString()}")
+            .AddClass($"mud-navmenu-margin-{Margin.ToDescriptionString()}")
+            .AddClass("mud-navmenu-dense", Dense)
+            .AddClass("mud-navmenu-rounded", Rounded)
+            .AddClass($"mud-navmenu-bordered mud-border-{Color.ToDescriptionString()}", Bordered)
+            .AddClass(Class)
         .Build();
 
         [Category(CategoryTypes.NavMenu.Behavior)]
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// The color of the active NavLink.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public Color Color { get; set; } = Color.Default;
+        
+        /// <summary>
+        /// If true, adds a border of the active NavLink, does nothing if variant outlined is used.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public bool Bordered { get; set; }
+        
+        /// <summary>
+        /// If true, default theme border-radius will be used on all navlinks.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public bool Rounded { get; set; }
+        
+        /// <summary>
+        ///  Adjust the vertical spacing between navlinks.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public Margin Margin { get; set; } = Margin.None;
+        
+        /// <summary>
+        /// If true, compact vertical padding will be applied to all navmenu items.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public bool Dense { get; set; }
+        
     }
 }

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -1,4 +1,6 @@
-﻿.mud-navmenu {
+﻿@import '../abstracts/variables';
+
+.mud-navmenu {
     margin: 0;
     position: relative;
     list-style: none;
@@ -78,11 +80,9 @@
         background-color: var(--mud-palette-action-default-hover);
     }
 
-    &.active:not(.mud-nav-link-disabled) {
-        font-weight: 500 !important;
-        color: var(--mud-palette-primary);
-        background-color: var(--mud-palette-action-default-hover);
-    }
+  &.active:not(.mud-nav-link-disabled) {
+    font-weight: 500 !important;
+  }
 
     &:not(.mud-nav-link-disabled) .mud-nav-link-icon.mud-nav-link-icon-default {
         color: var(--mud-palette-drawer-icon);
@@ -98,7 +98,6 @@
 
         &.mud-transform {
             transform: rotate(-180deg);
-            fill: var(--mud-palette-primary);
         }
 
         &.mud-transform-disabled {
@@ -114,6 +113,78 @@
         margin-inline-end: unset;
         letter-spacing: 0;
     }
+}
+
+.mud-navmenu{
+  
+  &.mud-navmenu-dense{
+    .mud-nav-link{
+      padding: 4px 16px 4px 16px;
+    }
+  }
+  
+  &.mud-navmenu-margin-dense{
+    .mud-nav-link{
+      margin: 2px 0;
+    }
+  }
+
+  &.mud-navmenu-margin-normal{
+    .mud-nav-link{
+      margin: 4px 0;
+    }
+  }
+
+  &.mud-navmenu-rounded{
+    .mud-nav-link{
+      border-radius: var(--mud-default-borderradius);
+    }
+  }
+  
+  &.mud-navmenu-bordered{
+    .mud-nav-link{
+      &.active:not(.mud-nav-link-disabled) {
+        border-right-style: solid;
+        border-right-width: 2px;
+      }
+    }
+  }
+  
+  &.mud-navmenu-default{
+    .mud-nav-link.active:not(.mud-nav-link-disabled) {
+      color: var(--mud-palette-primary);
+      background-color: var(--mud-palette-action-default-hover);
+
+      &:hover:not(.mud-nav-link-disabled), &:focus-visible:not(.mud-nav-link-disabled) {
+        background-color: var(--mud-palette-action-default-hover);
+      }
+    }
+    
+    .mud-nav-link-expand-icon.mud-transform {
+      fill: var(--mud-palette-primary);
+    }
+  }
+  
+  @each $color in $mud-palette-colors {
+    &.mud-navmenu-#{$color} {
+        .mud-nav-link.active:not(.mud-nav-link-disabled) {
+          color: var(--mud-palette-#{$color});
+          background-color: var(--mud-palette-#{$color}-hover);
+
+          &:hover:not(.mud-nav-link-disabled), &:focus-visible:not(.mud-nav-link-disabled) {
+            background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+          }
+
+          .mud-nav-link-icon {
+            color: var(--mud-palette-#{$color});
+          }
+        }
+
+      .mud-nav-link-expand-icon.mud-transform {
+        fill: var(--mud-palette-#{$color});
+      }
+    }
+  }
 }
 
 .mud-nav-group * .mud-navmenu > .mud-nav-group {


### PR DESCRIPTION
Updated NavMenu to give the users some customization / variant options built in without using any css.
All this was hardcoded before to Primary color when it comes to the active one.

## Description
Adds some styling options to MudNavMenu, as a first update.
New features:
### Bordered
![image](https://user-images.githubusercontent.com/10367109/147819655-eee28bda-6599-4d78-8742-32777f2fbd57.png)
### Color
![image](https://user-images.githubusercontent.com/10367109/147819699-4ad430b4-0ca5-4057-bb1f-b7531b373395.png)
### Margin
To showcase this in a picture i display them all with hover on so you can see the different auto margin options.
![image](https://user-images.githubusercontent.com/10367109/147819822-fba5d0dc-48c4-4d20-8487-b9d4fd438660.png)
### Rounded
![image](https://user-images.githubusercontent.com/10367109/147819846-bd7a0101-2d41-4aad-8cd3-7363b816ffdc.png)
### Dense
![image](https://user-images.githubusercontent.com/10367109/147819862-ae641d32-5758-499d-a9d7-12a00a901e6b.png)


## How Has This Been Tested?
Manually when making the examples.


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->




## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
✔️ I've added relevant tests.
