### PR TITLE
MudPopover: Fixes leaks caused by concurrency between OnAfterRenderAsync and DisposeAsync

### DIFF
--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -25,11 +25,13 @@ namespace MudBlazor
 
     public class MudPopoverHandler
     {
-        private IJSRuntime _runtime;
+        private readonly SemaphoreSlim _semaphore = new(1, 1);
+        private readonly IJSRuntime _runtime;
         private readonly Action _updater;
         private bool _locked;
+        private bool _detached;
 
-        public Guid Id { get; init; }
+        public Guid Id { get; }
         public RenderFragment Fragment { get; private set; }
         public bool IsConnected { get; private set; }
         public string Class { get; private set; }
@@ -69,21 +71,44 @@ namespace MudBlazor
 
         public async Task Initialize()
         {
-            await _runtime.InvokeVoidAsync("mudPopover.connect", Id);
-            IsConnected = true;
+            await _semaphore.WaitAsync();
+            try
+            {
+                if (_detached)
+                {
+                    // If _detached is True, it means Detach() was invoked before Initialize() has had
+                    // a chance to run. In this case, we just want to return and not do anything else
+                    // otherwise we will end up with a memory leak.
+                    return;
+                }
+
+                await _runtime.InvokeVoidAsync("mudPopover.connect", Id);
+                IsConnected = true;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
         }
 
         public async Task Detach()
         {
+            await _semaphore.WaitAsync();
             try
             {
-                await _runtime.InvokeVoidAsync("mudPopover.disconnect", Id);
+                _detached = true;
+
+                if (IsConnected)
+                {
+                    await _runtime.InvokeVoidAsync("mudPopover.disconnect", Id);
+                }
             }
             catch (JSDisconnectedException) { }
             catch (TaskCanceledException) { }
             finally
             {
                 IsConnected = false;
+                _semaphore.Release();
             }
         }
 
@@ -92,7 +117,7 @@ namespace MudBlazor
 
     public class MudPopoverService : IMudPopoverService, IAsyncDisposable
     {
-        private List<MudPopoverHandler> _handlers = new();
+        private Dictionary<Guid, MudPopoverHandler> _handlers = new();
         private bool _isInitilized = false;
         private readonly IJSRuntime _jsRuntime;
         private readonly PopoverOptions _options;
@@ -100,7 +125,7 @@ namespace MudBlazor
 
         public event EventHandler FragmentsChanged;
 
-        public IEnumerable<MudPopoverHandler> Handlers => _handlers.AsEnumerable();
+        public IEnumerable<MudPopoverHandler> Handlers => _handlers.Values.AsEnumerable();
 
         public MudPopoverService(IJSRuntime jsInterop, IOptions<PopoverOptions> options = null)
         {
@@ -131,7 +156,7 @@ namespace MudBlazor
         public MudPopoverHandler Register(RenderFragment fragment)
         {
             var handler = new MudPopoverHandler(fragment, _jsRuntime, () => FragmentsChanged?.Invoke(this, EventArgs.Empty));
-            _handlers.Add(handler);
+            _handlers.Add(handler.Id, handler);
 
             FragmentsChanged?.Invoke(this, EventArgs.Empty);
 
@@ -141,12 +166,9 @@ namespace MudBlazor
         public async Task<bool> Unregister(MudPopoverHandler handler)
         {
             if (handler == null) { return false; }
-            if (_handlers.Contains(handler) == false) { return false; }
-
-            if (handler.IsConnected == false) { return false; }
+            if (_handlers.Remove(handler.Id) == false) { return false; }
 
             await handler.Detach();
-            _handlers.Remove(handler);
 
             FragmentsChanged?.Invoke(this, EventArgs.Empty);
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Attempts fixing #3961 by controlling the concurrency with a semaphore slim.

In certain situations, Blazor will call DisposeAsync while OnAfterRenderAsync is still being executed. Apparently, this is by design and when it happens to a MudPopover component, it leads to the handler being detached first AND then initialized -- leaving the JS objects in the browser and slowing down the application over time.

This PR addresses two scenarios:

1) Calls are made concurrently and reach Initialize first and then Detach on MudPopoverHandler
In this case, everything works as expected as the semaphore will prevent Detach from proceeding until Initialise finishes.

2) Call are made concurrently and reach Detach first and then Initialise
In this case, the MudPopoverHandler will be marked as being detached and Initialize will be a no-op.

It also aims to improve overall performance by replacing MudPopoverService list of handlers with a dictionary.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

1) bUnit tests handling the above cases.
2) Following the steps to reproduce the issue in a local build of MudBlazor.Docs.Server

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
