### PR TITLE
Breadcrumbs: Adjust icon spacing, vertically center

### DIFF
--- a/src/MudBlazor/Styles/components/_breadcrumbs.scss
+++ b/src/MudBlazor/Styles/components/_breadcrumbs.scss
@@ -19,9 +19,10 @@
 
 .mud-breadcrumb-item > a {
     display: flex;
+    align-items: center;
 }
 
-.mud-breadcrumb-item > a > svg.mud-svg-icon-root {
+.mud-breadcrumb-item > a > svg.mud-icon-root {
     margin-right: 4px;
     margin-inline-end: 4px;
     margin-inline-start: unset;


### PR DESCRIPTION
## Description

`MudBreadcrumbs`: This re-introduces spacing between icon and text, as it appears that the selector `.mud-breadcrumb-item > a > svg.mud-svg-icon-root` in `_breadcrumbs.scss` was invalid.

This also vertically aligns the icon and text.

## How Has This Been Tested?

Tested visually, see before/after below.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![breadcrumbs-before](https://user-images.githubusercontent.com/1431941/150470059-c045e9e8-7369-44fb-a028-fc3982a10b9e.png)

After:
![breadcrumbs-after](https://user-images.githubusercontent.com/1431941/150470071-32e193a4-726d-4aeb-a18c-69a950d20c80.png)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
