### PR TITLE
MudTable, MudDataGrid: Center pager caption text

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -303,7 +303,6 @@
 .mud-table-pagination-information {
     white-space: nowrap;
     direction: initial;
-    margin-top: 6px;
 }
 
 .mud-table-page-number-information {
@@ -343,6 +342,7 @@
 }
 
 .mud-table-pagination-caption {
+    display: flex;
     flex-shrink: 0;
     align-items: center;
     padding-left: 10px;


### PR DESCRIPTION
## Description

A little add-on to  #3774, noticed that the left caption was also not centered vertically. Turns out one of the classes had `align-items: center;` but needed `display: flex;`, after adding that, the `margin-top` from `.mud-table-pagination-information` could be removed.

Sorry to re-visit this again :grin: but I thought I'd try my best to fully resolve this while I am paying attention to it.

This just leaves the number select about 2px down from center, but, I can't see a good way to resolve that in a way that doesn't implicitly depend on the font size, and also without un-centering the chevron.

## How Has This Been Tested?

Visually, see screenshot below. Changed "Rows" to "R0ws" via browser inspector just to give a better frame of reference.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![pager-align-2](https://user-images.githubusercontent.com/1431941/150602867-21e5f38e-9a70-4b44-9ef8-0d1fcfffd674.png)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
