### PR TITLE
Docs API: Shorter string representation of types, faster code, and other smaller changes

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -14,7 +14,7 @@
     <DocsPageContent>
 
         @{
-           // cache lists to speed up displaying the page
+           // save as lists to speed up displaying the page
            var properties = getProperties().ToList();
            var methods = getMethods().ToList();
            var eventCallbacks = getEventCallbacks().ToList();
@@ -98,7 +98,7 @@
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type.GetTypeDisplayName()</div></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type">@context.Type.GetTypeDisplayName()</MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
                     </MudTable>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -25,7 +25,7 @@
             <DocsPageSection>
                 <SectionHeader Title="Properties" />
                 <SectionContent Class="docs-content-api" Outlined="false">
-                    <EnumSwitch T="Grouping" @bind-Value="@_propertiesGrouping" Color="Color.Primary" />
+                    <EnumSwitch T="Grouping" @bind-Value="@_propertiesGrouping" />
                     <MudTable Items="@properties" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm" GroupBy="@PropertiesGroupDefinition">
                         <HeaderContent>
                             <MudTh>Name</MudTh>
@@ -67,14 +67,15 @@
                                 </div>
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Default">
-                                @if (PresentDefaultValue(context.Default).Contains("<path"))
+                                @{ var def = PresentDefaultValue(context.Default); }
+                                @if (def.Contains("<path"))
                                 {
-                                    <MudIcon Icon="@PresentDefaultValue(context.Default).Substring(1, PresentDefaultValue(context.Default).Length - 1)" />
+                                    <MudIcon Icon="@def.Substring(1, def.Length - 1)" />
                                 }
                                 else
                                 {
-                                    <MudText Typo="Typo.body2">@PresentDefaultValue(context.Default)</MudText>
-                                }                           
+                                    <MudText Typo="Typo.body2">@def</MudText>
+                                }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
@@ -180,27 +181,20 @@
 
     private IEnumerable<ApiMethod> getMethods()
     {
-        if (Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static) == null)
+        foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
         {
-            yield return null;
-        }
-        else
-        {
-            foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
+            if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
             {
-                if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
+                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
                 {
-                    if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
+                    yield return new ApiMethod()
                     {
-                        yield return new ApiMethod()
-                        {
-                            MethodInfo = info,
-                            Return = info.ReturnParameter,
-                            Signature = info.GetSignature(),
-                            Parameters = info.GetParameters(),
-                            Documentation = DocStrings.GetMemberDescription(Type, info)
-                        };
-                    }
+                        MethodInfo = info,
+                        Return = info.ReturnParameter,
+                        Signature = info.GetSignature(),
+                        Parameters = info.GetParameters(),
+                        Documentation = DocStrings.GetMemberDescription(Type, info)
+                    };
                 }
             }
         }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -342,7 +342,7 @@
 
     private enum Grouping { Categories, Inheritance, None }
 
