### PR TITLE
Exclude tsconfig.json from output

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -87,6 +87,10 @@
     <Content Remove="compilerconfig.json" />
     <Content Remove="excubowebcompiler.json" />
     <Content Remove="**/*/DoNotRemove.txt" />
+    <!--Don't include in output, Build Action = content-->
+    <Content Update="tsconfig.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TScripts\combined\" />


### PR DESCRIPTION
tsconfig.json was showing up in projects consuming the library, causing those projects to error on build. This change stops tsconfig.json from being included in output, which fixes the problem. Build Action remains 'Content' which is required for tsconfig.json.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
❌ I've added relevant tests.
