### PR TITLE
MudSelect: Added icon and icon color properties to MudSelect and MudSelectItem

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCheckboxColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCheckboxColorExample.razor
@@ -1,0 +1,57 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System.Linq
+
+<MudGrid>
+    <MudItem xs="12">
+        <MudSelect MultiSelection="true" SelectAll="@false" @bind-SelectedValues="selectedProgrammingLanguages" T="string" Label="Your favorite programming languages" AdornmentIcon="@Icons.Material.Filled.Code" AnchorOrigin="Origin.BottomCenter">
+            @foreach (var programmingLanguage in programmingLanguages)
+            {
+                <MudSelectItem T="string" Value="@programmingLanguage" CheckedIcon="@Icons.Filled.Star" CheckedIconColor="@Color.Warning" UncheckedIcon="@Icons.Filled.StarBorder" Disabled="@(programmingLanguage == "HTML")">
+                    @programmingLanguage
+                </MudSelectItem>
+            }
+        </MudSelect>
+    </MudItem>
+
+    <MudItem xs="12">
+        <MudSelect MultiSelection="true" SelectAll="@true" @bind-SelectedValues="selectedCountries" T="string" Label="Countries where you have been" AdornmentIcon="@Icons.Material.Filled.Flight" AnchorOrigin="Origin.BottomCenter" CheckedIcon="@Icons.Filled.Check" CheckedIconColor="@Color.Success" UncheckedIconColor="@Color.Transparent">
+            @foreach (var country in countries)
+            {
+                <MudSelectItem T="string" Value="@country" CheckedIcon="@Icons.Filled.FlightLand" CheckedIconColor="@Color.Info" UncheckedIcon="@Icons.Filled.FlightTakeoff" UncheckedIconColor="@Color.Dark">
+                    @country
+                </MudSelectItem>
+            }
+        </MudSelect>
+    </MudItem>
+
+    <MudItem xs="12">
+        <MudSelect MultiSelection="true" SelectAll="@true" @bind-SelectedValues="selectedSports" T="string" Label="Sports you like" AdornmentIcon="@Icons.Material.Filled.Sports" AnchorOrigin="Origin.BottomCenter" CheckedIcon="@Icons.Filled.Check" CheckedIconColor="@Color.Success" UncheckedIconColor="@Color.Transparent">
+            @foreach (var sport in sports)
+            {
+                <MudSelectItem T="string" Value="@sport" CheckedIcon="@Icons.Filled.ThumbUp" CheckedIconColor="@Color.Tertiary" UncheckedIcon="@Icons.Filled.ThumbDown" UncheckedIconColor="@Color.Tertiary">
+                    @sport
+                </MudSelectItem>
+            }
+        </MudSelect>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private IEnumerable<string> selectedProgrammingLanguages { get; set; } = new HashSet<string>() { "C#" };
+    private string[] programmingLanguages =
+    {
+        "C#", "Java", "JavaScript", "Python", "Ruby", "PHP", "HTML"
+    };
+
+    private IEnumerable<string> selectedCountries { get; set; } = new HashSet<string>();
+    private string[] countries =
+    {
+        "US", "Canada", "Mexico", "Spain", "Germany", "India"
+    };
+
+    private IEnumerable<string> selectedSports { get; set; } = new HashSet<string> { "Football" };
+    private string[] sports =
+    {
+        "Football", "Basketball", "Baseball", "Tennis", "Golf"            
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -71,6 +71,17 @@
             </SectionContent>
             <SectionSubGroups>
                 <DocsPageSection>
+                    <SectionHeader Title="Customized Checkbox color">
+                        <Description>
+                            You can change the 'Select all' checkbox icon color by setting <CodeInline>CheckedIconColor</CodeInline>, <CodeInline>UncheckedIconColor</CodeInline> and <CodeInline>IndeterminateIconColor</CodeInline> properties.
+                            You can also set a custom checked and unchecked icon and icon color to <CodeInline>MudSelectItem</CodeInline> by setting <CodeInline>CheckedIcon</CodeInline>, <CodeInline>CheckedIconColor</CodeInline>, <CodeInline>UncheckedIcon</CodeInline> and <CodeInline>UncheckedIconColor</CodeInline> properties.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent ShowCode="false" Code="MultiSelectCheckboxColorExample">
+                        <MultiSelectCheckboxColorExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
                     <SectionHeader Title="Customized Selection Text">
                         <Description>
                             If you set <CodeInline>MultiSelection="true"</CodeInline>, you can select multiple values.

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectCheckedIconTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectCheckedIconTest.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudSelect T=@string MultiSelection=@true SelectAll=@false>
+    <MudSelectItem T=@string Value=@("Item") CheckedIcon="@Icons.Filled.Star" UncheckedIcon="@Icons.Filled.StarBorder" />
+</MudSelect>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -610,6 +610,27 @@ namespace MudBlazor.UnitTests.Components
             value.Should().Be("Selected values: FirstA, SecondA");
         }
 
