### PR TITLE
MudSimpleTable: Fix TableContext null reference exception

### DIFF
--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -60,7 +60,8 @@ namespace MudBlazor
 
         public void OnRowClicked(MouseEventArgs args)
         {
-            if (Context?.Table.IsEditable == true && Context?.Table.IsEditing == true && Context?.Table.IsEditRowSwitchingBlocked == true) return;
+            if (Context == null || (Context?.Table.IsEditable == true && Context?.Table.IsEditing == true && Context?.Table.IsEditRowSwitchingBlocked == true)) 
+                return;
 
             // Manage any previous edited row
             Context.ManagePreviousEditedRow(this);


### PR DESCRIPTION
## Description
Added null checking for `TableContext Context` for `MudTr`

Resolves: [Issue](https://github.com/MudBlazor/MudBlazor/issues/4247)

## How Has This Been Tested?
Ran all table tests to see if anything was broken. I wasnt sure how to add test for this as it seems theres no `MudSimpleTable` tests. It seems `TableRowClickTest` is using `MudTable`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [] I've added relevant tests.
