### PR TITLE
Drop Zone: Exposed the "Drop Zone Index" for items dropped.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDraggingStyleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDraggingStyleExample.razor
@@ -26,7 +26,19 @@
 @code {
     private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
     {
+        // remove item from current list
+        _items.Remove(dropItem.Item);
+        // filter by dropped zone identifier
+        var newList = _items.Where(x => x.Identifier == dropItem.DropzoneIdentifier).ToList();
+
+        // insert at given index
+        newList.Insert(dropItem.Index, dropItem.Item);
+        
+        // rebuild the list (I'm VERY certain theres a better way to do this)
+        _items.RemoveAll(x => x.Identifier == dropItem.DropzoneIdentifier);
+        _items.AddRange(newList);
         dropItem.Item.Identifier = dropItem.DropzoneIdentifier;
+
     }
     
     private List<DropItem> _items = new()

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneOverrideExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneOverrideExample.razor
@@ -23,6 +23,17 @@
 @code {
     private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
     {
+        // remove item from current list
+        _items.Remove(dropItem.Item);
+        // filter by dropped zone identifier
+        var newList = _items.Where(x => x.Identifier == dropItem.DropzoneIdentifier).ToList();
+
+        // insert at given index
+        newList.Insert(dropItem.Index, dropItem.Item);
+        
+        // rebuild the list (I'm VERY certain theres a better way to do this)
+        _items.RemoveAll(x => x.Identifier == dropItem.DropzoneIdentifier);
+        _items.AddRange(newList);
         dropItem.Item.Identifier = dropItem.DropzoneIdentifier;
     }
     

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanReorderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanReorderTest.razor
@@ -1,0 +1,68 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDropContainer @ref="_container" T="SimpleDropItem" Items="_items" Item ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)" ItemDropped="ItemUpdated" Class="d-flex flex-column flex-grow-1">
+    <ChildContent>
+        <div class="d-flex flex-column flex-grow-1">
+            <MudListSubheader Class="mt-4 pb-2">Folders</MudListSubheader>
+            <MudDropZone T="SimpleDropItem" ItemDraggingClass="mud-info-text" Identifier="Column 1" Class="d-flex flex-wrap flex-grow-1 pa-2 rounded first-drop-zone" />
+        </div>
+    </ChildContent>
+    <ItemRenderer>
+        <div Class="rounded mud-paper-outlined d-flex align-center pa-3 ma-2">
+            <MudIcon Icon="@Icons.Custom.FileFormats.FileDocument" Color="Color.Inherit" Class="mr-2"/>
+            @context.Name
+        </div>
+    </ItemRenderer>
+</MudDropContainer>
+
+@code {
+    public class SimpleDropItem
+    {
+        public string Name { get; set; }
+        public string ZoneIdentifier { get; set; }
+
+        public SimpleDropItem(string name, string zoneIdentifier)
+        {
+            Name = name;
+            ZoneIdentifier = zoneIdentifier;
+        }
+    }
+
+    [Parameter]
+    public bool ApplyDropClassesOnDragStarted { get; set; } = false;
+
+    [Parameter]
+    public bool? SecondColumnAppliesClassesOnDragStarted { get; set; } = null;
+
+    private void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    {
+        // remove item from current list
+        _items.Remove(dropItem.Item);
+        // filter by dropped zone identifier
+        var newList = _items.Where(x => x.ZoneIdentifier == dropItem.DropzoneIdentifier).ToList();
+
+        // insert at given index
+        newList.Insert(dropItem.Index, dropItem.Item);
+
+        // rebuild the list (I'm VERY certain theres a better way to do this)
+        _items.RemoveAll(x => x.ZoneIdentifier == dropItem.DropzoneIdentifier);
+        _items.AddRange(newList);
+        dropItem.Item.ZoneIdentifier = dropItem.DropzoneIdentifier;
+    }
+
+    private List<SimpleDropItem> _items = new()
+		{
+		new SimpleDropItem("First Item", "Column 1"),
+		new SimpleDropItem("Second Item", "Column 1"),
+		new SimpleDropItem("Third Item", "Column 1"),
+	};
+	private MudDropContainer<SimpleDropItem> _container;
+
+    public async Task InvokeRefresh() => await InvokeAsync(_container.Refresh);
+
+    public void DragTopToBottom() 
+    {
+        ItemUpdated(new MudItemDropInfo<SimpleDropItem>( _items.First(), "Column 1", _items.Count - 1));
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -139,6 +139,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DropZone_DropItemOnItem()
+        {
+            var comp = Context.RenderComponent<DropzoneCanReorderTest>();
+
+            var firstDropZone = comp.Find(".first-drop-zone");
+
+            // should have three children
+            firstDropZone.Children.Should().HaveCount(3);
+
+            // First child should be the "First Item"
+            firstDropZone.Children[0].InnerHtml.Should().Contain("First Item");
+
+            // start dragging
+            await firstDropZone.Children[0].DragStartAsync(new DragEventArgs());
+
+
+            // drop on last child
+            await firstDropZone.Children[2].DropAsync(new DragEventArgs());
+
+
+            // Invoke refresh
+            await comp.Instance.InvokeRefresh();
+
+            // Ensure that each element is in the right place
+            firstDropZone.Children[0].InnerHtml.Should().Contain("Second Item");
+            firstDropZone.Children[1].InnerHtml.Should().Contain("Third Item");
+            firstDropZone.Children[2].InnerHtml.Should().Contain("First Item");
+        }
+
+        [Test]
         public async Task DropZone_SimpleDragAndDrop()
         {
             var comp = Context.RenderComponent<DropzoneBasicTest>();
@@ -682,6 +712,33 @@ namespace MudBlazor.UnitTests.Components
 
             //items should have been rendered
             secondDropZone.Children.Should().HaveCount(1);
+        }
+
+
+        [Test]
+        public async Task DropZone_ReorderTest()
+        {
+            var comp = Context.RenderComponent<DropzoneCanReorderTest>();
+
+            var firstDropZone = comp.Find(".first-drop-zone");
+
+            // should have three children
+            firstDropZone.Children.Should().HaveCount(3);
+
+            // First child should be the "First Item"
+            firstDropZone.Children[0].InnerHtml.Should().Contain("First Item");
+
+            // Move top dropitem to the bottom
+            comp.Instance.DragTopToBottom();
+
+            // Invoke refresh
+            await comp.Instance.InvokeRefresh();
+
+            // Ensure that each element is in the right place
+            firstDropZone.Children[0].InnerHtml.Should().Contain("Second Item");
+            firstDropZone.Children[1].InnerHtml.Should().Contain("Third Item");
+            firstDropZone.Children[2].InnerHtml.Should().Contain("First Item");
+
         }
     }
 }

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -66,7 +66,8 @@ namespace MudBlazor
     /// <typeparam name="T">Type of dragged item</typeparam>
     /// <param name="Item">The dragged item during the transaction</param>
     /// <param name="DropzoneIdentifier">Identifier of the zone where the transaction started</param>
-    public record MudItemDropInfo<T>(T Item, string DropzoneIdentifier);
+    /// <param name="Index">Identifier of the index where the item was dropped</param>
+    public record MudItemDropInfo<T>(T Item, string DropzoneIdentifier, int Index);
 
     /// <summary>
     /// The container of a drag and drop zones
@@ -187,10 +188,10 @@ namespace MudBlazor
         public bool TransactionInProgress() => _transaction != null;
         public string GetTransactionOrignZoneIdentiifer() => _transaction?.SourceZoneIdentifier ?? string.Empty;
 
-        public async Task CommitTransaction(string dropzoneIdentifier)
+        public async Task CommitTransaction(string dropzoneIdentifier, int index)
         {
             await _transaction.Commit();
-            await ItemDropped.InvokeAsync(new MudItemDropInfo<T>(_transaction.Item, dropzoneIdentifier));
+            await ItemDropped.InvokeAsync(new MudItemDropInfo<T>(_transaction.Item, dropzoneIdentifier, index));
             TransactionEnded?.Invoke(this, EventArgs.Empty);
             _transaction = null;
         }

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -8,6 +8,7 @@
 	 @ondrop="HandleDrop"
 	 @ondragenter="HandleDragEnter"
 	 @ondragleave="HandleDragLeave"
+     @ondragover="HandleDragOver"
 	 @attributes="UserAttributes">
 
 	@ChildContent
@@ -18,6 +19,7 @@
 						Item="item"
 						OnDragStarted="DragOperationStarted"
 						OnDragEnded="FinishedDragOperation"
+                        OnDropOnItem="HandleItemDropOnItem"
 						ZoneIdentifier="@Identifier"
 						Disabled="@GetItemDisabledStatus(item)"
 						DisabledClass="@(DisabledClass ?? Container?.DisabledClass)">

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -240,6 +240,18 @@ namespace MudBlazor
             _canDrop = isValidZone;
         }
 
