### PR TITLE
Select: fix scroll to selected item when list is long

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
@@ -29,10 +29,10 @@
     <MudChip Color="Color.Secondary">@(cultureValue?.DisplayName ?? "Select culture")</MudChip>
 </div>
 
-    @code {
+@code {
     private string stringValue { get; set; }
     private Drink enumValue { get; set; } = Drink.HotWater;
-    public enum Drink { Tee, SparklingWater, SoftDrink, Cider, Beer, Wine, Moonshine, Wodka, Cola, GreeTee, Fruit, Lemonade, HotWater, SpringWater, IceWater,  }
+    public enum Drink { Tea, SparklingWater, SoftDrink, Cider, Beer, Wine, Moonshine, Wodka, Cola, GreeTea, FruitJuice, Lemonade, HotWater, SpringWater, IceWater,  }
     private CultureInfo cultureValue { get; set; }
     private Func<CultureInfo, string> convertFunc = ci => ci?.DisplayName;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
@@ -29,10 +29,10 @@
     <MudChip Color="Color.Secondary">@(cultureValue?.DisplayName ?? "Select culture")</MudChip>
 </div>
 
-@code {
+    @code {
     private string stringValue { get; set; }
-    private Drink enumValue { get; set; }
-    public enum Drink { Tee, SparklingWater, SoftDrink, Cider, Beer, Wine, Moonshine }
+    private Drink enumValue { get; set; } = Drink.HotWater;
+    public enum Drink { Tee, SparklingWater, SoftDrink, Cider, Beer, Wine, Moonshine, Wodka, Cola, GreeTee, Fruit, Lemonade, HotWater, SpringWater, IceWater,  }
     private CultureInfo cultureValue { get; set; }
     private Func<CultureInfo, string> convertFunc = ci => ci?.DisplayName;
 }

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -36,7 +36,7 @@ namespace MudBlazor.UnitTests.Mocks
 
         public ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior) => ValueTask.CompletedTask;
 
-        public ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges) => ValueTask.CompletedTask;
+        public ValueTask ScrollToListItemAsync(string elementId) => ValueTask.CompletedTask;
 
         public Task ScrollToTop(ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => Task.CompletedTask;
         

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -74,10 +74,10 @@ namespace MudBlazor
                 }
             }
             await _elementReference.SetText(Text);
-            if (item != null)
-                await ScrollManager.ScrollToListItemAsync(item.ItemId, direction, true);
+            await ScrollToItemAsync(item);
         }
-
+        private ValueTask ScrollToItemAsync(MudSelectItem<T> item)
+            =>item != null? ScrollManager.ScrollToListItemAsync(item.ItemId): ValueTask.CompletedTask;
         private async Task SelectFirstItem(string startChar = null)
         {
             if (_items == null || _items.Count == 0)
@@ -111,7 +111,7 @@ namespace MudBlazor
                 HilightItem(item);
             }
             await _elementReference.SetText(Text);
-            await ScrollManager.ScrollToListItemAsync(item.ItemId, (item == firstItem ? -1 : 1), true);
+            await ScrollToItemAsync(item);
         }
 
         private async Task SelectLastItem()
@@ -133,7 +133,7 @@ namespace MudBlazor
                 HilightItem(item);
             }
             await _elementReference.SetText(Text);
-            await ScrollManager.ScrollToListItemAsync(item.ItemId, 1, true);
+            await ScrollToItemAsync(item);
         }
 
         /// <summary>
@@ -674,7 +674,7 @@ namespace MudBlazor
                 if (index > 0)
                 {
                     var item = _items[index];
-                    await ScrollManager.ScrollToListItemAsync(item.ItemId, 1, true);
+                    await ScrollToItemAsync(item);
                 }
             }
             //disable escape propagation: if selectmenu is open, only the select popover should close and underlying components should not handle escape key

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
         ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior);
         ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
         ValueTask ScrollToYearAsync(string elementId);
