### PR TITLE
MudProgressLinear: Fix completed bar rendering over child text (#4072)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
@@ -211,13 +211,7 @@ namespace MudBlazor.UnitTests.Components
             container.GetAttribute("role").Should().Be("progressbar");
 
             container.ChildElementCount.Should().Be(2);
-            var contentContainer = container.Children[0];
-
-            contentContainer.ClassList.Should().Contain("mud-progress-linear-content");
-            contentContainer.ChildElementCount.Should().Be(1);
-            contentContainer.TextContent.Should().Be("my content");
-
-            var barContainer = container.Children[1];
+            var barContainer = container.Children[0];
 
             barContainer.ClassList.Should().Contain("mud-progress-linear-bars");
             barContainer.ChildElementCount.Should().Be(2);
@@ -227,6 +221,12 @@ namespace MudBlazor.UnitTests.Components
 
             var secondBarElement = barContainer.Children[1];
             firstBarElement.ClassList.Should().Contain("mud-progress-linear-bar");
+
+            var contentContainer = container.Children[1];
+
+            contentContainer.ClassList.Should().Contain("mud-progress-linear-content");
+            contentContainer.ChildElementCount.Should().Be(1);
+            contentContainer.TextContent.Should().Be("my content");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor
@@ -3,12 +3,6 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@DivClassname" style="@Style" role="progressbar" aria-valuenow="@_value.ToInvariantString()" aria-valuemin="@_min.ToInvariantString()" aria-valuemax="@_max.ToInvariantString()">
-    @if(ChildContent != null)
-    {
-        <div class="mud-progress-linear-content">
-            @ChildContent
-        </div>
-    }
     <div class="mud-progress-linear-bars">
         @if (Indeterminate)
         {
@@ -26,4 +20,10 @@
             <div class="mud-progress-linear-bar" style="@GetStyledBar1Transform()"></div>
         }
     </div>
+    @if(ChildContent != null)
+    {
+        <div class="mud-progress-linear-content">
+            @ChildContent
+        </div>
+    }
 </div>


### PR DESCRIPTION
## Description
Re-order elements to render child content after the completed part of the progress bar.
fixes #4072

## How Has This Been Tested?
Tested visually with the progress bar with child content in the samples set to 75% to verify that the progress bar does not hide the text anymore.

Unit test was adjusted to check for changed order.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![Before](https://user-images.githubusercontent.com/755148/156181000-82cedbbe-ffed-4742-841f-79e277dc2b35.png)

After:
![After](https://user-images.githubusercontent.com/755148/156181029-eeba391d-3ac1-448c-b12c-ec9abdb15457.png)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