-    private Grouping _propertiesGrouping = Grouping.Inheritance;
+    private Grouping _propertiesGrouping = Grouping.Categories;
 
     private TableGroupDefinition<ApiProperty> PropertiesGroupDefinition => _propertiesGrouping switch
     {

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -10,7 +10,7 @@
 
 
 <DocsPage>
-    <DocsPageHeader ComponentLink="@ApiLink.GetComponentLinkFor(Type)" Title="@($"{Type.ConvertToCSharpSource()} API")" />
+    <DocsPageHeader ComponentLink="@ApiLink.GetComponentLinkFor(Type)" Title="@($"{Type.GetTypeDisplayName()} API")" />
     <DocsPageContent>
 
         @{
@@ -37,7 +37,7 @@
                             @if (_propertiesGrouping == Grouping.Inheritance && (Type)context.Key != Type)
                             {
                                 <MudTh colspan="4">
-                                    <MudText Typo="Typo.h6">@($"Inherited from {((Type)context.Key).ConvertToCSharpSource()}")</MudText>
+                                    <MudText Typo="Typo.h6">@($"Inherited from {((Type)context.Key).GetTypeDisplayName()}")</MudText>
                                 </MudTh>
                             }
                             else if (_propertiesGrouping == Grouping.Category)
@@ -98,7 +98,7 @@
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type.ConvertToCSharpSource()</div></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type.GetTypeDisplayName()</div></MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
                     </MudTable>
@@ -125,14 +125,14 @@
                             {
                                 foreach (var parameterInfo in context.Parameters)
                                 {
-                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{MudBlazor.Docs.Extensions.MethodInfoExtensions.GetAliases(parameterInfo.ParameterType.ConvertToCSharpSource())} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
+                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.GetTypeDisplayName()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
                                 }
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Return">
-                            @if (@context.Return != null && context.Return.ParameterType.ConvertToCSharpSource() != "Void")
+                            @if (@context.Return != null && context.Return.ParameterType.GetTypeDisplayName() != "void")
                             {
-                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{MudBlazor.Docs.Extensions.MethodInfoExtensions.GetAliases(context.Return.ParameterType.ConvertToCSharpSource())}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
+                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.GetTypeDisplayName()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -56,7 +56,7 @@
                                 }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Type">
-                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">
+                                <div style="display: inline-flex; flex-direction: row; align-items: center; white-space: nowrap;">
                                     <DocsTypeInfo Type="@context.Type" />
                                     @if (context.IsTwoWay)
                                     {
@@ -74,7 +74,7 @@
                                 }
                                 else
                                 {
-                                    <MudText Typo="Typo.body2">@def</MudText>
+                                    @def
                                 }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -40,7 +40,7 @@
                                     <MudText Typo="Typo.h6">@($"Inherited from {((Type)context.Key).GetTypeDisplayName()}")</MudText>
                                 </MudTh>
                             }
-                            else if (_propertiesGrouping == Grouping.Category)
+                            else if (_propertiesGrouping == Grouping.Categories)
                             {
                                 <MudTh colspan="4">
                                     <MudText Typo="Typo.h6">@context.Key</MudText>
@@ -210,7 +210,7 @@
 
         foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
                                  .OrderBy(x => _propertiesGrouping switch {
-                                                   Grouping.Category => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
+                                                   Grouping.Categories => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
                                                    Grouping.Inheritance => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
                                                    _ => 0
                                                })
@@ -340,13 +340,13 @@
 
     #region Grouping properties
 
-    private enum Grouping { Category, Inheritance, None }
+    private enum Grouping { Categories, Inheritance, None }
 
     private Grouping _propertiesGrouping = Grouping.Inheritance;
 
     private TableGroupDefinition<ApiProperty> PropertiesGroupDefinition => _propertiesGrouping switch
     {
-        Grouping.Category => new() { Selector = (p) => p.PropertyInfo.GetCustomAttribute<CategoryAttribute>()?.Name ?? "Misc" },
+        Grouping.Categories => new() { Selector = (p) => p.PropertyInfo.GetCustomAttribute<CategoryAttribute>()?.Name ?? "Misc" },
         Grouping.Inheritance => new() { Selector = (p) => BaseDefinitionClass(p.PropertyInfo) },
         _ => null
     };

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -13,13 +13,20 @@
     <DocsPageHeader ComponentLink="@ApiLink.GetComponentLinkFor(Type)" Title="@($"{Type.ConvertToCSharpSource()} API")" />
     <DocsPageContent>
 
-        @if (Properties != null && Properties.Count() > 0)
+        @{
+           // cache lists to speed up displaying the page
+           var properties = getProperties().ToList();
+           var methods = getMethods().ToList();
+           var eventCallbacks = getEventCallbacks().ToList();
+        }
+
+        @if (properties.Count() > 0)
         {
             <DocsPageSection>
                 <SectionHeader Title="Properties" />
                 <SectionContent Class="docs-content-api" Outlined="false">
                     <EnumSwitch T="Grouping" @bind-Value="@_propertiesGrouping" Color="Color.Primary" />
-                    <MudTable Items="@Properties" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm" GroupBy="@PropertiesGroupDefinition">
+                    <MudTable Items="@properties" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm" GroupBy="@PropertiesGroupDefinition">
                         <HeaderContent>
                             <MudTh>Name</MudTh>
                             <MudTh>Type</MudTh>
@@ -77,12 +84,12 @@
             </DocsPageSection>
         }
 
-        @if (EventCallbacks != null && EventCallbacks.Count() > 0)
+        @if (eventCallbacks.Count() > 0)
         {
             <DocsPageSection>
                 <SectionHeader Title="EventCallbacks" />
                 <SectionContent Class="docs-content-api" Outlined="false">
-                    <MudTable Items="@EventCallbacks" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm">
+                    <MudTable Items="@eventCallbacks" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm">
                         <HeaderContent>
                             <MudTh>Name</MudTh>
                             <MudTh>Type</MudTh>
@@ -98,12 +105,12 @@
             </DocsPageSection>
         }
 
-        @if (Methods != null && Methods.Count() > 0)
+        @if (methods.Count() > 0)
         {
             <DocsPageSection>
                 <SectionHeader Title="Methods" />
                 <SectionContent Class="docs-content-api" Outlined="false">
-                    <MudTable Items="@Methods" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm">
+                    <MudTable Items="@methods" Elevation="0" Class="ma-0 mud-width-full" Breakpoint="@Breakpoint.Sm">
                         <HeaderContent>
                             <MudTh>Name</MudTh>
                             <MudTd>Parameters</MudTd>
@@ -152,83 +159,74 @@
     };
     [Parameter] public Type Type { get; set; }
 
-    private IEnumerable<ApiProperty> EventCallbacks
+    private IEnumerable<ApiProperty> getEventCallbacks()
     {
-        get
+        foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
         {
-            foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
+            if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && info.PropertyType.Name.Contains("EventCallback"))
             {
-                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && info.PropertyType.Name.Contains("EventCallback"))
+                yield return new ApiProperty()
                 {
-                    yield return new ApiProperty()
-                    {
-                        Name = info.Name,
-                        PropertyInfo = info,
-                        Default = string.Empty,
-                        Description = DocStrings.GetMemberDescription(Type, info),
-                        IsTwoWay = CheckIsTwoWayEventCallback(info),
-                        Type = info.PropertyType,
-                    };
-                }
+                    Name = info.Name,
+                    PropertyInfo = info,
+                    Default = string.Empty,
+                    Description = DocStrings.GetMemberDescription(Type, info),
+                    IsTwoWay = CheckIsTwoWayEventCallback(info),
+                    Type = info.PropertyType,
+                };
             }
         }
     }
 
