### PR TITLE
MudDialog: Rendering only uncompleted MudDialog tasks

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogRender.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogRender.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDialog>
+    <DialogContent>
+        <MudText>Journey of life</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public static int OnInitializedCount = 0;
+    public static int OnParametersSetCount = 0;
+
+    [CascadingParameter] public MudDialogInstance MudDialog { get; set; }
+
+    void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    void Cancel() => MudDialog.Cancel();    
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(10);
+
+        OnInitializedCount++;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await Task.Delay(10);
+
+        OnParametersSetCount++;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            return;
+
+        await Task.Delay(10);
+
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -19,6 +19,29 @@ namespace MudBlazor.UnitTests.Components
     public class DialogTests : BunitTest
     {
         /// <summary>
+        /// Testing lifecycle of dialogs in dialogprovider
+        /// </summary>
+        [Test]
+        public async Task LifecycleTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            await comp.InvokeAsync(async () =>
+            {
+                dialogReference = service?.Show<DialogRender>();
+                var result1 = await dialogReference.Result;
+                //The second Dialog is added here, but the first dialog is still in the _dialogs collection of the dialogprovider, as only the result task was set to completion.
+                //So DialogProvider will render again with 2 dialogs, but 1 is completed. This one needs to be excluded from rendering to prevent double initialize with no params.
+                dialogReference = service?.Show<DialogRender>();
+                var result2 = await dialogReference.Result;
+            });
+            DialogRender.OnInitializedCount.Should().Be(2);
+            DialogRender.OnParametersSetCount.Should().Be(2);
+        }
+
+        /// <summary>
         /// Opening and closing a simple dialog
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -38,7 +38,6 @@ namespace MudBlazor.UnitTests.Components
                 var result2 = await dialogReference.Result;
             });
             DialogRender.OnInitializedCount.Should().Be(2);
-            DialogRender.OnParametersSetCount.Should().Be(2);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -35,9 +35,7 @@ namespace MudBlazor
 
         public virtual bool Dismiss(DialogResult result)
         {
-            _resultCompletion.TrySetResult(result);
-
-            return true;
+            return _resultCompletion.TrySetResult(result);
         }
 
         public Guid Id { get; }

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -2,7 +2,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
     <CascadingValue Value="_globalDialogOptions">
-        @foreach (var dialogReference in _dialogs)
+        @foreach (var dialogReference in _dialogs.Where(x => !x.Result.IsCompleted))
         {
             @dialogReference.RenderFragment
         }

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -156,7 +156,7 @@ namespace MudBlazor
             Close(dialog, DialogResult.Ok<object>(null));
         }
 
-        public void Close(DialogReference dialog, DialogResult result)
+        public virtual void Close(DialogReference dialog, DialogResult result)
         {
             OnDialogCloseRequested?.Invoke(dialog, result);
         }


### PR DESCRIPTION
A timing issue with opening a MudDialog after another in an async method causes unwanted behaviour.
This is fixed by this PR by rendering only the uncompleted MudDialog tasks.

https://try.mudblazor.com/snippet/wEQwuGbhGNHIKbeT  <- Check Console

## Description

```csharp
private async Task ButtonOnClick() 
{
        var dialog = DialogService.Show<Dialog1>("Dialog1");
        await dialog.Result;
        
        var dialog2 = DialogService.Show<Dialog2>("Dialog2");
        await dialog2.Result;
}
```

The first awaiting of dialog.Result causes the second Dialog.Show but without closing the first dialog.
So both dialogs are rendered with the .Add (the first dialog is rendered and initailized again, but without parameters as they are marked as already set by `AreParametersRendered`!). After this the first dialog gets removed from the _dialogs collection.

Reference should only be removed from _dialogs, if TrySetResult succeded. But this completes the Task, but not removed the reference. So the completed dialog task has to be excluded from rendering:

`@foreach (var dialogReference in _dialogs.Where(x => !x.Result.IsCompleted))`

Fixes #3976,  Fixes #3411, Fixes #3101


## How Has This Been Tested?
visually, debugging

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [x] I've added relevant tests.
