### PR TITLE
Docs API: Add information from <see cref="..." /> tags

### DIFF
--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -37,18 +37,8 @@ namespace MudBlazor.Docs.Compiler
                     foreach (var property in type.GetPropertyInfosWithAttribute<ParameterAttribute>())
                     {
                         var doc = property.GetDocumentation() ?? "";
-
-                        // Replace <see cref="TYPE_OR_MEMBER_QUALIFIED_NAME"/> tags by TYPE_OR_MEMBER_QUALIFIED_NAME without "MudBlazor." at the beginning.
-                        // It is a quick fix. It should be rather represented by <a href="...">...</a> but it is more difficult.
-                        doc = Regex.Replace(doc, "<see cref=\"[TFPME]:(MudBlazor\\.)?([^>]+)\" */>", match => {
-                            string result = match.Groups[2].Value;     // get the name of Type or type member (Field, Property, Method, or Event)
-                            result = Regex.Replace(result, "`1", "");  // remove `1 from generic type name
-                            return result;
-                        });
-
-                        // remove all other XML tags
-                        doc = Regex.Replace(doc, @"</?.+?>", "");
-
+                        doc = convertSeeTags(doc);
+                        doc = Regex.Replace(doc, @"</?.+?>", "");  // remove all other XML tags
                         cb.AddLine($"public const string {GetSaveTypename(type)}_{property.Name} = @\"{EscapeDescription(doc).Trim()}\";\n");
                     }
 
@@ -100,6 +90,18 @@ namespace MudBlazor.Docs.Compiler
         private static string GetSaveMethodIdentifier(MethodInfo method) => Regex.Replace(method.ToString(), "[^A-Za-z0-9_]", "_");
 
         private static Type GetBaseDefinitionClass(MethodInfo m) => m.GetBaseDefinition().DeclaringType;
+
+        /* Replace <see cref="TYPE_OR_MEMBER_QUALIFIED_NAME"/> tags by TYPE_OR_MEMBER_QUALIFIED_NAME without "MudBlazor." at the beginning.
+         * It is a quick fix. It should be rather represented by <a href="...">...</a> but it is more difficult.
+         */
+        private static string convertSeeTags(string doc)
+        {
+            return Regex.Replace(doc, "<see cref=\"[TFPME]:(MudBlazor\\.)?([^>]+)\" */>", match => {
+                string result = match.Groups[2].Value;     // get the name of Type or type member (Field, Property, Method, or Event)
+                result = Regex.Replace(result, "`1", "");  // remove `1 from generic type name
+                return result;
+            });
+        }
 
         private static string EscapeDescription(string doc)
         {

--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -37,7 +37,17 @@ namespace MudBlazor.Docs.Compiler
                     foreach (var property in type.GetPropertyInfosWithAttribute<ParameterAttribute>())
                     {
                         var doc = property.GetDocumentation() ?? "";
+
+                        // replace <see cref="TYPE_OR_MEMBER_QUALIFIED_NAME"/> tags by TYPE_OR_MEMBER_QUALIFIED_NAME without "MudBlazor." at the beginning
+                        doc = Regex.Replace(doc, "<see cref=\"[TFPME]:(MudBlazor.)?([^>]+)\" */>", match => {
+                            string result = match.Groups[2].Value;     // get the name of Type or type member (Field, Property, Method, or Event)
+                            result = Regex.Replace(result, "`1", "");  // remove `1 from generic type name
+                            return result;
+                        });
+
+                        // remove all other XML tags
                         doc = Regex.Replace(doc, @"</?.+?>", "");
+
                         cb.AddLine($"public const string {GetSaveTypename(type)}_{property.Name} = @\"{EscapeDescription(doc).Trim()}\";\n");
                     }
 

--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -38,8 +38,9 @@ namespace MudBlazor.Docs.Compiler
                     {
                         var doc = property.GetDocumentation() ?? "";
 
-                        // replace <see cref="TYPE_OR_MEMBER_QUALIFIED_NAME"/> tags by TYPE_OR_MEMBER_QUALIFIED_NAME without "MudBlazor." at the beginning
-                        doc = Regex.Replace(doc, "<see cref=\"[TFPME]:(MudBlazor.)?([^>]+)\" */>", match => {
+                        // Replace <see cref="TYPE_OR_MEMBER_QUALIFIED_NAME"/> tags by TYPE_OR_MEMBER_QUALIFIED_NAME without "MudBlazor." at the beginning.
+                        // It is a quick fix. It should be rather represented by <a href="...">...</a> but it is more difficult.
+                        doc = Regex.Replace(doc, "<see cref=\"[TFPME]:(MudBlazor\\.)?([^>]+)\" */>", match => {
                             string result = match.Groups[2].Value;     // get the name of Type or type member (Field, Property, Method, or Event)
                             result = Regex.Replace(result, "`1", "");  // remove `1 from generic type name
                             return result;


### PR DESCRIPTION
## Description

Until now all XML tags were removed from the documentation of properties and event handlers before displaying on the API documentation pages. This PR displays important information contained in the `<see cref="..." />` tags.

It fixes description of the following properties:
  MudCarousel.BulletsColor
  MudDrawer.OpenMiniOnHover
  MudDrawer.PreserveOpenState
  MudInput.HideSpinButtons
  MudTable.HeaderContent
  MudTable.FooterContent

and the following event handlers:
  MudInput.OnDecrement
  MudInput.OnIncrement

Fixes #3770.

## How Has This Been Tested?
Tested automatically using https://github.com/MudBlazor/MudBlazor/discussions/3595.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