-    private IEnumerable<ApiMethod> Methods
+    private IEnumerable<ApiMethod> getMethods()
     {
-        get
+        if (Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static) == null)
         {
-            if (Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static) == null)
+            yield return null;
+        }
+        else
+        {
+            foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
             {
-                yield return null;
-            }
-            else
-            {
-                foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
+                if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
                 {
-                    if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
+                    if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
                     {
-                        if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
+                        yield return new ApiMethod()
                         {
-                            yield return new ApiMethod()
-                            {
-                                MethodInfo = info,
-                                Return = info.ReturnParameter,
-                                Signature = info.GetSignature(),
-                                Parameters = info.GetParameters(),
-                                Documentation = DocStrings.GetMemberDescription(Type, info)
-                            };
-                        }
+                            MethodInfo = info,
+                            Return = info.ReturnParameter,
+                            Signature = info.GetSignature(),
+                            Parameters = info.GetParameters(),
+                            Documentation = DocStrings.GetMemberDescription(Type, info)
+                        };
                     }
                 }
             }
         }
     }
 
-    private IEnumerable<ApiProperty> Properties
+    private IEnumerable<ApiProperty> getProperties()
     {
-        get
+        foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
+                                 .OrderBy(x => _propertiesGrouping switch {
+                                                   Grouping.Category => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
+                                                   Grouping.Inheritance => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
+                                                   _ => 0
+                                               })
+                                 .ThenBy(x => x.Name))
         {
-            foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
-                                     .OrderBy(x => _propertiesGrouping switch {
-                                                        Grouping.Category => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
-                                                        Grouping.Inheritance => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
-                                                        _ => 0
-                                                    })
-                                     .ThenBy(x => x.Name))
+            if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && !info.PropertyType.Name.Contains("EventCallback"))
             {
-                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && !info.PropertyType.Name.Contains("EventCallback"))
+                yield return new ApiProperty()
                 {
-                    yield return new ApiProperty()
-                    {
-                        Name = info.Name,
-                        PropertyInfo = info,
-                        Default = GetDefaultValue(info),
-                        IsTwoWay = CheckIsTwoWayProperty(info),
-                        Description = DocStrings.GetMemberDescription(Type, info),
-                        Type = info.PropertyType
-                    };
-                }
+                    Name = info.Name,
+                    PropertyInfo = info,
+                    Default = GetDefaultValue(info),
+                    IsTwoWay = CheckIsTwoWayProperty(info),
+                    Description = DocStrings.GetMemberDescription(Type, info),
+                    Type = info.PropertyType
+                };
             }
         }
     }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -162,6 +162,8 @@
 
     private IEnumerable<ApiProperty> getEventCallbacks()
     {
+        string saveTypename = DocStrings.GetSaveTypename(Type);
+
         foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
         {
             if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && info.PropertyType.Name.Contains("EventCallback"))
@@ -171,7 +173,7 @@
                     Name = info.Name,
                     PropertyInfo = info,
                     Default = string.Empty,
-                    Description = DocStrings.GetMemberDescription(Type, info),
+                    Description = DocStrings.GetMemberDescription(saveTypename, info),
                     IsTwoWay = CheckIsTwoWayEventCallback(info),
                     Type = info.PropertyType,
                 };
