### PR TITLE
improvements to EnumExtensions.ToDescriptionString

### DIFF
--- a/src/MudBlazor.Docs/Components/NavigationFooter.razor
+++ b/src/MudBlazor.Docs/Components/NavigationFooter.razor
@@ -4,7 +4,7 @@
         <MudButton Color="Color.Primary"
                    Style="text-transform:none;"
                    StartIcon="@Icons.Filled.NavigateBefore"
-                   Link="@($"{Section.ToDescriptionString()}/{Previous.Link}")">
+                   Link="@($"{Section?.ToDescriptionString()}/{Previous.Link}")">
             @Previous.Name
         </MudButton>
     }
@@ -14,7 +14,7 @@
         <MudButton Color="Color.Primary"
                    Style="float:right;text-transform:none;"
                    EndIcon="@Icons.Filled.NavigateNext"
-                   Link="@($"{Section.ToDescriptionString()}/{Next.Link}")">
+                   Link="@($"{Section?.ToDescriptionString()}/{Next.Link}")">
             @Next.Name
         </MudButton>
     }

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,21 +1,17 @@
 ﻿using FluentAssertions;
 using MudBlazor.Extensions;
-
-
 using NUnit.Framework;
 
+namespace MudBlazor.UnitTests.Extensions;
 
-namespace MudBlazor.UnitTests.Extensions
+[TestFixture]
+public class EnumExtensionsTests
 {
-    [TestFixture]
-    public class EnumExtensionsTests
+    [Test]
+    public void ToDescriptionString()
     {
-        [Test]
-        public void ToDescriptionString()
-        {
-            Adornment.Start.ToDescriptionString().Should().Be("start");
-            Align.Inherit.ToDescriptionString().Should().Be("inherit");
-            Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
-        }
+        Adornment.Start.ToDescriptionString().Should().Be("start");
+        Align.Inherit.ToDescriptionString().Should().Be("inherit");
+        Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
     }
 }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -1,17 +1,20 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.ComponentModel;
+using System.Reflection;
 
-namespace MudBlazor.Extensions
+namespace MudBlazor.Extensions;
+
+public static class EnumExtensions
 {
-    public static class EnumExtensions
+    public static string? ToDescriptionString<T>(this T val)
+        where T : Enum
     {
-        public static string ToDescriptionString(this Enum val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
+        var field = typeof(T).GetField(val.ToString())!;
+        var attribute = field.GetCustomAttribute<DescriptionAttribute>(false);
 
-            return attributes.Length > 0
-                ? attributes[0].Description
-                : val.ToString().ToLower();
-        }
+        return attribute != null
+            ? attribute.Description
+            : val.ToString().ToLower();
     }
 }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -7,7 +7,7 @@ namespace MudBlazor.Extensions;
 
 public static class EnumExtensions
 {
-    public static string? ToDescriptionString<T>(this T val)
+    public static string ToDescriptionString<T>(this T val)
         where T : Enum
     {
         var field = typeof(T).GetField(val.ToString())!;


### PR DESCRIPTION
 * leverage `where T : Enum` to enforce only enums
 * `typeof(T)` instead of `instance.GetType()`
 * use singular + generic `GetCustomAttribute`