### PR TITLE
CSS Fix: MudTable and MudSimpleTable missing border radius

### DIFF
--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -109,6 +109,10 @@
                 border-radius: var(--mud-default-borderradius) 0 0 0;
             }
 
+            & * th:last-child {
+                border-radius: 0 var(--mud-default-borderradius) 0 0;
+            }
+
             & * th {
                 background-color: var(--mud-palette-surface);
                 position: sticky;

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -183,6 +183,10 @@
                 border-radius: var(--mud-default-borderradius) 0px 0px 0px;
             }
 
+            & * .mud-table-cell:last-child {
+                border-radius: 0px var(--mud-default-borderradius) 0px 0px;
+            }
+
             & * .mud-table-cell {
                 background-color: var(--mud-palette-surface);
                 position: sticky;


### PR DESCRIPTION
This PR fixes a missing top right border radius for MudTable, MudSimpleTable, and presumably MudDataGrid when using the FixedHeader feature.  The issue is initially only present when the scrollbar is not visible however on more extreme border radius settings the table header cell background can be seen with or without the scroll bar.

Demonstrated here.
https://try.mudblazor.com/snippet/QaQmkdFDygPwuJVy

## Description
I've applied the equivalent style on `:first-child` to `:last-child` for these components.

## How Has This Been Tested?
visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![image](https://user-images.githubusercontent.com/7678016/159121572-cca53e3b-a8fc-4776-8fa2-f959c3fbe2d1.png)

After:
![image](https://user-images.githubusercontent.com/7678016/159121557-c5ebcf58-c7b6-4e73-bb03-23c5b5e6bc06.png)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
