### PR TITLE
MudTextField : Expose input element reference

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -618,6 +618,15 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => input.Instance.Value.Should().Be(""));
             comp.WaitForAssertion(() => input.Instance.Text.Should().Be(""));
         }
+        
+        [Test]
+        public async Task TextField_ElementReferenceId_ShouldNot_BeEmpty()
+        {
+            var comp = Context.RenderComponent<MudTextField<string>>();
+            var inputId = comp.Instance.InputReference.ElementReference.Id;
+
+            Assert.IsNotEmpty(inputId);
+        }
     }
 
 }

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -19,7 +19,7 @@
 	@if (Lines > 1)
 	{
 	    <textarea class="@InputClassname"
-                @ref="_elementReference" 
+                @ref="ElementReference" 
                 rows="@Lines" 
                 @attributes="UserAttributes"
                 type="@InputTypeString"                  
@@ -50,7 +50,7 @@
 	else
 	{
 	    <input class="@InputClassname"
-                @ref="_elementReference" 
+                @ref="ElementReference" 
                 @attributes="UserAttributes" 
                 type="@InputTypeString"                  
                 value="@_internalText" 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        private ElementReference _elementReference;
+        public ElementReference ElementReference { get; private set; }
         private ElementReference _elementReference1;
 
         public override async ValueTask FocusAsync()
@@ -78,7 +78,7 @@ namespace MudBlazor
                 if (InputType == InputType.Hidden && ChildContent != null)
                     await _elementReference1.FocusAsync();
                 else
-                    await _elementReference.FocusAsync();
+                    await ElementReference.FocusAsync();
             }
             catch (Exception e)
             {
@@ -88,12 +88,12 @@ namespace MudBlazor
 
         public override ValueTask SelectAsync()
         {
-            return _elementReference.MudSelectAsync();
+            return ElementReference.MudSelectAsync();
         }
 
         public override ValueTask SelectRangeAsync(int pos1, int pos2)
         {
-            return _elementReference.MudSelectRangeAsync(pos1, pos2);
+            return ElementReference.MudSelectRangeAsync(pos1, pos2);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -20,7 +20,7 @@
                 @if (_mask == null)
                 {
                     <MudInput T="string"
-                              @ref="_elementReference"
+                              @ref="InputReference"
                               @attributes="UserAttributes"
                               InputType="@InputType"
                               Lines="@Lines"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
            .AddClass(Class)
            .Build();
 
-        private MudInput<string> _elementReference;
+        public MudInput<string> InputReference { get; private set; }
         private MudMask _maskReference;
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace MudBlazor
         public override ValueTask FocusAsync()
         {
             if (_mask == null)
-                return _elementReference.FocusAsync();
+                return InputReference.FocusAsync();
             else
                 return _maskReference.FocusAsync();
         }
@@ -50,7 +50,7 @@ namespace MudBlazor
         public override ValueTask SelectAsync()
         {
             if (_mask == null)
-                return _elementReference.SelectAsync();
+                return InputReference.SelectAsync();
             else
                 return _maskReference.SelectAsync();
         }
@@ -58,7 +58,7 @@ namespace MudBlazor
         public override ValueTask SelectRangeAsync(int pos1, int pos2)
         {
             if (_mask == null)
-                return _elementReference.SelectRangeAsync(pos1, pos2);
+                return InputReference.SelectRangeAsync(pos1, pos2);
             else
                 return _maskReference.SelectRangeAsync(pos1, pos2);
         }
@@ -66,7 +66,7 @@ namespace MudBlazor
         protected override void ResetValue()
         {
             if(_mask == null)            
-                _elementReference.Reset();            
+                InputReference.Reset();            
             else            
                 _maskReference.Reset();            
             base.ResetValue();
@@ -79,7 +79,7 @@ namespace MudBlazor
         public Task Clear()
         {
             if (_mask == null)
-                return _elementReference.SetText(null);
+                return InputReference.SetText(null);
             else
                 return _maskReference.Clear();
         }
@@ -92,7 +92,7 @@ namespace MudBlazor
         public Task SetText(string text)
         {
             if (_mask == null)
-                return _elementReference?.SetText(text);
+                return InputReference?.SetText(text);
             else
                 return _maskReference.Clear().ContinueWith(t => _maskReference.OnPaste(text));
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Some javascript librairies need access to the underlying input element of the `MudTextField`. The properties were existing and private but now we can access them like so:
`MudTextField.InputReference.ElementReference`

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

A simple unit test has been written and I tested the changes is a personal project.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
