### PR TITLE
MudTimePicker: Fix empty string throwing error (#3121)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -370,11 +370,12 @@ namespace MudBlazor.UnitTests.Components
             // valid time
             comp.Find("input").Change("23:02");
             picker.TimeIntermediate.Should().Be(new TimeSpan(23, 2, 0));
+            // empty string equals null TimeSpan?
+            comp.Find("input").Change("");
+            picker.TimeIntermediate.Should().BeNull();
+            picker.Error.Should().BeFalse();
             // invalid time
             comp.Find("input").Change("25:06");
-            picker.TimeIntermediate.Should().BeNull();
-            // invalid time
-            comp.Find("input").Change("");
             picker.TimeIntermediate.Should().BeNull();
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -37,6 +37,9 @@ namespace MudBlazor
 
         private TimeSpan? OnGet(string value)
         {
+            if (string.IsNullOrEmpty(value))
+                return null;
+
             if (DateTime.TryParseExact(value, ((DefaultConverter<TimeSpan?>)Converter).Format, Culture, DateTimeStyles.None, out var time))
             {
                 return time.TimeOfDay;


### PR DESCRIPTION
## Description
If MudTimePicker is editable entering an empty string was considered invalid. This resulted in a error message on screen. This fix allows an empty string to be entered resulting in a null TimeSpan.
Fixes #3121

## How Has This Been Tested?
There was already an unit test testing for entering a empty string. This unit test has been expanded by testing on the error state after conversion from string to TimeSpan?.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