+        /// <summary>
+        /// MudSelect with changed the multiselect checked and unchecked icons.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task MultiSelectCheckedIcon()
+        {
+            var comp = Context.RenderComponent<MultiSelectCheckedIconTest>();
+            var menu = comp.Find("div.mud-popover");
+            var input = comp.Find("div.mud-input-control");
+            // Open the menu
+            input.Click();
+            menu.ClassList.Should().Contain("mud-popover-open");
+
+            var item = comp.FindComponent<MudListItem>();
+
+            item.Instance.Icon.Should().Be(Icons.Filled.StarBorder); // Unchecked
+            comp.Find(".mud-list-item-clickable").Click();
+            item.Instance.Icon.Should().Be(Icons.Filled.Star); // Checked
+        }
+
         [Test]
         public async Task SelectClearableTest()
         {

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -27,7 +27,7 @@
 						<MudList Clickable="true" Dense="@Dense" @bind-SelectedValue="_activeItemId">
                             @if (MultiSelection && SelectAll)
 							{
-								<MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" OnClick="SelectAllClickAsync" Dense="@Dense" Class="mb-2" />
+								<MudListItem Icon="@SelectAllCheckBoxIcon" IconColor="@SelectAllCheckBoxIconColor" Text="@SelectAllText" OnClick="SelectAllClickAsync" Dense="@Dense" Class="mb-2" />
                                 <MudDivider />
 							}
 							@ChildContent

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -809,11 +809,25 @@ namespace MudBlazor
         public string CheckedIcon { get; set; } = Icons.Material.Filled.CheckBox;
 
         /// <summary>
+        /// Custom checked icon color.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public Color CheckedIconColor { get; set; } = Color.Inherit;
+
+        /// <summary>
         /// Custom unchecked icon.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
         public string UncheckedIcon { get; set; } = Icons.Material.Filled.CheckBoxOutlineBlank;
+
+        /// <summary>
+        /// Custom unchecked icon color.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public Color UncheckedIconColor { get; set; } = Color.Inherit;
 
         /// <summary>
         /// Custom indeterminate icon.
@@ -823,6 +837,13 @@ namespace MudBlazor
         public string IndeterminateIcon { get; set; } = Icons.Material.Filled.IndeterminateCheckBox;
 
         /// <summary>
+        /// Custom indeterminate icon color.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public Color IndeterminateIconColor { get; set; } = Color.Inherit;
+
+        /// <summary>
         /// The checkbox icon reflects the select all option's state
         /// </summary>
         protected string SelectAllCheckBoxIcon
@@ -830,6 +851,14 @@ namespace MudBlazor
             get
             {
                 return _selectAllChecked.HasValue ? _selectAllChecked.Value ? CheckedIcon : UncheckedIcon : IndeterminateIcon;
+            }
+        }
+
+        protected Color SelectAllCheckBoxIconColor
+        {
+            get
+            {
+                return _selectAllChecked.HasValue ? _selectAllChecked.Value ? CheckedIconColor : UncheckedIconColor : IndeterminateIconColor;
             }
         }
 

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor
@@ -4,7 +4,7 @@
 
 @if (HideContent == false)
 {
-	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" @onclick="@OnClicked" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
+	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" @onclick="@OnClicked" Icon="@CheckBoxIcon" IconColor="@CheckBoxIconColor" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
 		@if (ChildContent != null)
 		{
 			@ChildContent

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -87,6 +87,34 @@ namespace MudBlazor
         public T Value { get; set; }
 
         /// <summary>
+        /// Icon displayed if this item is selected
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string CheckedIcon { get; set; } = Icons.Material.Filled.CheckBox;
+
+        /// <summary>
+        /// Color of icon displayed when this item is selected
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public Color CheckedIconColor { get; set; } = Color.Inherit;
+
+        /// <summary>
+        /// Icon displayed if this item is not selected
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string UncheckedIcon { get; set; } = Icons.Material.Filled.CheckBoxOutlineBlank;
+
+        /// <summary>
+        /// Color of icon displayed when this item is not selected
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public Color UncheckedIconColor { get; set; } = Color.Inherit;
+
+        /// <summary>
         /// Mirrors the MultiSelection status of the parent select
         /// </summary>
         protected bool MultiSelection
@@ -120,9 +148,11 @@ namespace MudBlazor
             {
                 if (!MultiSelection)
                     return null;
-                return IsSelected ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank;
+                return IsSelected ? CheckedIcon : UncheckedIcon;
             }
         }
+
+        protected Color CheckBoxIconColor => IsSelected ? CheckedIconColor : UncheckedIconColor;
 
         protected string DisplayString
         {


### PR DESCRIPTION
## Description
Added properties to change the icon color of the 'Select all' button of `MudSelect` component (`CheckedIconColor`, `UncheckedIconColor` and `IndterminateIconColor`) and properties to change the icon and icon color of `MudSelectItem` (`CheckedIcon`, `CheckedIconColor`, `UncheckedIcon` and `UncheckedIconColor`). 
Also updated the documentation accordingly.

## How Has This Been Tested?
Added a unit test in `SelectTests` following the convention of other `MudSelect` component tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![imagen](https://user-images.githubusercontent.com/50383201/152541306-5ede067a-e41b-4cc4-ba66-e44981125056.png)
![imagen](https://user-images.githubusercontent.com/50383201/152541371-015f4fd5-4f22-46d9-942b-b55f7d0d9a5b.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