+        public void HandleDragOver()
+        {
+            var (context, isValidZone) = ItemCanBeDropped();
+            if (context == null)
+            {
+                return;
+            }
+
+            _itemOnDropZone = true;
+            _canDrop = isValidZone;
+        }
+
         private void HandleDragLeave()
         {
             var (context, _) = ItemCanBeDropped();
@@ -249,6 +261,25 @@ namespace MudBlazor
             }
 
             _itemOnDropZone = false;
+        }
+
+        public async Task HandleItemDropOnItem(T item)
+        {
+            var (context, isValidZone) = ItemCanBeDropped();
+            if (context == null)
+            {
+                return;
+            }
+
+            _itemOnDropZone = false;
+
+            if (isValidZone == false)
+            {
+                await Container.CancelTransaction();
+                return;
+            }
+            var index = GetDropIndex(item);
+            await Container.CommitTransaction(Identifier, index);
         }
 
         private async Task HandleDrop()
@@ -266,8 +297,14 @@ namespace MudBlazor
                 await Container.CancelTransaction();
                 return;
             }
+            
+            await Container.CommitTransaction(Identifier, 0);
+        }
 
-            await Container.CommitTransaction(Identifier);
+        private int GetDropIndex(T landingItem)
+        {
+            return GetItems().ToList().IndexOf(landingItem);
+
         }
 
         private void FinishedDragOperation() => _dragInProgress = false;

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
@@ -6,6 +6,7 @@
 	 @attributes="UserAttributes"
 	 draggable="@(Disabled == false ? "true" : "false")"
 	 @ondragstart="DragStarted"
