### PR TITLE
MudThemeProvider: Set clearer boundary between MudThemeProvider and M…

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesDarkPaletteExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesDarkPaletteExample.razor
@@ -2,7 +2,7 @@
 @namespace MudBlazor.Docs.Examples
 @page "/iframe/docs/examples/themeprovider/darkpalette"
 
-<MudThemeProvider Theme="_theme" />
+<MudThemeProvider Theme="_theme" @bind-IsDarkMode="_isDarkMode"/>
 <MudSwitch Color="Color.Primary" Class="ma-4" T="bool" CheckedChanged="DarkMode" Label="Toggle Light/Dark Mode"/>
 
 <MudText Class="ma-4">This is an example text!</MudText>
@@ -10,8 +10,10 @@
 @code{
 
     private MudTheme _theme = new();
+    private bool _isDarkMode = false;
     
-    void DarkMode(bool value) {
-        _theme.IsDarkMode = value;
+    void DarkMode(bool value)
+    {
+        _isDarkMode = value;
     }
 }

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -4,7 +4,7 @@
 <PageTitle>MudBlazor - Blazor Component Library</PageTitle>
 
 <MudRTLProvider RightToLeft="@_rightToLeft">
-    <MudThemeProvider Theme="_theme"/>
+    <MudThemeProvider Theme="_theme" @bind-IsDarkMode="_isDarkMode"/>
     <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
     <MudSnackbarProvider />
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -11,6 +11,7 @@ namespace MudBlazor.Docs.Shared
     {
         private bool _drawerOpen = false;
         private bool _rightToLeft = false;
+        private bool _isDarkMode = false;
         private NavMenu _navMenuRef;
 
         [Inject] private NavigationManager NavigationManager { get; set; }
@@ -90,7 +91,7 @@ namespace MudBlazor.Docs.Shared
         #region Theme   
         private void DarkMode()
         {
-            _theme.IsDarkMode = !_theme.IsDarkMode;
+            _isDarkMode = !_isDarkMode;
         }
 
         private MudTheme _theme = new();

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -1,29 +1,85 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public class BaseMudThemeProvider : ComponentBase
     {
-        [Parameter] public MudTheme Theme { get; set; }
+        /// <summary>
+        /// The theme used by the application.
+        /// </summary>
+        [Parameter]
+        public MudTheme Theme { get; set; }
 
         /// <summary>
         ///  If true, will not apply MudBlazor styled scrollbar and use browser default. 
         /// </summary>
-        [Parameter] public bool DefaultScrollbar { get; set; }
+        [Parameter]
+        public bool DefaultScrollbar { get; set; }
 
-        protected override void OnInitialized()
+        #region Dark mode handeling
+
+        public BaseMudThemeProvider()
         {
-            if (Theme == null)
+            _dotNetRef = DotNetObjectReference.Create(this);
+        }
+
+        private readonly DotNetObjectReference<BaseMudThemeProvider> _dotNetRef;
+        [Inject] private IJSRuntime JsRuntime { get; set; }
+
+        /// <summary>
+        /// Returns the dark mode preference of the user. True if dark mode is preferred.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> GetSystemPreference()
+        {
+            return await JsRuntime.InvokeAsync<bool>("darkModeChange", _dotNetRef);
+        }
+
+        private bool _isDarkMode;
+
+        /// <summary>
+        /// The active palette of the theme.
+        /// </summary>
+        [Parameter]
+        public bool IsDarkMode
+        {
+            get => _isDarkMode;
+            set
             {
-                var theme = new MudTheme();
-                Theme = theme;
+                if (_isDarkMode == value)
+                {
+                    return;
+                }
+
+                _isDarkMode = value;
+                IsDarkModeChanged.InvokeAsync(_isDarkMode);
             }
         }
 
-        public string BuildTheme()
+        /// <summary>
+        /// Invoked when the dark mode changes.
+        /// </summary>
+        [Parameter]
+        public EventCallback<bool> IsDarkModeChanged
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        protected override void OnInitialized()
+        {
+            Theme ??= new MudTheme();
+        }
+
+        protected string BuildTheme()
         {
             var theme = new StringBuilder();
             theme.AppendLine("<style>");
@@ -35,7 +91,7 @@ namespace MudBlazor
             return theme.ToString();
         }
 
-        public string BuildMudBlazorScrollbar()
+        protected string BuildMudBlazorScrollbar()
         {
             var scrollbar = new StringBuilder();
             scrollbar.AppendLine("<style>");
@@ -58,95 +114,115 @@ namespace MudBlazor
 
         protected virtual void GenerateTheme(StringBuilder theme)
         {
+            var palette = _isDarkMode == false ? Theme.Palette : Theme.PaletteDark;
+            
             //Palette
-            theme.AppendLine($"--{Palette}-black: {Theme.CurrentPalette.Black};");
-            theme.AppendLine($"--{Palette}-white: {Theme.CurrentPalette.White};");
+            theme.AppendLine($"--{Palette}-black: {palette.Black};");
+            theme.AppendLine($"--{Palette}-white: {palette.White};");
 
-            theme.AppendLine($"--{Palette}-primary: {Theme.CurrentPalette.Primary};");
-            theme.AppendLine($"--{Palette}-primary-rgb: {Theme.CurrentPalette.Primary.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-primary-text: {Theme.CurrentPalette.PrimaryContrastText};");
-            theme.AppendLine($"--{Palette}-primary-darken: {Theme.CurrentPalette.PrimaryDarken};");
-            theme.AppendLine($"--{Palette}-primary-lighten: {Theme.CurrentPalette.PrimaryLighten};");
-            theme.AppendLine($"--{Palette}-primary-hover: { Theme.CurrentPalette.Primary.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-secondary: {Theme.CurrentPalette.Secondary};");
-            theme.AppendLine($"--{Palette}-secondary-rgb: {Theme.CurrentPalette.Secondary.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-secondary-text: {Theme.CurrentPalette.SecondaryContrastText};");
-            theme.AppendLine($"--{Palette}-secondary-darken: {Theme.CurrentPalette.SecondaryDarken};");
-            theme.AppendLine($"--{Palette}-secondary-lighten: {Theme.CurrentPalette.SecondaryLighten};");
-            theme.AppendLine($"--{Palette}-secondary-hover: { Theme.CurrentPalette.Secondary.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-tertiary: {Theme.CurrentPalette.Tertiary};");
-            theme.AppendLine($"--{Palette}-tertiary-rgb: {Theme.CurrentPalette.Tertiary.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-tertiary-text: {Theme.CurrentPalette.TertiaryContrastText};");
-            theme.AppendLine($"--{Palette}-tertiary-darken: {Theme.CurrentPalette.TertiaryDarken};");
-            theme.AppendLine($"--{Palette}-tertiary-lighten: {Theme.CurrentPalette.TertiaryLighten};");
-            theme.AppendLine($"--{Palette}-tertiary-hover: { Theme.CurrentPalette.Tertiary.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-info: {Theme.CurrentPalette.Info};");
-            theme.AppendLine($"--{Palette}-info-rgb: {Theme.CurrentPalette.Info.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-info-text: {Theme.CurrentPalette.InfoContrastText};");
-            theme.AppendLine($"--{Palette}-info-darken: {Theme.CurrentPalette.InfoDarken};");
-            theme.AppendLine($"--{Palette}-info-lighten: {Theme.CurrentPalette.InfoLighten};");
-            theme.AppendLine($"--{Palette}-info-hover: { Theme.CurrentPalette.Info.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-success: {Theme.CurrentPalette.Success};");
-            theme.AppendLine($"--{Palette}-success-rgb: {Theme.CurrentPalette.Success.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-success-text: {Theme.CurrentPalette.SuccessContrastText};");
-            theme.AppendLine($"--{Palette}-success-darken: {Theme.CurrentPalette.SuccessDarken};");
-            theme.AppendLine($"--{Palette}-success-lighten: {Theme.CurrentPalette.SuccessLighten};");
-            theme.AppendLine($"--{Palette}-success-hover: { Theme.CurrentPalette.Success.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-warning: {Theme.CurrentPalette.Warning};");
-            theme.AppendLine($"--{Palette}-warning-rgb: {Theme.CurrentPalette.Warning.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-warning-text: {Theme.CurrentPalette.WarningContrastText};");
-            theme.AppendLine($"--{Palette}-warning-darken: {Theme.CurrentPalette.WarningDarken};");
-            theme.AppendLine($"--{Palette}-warning-lighten: {Theme.CurrentPalette.WarningLighten};");
-            theme.AppendLine($"--{Palette}-warning-hover: { Theme.CurrentPalette.Warning.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-error: {Theme.CurrentPalette.Error};");
-            theme.AppendLine($"--{Palette}-error-rgb: {Theme.CurrentPalette.Error.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-error-text: {Theme.CurrentPalette.ErrorContrastText};");
-            theme.AppendLine($"--{Palette}-error-darken: {Theme.CurrentPalette.ErrorDarken};");
-            theme.AppendLine($"--{Palette}-error-lighten: {Theme.CurrentPalette.ErrorLighten};");
-            theme.AppendLine($"--{Palette}-error-hover: { Theme.CurrentPalette.Error.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-dark: {Theme.CurrentPalette.Dark};");
-            theme.AppendLine($"--{Palette}-dark-rgb: {Theme.CurrentPalette.Dark.ToString(MudColorOutputFormats.ColorElements)};");
-            theme.AppendLine($"--{Palette}-dark-text: {Theme.CurrentPalette.DarkContrastText};");
-            theme.AppendLine($"--{Palette}-dark-darken: {Theme.CurrentPalette.DarkDarken};");
-            theme.AppendLine($"--{Palette}-dark-lighten: {Theme.CurrentPalette.DarkLighten};");
-            theme.AppendLine($"--{Palette}-dark-hover: { Theme.CurrentPalette.Dark.SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-primary: {palette.Primary};");
+            theme.AppendLine(
+                $"--{Palette}-primary-rgb: {palette.Primary.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-primary-text: {palette.PrimaryContrastText};");
+            theme.AppendLine($"--{Palette}-primary-darken: {palette.PrimaryDarken};");
+            theme.AppendLine($"--{Palette}-primary-lighten: {palette.PrimaryLighten};");
+            theme.AppendLine(
+                $"--{Palette}-primary-hover: {palette.Primary.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-secondary: {palette.Secondary};");
+            theme.AppendLine(
+                $"--{Palette}-secondary-rgb: {palette.Secondary.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-secondary-text: {palette.SecondaryContrastText};");
+            theme.AppendLine($"--{Palette}-secondary-darken: {palette.SecondaryDarken};");
+            theme.AppendLine($"--{Palette}-secondary-lighten: {palette.SecondaryLighten};");
+            theme.AppendLine(
+                $"--{Palette}-secondary-hover: {palette.Secondary.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-tertiary: {palette.Tertiary};");
+            theme.AppendLine(
+                $"--{Palette}-tertiary-rgb: {palette.Tertiary.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-tertiary-text: {palette.TertiaryContrastText};");
+            theme.AppendLine($"--{Palette}-tertiary-darken: {palette.TertiaryDarken};");
+            theme.AppendLine($"--{Palette}-tertiary-lighten: {palette.TertiaryLighten};");
+            theme.AppendLine(
+                $"--{Palette}-tertiary-hover: {palette.Tertiary.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-info: {palette.Info};");
+            theme.AppendLine(
+                $"--{Palette}-info-rgb: {palette.Info.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-info-text: {palette.InfoContrastText};");
+            theme.AppendLine($"--{Palette}-info-darken: {palette.InfoDarken};");
+            theme.AppendLine($"--{Palette}-info-lighten: {palette.InfoLighten};");
+            theme.AppendLine(
+                $"--{Palette}-info-hover: {palette.Info.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-success: {palette.Success};");
+            theme.AppendLine(
+                $"--{Palette}-success-rgb: {palette.Success.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-success-text: {palette.SuccessContrastText};");
+            theme.AppendLine($"--{Palette}-success-darken: {palette.SuccessDarken};");
+            theme.AppendLine($"--{Palette}-success-lighten: {palette.SuccessLighten};");
+            theme.AppendLine(
+                $"--{Palette}-success-hover: {palette.Success.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-warning: {palette.Warning};");
+            theme.AppendLine(
+                $"--{Palette}-warning-rgb: {palette.Warning.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-warning-text: {palette.WarningContrastText};");
+            theme.AppendLine($"--{Palette}-warning-darken: {palette.WarningDarken};");
+            theme.AppendLine($"--{Palette}-warning-lighten: {palette.WarningLighten};");
+            theme.AppendLine(
+                $"--{Palette}-warning-hover: {palette.Warning.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-error: {palette.Error};");
+            theme.AppendLine(
+                $"--{Palette}-error-rgb: {palette.Error.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-error-text: {palette.ErrorContrastText};");
+            theme.AppendLine($"--{Palette}-error-darken: {palette.ErrorDarken};");
+            theme.AppendLine($"--{Palette}-error-lighten: {palette.ErrorLighten};");
+            theme.AppendLine(
+                $"--{Palette}-error-hover: {palette.Error.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-dark: {palette.Dark};");
+            theme.AppendLine(
+                $"--{Palette}-dark-rgb: {palette.Dark.ToString(MudColorOutputFormats.ColorElements)};");
+            theme.AppendLine($"--{Palette}-dark-text: {palette.DarkContrastText};");
+            theme.AppendLine($"--{Palette}-dark-darken: {palette.DarkDarken};");
+            theme.AppendLine($"--{Palette}-dark-lighten: {palette.DarkLighten};");
+            theme.AppendLine(
+                $"--{Palette}-dark-hover: {palette.Dark.SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
 
-            theme.AppendLine($"--{Palette}-text-primary: {Theme.CurrentPalette.TextPrimary};");
-            theme.AppendLine($"--{Palette}-text-secondary: {Theme.CurrentPalette.TextSecondary};");
-            theme.AppendLine($"--{Palette}-text-disabled: {Theme.CurrentPalette.TextDisabled};");
+            theme.AppendLine($"--{Palette}-text-primary: {palette.TextPrimary};");
+            theme.AppendLine($"--{Palette}-text-secondary: {palette.TextSecondary};");
+            theme.AppendLine($"--{Palette}-text-disabled: {palette.TextDisabled};");
 
-            theme.AppendLine($"--{Palette}-action-default: {Theme.CurrentPalette.ActionDefault};");
-            theme.AppendLine($"--{Palette}-action-default-hover: { new MudColor(Colors.Shades.Black).SetAlpha(Theme.CurrentPalette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
-            theme.AppendLine($"--{Palette}-action-disabled: {Theme.CurrentPalette.ActionDisabled};");
-            theme.AppendLine($"--{Palette}-action-disabled-background: {Theme.CurrentPalette.ActionDisabledBackground};");
+            theme.AppendLine($"--{Palette}-action-default: {palette.ActionDefault};");
+            theme.AppendLine(
+                $"--{Palette}-action-default-hover: {new MudColor(Colors.Shades.Black).SetAlpha(palette.HoverOpacity).ToString(MudColorOutputFormats.RGBA)};");
+            theme.AppendLine($"--{Palette}-action-disabled: {palette.ActionDisabled};");
+            theme.AppendLine(
+                $"--{Palette}-action-disabled-background: {palette.ActionDisabledBackground};");
 
-            theme.AppendLine($"--{Palette}-surface: {Theme.CurrentPalette.Surface};");
-            theme.AppendLine($"--{Palette}-background: {Theme.CurrentPalette.Background};");
-            theme.AppendLine($"--{Palette}-background-grey: {Theme.CurrentPalette.BackgroundGrey};");
-            theme.AppendLine($"--{Palette}-drawer-background: {Theme.CurrentPalette.DrawerBackground};");
-            theme.AppendLine($"--{Palette}-drawer-text: {Theme.CurrentPalette.DrawerText};");
-            theme.AppendLine($"--{Palette}-drawer-icon: {Theme.CurrentPalette.DrawerIcon};");
-            theme.AppendLine($"--{Palette}-appbar-background: {Theme.CurrentPalette.AppbarBackground};");
-            theme.AppendLine($"--{Palette}-appbar-text: {Theme.CurrentPalette.AppbarText};");
+            theme.AppendLine($"--{Palette}-surface: {palette.Surface};");
+            theme.AppendLine($"--{Palette}-background: {palette.Background};");
+            theme.AppendLine($"--{Palette}-background-grey: {palette.BackgroundGrey};");
+            theme.AppendLine($"--{Palette}-drawer-background: {palette.DrawerBackground};");
+            theme.AppendLine($"--{Palette}-drawer-text: {palette.DrawerText};");
+            theme.AppendLine($"--{Palette}-drawer-icon: {palette.DrawerIcon};");
+            theme.AppendLine($"--{Palette}-appbar-background: {palette.AppbarBackground};");
+            theme.AppendLine($"--{Palette}-appbar-text: {palette.AppbarText};");
 
-            theme.AppendLine($"--{Palette}-lines-default: {Theme.CurrentPalette.LinesDefault};");
-            theme.AppendLine($"--{Palette}-lines-inputs: {Theme.CurrentPalette.LinesInputs};");
+            theme.AppendLine($"--{Palette}-lines-default: {palette.LinesDefault};");
+            theme.AppendLine($"--{Palette}-lines-inputs: {palette.LinesInputs};");
 
-            theme.AppendLine($"--{Palette}-table-lines: {Theme.CurrentPalette.TableLines};");
-            theme.AppendLine($"--{Palette}-table-striped: {Theme.CurrentPalette.TableStriped};");
-            theme.AppendLine($"--{Palette}-table-hover: {Theme.CurrentPalette.TableHover};");
+            theme.AppendLine($"--{Palette}-table-lines: {palette.TableLines};");
+            theme.AppendLine($"--{Palette}-table-striped: {palette.TableStriped};");
+            theme.AppendLine($"--{Palette}-table-hover: {palette.TableHover};");
 
-            theme.AppendLine($"--{Palette}-divider: {Theme.CurrentPalette.Divider};");
-            theme.AppendLine($"--{Palette}-divider-light: {Theme.CurrentPalette.DividerLight};");
+            theme.AppendLine($"--{Palette}-divider: {palette.Divider};");
+            theme.AppendLine($"--{Palette}-divider-light: {palette.DividerLight};");
 
-            theme.AppendLine($"--{Palette}-grey-default: {Theme.CurrentPalette.GrayDefault};");
-            theme.AppendLine($"--{Palette}-grey-light: {Theme.CurrentPalette.GrayLight};");
-            theme.AppendLine($"--{Palette}-grey-lighter: {Theme.CurrentPalette.GrayLighter};");
-            theme.AppendLine($"--{Palette}-grey-dark: {Theme.CurrentPalette.GrayDark};");
-            theme.AppendLine($"--{Palette}-grey-darker: {Theme.CurrentPalette.GrayDarker};");
+            theme.AppendLine($"--{Palette}-grey-default: {palette.GrayDefault};");
+            theme.AppendLine($"--{Palette}-grey-light: {palette.GrayLight};");
+            theme.AppendLine($"--{Palette}-grey-lighter: {palette.GrayLighter};");
+            theme.AppendLine($"--{Palette}-grey-dark: {palette.GrayDark};");
+            theme.AppendLine($"--{Palette}-grey-darker: {palette.GrayDarker};");
 
-            theme.AppendLine($"--{Palette}-overlay-dark: {Theme.CurrentPalette.OverlayDark};");
-            theme.AppendLine($"--{Palette}-overlay-light: {Theme.CurrentPalette.OverlayLight};");
+            theme.AppendLine($"--{Palette}-overlay-dark: {palette.OverlayDark};");
+            theme.AppendLine($"--{Palette}-overlay-light: {palette.OverlayLight};");
 
             //Elevations
             theme.AppendLine($"--{Elevation}-0: {Theme.Shadows.Elevation.GetValue(0)};");
@@ -177,11 +253,14 @@ namespace MudBlazor
             theme.AppendLine($"--{Elevation}-25: {Theme.Shadows.Elevation.GetValue(25)};");
 
             //Layout Properties
-            theme.AppendLine($"--{LayoutProperties}-default-borderradius: {Theme.LayoutProperties.DefaultBorderRadius};");
+            theme.AppendLine(
+                $"--{LayoutProperties}-default-borderradius: {Theme.LayoutProperties.DefaultBorderRadius};");
             theme.AppendLine($"--{LayoutProperties}-drawer-width-left: {Theme.LayoutProperties.DrawerWidthLeft};");
             theme.AppendLine($"--{LayoutProperties}-drawer-width-right: {Theme.LayoutProperties.DrawerWidthRight};");
-            theme.AppendLine($"--{LayoutProperties}-drawer-width-mini-left: {Theme.LayoutProperties.DrawerMiniWidthLeft};");
-            theme.AppendLine($"--{LayoutProperties}-drawer-width-mini-right: {Theme.LayoutProperties.DrawerMiniWidthRight};");
+            theme.AppendLine(
+                $"--{LayoutProperties}-drawer-width-mini-left: {Theme.LayoutProperties.DrawerMiniWidthLeft};");
+            theme.AppendLine(
+                $"--{LayoutProperties}-drawer-width-mini-right: {Theme.LayoutProperties.DrawerMiniWidthRight};");
             theme.AppendLine($"--{LayoutProperties}-appbar-height: {Theme.LayoutProperties.AppbarHeight};");
 
             //Breakpoint
@@ -193,101 +272,129 @@ namespace MudBlazor
             //theme.AppendLine($"--{Breakpoint}-xxl: {Theme.Breakpoints.xxl};");
 
             //Typography
-            theme.AppendLine($"--{Typography}-default-family: '{string.Join("','", Theme.Typography.Default.FontFamily)}';");
+            theme.AppendLine(
+                $"--{Typography}-default-family: '{string.Join("','", Theme.Typography.Default.FontFamily)}';");
             theme.AppendLine($"--{Typography}-default-size: {Theme.Typography.Default.FontSize};");
             theme.AppendLine($"--{Typography}-default-weight: {Theme.Typography.Default.FontWeight};");
-            theme.AppendLine($"--{Typography}-default-lineheight: {Theme.Typography.Default.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-default-lineheight: {Theme.Typography.Default.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-default-letterspacing: {Theme.Typography.Default.LetterSpacing};");
             theme.AppendLine($"--{Typography}-default-text-transform: {Theme.Typography.Default.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h1-family: '{string.Join("','", (Theme.Typography.H1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H1.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h1-family: '{string.Join("','", (Theme.Typography.H1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h1-size: {Theme.Typography.H1.FontSize};");
             theme.AppendLine($"--{Typography}-h1-weight: {Theme.Typography.H1.FontWeight};");
-            theme.AppendLine($"--{Typography}-h1-lineheight: {Theme.Typography.H1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h1-lineheight: {Theme.Typography.H1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h1-letterspacing: {Theme.Typography.H1.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h1-text-transform: {Theme.Typography.H1.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h2-family: '{string.Join("','", (Theme.Typography.H2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H2.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h2-family: '{string.Join("','", (Theme.Typography.H2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h2-size: {Theme.Typography.H2.FontSize};");
             theme.AppendLine($"--{Typography}-h2-weight: {Theme.Typography.H2.FontWeight};");
-            theme.AppendLine($"--{Typography}-h2-lineheight: {Theme.Typography.H2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h2-lineheight: {Theme.Typography.H2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h2-letterspacing: {Theme.Typography.H2.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h2-text-transform: {Theme.Typography.H2.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h3-family: '{string.Join("','", (Theme.Typography.H3.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H3.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h3-family: '{string.Join("','", (Theme.Typography.H3.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H3.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h3-size: {Theme.Typography.H3.FontSize};");
             theme.AppendLine($"--{Typography}-h3-weight: {Theme.Typography.H3.FontWeight};");
-            theme.AppendLine($"--{Typography}-h3-lineheight: {Theme.Typography.H3.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h3-lineheight: {Theme.Typography.H3.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h3-letterspacing: {Theme.Typography.H3.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h3-text-transform: {Theme.Typography.H3.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h4-family: '{string.Join("','", (Theme.Typography.H4.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H4.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h4-family: '{string.Join("','", (Theme.Typography.H4.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H4.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h4-size: {Theme.Typography.H4.FontSize};");
             theme.AppendLine($"--{Typography}-h4-weight: {Theme.Typography.H4.FontWeight};");
-            theme.AppendLine($"--{Typography}-h4-lineheight: {Theme.Typography.H4.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h4-lineheight: {Theme.Typography.H4.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h4-letterspacing: {Theme.Typography.H4.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h4-text-transform: {Theme.Typography.H4.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h5-family: '{string.Join("','", (Theme.Typography.H5.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H5.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h5-family: '{string.Join("','", (Theme.Typography.H5.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H5.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h5-size: {Theme.Typography.H5.FontSize};");
             theme.AppendLine($"--{Typography}-h5-weight: {Theme.Typography.H5.FontWeight};");
-            theme.AppendLine($"--{Typography}-h5-lineheight: {Theme.Typography.H5.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h5-lineheight: {Theme.Typography.H5.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h5-letterspacing: {Theme.Typography.H5.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h5-text-transform: {Theme.Typography.H5.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-h6-family: '{string.Join("','", (Theme.Typography.H6.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H6.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-h6-family: '{string.Join("','", (Theme.Typography.H6.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.H6.FontFamily))}';");
             theme.AppendLine($"--{Typography}-h6-size: {Theme.Typography.H6.FontSize};");
             theme.AppendLine($"--{Typography}-h6-weight: {Theme.Typography.H6.FontWeight};");
-            theme.AppendLine($"--{Typography}-h6-lineheight: {Theme.Typography.H6.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-h6-lineheight: {Theme.Typography.H6.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-h6-letterspacing: {Theme.Typography.H6.LetterSpacing};");
             theme.AppendLine($"--{Typography}-h6-text-transform: {Theme.Typography.H6.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-subtitle1-family: '{string.Join("','", (Theme.Typography.Subtitle1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle1.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-subtitle1-family: '{string.Join("','", (Theme.Typography.Subtitle1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-subtitle1-size: {Theme.Typography.Subtitle1.FontSize};");
             theme.AppendLine($"--{Typography}-subtitle1-weight: {Theme.Typography.Subtitle1.FontWeight};");
-            theme.AppendLine($"--{Typography}-subtitle1-lineheight: {Theme.Typography.Subtitle1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-subtitle1-lineheight: {Theme.Typography.Subtitle1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-subtitle1-letterspacing: {Theme.Typography.Subtitle1.LetterSpacing};");
             theme.AppendLine($"--{Typography}-subtitle1-text-transform: {Theme.Typography.Subtitle1.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-subtitle2-family: '{string.Join("','", (Theme.Typography.Subtitle2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle2.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-subtitle2-family: '{string.Join("','", (Theme.Typography.Subtitle2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Subtitle2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-subtitle2-size: {Theme.Typography.Subtitle2.FontSize};");
             theme.AppendLine($"--{Typography}-subtitle2-weight: {Theme.Typography.Subtitle2.FontWeight};");
-            theme.AppendLine($"--{Typography}-subtitle2-lineheight: {Theme.Typography.Subtitle2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-subtitle2-lineheight: {Theme.Typography.Subtitle2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-subtitle2-letterspacing: {Theme.Typography.Subtitle2.LetterSpacing};");
             theme.AppendLine($"--{Typography}-subtitle2-text-transform: {Theme.Typography.Subtitle2.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-body1-family: '{string.Join("','", (Theme.Typography.Body1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body1.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-body1-family: '{string.Join("','", (Theme.Typography.Body1.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body1.FontFamily))}';");
             theme.AppendLine($"--{Typography}-body1-size: {Theme.Typography.Body1.FontSize};");
             theme.AppendLine($"--{Typography}-body1-weight: {Theme.Typography.Body1.FontWeight};");
-            theme.AppendLine($"--{Typography}-body1-lineheight: {Theme.Typography.Body1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-body1-lineheight: {Theme.Typography.Body1.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-body1-letterspacing: {Theme.Typography.Body1.LetterSpacing};");
             theme.AppendLine($"--{Typography}-body1-text-transform: {Theme.Typography.Body1.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-body2-family: '{string.Join("','", (Theme.Typography.Body2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body2.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-body2-family: '{string.Join("','", (Theme.Typography.Body2.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Body2.FontFamily))}';");
             theme.AppendLine($"--{Typography}-body2-size: {Theme.Typography.Body2.FontSize};");
             theme.AppendLine($"--{Typography}-body2-weight: {Theme.Typography.Body2.FontWeight};");
-            theme.AppendLine($"--{Typography}-body2-lineheight: {Theme.Typography.Body2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-body2-lineheight: {Theme.Typography.Body2.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-body2-letterspacing: {Theme.Typography.Body2.LetterSpacing};");
             theme.AppendLine($"--{Typography}-body2-text-transform: {Theme.Typography.Body2.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-button-family: '{string.Join("','", (Theme.Typography.Button.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Button.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-button-family: '{string.Join("','", (Theme.Typography.Button.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Button.FontFamily))}';");
             theme.AppendLine($"--{Typography}-button-size: {Theme.Typography.Button.FontSize};");
             theme.AppendLine($"--{Typography}-button-weight: {Theme.Typography.Button.FontWeight};");
-            theme.AppendLine($"--{Typography}-button-lineheight: {Theme.Typography.Button.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-button-lineheight: {Theme.Typography.Button.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-button-letterspacing: {Theme.Typography.Button.LetterSpacing};");
             theme.AppendLine($"--{Typography}-button-text-transform: {Theme.Typography.Button.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-caption-family: '{string.Join("','", (Theme.Typography.Caption.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Caption.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-caption-family: '{string.Join("','", (Theme.Typography.Caption.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Caption.FontFamily))}';");
             theme.AppendLine($"--{Typography}-caption-size: {Theme.Typography.Caption.FontSize};");
             theme.AppendLine($"--{Typography}-caption-weight: {Theme.Typography.Caption.FontWeight};");
-            theme.AppendLine($"--{Typography}-caption-lineheight: {Theme.Typography.Caption.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-caption-lineheight: {Theme.Typography.Caption.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-caption-letterspacing: {Theme.Typography.Caption.LetterSpacing};");
             theme.AppendLine($"--{Typography}-caption-text-transform: {Theme.Typography.Caption.TextTransform};");
 
-            theme.AppendLine($"--{Typography}-overline-family: '{string.Join("','", (Theme.Typography.Overline.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Overline.FontFamily))}';");
+            theme.AppendLine(
+                $"--{Typography}-overline-family: '{string.Join("','", (Theme.Typography.Overline.FontFamily == null ? Theme.Typography.Default.FontFamily : Theme.Typography.Overline.FontFamily))}';");
             theme.AppendLine($"--{Typography}-overline-size: {Theme.Typography.Overline.FontSize};");
             theme.AppendLine($"--{Typography}-overline-weight: {Theme.Typography.Overline.FontWeight};");
-            theme.AppendLine($"--{Typography}-overline-lineheight: {Theme.Typography.Overline.LineHeight.ToString(CultureInfo.InvariantCulture)};");
+            theme.AppendLine(
+                $"--{Typography}-overline-lineheight: {Theme.Typography.Overline.LineHeight.ToString(CultureInfo.InvariantCulture)};");
             theme.AppendLine($"--{Typography}-overline-letterspacing: {Theme.Typography.Overline.LetterSpacing};");
             theme.AppendLine($"--{Typography}-overline-text-transform: {Theme.Typography.Overline.TextTransform};");
 

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -5,15 +5,6 @@
         //public Breakpoints Breakpoints { get; set; }
         public Palette Palette { get; set; }
         public Palette PaletteDark { get; set; }
-
-        public Palette CurrentPalette
-        {
-            get
-            {
-                return IsDarkMode ? PaletteDark : Palette;
-            }
-        }
-        public bool IsDarkMode { get; set; }
         public Shadow Shadows { get; set; }
         public Typography Typography { get; set; }
         public LayoutProperties LayoutProperties { get; set; }


### PR DESCRIPTION
Setting clearer boundaries between ``MudTheme`` and ``MudThemeProvider``

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description

Currently, there is a bit of confusion between the ``IsDarkMode`` property of a ``MudTheme`` and the property ``IsDarkMode`` of the ``MudThemeProvider``. The latter can create a condition where the dark mode is enabled in the Themeprovider but not in the theme itself, which creates "unstable" rendering.  With this PR, the theme itself is only providing a dark palette but the ThemeProvider "decides" if it should be used.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually. Unit tests were neither changed nor newly created. This will be done when there is a major change regarding themes. 


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->





## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
✔️ The PR is submitted to the correct branch (`dev`).
✔️ My code follows the code style of this project.
❌ I've added relevant tests.
