### PR TITLE
Docs: Better examples how to use MudSelect with custom types

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectCustomConverterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectCustomConverterExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudText Typo="Typo.h6" Class="mud-width-full">@(pizza == null ? "Nothing selected yet." : $"Pizza: {pizza.Name}")</MudText>
+<MudText Typo="Typo.h6" Class="mud-width-full">@(pizza == null ? "Nothing selected." : $"Pizza: {pizza.Name}")</MudText>
 
-<MudSelect T="Pizza" @bind-Value="@pizza" ToStringFunc="@converter" Label="Select your pizza" AnchorOrigin="Origin.BottomCenter" Variant="Variant.Outlined">
+<MudSelect T="Pizza" @bind-Value="@pizza" ToStringFunc="@converter" Label="Select your pizza" AnchorOrigin="Origin.BottomCenter" Variant="Variant.Outlined" Clearable>
     <MudSelectItem Value="@(new Pizza() { Name="Cardinale"})" />
     <MudSelectItem Value="@(new Pizza() { Name="Diavolo"})" />
     <MudSelectItem Value="@(new Pizza() { Name="Margarita"})" />
@@ -10,11 +10,20 @@
 </MudSelect>
 
 @code {
-    Pizza pizza;
+    Pizza pizza = new Pizza { Name = "Diavolo" };
 
     public class Pizza
     {
         public string Name { get; set; }
+
+        // Note: this is important so the select can compare pizzas
+        public override bool Equals(object o) {
+            var other = o as Pizza;
+            return other?.Name==Name;
+        }
+
+        // Note: this is important so the select can compare pizzas
+        public override int GetHashCode() => Name.GetHashCode();
     }
 
     Func<Pizza,string> converter = p => p?.Name;

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
@@ -10,8 +10,33 @@
     <MudSelectItem T="double" Value="4.99"/>
     <MudSelectItem T="double" Value="3.60"/>
 </MudSelect>
-<MudSelect T="string" Label="Pies" Variant="Variant.Filled" AnchorOrigin="Origin.BottomCenter">
-    <MudSelectItem Value="@("Apple Pie")" />
-    <MudSelectItem Value="@("Blackberry Pie")" />
-    <MudSelectItem Value="@("Lemon Pie")" />
+<MudSelect T="Pizza" Label="Pizza" Variant="Variant.Filled" AnchorOrigin="Origin.BottomCenter">
+    <MudSelectItem Value="@(new Pizza("Cardinale"))" />
+    <MudSelectItem Value="@(new Pizza("Diavolo"))" />
+    <MudSelectItem Value="@(new Pizza("Margarita"))" />
+    <MudSelectItem Value="@(new Pizza("Spinaci"))" />
 </MudSelect>
+
+@code {
+    public class Pizza
+    {
+        public Pizza(string name)
+        {
+            Name = name;
+        }
+
+        public readonly string Name;
+
+        // Note: this is important so the MudSelect can compare pizzas
+        public override bool Equals(object o) {
+            var other = o as Pizza;
+            return other?.Name==Name;
+        }
+
+        // Note: this is important too!
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+
+        // Implement this for the Pizza to display correctly in MudSelect
+        public override string ToString() => Name;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -7,7 +7,15 @@
 
         <DocsPageSection>
             <SectionHeader Title="Variants">
-                <Description>Select comes in the variants Text, Filled and Outline.<br />Select is generic, meaning you can use values of any type with it. See the example code how that works.</Description>
+                <Description>
+                    Select comes in the variants Text, Filled and Outline. Select is generic, meaning you can use values of any type with it. See the example code how that works.<br />
+                    <br />
+                    <MudAlert Severity="Severity.Info">
+                        <b>Note:</b> If you use custom types as values, make sure they override <CodeInline>Equals</CodeInline> and <CodeInline>GetHashCode</CodeInline> as well as <CodeInline>ToString</CodeInline>. See the example below.
+                    </MudAlert>
+                    <br />
+                    <br />
+                </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="SelectVariantsExample">
                 <SelectVariantsExample />

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
         /// Click should open the Menu and selecting a value should update the bindable value.
         /// </summary>
         [Test]
-        public void SelectTest1()
+        public async Task SelectTest1()
         {
             var comp = Context.RenderComponent<SelectTest1>();
             // print the generated html
@@ -56,10 +56,10 @@ namespace MudBlazor.UnitTests.Components
             items[0].Click();
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("1"));
             //Check user on blur implementation works
-            var _switch = comp.FindComponent<MudSwitch<bool>>();
-            _switch.Instance.Checked = true;
-            comp.InvokeAsync(() => select.Instance.OnLostFocus(new FocusEventArgs())).AndForget();
-            _switch.Instance.Checked.Should().Be(false);
+            var @switch = comp.FindComponent<MudSwitch<bool>>();
+            @switch.Instance.Checked = true;
+            await comp.InvokeAsync(() => select.Instance.OnLostFocus(new FocusEventArgs()));
+            comp.WaitForAssertion(() => @switch.Instance.Checked.Should().Be(false));
         }
 
         /// <summary>


### PR DESCRIPTION
This is necessary because Stackoverflow is full with questions about how to use Select. Also our Pizza example was misleading because it did not implement the overrides. 

- Added a note to the select page about custom types that they need to override Equals, GetHashCode and ToString. 
- Added a good example of that in the first example so it is guaranteed **not** to be overlooked.

![image](https://user-images.githubusercontent.com/44090/149594140-e6a16d08-f3aa-4fec-b655-84b146adf7d7.png)

Also fix test regression introduced by #3531