### PR TITLE
MudTable: Fix to include Virtualiation in a grouped rows (#4008)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingExample.razor
@@ -16,6 +16,7 @@
 
 <MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
           Items="@Elements"
+          Virtualize="@_virtualize"
           GroupBy="@_groupDefinition"
           GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
           GroupFooterClass="mb-4"
@@ -60,12 +61,14 @@
 
 <MudSwitch @bind-Checked="_dense" Color="Color.Primary">Dense</MudSwitch>
 <MudSwitch @bind-Checked="_multiSelect" Color="Color.Primary">MultiSelect</MudSwitch>
+<MudSwitch @bind-Checked="_virtualize" Color="Color.Primary">Virtualize</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Indentation" Color="Color.Primary">Indentation</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Expandable" Color="Color.Primary">Expandable</MudSwitch>
 
 @code { 
     private bool _dense = false;
     private bool _multiSelect = true;
+    private bool _virtualize = false;    
 
     private TableGroupDefinition<Element> _groupDefinition = new()
     {

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
@@ -16,7 +16,6 @@
 
 <MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
           Items="@Elements"
-          Virtualize="@_virtualize"
           GroupBy="@_groupDefinition"
           GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
           GroupFooterClass="mb-4"
@@ -47,7 +46,6 @@
 </MudTable>
 <MudSwitch @bind-Checked="_dense" Color="Color.Primary">Dense</MudSwitch>
 <MudSwitch @bind-Checked="_multiSelect" Color="Color.Primary">MultiSelect</MudSwitch>
-<MudSwitch @bind-Checked="_virtualize" Color="Color.Primary">Virtualize</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Indentation" Color="Color.Primary">Indentation</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Expandable" Color="Color.Primary">Expandable (Root Level)</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.InnerGroup.Expandable" Color="Color.Primary">Expandable (Second Level)</MudSwitch>
@@ -55,8 +53,6 @@
 @code {
     private bool _dense = false;
     private bool _multiSelect = true;
-    private bool _virtualize = false;    
-
 
     private TableGroupDefinition<Element> _groupDefinition = new TableGroupDefinition<Element>()
     {

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
@@ -16,6 +16,7 @@
 
 <MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
           Items="@Elements"
+          Virtualize="@_virtualize"
           GroupBy="@_groupDefinition"
           GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
           GroupFooterClass="mb-4"
@@ -46,6 +47,7 @@
 </MudTable>
 <MudSwitch @bind-Checked="_dense" Color="Color.Primary">Dense</MudSwitch>
 <MudSwitch @bind-Checked="_multiSelect" Color="Color.Primary">MultiSelect</MudSwitch>
+<MudSwitch @bind-Checked="_virtualize" Color="Color.Primary">Virtualize</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Indentation" Color="Color.Primary">Indentation</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.Expandable" Color="Color.Primary">Expandable (Root Level)</MudSwitch>
 <MudSwitch @bind-Checked="_groupDefinition.InnerGroup.Expandable" Color="Color.Primary">Expandable (Second Level)</MudSwitch>
@@ -53,6 +55,8 @@
 @code {
     private bool _dense = false;
     private bool _multiSelect = true;
+    private bool _virtualize = false;    
+
 
     private TableGroupDefinition<Element> _groupDefinition = new TableGroupDefinition<Element>()
     {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -185,13 +185,20 @@
     internal RenderFragment RenderRows(IEnumerable<T> source, string customClass = null, bool isExpandable = false)
     {
         var rowIndex = 0;
-        return
-        @<text>
-            @foreach (T item in source)
-            {
+
+         RenderFragment rootNode =
+            @<text>
+                <MudVirtualize IsEnabled="@Virtualize" Items="@source?.ToList()" Context="item" ChildContent="@child()">              
+                </MudVirtualize>
+            </text>;
+
+         RenderFragment<T> child() => item =>
+             @<text>
+             @{
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, ! string.IsNullOrEmpty("mud-table-row-group-indented-1")).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
+             } 
+             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
                         IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
@@ -227,8 +234,11 @@
                 {
                     @ChildRowContent(item)
                 }
-                rowIndex++;
-            }
-        </text>;
-     }
+                @{rowIndex++;}
+        </text>
+    ;
+
+
+        return rootNode;
+    }
 }


### PR DESCRIPTION

MudTable Grouping to have support for Virtualization. Currently, Mud table have this feature which was added now for Grouped rows

[Note]  Already create a [PR4022](https://github.com/MudBlazor/MudBlazor/pull/4022) which I have deleted now.  This will follow the proper guidance

## Description
Resolves #4008 

## Testing
Tested Visually 

## Types of changes
-  [x] New feature (non-breaking change which adds functionality)
-  [x]  Bug fix (non-breaking change which fixes an issue)

![image](https://user-images.githubusercontent.com/13073344/155157694-df80a28f-ca13-427f-8609-952b1e859680.png)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
