### PR TITLE
DatePicker: Fix editable DatePicker not opening to current date 

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -723,11 +723,13 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
 
-            //Console.WriteLine(comp.Markup);
+            CultureInfo cultureInfo = new CultureInfo("en-US");
+
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
             datePicker.Editable = true;
+            datePicker.Culture = cultureInfo;
 
-            await comp.InvokeAsync(() => comp.Find("input").Change("10.10.2020"));
+            await comp.InvokeAsync(() => comp.Find("input").Change("10/10/2020"));
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2020, 10, 10)));
             comp.WaitForAssertion(() => datePicker.PickerMonth.Should().Be(null));
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -719,6 +719,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DatePickerTest_Editable()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+
+            //Console.WriteLine(comp.Markup);
+            var datePicker = comp.FindComponent<MudDatePicker>().Instance;
+            datePicker.Editable = true;
+
+            await comp.InvokeAsync(() => comp.Find("input").Change("10.10.2020"));
+            comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2020, 10, 10)));
+            comp.WaitForAssertion(() => datePicker.PickerMonth.Should().Be(null));
+
+            await comp.InvokeAsync(() => datePicker.Open());
+            comp.WaitForAssertion(() => datePicker.PickerMonth.Should().Be(new DateTime(2020, 10, 01)));
+        }
+
+        [Test]
         public async Task DatePickerTest_KeyboardNavigation()
         {
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -214,6 +214,15 @@ namespace MudBlazor
         protected override void OnPickerOpened()
         {
             base.OnPickerOpened();
+            if (Editable == true && Text != null)
+            {
+                DateTime? a = Converter.Get(Text);
+                if (a.HasValue)
+                {
+                    a = new DateTime(a.Value.Year, a.Value.Month, 1);
+                }
+                PickerMonth = a;
+            }
             if (OpenTo == OpenTo.Date && FixDay.HasValue)
             {
                 OpenTo = OpenTo.Month;

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -220,8 +220,8 @@ namespace MudBlazor
                 if (a.HasValue)
                 {
                     a = new DateTime(a.Value.Year, a.Value.Month, 1);
+                    PickerMonth = a;
                 }
-                PickerMonth = a;
             }
             if (OpenTo == OpenTo.Date && FixDay.HasValue)
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #2345. When we change datepicker's date with input, date changed, but shown date in popover did not follow the changed date's section and showed the old section.

## How Has This Been Tested?
Added test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->


https://user-images.githubusercontent.com/78308169/154761101-85dff69d-b040-4deb-ba96-87fa43350f4d.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
