### PR TITLE
Pagination : Add default English aria-labels

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -52,6 +52,51 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Tests the aria-labels for the control buttons
+        /// </summary>
+        /// <param name="controlButton">The type of the control button. Page.First for the navigate-to-first-page button.</param>
+        /// <param name="expectedButtonAriaLabel">The expected value in the aria-label.</param>
+        [TestCase(Page.First, "First page")]
+        [TestCase(Page.Previous, "Previous page")]
+        [TestCase(Page.Next, "Next page")]
+        [TestCase(Page.Last, "Last page")]
+        [Test]
+        public void PaginationControlButtonAriaLabelTest(Page controlButton, string expectedButtonAriaLabel)
+        {
+            var comp = Context.RenderComponent<PaginationButtonTest>();
+            //Console.WriteLine(comp.Markup);
+
+            //get control button
+            var button = FindControlButton(comp, controlButton);
+
+            //Expected values
+            button.Attributes.GetNamedItem("aria-label")?.Value.Should().Be(expectedButtonAriaLabel);
+        }
+
+        /// <summary>
+        /// Tests the aria-labels for the page buttons. . . note the index's aren't sequential because there are elements of "..."
+        /// </summary>
+        /// <param name="index">The index of the control button. first page button has index 2.</param>
+        /// <param name="label">The expected value in the aria-label.</param>
+        [TestCase(2, "Page 1")]
+        [TestCase(3, "Page 2")]
+        [TestCase(5, "Current page 6")]
+        [TestCase(7, "Page 10")]
+        [TestCase(8, "Page 11")]
+        [Test]
+        public void PaginationPageButtonAriaLabelTest(int index, string label)
+        {
+            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var buttons = comp.FindAll(".mud-pagination-item button");
+            var button = buttons[index];
+            button.Attributes.GetNamedItem("aria-label")?.Value.Should().Be(label);
+            if (index == 5)
+            {
+                button.Attributes.GetNamedItem("aria-current")?.Value.Should().Be("page");
+            }
+        }
+        
+        /// <summary>
         /// Tests the event callbacks of control button click events
         /// </summary>
         /// <param name="controlButton">The type of the control button. Page.First for the navigate-to-first-page button.</param>

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -6,13 +6,13 @@
     @if (ShowFirstButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.First))"></MudIconButton>
+            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.First))" aria-label="First page"></MudIconButton>
         </li>
     }
     @if (ShowPreviousButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.Previous))"></MudIconButton>
+            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.Previous))" aria-label="Previous page"></MudIconButton>
         </li>
     }
     @foreach (var state in GeneratePagination())
@@ -27,25 +27,25 @@
         else if (currentPage == Selected)
         {
             <li class="@SelectedItemClassname">
-                <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" DisableRipple="true" Disabled="@Disabled" Color="@Color">@currentPage</MudButton>
+                <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" DisableRipple="true" Disabled="@Disabled" Color="@Color" aria-current="page" aria-label="@($"Current page {currentPage}")">@currentPage</MudButton>
             </li>
         }
         else {
             <li class="@ItemClassname">
-                <MudButton OnClick="@(() => Selected = currentPage)" Variant="@Variant" Size="@Size" DisableRipple="true" Disabled="@Disabled">@currentPage</MudButton>
+                <MudButton OnClick="@(() => Selected = currentPage)" Variant="@Variant" Size="@Size" DisableRipple="true" Disabled="@Disabled" aria-label="@($"Page {currentPage}")">@currentPage</MudButton>
             </li>
         }
     }
     @if (ShowNextButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Next))"></MudIconButton>
+            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Next))" aria-label="Next page"></MudIconButton>
         </li>
     }
     @if (ShowLastButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Last))"></MudIconButton>
+            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Last))" aria-label="Last page"></MudIconButton>
         </li>
     }
 </MudElement>


### PR DESCRIPTION
Added default English aria-labels for paginator.

## Description
Simply added `aria-label` attributes for the paginator buttons and numbers for WCAG compliance. This is discussed in #2233 and #2187. No functional changes.

## How Has This Been Tested?
Manual inspection of test files

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
