### PR TITLE
MudTreeViewItem: added IgnoreServerData Property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -3,7 +3,7 @@
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView ServerData="LoadServerData" Items="TreeItems">
         <ItemTemplate>
-            <MudTreeViewItem Value="@context" Icon="@context.Icon" LoadingIconColor="Color.Info" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+            <MudTreeViewItem Value="@context" Icon="@context.Icon" LoadingIconColor="Color.Info" IgnoreServerData="@context.IgnoreServerData" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>
@@ -19,14 +19,17 @@
         public string Icon { get; set; }
 
         public int? Number { get; set; }
+        
+        public bool IgnoreServerData { get; set; }
 
         public HashSet<TreeItemData> TreeItems { get; set; }
 
-        public TreeItemData(string title, string icon, int? number = null)
+        public TreeItemData(string title, string icon, int? number = null, bool ignoreServerData = false)
         {
             Title = title;
             Icon = icon;
             Number = number;
+            IgnoreServerData = ignoreServerData;
         }
     }
 
@@ -44,7 +47,7 @@
                 new TreeItemData("Promotions", Icons.Filled.LocalOffer, 733)
             }
         });
-        TreeItems.Add(new TreeItemData("History", Icons.Filled.Label));
+        TreeItems.Add(new TreeItemData("History", Icons.Filled.Label, null, true));
     }
 
     public async Task<HashSet<TreeItemData>> LoadServerData(TreeItemData parentNode)

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -98,7 +98,9 @@
 
         <DocsPageSection>
             <SectionHeader Title="Server Side Data">
-                <Description>Data can be loaded on demand with the use of <CodeInline>ServerData</CodeInline> prop, the loading icon and its color can be changed with <CodeInline>LoadingIcon</CodeInline> and <CodeInline>LoadingIconColor</CodeInline> prop.</Description>
+                <Description>Data can be loaded on demand with the use of <CodeInline>ServerData</CodeInline> prop, the loading icon and its color can be changed with <CodeInline>LoadingIcon</CodeInline> and <CodeInline>LoadingIconColor</CodeInline> prop.
+                    It can also be disabled for certain items with the <CodeInline>IgnoreServerData</CodeInline> property
+                    </Description>
             </SectionHeader>
             <SectionContent Code="TreeViewServerExample" ShowCode="false">
                 <TreeViewServerExample />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
@@ -2,7 +2,7 @@
 
 <MudTreeView ExpandOnClick="true" ServerData="LoadServerData" Items="TreeItems" Width="350px">
     <ItemTemplate>
-        <MudTreeViewItem Value="@context" Icon="@context.Icon" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+        <MudTreeViewItem Value="@context" Icon="@context.Icon" IgnoreServerData="@context.IgnoreServerLoading" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
     </ItemTemplate>
 </MudTreeView>
 
@@ -17,13 +17,16 @@
 
         public int? Number { get; set; }
 
+        public bool IgnoreServerLoading { get; set; }
+
         public HashSet<TreeItemData> TreeItems { get; set; }
 
-        public TreeItemData(string title, string icon, int? number = null)
+        public TreeItemData(string title, string icon, int? number = null, bool ignoreServerLoading = false)
         {
             Title = title;
             Icon = icon;
             Number = number;
+            IgnoreServerLoading = ignoreServerLoading;
         }
     }
 
@@ -41,7 +44,7 @@
                 new TreeItemData("Promotions", Icons.Filled.LocalOffer, 733)
             }
         });
-        TreeItems.Add(new TreeItemData("History", Icons.Filled.Label));
+        TreeItems.Add(new TreeItemData("History", Icons.Filled.Label, null, true));
     }
 
     public Task<HashSet<TreeItemData>> LoadServerData(TreeItemData parentNode)

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -1,5 +1,5 @@
-﻿
-using System;
+﻿using System;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
@@ -105,6 +105,9 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
             comp.FindAll("div.mud-treeview-item-content")[0].Click();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
+            comp.FindAll("div.mud-treeview-item-content")[3]
+                .GetElementsByClassName("mud-treeview-item-arrow")[0]
+                .ChildElementCount.Should().Be(0);
             comp.FindAll("div.mud-treeview-item-content")[2].Click();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(8);
         }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     public partial class MudTreeViewItem<T> : MudComponentBase
     {
         private string _text;
-        private bool _disabled;
+        private bool _disabled, _ignoreServerData;
         private bool _isChecked, _isSelected, _isServerLoaded;
         private Converter<T> _converter = new DefaultConverter<T>();
         private readonly List<MudTreeViewItem<T>> _childItems = new();
@@ -117,6 +117,17 @@ namespace MudBlazor
         {
             get => _disabled || (MudTreeRoot?.Disabled ?? false);
             set => _disabled = value;
+        }
+
+        /// <summary>
+        /// If true, ServerData will be ignored
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.TreeView.Behavior)]
+        public bool IgnoreServerData
+        {
+            get => _ignoreServerData;
+            set => _ignoreServerData = value;
         }
 
         /// <summary>
@@ -258,8 +269,8 @@ namespace MudBlazor
         public bool Loading { get; set; }
 
         bool HasChild => ChildContent != null ||
-            (MudTreeRoot != null && Items != null && Items.Count != 0) ||
-            (MudTreeRoot?.ServerData != null && !_isServerLoaded && (Items == null || Items.Count == 0));
+             (MudTreeRoot != null && Items != null && Items.Count != 0) ||
+             (MudTreeRoot?.ServerData != null && !_ignoreServerData && !_isServerLoaded && (Items == null || Items.Count == 0));
 
         protected bool IsChecked
         {
@@ -384,7 +395,7 @@ namespace MudBlazor
 
         internal async void TryInvokeServerLoadFunc()
         {
-            if (Expanded && (Items == null || Items.Count == 0) && MudTreeRoot?.ServerData != null)
+            if (Expanded && (Items == null || Items.Count == 0) && !_ignoreServerData && MudTreeRoot?.ServerData != null)
             {
                 Loading = true;
                 StateHasChanged();


### PR DESCRIPTION
## Description
So that the Expandable icon is no longer displayed when you already know that no more new data needs to be loaded
resolves #4093 

## How Has This Been Tested?
I have modified an existing test case that checks if there is no more treeview item arrow when the IgnoreServerData property is true

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<img width="232" alt="image" src="https://user-images.githubusercontent.com/62129308/156596342-17bc5a76-2d04-446a-ac4d-9cbe465f0ab1.png">

The IgnoreServerData Property is true on the History TreeViewItem. So there is no more treeview item arrow and it cannot be expanded

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR is submitted to the correct branch (`dev`).
- [ x] My code follows the code style of this project.
- [ x] I've added relevant tests.
