### PR TITLE
Select: Fix memory leak caused by key interceptor (#4060)

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1026,6 +1026,15 @@ namespace MudBlazor
                 _elementReference.FocusAsync().AndForget(TaskOption.Safe);
             }
             base.OnBlur.InvokeAsync(obj);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _keyInterceptor.Dispose();
+            }
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -95,6 +95,8 @@ namespace MudBlazor.Services
             if (!disposing || _isDisposed)
                 return;
             _isDisposed = true;
+            KeyDown = null;
+            KeyUp = null;
             Disconnect().AndForget();
             _dotNetRef.Dispose();
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
This fixes #4060, the problem is caused by the transient `KeyInterceptor` holding a reference to the component via the `KeyUp/Down` events.
Since it is not disposed until the scope is also disposed, and the scope is disposed when the Blazor connection is, rather than the page, it hangs around and can't be collected.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested manually, using https://github.com/lachlanwgordon/MudBlazorMemoryLeakRepro and triggering a GC to confirm.
I don't know how to test this automatically, so have not added a unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
