### PR TITLE
DatePicker: Navigate programmatically with GoToDate

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -104,15 +104,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Move To Date">
+            <SectionHeader Title="Go To Date">
                 <Description>
-                    <CodeInline>MoveToDate</CodeInline> method helps to control the component programmatically. With <CodeInline>MoveToDate</CodeInline> users can navigate between dates with or without submitting. Works with all picker variants.
+                    <CodeInline>GoToDate</CodeInline> method helps to control the component programmatically. With <CodeInline>GoToDate</CodeInline>, users can navigate between dates with or without submitting. Works with all picker variants.
                     <br />
-                    This example shows the possible usage of <CodeInline>MoveToDate</CodeInline>.
+                    This example shows the possible usage of <CodeInline>GoToDate</CodeInline>.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="DatePickerMoveToDateExample" DarkenBackground="true" ShowCode="false">
-                <DatePickerMoveToDateExample/>
+            <SectionContent Code="DatePickerGoToDateExample" DarkenBackground="true" ShowCode="false">
+                <DatePickerGoToDateExample/>
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -104,6 +104,19 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Move To Date">
+                <Description>
+                    <CodeInline>MoveToDate</CodeInline> method helps to control the component programmatically. With <CodeInline>MoveToDate</CodeInline> users can navigate between dates with or without submitting. Works with all picker variants.
+                    <br />
+                    This example shows the possible usage of <CodeInline>MoveToDate</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="DatePickerMoveToDateExample" DarkenBackground="true" ShowCode="false">
+                <DatePickerMoveToDateExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Fixed Values Usage">
                 <Description>
                     You can set fix values for day, month or year via <CodeInline>FixDay</CodeInline>, <CodeInline>FixMonth</CodeInline> and <CodeInline>FixYear</CodeInline>, default value is null for all of them.

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
@@ -21,27 +21,27 @@
     {
         if (firstRender)
         {
-            _picker.MoveToDate();
+            _picker.GoToDate();
         }
     }
 
     private async Task Today()
     {
-        await _picker.MoveToDate(DateTime.Today);
+        await _picker.GoToDate(DateTime.Today);
     }
 
     private void CurrentDate()
     {
-        _picker.MoveToDate();
+        _picker.GoToDate();
     }
 
     private async Task MudRelease()
     {
-        await _picker.MoveToDate(new DateTime(2020, 09, 11));
+        await _picker.GoToDate(new DateTime(2020, 09, 11));
     }
 
     private async Task GoMaxDateWithoutSubmit()
     {
-        await _picker.MoveToDate(maxDate.Value, false);
+        await _picker.GoToDate(maxDate.Value, false);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
@@ -8,7 +8,7 @@
 
 <div class="d-flex flex-column gap-4">
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CurrentDate">Move To Current Date</MudButton>
-    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="MudRelease">When Mud 1.0 Released?</MudButton>
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="MudRelease">When First Mud Released?</MudButton>
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="GoMaxDateWithoutSubmit">Go To Max Date Without Submit</MudButton>
 </div>
 
@@ -37,7 +37,7 @@
 
     private async Task MudRelease()
     {
-        await _picker.GoToDate(new DateTime(2020, 09, 11));
+        await _picker.GoToDate(new DateTime(2020, 10, 18));
     }
 
     private async Task GoMaxDateWithoutSubmit()

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMoveToDateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMoveToDateExample.razor
@@ -1,0 +1,47 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDatePicker @ref="_picker" @bind-Date="date" PickerVariant="PickerVariant.Static" MaxDate="maxDate">
+    <PickerActions>
+        <MudButton Class="mr-auto align-self-start" OnClick="Today">Today</MudButton>
+    </PickerActions>
+</MudDatePicker>
+
+<div class="d-flex flex-column gap-4">
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CurrentDate">Move To Current Date</MudButton>
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="MudRelease">When Mud 1.0 Released?</MudButton>
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="GoMaxDateWithoutSubmit">Go To Max Date Without Submit</MudButton>
+</div>
+
+@code {
+    MudDatePicker _picker;
+    DateTime? date = DateTime.Today.AddDays(210);
+    DateTime? maxDate = new DateTime(2050, 12, 31);
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _picker.MoveToDate();
+        }
+    }
+
+    private async Task Today()
+    {
+        await _picker.MoveToDate(DateTime.Today);
+    }
+
+    private void CurrentDate()
+    {
+        _picker.MoveToDate();
+    }
+
+    private async Task MudRelease()
+    {
+        await _picker.MoveToDate(new DateTime(2020, 09, 11));
+    }
+
+    private async Task GoMaxDateWithoutSubmit()
+    {
+        await _picker.MoveToDate(maxDate.Value, false);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -807,5 +807,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.ToggleState());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
         }
