### PR TITLE
Add AriaLabel params for Adornment Buttons for WCAG Standards

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAdornmentsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAdornmentsExample.razor
@@ -3,17 +3,17 @@
 <div class="d-flex">
     <MudTextField @bind-Value="Amount" Label="Amount" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
     <MudTextField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Text" Adornment="Adornment.End" AdornmentText="Kg" Class="mx-8" />
-    <MudTextField @bind-Value="Password" Label="Password" Variant="Variant.Text" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" />
+    <MudTextField @bind-Value="Password" Label="Password" Variant="Variant.Text" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" AdornmentAriaLabel="Show Password" />
 </div>
 <div class="d-flex">
     <MudTextField @bind-Value="Amount" Label="Amount" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
     <MudTextField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Filled" Adornment="Adornment.End" AdornmentText="Kg" Class="mx-8" />
-    <MudTextField  @bind-Value="Password" Label="Password"  Variant="Variant.Filled" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" />
+    <MudTextField  @bind-Value="Password" Label="Password"  Variant="Variant.Filled" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" AdornmentAriaLabel="Show Password" />
 </div>
 <div class="d-flex">
     <MudTextField @bind-Value="Amount" Label="Amount" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
     <MudTextField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentText="Kg" Class="mx-8" />
-    <MudTextField  @bind-Value="Password" Label="Password" Variant="Variant.Outlined" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" />
+    <MudTextField  @bind-Value="Password" Label="Password" Variant="Variant.Outlined" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="ButtonTestclick" AdornmentAriaLabel="Show Password" />
 </div>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -83,7 +83,7 @@
 
 <DocsPageSection>
     <SectionHeader Title="Adornments">
-        <Description>This can be used to add a prefix or a suffix. Text, Icon or Icon Button.</Description>
+        <Description>This can be used to add a prefix or a suffix. Text, Icon or Icon Button. For WCAG standards for buttons, an <CodeInline>AdornmentAriaLabel</CodeInline> can be added to use as the <CodeInline>aria-label</CodeInline>.</Description>
     </SectionHeader>
     <SectionContent Code="TextFieldAdornmentsExample" ShowCode="false" Block="true" FullWidth="true">
         <TextFieldAdornmentsExample/>

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -150,6 +150,14 @@ namespace MudBlazor.UnitTests.Components
         private IHtmlInputElement GetColorInput(IRenderedComponent<SimpleColorPickerTest> comp, int index, int expectedCount = 4) => GetColorInputs(comp, expectedCount)[index];
 
         [Test]
