### PR TITLE
Fix `MudTable` multi-select when using server data and paging

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataPagedSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataPagedSelectionTest.razor
@@ -1,0 +1,37 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", _selectedItems) }</MudText>
+
+<MudTable
+    @bind-SelectedItems="_selectedItems"
+    ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))"
+    MultiSelection="true"
+    Dense>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "The server-side loaded table should allow for multi-selection with paging.";
+
+    public const int TotalItems = 99;
+
+    private HashSet<int> _selectedItems = new();
+    
+    private async Task<TableData<int>> ServerReload(TableState state)
+    {
+        await Task.Delay(1);
+
+        var offset = state.Page * state.PageSize;
+        var items = Enumerable.Range(offset + 1, state.PageSize).ToArray();
+
+        return new TableData<int> { TotalItems = TotalItems, Items = items };
+    }
+}

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -57,15 +57,17 @@ namespace MudBlazor
             }
             if (HeaderRows.Count > 0 || FooterRows.Count > 0)
             {
-                var itemsCount = Table.GetFilteredItemsCount();
-                var b = Selection.Count == itemsCount && itemsCount != 0;
+                var allSelected = Table.HasServerData
+                    ? Rows.Values.DefaultIfEmpty().All(row => row?.IsChecked ?? false)
+                    : Table.GetFilteredItemsCount() is var count and > 0 && count == Selection.Count;
+
                 // update header checkbox
                 foreach (var header in HeaderRows)
-                    header.SetChecked(b, notify: false);
+                    header.SetChecked(allSelected, notify: false);
 
                 // update footer checkbox
                 foreach (var footer in FooterRows)
-                    footer.SetChecked(b, notify: false);
+                    footer.SetChecked(allSelected, notify: false);
             }
         }
 


### PR DESCRIPTION
## Description

Fixes #2366 in `MudTable` by changing how the header/footer selection checkbox works when `ServerFunc` is provided. More specifically, in this case, any select all checkboxes will only apply to items that are displayed on the current page.

The behavior for `MudTable` for non-server data (`ServerFunc` not provided) is unchanged, in that select all checkboxes will still select items across all pages.

This also fixes the loading indicator when `ServerFunc` is legitimately async. In this case, `StateHasChanged` needs to be called after `IsLoading` is set to `true`, and then again after the `Task` is awaited. Before, I think in many cases the loading indicator would show, likely by luck due to other `StateHasChanged` calls, but I had noticed that the initial load in particular failed to show the indicator, and sorting had the same issue IIRC.

## How Has This Been Tested?

Tested visually via added `TableServerSideDataPagedSelection.razor`, and other existing table tests.  
Associated bUnit test also added to `TableTests`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


https://user-images.githubusercontent.com/1431941/150621242-03572e03-41aa-4d07-addb-4380eaab5505.mp4



## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