+
+        [Test]
+        public async Task DatePickerTest_MoveToDate()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+
+            var datePicker = comp.FindComponent<MudDatePicker>().Instance;
+
+            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2022, 03, 20)));
+            comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2022, 03, 20)));
+
+            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2023, 04, 21), false));
+            comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2022, 03, 20)));
+
+            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2023, 04, 21)));
+            comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2023, 04, 21)));
+
+            await comp.InvokeAsync(() => datePicker.MoveToDate());
+            comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2023, 04, 21)));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -809,22 +809,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DatePickerTest_MoveToDate()
+        public async Task DatePickerTest_GoToDate()
         {
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
 
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
 
-            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2022, 03, 20)));
+            await comp.InvokeAsync(() => datePicker.GoToDate(new DateTime(2022, 03, 20)));
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2022, 03, 20)));
 
-            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2023, 04, 21), false));
+            await comp.InvokeAsync(() => datePicker.GoToDate(new DateTime(2023, 04, 21), false));
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2022, 03, 20)));
 
-            await comp.InvokeAsync(() => datePicker.MoveToDate(new DateTime(2023, 04, 21)));
+            await comp.InvokeAsync(() => datePicker.GoToDate(new DateTime(2023, 04, 21)));
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2023, 04, 21)));
 
-            await comp.InvokeAsync(() => datePicker.MoveToDate());
+            await comp.InvokeAsync(() => datePicker.GoToDate());
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2023, 04, 21)));
         }
     }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -542,7 +542,7 @@ namespace MudBlazor
             return Typo.subtitle1;
         }
 
-
+        
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -287,5 +287,30 @@ namespace MudBlazor
         {
             Close();
         }
+
+        /// <summary>
+        /// Scrolls to the date.
+        /// </summary>
+        public void MoveToDate()
+        {
+            if (Date.HasValue)
+            {
+                PickerMonth = new DateTime(Date.Value.Year, Date.Value.Month, 1);
+                ScrollToYear();
+            }
+        }
+
+        /// <summary>
+        /// Scrolls to the defined date.
+        /// </summary>
+        public async Task MoveToDate(DateTime date, bool submitDate = true)
+        {
+            PickerMonth = new DateTime(date.Year, date.Month, 1);
+            if (submitDate)
+            {
+                await SetDateAsync(date, true);
+                ScrollToYear();
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -291,7 +291,7 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to the date.
         /// </summary>
-        public void MoveToDate()
+        public void GoToDate()
         {
             if (Date.HasValue)
             {
@@ -303,7 +303,7 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to the defined date.
         /// </summary>
-        public async Task MoveToDate(DateTime date, bool submitDate = true)
+        public async Task GoToDate(DateTime date, bool submitDate = true)
         {
             PickerMonth = new DateTime(date.Year, date.Month, 1);
             if (submitDate)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Why We Need This
We just fixed DatePicker date when dropdown opens in last release. But we have still issues in static picker etc. And i also think we can not cover all possible situations.

So the best way is adding a basic, simple method in API: `MoveToDate`

With this basic version, just called and date scrolls and shows the DatePicker's date (if it not null)

With the overrided version, user can set a date whatever they want and go to this date with or without submitting.

## Usage Examples
- Can add Today button in picker actions easily,
- Navigate MinDate or MaxDate with one click.
- Can use for possible situations when date changed but the visual did not. So solves all possible visual bugs. (Its not about StateHasChanged because visual is controlled by PickerMonth property)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


https://user-images.githubusercontent.com/78308169/159156612-3ed6899b-1148-4644-be3a-d687b7c0bff2.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
