### PR TITLE
`MudAutoComplete`: Fix initial open with server-side, non-async search

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSyncTest.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider />
+
+<MudAutocomplete T="@string" SearchFunc="@Search" Label="Item" Class="@AutocompleteClass" />
+
+@code {
+    public static string __description__ = "Autocomplete should allow for a SearchFunc that returns a non-async task";
+
+    public const string AutocompleteClass = "autocomplete-test";
+
+    public static readonly string[] Items = { "One", "Two", "Three" };
+
+    private Task<IEnumerable<string>> Search(string text)
+    {
+        var result = string.IsNullOrWhiteSpace(text)
+            ? Items
+            : Items.Where(value => value.Contains(text, StringComparison.OrdinalIgnoreCase));
+
+        return Task.FromResult(result);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -131,7 +131,6 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
             autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S.
-            await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             // IsOpen must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
             autocomplete.IsOpen.Should().BeTrue();
             // now trigger the coercion by closing the menu
@@ -747,6 +746,31 @@ namespace MudBlazor.UnitTests.Components
             autocompletecomp.Find("input").Input("");
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+        }
+
+        [Test]
+        public async Task Autocomplete_Should_Support_Sync_Search()
+        {
+            var root = Context.RenderComponent<AutocompleteSyncTest>();
+
+            var popoverProvider = root.FindComponent<MudPopoverProvider>();
+            var autocomplete = root.FindComponent<MudAutocomplete<string>>();
+            var popover = autocomplete.FindComponent<MudPopover>();
+
+            popover.Instance.Open.Should().BeFalse("Should start as closed");
+
+            await autocomplete
+                .Find($".{AutocompleteSyncTest.AutocompleteClass}")
+                .ClickAsync(new MouseEventArgs());
+
+            popoverProvider.WaitForAssertion(() =>
+            {
+                popover.Instance.Open.Should().BeTrue("Should be open once clicked");
+
+                popoverProvider
+                    .FindComponents<MudListItem>().Count
+                    .Should().Be(AutocompleteSyncTest.Items.Length, "Should show the expected items");
+            });
         }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -287,7 +287,6 @@ namespace MudBlazor
 
         private async Task ChangeMenu(bool open)
         {
-            IsOpen = open;
             if (open)
             {
                 await _elementReference.SelectAsync();
@@ -298,8 +297,9 @@ namespace MudBlazor
                 _timer?.Dispose();
                 RestoreScrollPosition();
                 await CoerceTextToValue();
+                IsOpen = false;
+                StateHasChanged();
             }
-            StateHasChanged();
         }
 
         private void UpdateIcon()
@@ -377,6 +377,8 @@ namespace MudBlazor
             _enabledItemIndices = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true).Select(tuple => tuple.idx).ToList();
             _selectedListItemIndex = _enabledItemIndices.Any() ? _enabledItemIndices.First() : -1;
 
+            IsOpen = true;
+
             if (_items?.Length == 0)
             {
                 await CoerceValueToText();
@@ -384,7 +386,6 @@ namespace MudBlazor
                 return;
             }
 
-            IsOpen = true;
             StateHasChanged();
         }
 
@@ -567,18 +568,15 @@ namespace MudBlazor
         {
             if (CoerceText == false)
                 return Task.CompletedTask;
-            if (Value == null)
-            {
-                _timer?.Dispose();
-                //Below line's false parameter added for prevent opening popover again, it may break something else
-                return SetTextAsync(null, false);
-            }
-            var actualvalueStr = GetItemString(Value);
-            if (!Equals(actualvalueStr, Text))
-            {
-                _timer?.Dispose();
-                return SetTextAsync(actualvalueStr);
-            }
+
+            _timer?.Dispose();
+
+            var text = Value == null ? null : GetItemString(Value);
+
+            // Don't update the value to prevent the popover from opening again after coercion
+            if (text != Text)
+                return SetTextAsync(text, updateValue: false);
+
             return Task.CompletedTask;
         }
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -174,6 +174,12 @@ namespace MudBlazor
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
+            
+            // Only update the fragment if the popover is currently shown or will show
+            // This prevents unnecessary renders and popover handle locking
+            if (!_handler.ShowContent && !Open)
+                return;
+
             _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
         }
 


### PR DESCRIPTION
## Description

Fixes #3640.

With `MudAutocomplete` and a non-async `SearchFunc` in server-side Blazor, the popover would not open on initial click, because the popover handler was always already locked (for fragment update) before `OnSearchAsync`  was called. This introduces some minor optimizations which has the side-effect of preventing this issue from occurring.

## How Has This Been Tested?

Tested with local server-side Blazor app, as I don't think this could be reproduced in WASM or, bUnit for that matter.  
I did add a bUnit test for this in any case.

Recording to show behavior after changes, which seems to match the current behavior:

![chrome_8qq2wOyVzF](https://user-images.githubusercontent.com/1431941/150594580-a9401550-4a27-43ea-9e74-345c038b760d.gif)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
