### PR TITLE
NumericField: Fix not updating value from text on blur when debounced

### DIFF
--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -154,8 +154,8 @@ namespace MudBlazor
         protected override async void OnBlurred(FocusEventArgs obj)
         {
             base.OnBlurred(obj);
-            await UpdateValuePropertyAsync(true);
-            await UpdateTextPropertyAsync(false);
+            await UpdateValuePropertyAsync(true); //Required to set the value after a blur before the debounce period has elapsed
+            await UpdateTextPropertyAsync(false); //Required to update the string formatting after a blur before the debouce period has elapsed
         }
 
         protected async Task<bool> ValidateInput(T value)

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -154,6 +154,7 @@ namespace MudBlazor
         protected override async void OnBlurred(FocusEventArgs obj)
         {
             base.OnBlurred(obj);
+            await UpdateValuePropertyAsync(true);
             await UpdateTextPropertyAsync(false);
         }
 


### PR DESCRIPTION
## Description
Fixes #3651 - Numeric field with debounce interval doesn't apply change when the field loses focus.

Update the value before updating the text formatting on losing focus (on blur) of debounced numeric fields.

## How Has This Been Tested?
Unit tests all pass. Also tested via demo in docs.


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->




## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
❌ I've added relevant tests.

- No Tests Added
