### PR TITLE
MudMask: Fix cursor jumping in table inline edit mode.

### DIFF
--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -174,7 +174,7 @@ namespace MudBlazor
                 _keyInterceptor.KeyDown += e => HandleKeyDown(e).AndForget();
             }
             if (_isFocused && Mask.Selection == null)
-                SetCaretPosition(_caret, _selection, render: false);
+                SetCaretPosition(Mask.CaretPos, _selection, render: false);
             await base.OnAfterRenderAsync(firstRender);
         }
 


### PR DESCRIPTION
Fixes #3921 

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

As described in #3921 above, editing a masked textfield inline in a table is a poor experience. Clicking anywhere in the field will "jump" the cursor to position 0, though the arrow keys could be used to move through the mask. See this try.mudblazor for an example of the issue: https://try.mudblazor.com/snippet/GumQawPkLXPfXone

I believe the click on the textfield causes additional renders to the internal mask, which causes the caret position to be set:
https://github.com/MudBlazor/MudBlazor/blob/dev/src/MudBlazor/Components/Mask/MudMask.razor.cs#L177

From what I can tell, the internal `_caret` is reset back to 0 regardless of the value returned from `OnCaretPositionChanged`: https://github.com/MudBlazor/MudBlazor/blob/dev/src/MudBlazor/Components/Mask/MudMask.razor.cs#L374

However this does not happen if the Mask.CaretPos is used when setting the caret position.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

This has been tested visually. All existing masks behave as before in docs and all tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
