### PR TITLE
MudTab: Add support for render fragment tooltips.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsToolTipExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsToolTipExample.razor
@@ -7,7 +7,13 @@
     <MudTabPanel Text="Item Two" ToolTip="ToolTip Two">
         <MudText>Item Two</MudText>
     </MudTabPanel>
-    <MudTabPanel Text="Item Three" ToolTip="ToolTip Three">
-        <MudText>Item Three</MudText>
+    <MudTabPanel Text="Item Three">
+        <ChildContent>
+            <MudText>Item Three</MudText>
+        </ChildContent>
+        <TooltipContent>
+            <MudText Typo="Typo.h6">HTML Content</MudText>
+            <MudText Typo="Typo.body2">ToolTip Three</MudText>
+        </TooltipContent>
     </MudTabPanel>
 </MudTabs>

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -92,6 +92,13 @@ else
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]
     public string ToolTip { get; set; }
+    
+    /// <summary>
+    /// TabPanel Tooltip RenderFragment
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Tabs.Behavior)]
+    public RenderFragment TooltipContent { get; set; }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -8,7 +8,7 @@
                 @if(HeaderPosition == TabHeaderPosition.Before && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
-                       @Header(this)
+                        @Header(this)
                     </div>
                 }
                 @if(_showScrollButtons)
@@ -21,39 +21,23 @@
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {
-                            <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
-                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
-                                    @if(TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
-                                    {
-                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
-                                            @TabPanelHeader(panel)
-                                        </div>
-                                    }
-                                    @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" />
-                                    }
-                                    else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    @if (panel.BadgeData != null || panel.BadgeDot)
-                                    {
-                                        <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
-                                    }
-                                    @if(TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
-                                    {
-                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
-                                            @TabPanelHeader(panel)
-                                        </div>
-                                    }
-                                </div>
-                            </MudTooltip>
+                            @if(panel.TooltipContent != null) //user render fragment if one is provided
+                            {
+                                <MudTooltip Placement="@GetTooltipPlacement()">
+                                    <TooltipContent>
+                                        @panel.TooltipContent
+                                    </TooltipContent>
+                                    <ChildContent>
+                                        @RenderPanel(panel)
+                                    </ChildContent>
+                                </MudTooltip>
+                            }
+                            else
+                            {
+                                <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
+                                    @RenderPanel(panel)
+                                </MudTooltip>
+                            }
                         }
                         @if (!HideSlider)
                         {
@@ -75,14 +59,42 @@
                 }
             </div>
         </div>
-		@if(PrePanelContent != null)
-		{
-			@PrePanelContent(ActivePanel)
-		}
+        @if(PrePanelContent != null)
+        {
+            @PrePanelContent(ActivePanel)
+        }
         <div class="@PanelsClassnames">
             @ChildContent
         </div>
     </CascadingValue>
 </div>
 
-
+@code{
+    private RenderFragment RenderPanel(MudTabPanel panel) //this render fragment is used for the client autocomplete
+    {
+        return@<div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
+        @if (TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
+        {
+            <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
+                @TabPanelHeader(panel)
+            </div>
+        }
+        @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
+        {@((MarkupString)panel.Text) }
+        else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+        {
+            <MudIcon Icon="@panel.Icon" Color="@IconColor" /> }
+        else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+        {
+            <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" /> @((MarkupString)panel.Text)}
+        @if (panel.BadgeData != null || panel.BadgeDot)
+        {
+            <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />}
+        @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
+        {
+            <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                @TabPanelHeader(panel)
+            </div>}
+    </div>;
+}
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

I noticed the tooltip feature of the `MudTab` component does not support the render fragment variant of `MudTooltip`, which I have added in this PR. This required moving the rendering of each panel to a `RenderPanel` method.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I noticed there were no tests for tooltips within the mudtab tests so I didn't add any for this and tested it visually.

Existing text tooltips behave identically:
![image](https://user-images.githubusercontent.com/26885142/153292236-c4c38669-1c51-47b5-b231-5a6b5879236f.png)

Render fragment tooltips also work:
![image](https://user-images.githubusercontent.com/26885142/153292302-3cb04d4b-4a11-4f1e-a989-492c45c78251.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