@@ -181,6 +183,8 @@
 
     private IEnumerable<ApiMethod> getMethods()
     {
+        string saveTypename = DocStrings.GetSaveTypename(Type);
+
         foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
         {
             if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
@@ -193,7 +197,7 @@
                         Return = info.ReturnParameter,
                         Signature = info.GetSignature(),
                         Parameters = info.GetParameters(),
-                        Documentation = DocStrings.GetMemberDescription(Type, info)
+                        Documentation = DocStrings.GetMemberDescription(saveTypename, info)
                     };
                 }
             }
@@ -202,6 +206,8 @@
 
     private IEnumerable<ApiProperty> getProperties()
     {
+        string saveTypename = DocStrings.GetSaveTypename(Type);
+
         foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
                                  .OrderBy(x => _propertiesGrouping switch {
                                                    Grouping.Category => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
@@ -218,7 +224,7 @@
                     PropertyInfo = info,
                     Default = GetDefaultValue(info),
                     IsTwoWay = CheckIsTwoWayProperty(info),
-                    Description = DocStrings.GetMemberDescription(Type, info),
+                    Description = DocStrings.GetMemberDescription(saveTypename, info),
                     Type = info.PropertyType
                 };
             }

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -1,13 +1,13 @@
-﻿@if (NonnullableType.IsEnum)
+﻿@if (_nonnullableType.IsEnum)
 {
     <MudTooltip>
         <ChildContent>@Type.ConvertToCSharpSource()</ChildContent>
         <TooltipContent>
             enumeration type
             <MudText Align="Align.Left" Typo="Typo.body2">
-                @foreach (var name in Enum.GetNames(NonnullableType))
+                @foreach (var name in Enum.GetNames(_nonnullableType))
                 {
-                    @(NonnullableType.Name + "." + name)<br />
+                    @(_nonnullableType.Name + "." + name)<br />
                 }
             </MudText>
         </TooltipContent>
@@ -21,5 +21,10 @@ else
 @code {
     [Parameter] public Type Type { get; set; }
 
-    private Type NonnullableType => Nullable.GetUnderlyingType(Type) ?? Type;
+    private Type _nonnullableType;
+
+    protected override void OnInitialized()
+    {
+        _nonnullableType = Nullable.GetUnderlyingType(Type) ?? Type;
+    }
 }

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -1,7 +1,9 @@
-﻿@if (_nonnullableType.IsEnum)
+﻿@using MudBlazor.Docs.Extensions
+
+@if (_nonnullableType.IsEnum)
 {
     <MudTooltip>
-        <ChildContent>@Type.ConvertToCSharpSource()</ChildContent>
+        <ChildContent>@Type.GetTypeDisplayName()</ChildContent>
         <TooltipContent>
             enumeration type
             <MudText Align="Align.Left" Typo="Typo.body2">
@@ -15,7 +17,7 @@
 }
 else
 {
-    @Type.ConvertToCSharpSource()
+    @Type.GetTypeDisplayName()
 }
 
 @code {

--- a/src/MudBlazor.Docs/Components/EnumSwitch.razor
+++ b/src/MudBlazor.Docs/Components/EnumSwitch.razor
@@ -26,7 +26,5 @@
 
     [Parameter] public EventCallback<T> ValueChanged { get; set; }
 
-    [Parameter] public Color Color { get; set; }
-
     private Type Type => typeof(T);
 }

--- a/src/MudBlazor.Docs/Extensions/TypeNameHelper.cs
+++ b/src/MudBlazor.Docs/Extensions/TypeNameHelper.cs
@@ -1,0 +1,226 @@
+﻿// Adapted from https://github.com/benaadams/Ben.Demystifier/blob/main/src/Ben.Demystifier/TypeNameHelper.cs - copied on 2022-01-10
+
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MudBlazor.Docs.Extensions
+{
+    // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+    public static class TypeNameHelper
+    {
+        public static string GetTypeDisplayName(this Type type)
+        {
+            return TypeNameHelper.GetTypeDisplayName(type, false);
+        }
+
+        public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
+        {
+            { typeof(void), "void" },
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" }
+        };
+
+        public static readonly Dictionary<string, string> FSharpTypeNames = new Dictionary<string, string>
+        {
+            { "Unit", "void" },
+            { "FSharpOption", "Option" },
+            { "FSharpAsync", "Async" },
+            { "FSharpOption`1", "Option" },
+            { "FSharpAsync`1", "Async" }
+        };
+
+        /// <summary>
+        /// Pretty print a type name.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <param name="fullName"><c>true</c> to print a fully qualified name.</param>
+        /// <param name="includeGenericParameterNames"><c>true</c> to include generic parameter names.</param>
+        /// <returns>The pretty printed type name.</returns>
+        public static string GetTypeDisplayName(Type type, bool fullName = true, bool includeGenericParameterNames = false)
+        {
+            var builder = new StringBuilder();
+            ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames));
+            return builder.ToString();
+        }
+
+        public static StringBuilder AppendTypeDisplayName(this StringBuilder builder, Type type, bool fullName = true, bool includeGenericParameterNames = false)
+        {
+            ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames));
+            return builder;
+        }
+
+        /// <summary>
+        /// Returns a name of given generic type without '`'.
+        /// </summary>
+        public static string GetTypeNameForGenericType(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                throw new ArgumentException("The given type should be generic", nameof(type));
+            }
+
+            var genericPartIndex = type.Name.IndexOf('`');
+
+            return (genericPartIndex >= 0) ? type.Name.Substring(0, genericPartIndex) : type.Name;
+        }
+
+        private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
+        {
+            if (type.IsGenericType)
+            {
+                var underlyingType = Nullable.GetUnderlyingType(type);
+                if (underlyingType != null)
+                {
+                    ProcessType(builder, underlyingType, options);
+                    builder.Append('?');
+                }
+                else
+                {
+                    var genericArguments = type.GetGenericArguments();
+                    ProcessGenericType(builder, type, genericArguments, genericArguments.Length, options);
+                }
+            }
+            else if (type.IsArray)
+            {
+                ProcessArrayType(builder, type, options);
+            }
+            else if (BuiltInTypeNames.TryGetValue(type, out var builtInName))
+            {
+                builder.Append(builtInName);
+            }
+            else if (type.Namespace == nameof(System))
+            {
+                builder.Append(type.Name);
+            }
+            else if (type.Assembly.ManifestModule.Name == "FSharp.Core.dll"
+                     && FSharpTypeNames.TryGetValue(type.Name, out builtInName))
+            {
+                builder.Append(builtInName);
+            }
+            else if (type.IsGenericParameter)
+            {
+                if (options.IncludeGenericParameterNames)
+                {
+                    builder.Append(type.Name);
+                }
+            }
+            else
+            {
+                builder.Append(options.FullName ? type.FullName ?? type.Name : type.Name);
+            }
+        }
+
+        private static void ProcessArrayType(StringBuilder builder, Type type, DisplayNameOptions options)
+        {
+            var innerType = type;
+            while (innerType.IsArray)
+            {
+                if (innerType.GetElementType() is { } inner)
+                {
+                    innerType = inner;
+                }
+            }
+
+            ProcessType(builder, innerType, options);
+
+            while (type.IsArray)
+            {
+                builder.Append('[');
+                builder.Append(',', type.GetArrayRank() - 1);
+                builder.Append(']');
+                if (type.GetElementType() is not { } elementType)
+                {
+                    break;
+                }
+                type = elementType;
+            }
+        }
+
+        private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
+        {
+            var offset = 0;
+            if (type.IsNested && type.DeclaringType is not null)
+            {
+                offset = type.DeclaringType.GetGenericArguments().Length;
+            }
+
+            if (options.FullName)
+            {
+                if (type.IsNested && type.DeclaringType is not null)
+                {
+                    ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, options);
+                    builder.Append('+');
+                }
+                else if (!string.IsNullOrEmpty(type.Namespace))
+                {
+                    builder.Append(type.Namespace);
+                    builder.Append('.');
+                }
+            }
+
+            var genericPartIndex = type.Name.IndexOf('`');
+            if (genericPartIndex <= 0)
+            {
+                builder.Append(type.Name);
+                return;
+            }
+
+            if (type.Assembly.ManifestModule.Name == "FSharp.Core.dll"
+                     && FSharpTypeNames.TryGetValue(type.Name, out var builtInName))
+            {
+                builder.Append(builtInName);
+            }
+            else
+            {
+                builder.Append(type.Name, 0, genericPartIndex);
+            }
+
+            builder.Append('<');
+            for (var i = offset; i < length; i++)
+            {
+                ProcessType(builder, genericArguments[i], options);
+                if (i + 1 == length)
+                {
+                    continue;
+                }
+
+                builder.Append(',');
+                if (options.IncludeGenericParameterNames || !genericArguments[i + 1].IsGenericParameter)
+                {
+                    builder.Append(' ');
+                }
+            }
+            builder.Append('>');
+        }
+
+        private struct DisplayNameOptions
+        {
+            public DisplayNameOptions(bool fullName, bool includeGenericParameterNames)
+            {
+                FullName = fullName;
+                IncludeGenericParameterNames = includeGenericParameterNames;
+            }
+
+            public bool FullName { get; }
+
+            public bool IncludeGenericParameterNames { get; }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -7,9 +7,13 @@ namespace MudBlazor.Docs.Models
     // this is needed for the api docs 
     public static partial class DocStrings
     {
-        public static string GetMemberDescription(Type t, MemberInfo member)
+        /* To speed up the method, run it in this way:
+         *   string saveTypename = DocStrings.GetSaveTypename(type);  // calculate it only once
+         *   DocStrings.GetMemberDescription(saveTypename, member);
+         */
+        public static string GetMemberDescription(string saveTypename, MemberInfo member)
         {
-            var name = GetSaveTypename(t);
+            var name = saveTypename;
 
             if (member is PropertyInfo property)
                 name += "_" + property.Name;
@@ -24,7 +28,7 @@ namespace MudBlazor.Docs.Models
             return (string)field.GetValue(null);
         }
 
-        private static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").TrimEnd('_');
+        public static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").TrimEnd('_');
 
         private static string GetSaveMethodIdentifier(MethodInfo method) => Regex.Replace(method.ToString().Replace("MudBlazor.Docs.Models.T", "T"), "[^A-Za-z0-9_]", "_");  // method signature
     }

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -13,12 +13,12 @@ namespace MudBlazor.Docs.Models
          */
         public static string GetMemberDescription(string saveTypename, MemberInfo member)
         {
-            var name = saveTypename;
+            string name;
 
             if (member is PropertyInfo property)
-                name += "_" + property.Name;
+                name = saveTypename + "_" + property.Name;
             else if (member is MethodInfo method)
-                name += "_method_" + GetSaveMethodIdentifier(method);
+                name = saveTypename + "_method_" + GetSaveMethodIdentifier(method);
             else
                 throw new Exception("Implemented only for properties and methods.");
 

--- a/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
@@ -60,7 +60,6 @@ namespace MudBlazor.UnitTests.Other
                 typeof(MudSparkLine),
 
                 typeof(MudRatingItem),  // TODO: remove it later; see also: https://github.com/MudBlazor/MudBlazor/discussions/3452
-                typeof(MudPicker<>),  // TODO: remove it later; see also: https://github.com/MudBlazor/MudBlazor/pull/3481
             };
 
             bool isTestOK = true;


### PR DESCRIPTION
## Description

### Changed string representation of types from .NET format to C# format
Examples:   `Int32` changed to `int`, `Nullable<DateTime>` changed to `DateTime?`, and `Converter<Nullable<DateTime>, String>` changed to `Converter<DateTime?, string>`. More info: https://github.com/MudBlazor/MudBlazor/discussions/3520.

The code uses https://github.com/benaadams/Ben.Demystifier/blob/main/src/Ben.Demystifier/TypeNameHelper.cs (Apache License). The speed of new and old method is the same. I tested automatically each page, and then I tested manually the differences: all changes are correct except of type of `MudDialogInstance.Close(T returnValue)` method parameter, but it isn't important.

### The code is two times faster now
 - The `Properties`, `EventCallbacks`, and `Methods` properties were called respectively: 4, 6, and 6 times per one page, but should be only once which will speeds up the code **about two times**. Generally, C# properties are too easy to call, so I changed them to these methods: `getProperties()`, `getEventCallbacks()`, `getMethods()`. Each of these methods is called only once and the result is stored in a list. I wanted to call them in the `OnParametersSet()` method, but I doesn't work because the properties table depends not only on the `Type` parameter but also on the value of the "CATEGORIES - INHERITANCE - NONE" grouping switch. I don't know Blazor well, so I ended with calling these methods in the Razor markup code.
 - The `DocStrings.GetMemberDescription(type, member)` method is about 10 ms faster because now the `GetSaveTypename()` method is run only once per table, and not for every table row.
 - The `DocsTypeInfo` component is about 10 ms faster because now the `_nonnullableType` is computed only once in the `OnInitialized()` method.

All 3 changes speed up MudAutocomplete API page from 290 ms to 135 ms on my computer. The properties grouping switch was set to None during the measurement, but grouping is fast. I measured speed using the "Rendered in ... ms" counter.

### Other changes
 - By default, properties are grouped by a category (temporarily until it will be set in user settings).
 - I changed "CATEGORY" label to "CATEGORIES" in the "CATEGORY - INHERITANCE - NONE" switch.
 - New line characters in a text copied to clipboard make more sense now.
 - I refactored (simplified) some code.

## How Has This Been Tested?

I tested each page automatically using the https://github.com/MudBlazor/MudBlazor/discussions/3595 code, and additionally performed manual tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