+        public void ColorPickerOpenButtonAriaLabel()
+        {
+            var comp = Context.RenderComponent<MudColorPicker>();
+            var openButton = comp.Find(".mud-input-adornment button");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Color Picker");
+        }
+        
+        [Test]
         public async Task Default()
         {
             var comp = Context.RenderComponent<MudColorPicker>();

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -21,6 +21,14 @@ namespace MudBlazor.UnitTests.Components
     public class DatePickerTests : BunitTest
     {
         [Test]
+        public void DatePickerOpenButtonAriaLabel()
+        {
+            var comp = Context.RenderComponent<DatePickerValidationTest>();
+            var openButton = comp.Find(".mud-input-adornment button");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Picker");
+        }
+        
+        [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void DatePicker_Render_Performance()
         {

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -18,6 +18,14 @@ namespace MudBlazor.UnitTests.Components
     public class DateRangePickerTests : BunitTest
     {
         [Test]
+        public void DateRangePickerOpenButtonAriaLabel()
+        {
+            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var openButton = comp.Find(".mud-input-adornment button");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Range Picker");
+        }
+        
+        [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void RenderDateRangePicker_10000_Times_CheckPerformance()
         {

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -41,6 +41,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TimePickerOpenButtonAriaLabel()
+        {
+            var comp = Context.RenderComponent<MudTimePicker>();
+            var openButton = comp.Find(".mud-input-adornment button");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Time Picker");
+        }
+
+        [Test]
         public void Open_ClickOutside_CheckClosed()
         {
             var comp = OpenPicker();

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -90,6 +90,13 @@ namespace MudBlazor
         public Color AdornmentColor { get; set; } = Color.Default;
 
         /// <summary>
+        /// The aria-label of the adornment.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string AdornmentAriaLabel { get; set; } = string.Empty;
+
+        /// <summary>
         /// The Icon Size.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
             DisableToolbar = true;
             Value = "#594ae2"; //MudBlazor Blue
             Text = GetColorTextValue();
+            AdornmentAriaLabel = "Open Color Picker";
         }
 
         #region Fields

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -17,7 +17,9 @@ namespace MudBlazor
             Format = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
             Culture = CultureInfo.CurrentCulture
         })
-        { }
+        {
+            AdornmentAriaLabel = "Open Date Picker";
+        }
 
         [Inject] protected IScrollManager ScrollManager { get; set; }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -12,7 +12,7 @@
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
-                                   Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin"/>
+                                   Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"/>
                </InputContent>
            </MudInputControl>;
     

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         public MudDateRangePicker()
         {
             DisplayMonths = 2;
+            AdornmentAriaLabel = "Open Date Range Picker";
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -13,6 +13,7 @@
                 Text="@AdornmentText" 
                 Edge="@Edge.Start" 
                 AdornmentClick="@OnAdornmentClick" 
+                AriaLabel="@AdornmentAriaLabel"
         />
 	}
 
@@ -117,6 +118,7 @@
                 Text="@AdornmentText" 
                 Edge="@Edge.End" 
                 AdornmentClick="@OnAdornmentClick" 
+                AriaLabel="@AdornmentAriaLabel"
         />
 	}
 

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -11,11 +11,11 @@
     {
         @if (AdornmentClick.HasDelegate)
         {
-            <MudIconButton Icon="@Icon" OnClick="@AdornmentClick" Edge="@Edge" Size="@Size" Color="@Color"  tabindex="-1"/>
+            <MudIconButton Icon="@Icon" OnClick="@AdornmentClick" Edge="@Edge" Size="@Size" Color="@Color" aria-label="@(!string.IsNullOrEmpty(AriaLabel) ? AriaLabel : "Icon Button")" tabindex="-1"/>
         }
         else
         {
-            <MudIcon Icon="@Icon" Size="@Size" Color="@Color" tabindex="-1"/>
+            <MudIcon Icon="@Icon" Size="@Size" Color="@Color" aria-label="@(!string.IsNullOrEmpty(AriaLabel) ? AriaLabel : "Icon")" tabindex="-1"/>
         }
     }
 </div>
@@ -28,6 +28,7 @@
     [Parameter] public Edge Edge { get; set; }
     [Parameter] public Size Size { get; set; } = Size.Medium;
     [Parameter] public Color Color { get; set; } = Color.Default;
+    [Parameter] public string AriaLabel { get; set; }
 
     [Parameter] public EventCallback<MouseEventArgs> AdornmentClick { get; set; }
 }

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -6,7 +6,7 @@
 <div class="@Classname" style="@Style">
     @if (Adornment == Adornment.Start)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
+        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (InputType == InputType.Hidden && ChildContent != null)
@@ -24,7 +24,7 @@
 
     @if (Adornment == Adornment.End)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
+        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -27,6 +27,7 @@
              Adornment="@Adornment"
              AdornmentIcon="@AdornmentIcon" 
              AdornmentColor="@AdornmentColor" 
+             AdornmentAriaLabel="@AdornmentAriaLabel"
              IconSize="@IconSize" 
              Margin="@Margin" 
              Required="@Required" 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -87,6 +87,13 @@ namespace MudBlazor
         public string AdornmentIcon { get; set; } = Icons.Material.Filled.Event;
 
         /// <summary>
+        /// Sets the aria-label of the input text field icon
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string AdornmentAriaLabel { get; set; } = string.Empty;
+
+        /// <summary>
         /// The short hint displayed in the input before the user enters a value.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -38,6 +38,7 @@
                               AdornmentText="@AdornmentText"
                               AdornmentIcon="@AdornmentIcon"
                               AdornmentColor="@AdornmentColor"
+                              AdornmentAriaLabel="@AdornmentAriaLabel"
                               IconSize="@IconSize"
                               OnAdornmentClick="@OnAdornmentClick"
                               Error="@Error"

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
             Converter.SetFunc = OnSet;
             ((DefaultConverter<TimeSpan?>)Converter).Format = format24Hours;
             AdornmentIcon = Icons.Material.Filled.AccessTime;
+            AdornmentAriaLabel = "Open Time Picker";
         }
 
         private string OnSet(TimeSpan? timespan)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

Added a parameter to the `Adornment` component to handle a label to be used as an `aria-label` when the Adornment is an Icon Button. Also found text in date picker for `aria-labels` and added similar text for the `open date picker` Adornment Button in the date picker.

## Description
A step in the progress towards WCAG (accessibility) compliance. This is discussed in #2233 and #2187. The jury is still out on hour to internationalize this. For now the standard found in the `DatePicker` was to use generic English text. There is no functional change, it only addresses accessibility. The Text Field docs page has been updated to implement this in the Adornments section and the Section Header updated to explain it's use. If a `AdornmentLabel` is not used for a button implementation, the `aria-label` will default to "Icon" or "Icon Button". Sufficient for WCAG but not very descriptive which would be better but we leave that to the implementor.

Generic text has been implemented for the existing pickers:

- DatePicker: "Open Date Picker"
- ColorPicker: "Open Color Picker"
- TimePicker: "Open Time Picker" 

This can be used anywhere a button type `Adornment` is used.

## How Has This Been Tested?
This has been manually tested through the Docs to see the presence of the aria-label on an adornment button.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![image](https://user-images.githubusercontent.com/24905572/156214953-6a0c2de6-4d08-4951-93d3-21ebebba530f.png)

![image](https://user-images.githubusercontent.com/24905572/156214851-fe7e682e-3c96-4428-a277-565df64af6e6.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests. N/A
