### PR TITLE
MudTable: Align pager elements vertically

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -353,7 +353,7 @@
     cursor: pointer;
     margin-left: 10px !important;
     margin-right: 10px !important;
-    margin-top: 3px !important;
+    margin-top: 0px !important;
     min-width: 52px;
 
     & .mud-select-input {
@@ -379,7 +379,6 @@
     margin-left: 10px;
     margin-inline-start: 10px;
     margin-inline-end: unset;
-    margin-bottom: 3px !important;
 }
 
 .mud-table-smalldevices-sortselect {


### PR DESCRIPTION
## Description
Fixes #698
CSS changes for `MudTable` that adjust pager element styling to improve vertical centering.

## How Has This Been Tested?

Tested visually with existing test components.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![paging-before](https://user-images.githubusercontent.com/1431941/150464938-c9797e4b-83f6-42e6-8d77-1dd79c27963b.png)

After:
![paging-after](https://user-images.githubusercontent.com/1431941/150467177-df65e022-c8c1-4bc8-b6c2-6a1b15df9819.png)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] (N/A) I've added relevant tests.