-        ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges);
+        ValueTask ScrollToListItemAsync(string elementId);
         ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
         ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
         ValueTask ScrollToBottomAsync(string elementId, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
@@ -97,8 +97,8 @@ namespace MudBlazor
         public ValueTask ScrollToYearAsync(string elementId) =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToYear", elementId);
 
-        public ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges) =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId, increment, onEdges);
+        public ValueTask ScrollToListItemAsync(string elementId) =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId);
 
         public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -4,7 +4,7 @@
 
 class MudScrollManager {
     //scrolls to an Id. Useful for navigation to fragments
-    scrollToFragment (elementId, behavior) {
+    scrollToFragment(elementId, behavior) {
         let element = document.getElementById(elementId);
 
         if (element) {
@@ -13,7 +13,7 @@ class MudScrollManager {
     }
 
     //scrolls to year in MudDatePicker
-    scrollToYear (elementId, offset) {
+    scrollToYear(elementId, offset) {
         let element = document.getElementById(elementId);
 
         if (element) {
@@ -21,59 +21,20 @@ class MudScrollManager {
         }
     }
 
-    // scrolls down or up in a select input
-    //increment is 1 if moving dow and -1 if moving up
-    //onEdges is a boolean. If true, it waits to reach the bottom or the top
-    //of the container to scroll.   
-    scrollToListItem (elementId, increment, onEdges) {
+    // sets the scroll position of the elements container, 
+    // to the position of the element with the given element id
+    scrollToListItem(elementId) {
         let element = document.getElementById(elementId);
         if (element) {
-
-            //this is the scroll container
             let parent = element.parentElement;
-            //reset the scroll position when close the menu
-            if (increment == 0) {
-                parent.scrollTop = 0;
-                return;
-            }
-
-            //position of the elements relative to the screen, so we can compare
-            //one with the other
-            //e:element; p:parent of the element; For example:eBottom is the element bottom
-            let { bottom: eBottom, height: eHeight, top: eTop } = element.getBoundingClientRect();
-            let { bottom: pBottom, top: pTop } = parent.getBoundingClientRect();
-
-            //define the height of an disabled item
-            let dHeight = eHeight;
-
-            //get the absolute increment
-            const absIncrement = Math.abs(increment);
-
-            //check if we are jumping
-            if (absIncrement > 1) {
-                let listItem = parent.querySelector(".mud-list-item-disabled");
-                if (listItem)
-                    dHeight = listItem.getBoundingClientRect().height;
-                else
-                    dHeight = eHeight;
-            }
-
-            if (
-                //if element reached bottom and direction is down
-                ((pBottom - eBottom <= 0) && increment > 0)
-                //or element reached top and direction is up
-                || ((eTop - pTop <= 0) && increment < 0)
-                // or scroll is not constrained to the Edges
-                || !onEdges
-            ) {
-                const multiplicator = increment / absIncrement; // will always be 1 or -1
-                parent.scrollTop += (eHeight + ((absIncrement-1)*dHeight)) * multiplicator;
+            if (parent) {
+                parent.scrollTop = element.offsetTop;
             }
         }
     }
 
     //scrolls to the selected element. Default is documentElement (i.e., html element)
-    scrollTo (selector, left, top, behavior) {
+    scrollTo(selector, left, top, behavior) {
         let element = document.querySelector(selector) || document.documentElement;
         element.scrollTo({ left, top, behavior });
     }
@@ -87,7 +48,7 @@ class MudScrollManager {
     }
 
     //locks the scroll of the selected element. Default is body
-    lockScroll (selector, lockclass) {
+    lockScroll(selector, lockclass) {
         let element = document.querySelector(selector) || document.body;
 
         //if the body doesn't have a scroll bar, don't add the lock class
@@ -98,7 +59,7 @@ class MudScrollManager {
     }
 
     //unlocks the scroll. Default is body
-    unlockScroll (selector, lockclass) {
+    unlockScroll(selector, lockclass) {
         let element = document.querySelector(selector) || document.body;
         element.classList.remove(lockclass);
     }


### PR DESCRIPTION
fixes #3847

## Description

This patch fixes issues with the scroll manager. It correctly selects the current value in a `MudSelect` component. Also it fixes the **Home** and **End** keyboard navigation.

It uses a new implementation of the `scrollToList`. The complex calculations where removed, since an element reference is known an the browser knows the position.

A more general approach to support `Virtualize` within `MudSelect` requires much more rethinking and refactoring. Scrolling to the correct element with Virtualized items is not possible, since the items are not known to MudSelect. However, it is working as before, but just still not scrolling.
I think that should be a new component. I have some ideas here, but this will be part of a separate pull request.

The `MudAutoComplete` component had to be adjusted as well. One public API method (I'm not sure if it was ever used) is marked as obsolete and an obsolete attribute with usage hint was added. I'm not sure if either of these methods should be public.

## How Has This Been Tested?

- Just by visual trying, since it uses Java Script Interop.
- one example in MudDocs had been enhanced to create a long list, so the effect of the changes can be seen.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
