### PR TITLE
Landing page: Fix gradients of apps in firefox

### DIFF
--- a/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
@@ -69,7 +69,7 @@
             height: 100%;
             z-index: 2;
             background-color: var(--mud-palette-background);
-            border-right: 1px solid var(--mud-palette-table-lines);
+            border-right: 1px solid var(--mud-palette-divider);
             overflow: hidden;
             transition: width ease-in 0.1s;
         }
@@ -99,7 +99,7 @@
     .lp-device {
         overflow: hidden;
         position: absolute;
-        outline: rgba(255, 255, 255, 0.8) solid 1px;
+        outline: var(--mud-palette-divider) solid 1px;
         box-shadow: inset 0 1px 1px 0 hsla(0deg, 0%, 100%, 0.1), 0 50px 100px -20px rgba(50, 50, 93, 0.25), 0 30px 60px -30px rgba(0, 0, 0, 0.3);
         background: linear-gradient(0deg, rgba(0,0,0,0.2) 0%, rgba(255,255,255,0.2) 50%, rgba(0,0,0,0.2) 100%);
 
@@ -240,10 +240,13 @@
             left: 240px;
             width: calc(calc(2560px / 2) + 24px);
             height: calc(calc(1440px / 2) + 24px);
-            filter: blur(2px);
             border-radius: 12px;
             animation: spin 10s reverse infinite;
             background-image: linear-gradient(var(--rotate), rgba(89, 74, 226, 0.5), rgba(255, 64, 129, 0.5) 43%, rgba(116, 103, 239, 0.5));
+            //rotation animation doesn't work in firefox
+            @supports (-moz-appearance:none) {
+                background-image: linear-gradient(132deg, rgba(89, 74, 226, 0.5), rgba(255, 64, 129, 0.5) 43%, rgba(116, 103, 239, 0.5));
+            }
         }
 
         &.phone-shadow {
@@ -252,9 +255,12 @@
             width: calc(calc(1170px / 4) + 28px);
             height: calc(calc(2432px / 4) + 28px);
             border-radius: 46px;
-            filter: grayscale(1);
             animation: spin 20s linear infinite;
-            background-image: linear-gradient(var(--rotate), rgba(89, 74, 226, 0.5), rgba(255, 255, 255, 0.5) 43%, rgba(116, 103, 239, 0.5));
+            background-image: linear-gradient(var(--rotate), rgba(100, 100, 100, 0.5), rgba(255, 255, 255, 0.5) 43%, rgba(100, 100, 100, 0.5));
+            //rotation animation doesn't work in firefox
+            @supports (-moz-appearance:none) {
+                background-image: linear-gradient(rgba(100, 100, 100, 0.5), rgba(255, 255, 255, 0.5) 43%, rgba(100, 100, 100, 0.5));
+            }
         }
     }
 

--- a/src/MudBlazor.Docs/Theme/Theme.cs
+++ b/src/MudBlazor.Docs/Theme/Theme.cs
@@ -171,7 +171,8 @@ namespace MudBlazor.Docs
             DrawerIcon = "#92929f",
             DrawerText = "#92929f",
             DrawerBackground = "#151521",
-            OverlayLight = "#1e1e2d80"
+            OverlayLight = "#1e1e2d80",
+            Divider = "#5c5c6a"
         };
 
         private static readonly Shadow LandingPageShadows = new()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes gradients of apps on the landing page in firefox

Firefox (Left before / right after):
![grafik](https://user-images.githubusercontent.com/62108893/149125663-5360a650-7c41-4b9c-b5c4-38589be32e3c.png)


Chrome (Left before / right after)
![grafik](https://user-images.githubusercontent.com/62108893/149126003-a5c1b81c-a078-4c1d-ae06-9a63ae0f3026.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