+     @ondrop="DropOnItem"
 	 @ondragend="DragEnded">
 	@ChildContent
 </div>

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -60,6 +60,13 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
     public EventCallback<T> OnDragEnded { get; set; }
 
     /// <summary>
+    /// Event callback for when the dragged item is dropped on another item, overriding DragEnded
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.DropZone.Behavior)]
+    public EventCallback<T> OnDropOnItem { get; set; }
+
+    /// <summary>
     /// When true, the item can't be dragged. defaults to false
     /// </summary>
     [Parameter]
@@ -97,6 +104,14 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
         _dragOperationIsInProgress = false;
 
         await OnDragEnded.InvokeAsync(Item);
+        StateHasChanged();
+    }
+
+    private async Task DropOnItem(DragEventArgs e)
+    {
+        _dragOperationIsInProgress = false;
+
+        await OnDropOnItem.InvokeAsync(Item);
         StateHasChanged();
     }
 


### PR DESCRIPTION
This will allow users to re-order Drop Zone lists

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
I needed the Drop Zone to expose the index of the element it was dropped on, so that I can re-order the list
This is my first contribution ever, so let me know if I got it wrong and I'll try again :)

## How Has This Been Tested?
Tested physically by dragging etc, this change doesn't affect anything other than exposing an extra integer "Index" in the MudItemDropInfo<T> record.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![DropZoneDemo](https://user-images.githubusercontent.com/6437746/153879168-60a28a63-e9b4-4192-bfc8-ea1e275817c9.gif)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
