### PR TITLE
Label: added "for" attribute when input "id" attribute is set for WCAG Standards

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
+<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
 
 @code {
     public static string __description__ = "Initial value should be shown and popup should not open.";

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerValidationTest.razor
@@ -2,7 +2,7 @@
 @namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm @bind-IsValid="fIsValid">
-    <MudDatePicker Label="Cheese it" Required="true" RequiredError="Please provide a date" @bind-Date="@(theDate)" />
+    <MudDatePicker id="datePickerLabelTest" Label="Cheese it" Required="true" RequiredError="Please provide a date" @bind-Date="@(theDate)" />
 </MudForm>
 
 Valid: @fIsValid

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
@@ -6,7 +6,7 @@
         @($"Status: {_submitStatus ?? "Not yet submitted/validated"}")
     </MudPaper>
     
-    <MudDateRangePicker @ref="@(_picker)" @bind-DateRange="@(_dateRange)" Label="Select Date Range" Required="true" RequiredError="This field is required!">
+    <MudDateRangePicker id="dateRangeLabelTest" @ref="@(_picker)" @bind-DateRange="@(_dateRange)" Label="Select Date Range" Required="true" RequiredError="This field is required!">
         <PickerActions>
             <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
             <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldTest.razor
@@ -11,7 +11,7 @@
         <MudField Label="Filled" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Outlined" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>
+        <MudField id="fieldLabelTest" Label="Outlined" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
@@ -1,6 +1,6 @@
 ﻿<div style="max-width: 400px;">
     <MudForm @ref="form1" @bind-IsValid="@valid" @bind-IsTouched="@touched" ValidationDelay="0" >
-        <MudTextField T="string" Label="First Name" />
+        <MudTextField id="textFieldLabelTest" T="string" Label="First Name"/>
         <MudTextField T="string" Required="true" Label="Last Name" />
     </MudForm>
     <div class="d-flex mt-5">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
@@ -1,9 +1,10 @@
-﻿<MudNumericField @bind-Value="_value"
+﻿<MudNumericField id="numericFieldLabelTest"
+                 @bind-Value="_value"
 				 Label="int 0, 10, 2"
 				 Variant="Variant.Text"
 				 Min="0"
 				 Max="10"
-				 Step="2" />
+                 Step="2" />
 <br/>
 <MudNumericField @bind-Value="_value2"
 				 Label="int 3, 10, 2"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectRequiredTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudSelect @bind-Value="value" Label="RequiredTest" Required="true">
+<MudSelect id="selectLabelTest" @bind-Value="value" Label="RequiredTest" Required="true">
     <MudSelectItem Value="@(string.Empty)" />
     <MudSelectItem Value="@("1")" />
     <MudSelectItem Value="@("2")" />

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -102,6 +102,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Autocomplete id should propagate to label for attribute
+        /// </summary>
+        [Test]
+        public void AutocompleteLabelFor()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var label = comp.FindAll(".mud-input-label");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("autocompleteLabelTest");
+        }
+
+        /// <summary>
         /// Autocomplete should show 'Assam' (using state.ToString())
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -29,6 +29,14 @@ namespace MudBlazor.UnitTests.Components
         }
         
         [Test]
