### PR TITLE
Added missing @ for style in MudFocusTrap

### DIFF
--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase;
 
-<div @ref="_root" @attributes="UserAttributes" class="@Classname" style="Style" @onkeydown="OnRootKeyDown" @onkeyup="OnRootKeyUp" @onfocus="OnRootFocusAsync" tabindex="-1">
+<div @ref="_root" @attributes="UserAttributes" class="@Classname" style="@Style" @onkeydown="OnRootKeyDown" @onkeyup="OnRootKeyUp" @onfocus="OnRootFocusAsync" tabindex="-1">
 
     <div class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"


### PR DESCRIPTION
The style attribute in MudFocusTrap was missing an `@`. So the string Style was used as Style.

## Description
Added an `@`
Fixes #4070 

## How Has This Been Tested?
visually 

![image](https://user-images.githubusercontent.com/26269158/156508623-7eebe26e-15b9-4e73-b809-dd4bf7ed462e.png)
![image](https://user-images.githubusercontent.com/26269158/156508655-e7f1141b-92ab-4009-bf9c-0209af8476bf.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
