### PR TITLE
Modify Chart Options to allow for configuring stroke-width - resolves issue #3536

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/Chart Types/Examples/LineExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Chart Types/Examples/LineExample1.razor
@@ -1,13 +1,16 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div>
-    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
+    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="chartOptions"></MudChart>
     <MudButton @onclick="RandomizeData">Randomize Data</MudButton>
+    <MudButton @onclick="RandomizeLineWidths">Randomize Line Widths</MudButton>
     <MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
 </div>
 
 @code {
     private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.
+
+    public ChartOptions chartOptions = new ChartOptions();
 
     public List<ChartSeries> Series = new List<ChartSeries>()
     {
@@ -30,6 +33,12 @@
             new_series[1].Data[i] = random.NextDouble() * 100;
         }
         Series = new_series;
+        StateHasChanged();
+    }
+
+    public void RandomizeLineWidths()
+    {
+        chartOptions.LineStrokeWidth = random.NextInt64(1, 10);
         StateHasChanged();
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor
@@ -35,7 +35,7 @@
     <g class="mud-charts-line-series">
         @foreach (var chartLine in _chartLines)
         {
-            <path class="mud-chart-line" @onclick="() => SelectedIndex = chartLine.Index"  fill="none" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(chartLine.Index % ChartOptions.ChartPalette.Count()))" stroke-width="3" d="@chartLine.Data"></path>
+            <path class="mud-chart-line" @onclick="() => SelectedIndex = chartLine.Index"  fill="none" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(chartLine.Index % ChartOptions.ChartPalette.Count()))" stroke-width="@(MudChartParent.ChartOptions.LineStrokeWidth)" d="@chartLine.Data"></path>
         }
     </g>
 

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -22,6 +22,11 @@
         public bool DisableLegend { get; set; }
         public string[] ChartPalette { get; set; } = { Colors.Blue.Accent3, Colors.Teal.Accent3, Colors.Amber.Accent3, Colors.Orange.Accent3, Colors.Red.Accent3, Colors.DeepPurple.Accent3, Colors.Green.Accent3, Colors.LightBlue.Accent3, Colors.Teal.Lighten1, Colors.Amber.Lighten1, Colors.Orange.Lighten1, Colors.Red.Lighten1, Colors.DeepPurple.Lighten1, Colors.Green.Lighten1, Colors.LightBlue.Lighten1, Colors.Amber.Darken2, Colors.Orange.Darken2, Colors.Red.Darken2, Colors.DeepPurple.Darken2, Colors.Grey.Darken2 };
         public InterpolationOption InterpolationOption { get; set; } = InterpolationOption.Straight;
+
+        /// <summary>
+        /// Line width of series in px
+        /// </summary>
+        public double LineStrokeWidth { get; set; } = 3;
     }
     public enum InterpolationOption
     {


### PR DESCRIPTION
## Description
Adds stroke-width to Chart Options to allow for custom line width on a line chart.

- Resolves issue #3536

## How Has This Been Tested?
Tested visually as the line chart only has limited unit testing currently and implementing more tests is out of the scope of this work.






![image](https://user-images.githubusercontent.com/21277696/147856513-b8250b9e-48c7-4568-b147-7cbb0584184e.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
I've added relevant tests.