+        public void DatePickerLabelFor()
+        {
+            var comp = Context.RenderComponent<DatePickerValidationTest>();
+            var label = comp.Find(".mud-input-label");
+            label.Attributes.GetNamedItem("for")?.Value.Should().Be("datePickerLabelTest");
+        }
+        
+        [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void DatePicker_Render_Performance()
         {

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -26,6 +26,14 @@ namespace MudBlazor.UnitTests.Components
         }
         
         [Test]
+        public void DateRangePickerLabelFor()
+        {
+            var comp = Context.RenderComponent<DateRangePickerValidationTest>();
+            var label = comp.Find(".mud-input-label");
+            label.Attributes.GetNamedItem("for")?.Value.Should().Be("dateRangeLabelTest");
+        }
+        
+        [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void RenderDateRangePicker_10000_Times_CheckPerformance()
         {

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -42,6 +42,17 @@ namespace MudBlazor.UnitTests.Components
         };
 
         /// <summary>
+        /// Numeric Field id should propagate to label for attribute
+        /// </summary>
+        [Test]
+        public void NumericFieldLabelFor()
+        {
+            var comp = Context.RenderComponent<NumericFieldTest>();
+            var label = comp.FindAll(".mud-input-label");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("numericFieldLabelTest");
+        }
+        
+        /// <summary>
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -20,6 +20,17 @@ namespace MudBlazor.UnitTests.Components
     public class SelectTests : BunitTest
     {
         /// <summary>
+        /// Select id should propagate to label for attribute
+        /// </summary>
+        [Test]
+        public void SelectLabelFor()
+        {
+            var comp = Context.RenderComponent<SelectRequiredTest>();
+            var label = comp.FindAll(".mud-input-label");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("selectLabelTest");
+        }
+
+        /// <summary>
         /// Click should open the Menu and selecting a value should update the bindable value.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -14,6 +14,8 @@ using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.TestComponents.Field;
+using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.UnitTests.TestComponents.TextField;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -23,6 +25,31 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TextFieldTests : BunitTest
     {
+        /// <summary>
+        /// Text Field id should propagate to label for attribute
+        /// </summary>
+        [Test]
+        public void TestFieldLabelFor()
+        {
+            var comp = Context.RenderComponent<FormIsValidTest3>();
+            var label = comp.FindAll(".mud-input-label");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("textFieldLabelTest");
+            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
+        }
+        
+        /// <summary>
+        /// Initial Text for double should be 0, with F1 format it should be 0.0
+        /// </summary>
+        [Test]
+        public async Task TextFieldLabelFor()
+        {
+            var comp = Context.RenderComponent<FieldTest>();
+            var label = comp.FindAll(".mud-input-label");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
+            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
+            label[2].Attributes.GetNamedItem("for")?.Value.Should().Be("fieldLabelTest");
+        }
+        
         /// <summary>
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
@@ -33,5 +34,10 @@ namespace MudBlazor
         [Parameter(CaptureUnmatchedValues = true)]
         [Category(CategoryTypes.ComponentBase.Common)]
         public Dictionary<string, object> UserAttributes { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
+        /// </summary>
+        public string FieldId => (UserAttributes?.ContainsKey("id") == true ? UserAttributes["id"].ToString() : $"mudinput-{Guid.NewGuid()}");
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -5,7 +5,7 @@
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
     <div class="mud-select mud-autocomplete">
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" HelperTextOnFocus="@HelperTextOnFocus" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
-                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
+                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required" ForId="@FieldId">
             <InputContent>
                 <MudInput @ref="_elementReference" @key="_elementKey" InputType="InputType.Text"
                           Class="mud-select-input" Margin="@Margin"

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -8,7 +8,7 @@
     protected override RenderFragment InputContent=> 
         @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@Error" 
                           ErrorText="@ErrorText" Disabled="@Disabled" Margin="@Margin" Required="@Required"
-                          @onclick="() => { if (!Editable) ToggleState(); }">
+                          @onclick="() => { if (!Editable) ToggleState(); }" ForId="@FieldId">
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"

--- a/src/MudBlazor/Components/Field/MudField.razor
+++ b/src/MudBlazor/Components/Field/MudField.razor
@@ -3,7 +3,7 @@
 @using MudBlazor.Internal
 
 <MudInputControl Label="@Label" HelperText="@HelperText" Variant="@Variant" FullWidth="@FullWidth" Margin="@Margin" Disabled="@Disabled"
-                 Class="@InputControlClassname" Error="@Error" ErrorText="@ErrorText" Style="@Style" @attributes="UserAttributes">
+                 Class="@InputControlClassname" Error="@Error" ErrorText="@ErrorText" Style="@Style" @attributes="UserAttributes" ForId="@FieldId">
     <InputContent>
         <div class="@Classname">
             @if (Adornment == Adornment.Start)

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-
-<label @attributes="UserAttributes" class="@Classname" style="@Style">
+<label @attributes="UserAttributes" class="@Classname" style="@Style" for="@ForId">
     @ChildContent
 </label>

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -42,5 +42,9 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public Margin Margin { get; set; } = Margin.None;
 
+        /// <summary>
+        ///  Will set the for attribute for WCAG accessiblility
+        /// </summary>
+        [Parameter] public string ForId { get; set; } = string.Empty;
     }
 }

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -6,7 +6,8 @@
         @InputContent
         @if (!String.IsNullOrEmpty(Label))
         {
-            <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" Margin="@Margin">
+            <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" 
+                           Margin="@Margin" ForId="@ForId">
                 @Label
             </MudInputLabel>
         }

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -92,5 +92,9 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool Disabled { get; set; }
 
+        /// <summary>
+        /// If string has value the label "for" attribute will be added.
+        /// </summary>
+        [Parameter] public string ForId { get; set; } = string.Empty;
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -17,7 +17,8 @@
                      Disabled="@Disabled"
                      Margin="@Margin"
                      Required="@Required"
-                     CounterText="@GetCounterText()">
+                     CounterText="@GetCounterText()"
+                     ForId="@FieldId">
         <InputContent>
             <CascadingValue Name="Standalone" Value="false" IsFixed="true">
                 <MudInput T="string"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -5,7 +5,7 @@
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
 	<div class="mud-select" id="@_elementId">
 		<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" HelperTextOnFocus="@HelperTextOnFocus" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
-						 Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
+						 Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required" ForId="@FieldId">
 			<InputContent>
                 <MudInput @ref="_elementReference" InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
                           Class="mud-select-input" Margin="@Margin" Placeholder="@Placeholder"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -14,7 +14,8 @@
                      ErrorText="@GetErrorText()"
                      Disabled="@Disabled"
                      Margin="@Margin"
-                     Required="@Required">
+                     Required="@Required"
+                     ForId="@FieldId">
         <InputContent>
             <CascadingValue Name="Standalone" Value="false" IsFixed="true">
                 @if (_mask == null)


### PR DESCRIPTION
Added responsive handling of field's that include an "id" `UserAttribute` and propagates it to the "for" attribute on the associated label

## Description
A step in the progress towards WCAG (accessibility) compliance. This is discussed in #2233 and #2187. There is no functional change, it only improves accessibility. When a field, textField, autocomplete, select, datePicker, daterangepicker includes an HTML attribute for "id" the associated label generates an HTML "for" attribute.

## How Has This Been Tested?
Manually inspected on the following test components with a respective id placed in the tests:

- autocomplete: AutocompleteTest1
- date range picker: DateRangePickerValidationTest
- date picker: DatePickerValidationTest
- field: FieldTest
- numeric field: NumericFieldTest
- select: SelectRequiredTest
- text field: FormIsValidTest3

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![image](https://user-images.githubusercontent.com/24905572/156889088-2ac80f23-b263-493c-abe1-77b501a6f3c0.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
