### PR TITLE
Switch: Add ability to reverse label direction

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
@@ -4,9 +4,11 @@
 <MudSwitch @bind-Checked="@Label_Switch2" Label="Success" Color="Color.Success" />
 <MudSwitch @bind-Checked="@Label_Switch3" Label="Warning" Color="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" Label="Disabled" />
+<MudSwitch @bind-Checked="@Label_Switch4" Label="Reversed" ReverseLabel="true" Color="Color.Primary" />
 
 @code{
     public bool Label_Switch1 { get; set; } = false;
     public bool Label_Switch2 { get; set; } = true;
     public bool Label_Switch3 { get; set; } = true;
+    public bool Label_Switch4 { get; set; } = true;
 }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -37,5 +37,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
         }
+
+        [Test]
+        public void SwitchTest_ReverseLabel()
+        {
+            var comp = Context.RenderComponent<MudSwitch<bool>>();
+            //Console.WriteLine(comp.Markup);
+
+            comp.Find(".mud-switch").ClassList.Should().NotContain("flex-row-reverse", "Reverse should not be applied");
+
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("ReverseLabel", true));
+            comp.Find(".mud-switch").ClassList.Should().Contain("flex-row-reverse", "Reverse should be applied");
+        }
     }
 }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -14,6 +14,7 @@ namespace MudBlazor
         new CssBuilder("mud-switch")
             .AddClass($"mud-disabled", Disabled)
             .AddClass($"mud-readonly", ReadOnly)
+            .AddClass($"flex-row-reverse", ReverseLabel)
           .AddClass(Class)
         .Build();
         protected string SwitchClassname =>
@@ -65,6 +66,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool DisableRipple { get; set; }
+
+        /// <summary>
+        /// If true, reverses label direction
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public bool ReverseLabel { get; set; }
 
         protected internal void HandleKeyDown(KeyboardEventArgs obj)
         {


### PR DESCRIPTION
This PR adds a `ReverseLabel` parameter which when set reverses label direction through a `flex-row-reverse` CSS class.

## Description
Sometimes there is a need to reverse label direction. This PR adds this ability with a simple parameter.

## How Has This Been Tested?
A specific test is added.
Also added a corresponding sample to [docs](https://mudblazor.com/components/switch#switch-with-label)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
