### PR TITLE
Fixed MudSimpleTable uneven horizontal padding

### DIFF
--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -52,14 +52,7 @@
 .mud-simple-table.mud-table-dense {
     & * tr {
         & td, th {
-            padding: 6px 24px 6px 16px;
-            padding-inline-start: 16px;
-            padding-inline-end: 24px;
-        }
-
-        & td, th:last-child {
-            padding-right: 16px;
-            padding-inline-end: 16px;
+            padding: 6px 16px;
         }
     }
 }


### PR DESCRIPTION
`MudSimpleTable` cell padding is uneven, this PR fixes it.

## Description
Changed the component CSS to remove the right padding bias for dense. Removed the `-inline-` too as they are even now.

Fixes #3798 

## How Has This Been Tested?
Visually tested.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before
![image](https://user-images.githubusercontent.com/14835013/150777336-d08ef2e0-b97d-475f-873f-f2ac4c2cb290.png)

After
![image](https://user-images.githubusercontent.com/14835013/150776463-dff390f0-0e67-4c92-ab6e-5716e9035b5c.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.

I've not committed the visual test, the test is just a copy of the try mudblazor of the issue.