### PR TITLE
DatePicker and TimePicker: Clear shouldn't close the picker when AutoClose is false

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -551,6 +551,7 @@ namespace MudBlazor.UnitTests.Components
                 .Should().OnlyContain(disabled => disabled == false);
         }
 
+        [Test]
         public async Task CheckAutoCloseDatePickerTest()
         {
             // Define a date for comparison
@@ -585,6 +586,13 @@ namespace MudBlazor.UnitTests.Components
             // The date of the datepicker remains equal to now 
             await comp.InvokeAsync(() => datePicker.Instance.Close(false));
 
+            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => datePicker.Instance.Clear());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+            await comp.InvokeAsync(() => datePicker.Instance.Close(false));
+
             // Change the value of autoclose
             datePicker.Instance.AutoClose = true;
 
@@ -612,6 +620,12 @@ namespace MudBlazor.UnitTests.Components
             {
                 datePicker.Instance.Date.Should().Be(new DateTime(now.Year, now.Month, 19));
             }
+
+            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => datePicker.Instance.Clear());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(0));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -666,48 +666,51 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(0));
         }
 
+        [Test]
         public async Task CheckReadOnlyTest()
         {
             // Get access to the timepicker of the instance
-            var comp = Context.RenderComponent<MudTimePicker>();
-            var picker = comp.Instance;
-
+            var comp = Context.RenderComponent<SimpleTimePickerTest>();
+            var picker = comp.FindComponent<MudTimePicker>().Instance;
+            comp.WaitForAssertion(() => picker.Time.Should().Be(null));
             // Open the timepicker
             await comp.InvokeAsync(() => picker.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 16 hours
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click());
             picker.TimeIntermediate.Value.Hours.Should().Be(16);
 
             // Select 30 minutes
-            comp.FindAll("div.mud-minute")[30].Click();
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click());
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);
 
             // Click outside of the timepicker
-            comp.Find("div.mud-overlay").Click();
+            await comp.InvokeAsync(() => comp.Find("div.mud-overlay").Click());
 
             // Check that the time have been changed
-            picker.Time.Should().Be(new TimeSpan(16, 30, 00));
+            comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
 
             // Changer the readonly to true
-            picker.ReadOnly = true;
+            await comp.InvokeAsync(() => picker.ReadOnly = true);
 
             // Open the timepicker
             await comp.InvokeAsync(() => picker.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 17 hours
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
-            picker.TimeIntermediate.Value.Hours.Should().Be(17);
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click());
+            comp.WaitForAssertion(() => picker.TimeIntermediate.Value.Hours.Should().Be(17));
 
             // Select 31 minutes
-            comp.FindAll("div.mud-minute")[34].Click();
-            picker.TimeIntermediate.Value.Minutes.Should().Be(34);
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[34].Click());
+            comp.WaitForAssertion(() => picker.TimeIntermediate.Value.Minutes.Should().Be(34));
 
             // Click outside of the timepicker
-            comp.Find("div.mud-overlay").Click();
+            await comp.InvokeAsync(() => comp.Find("div.mud-overlay").Click());
 
             // Check that the time have not been changed
-            picker.Time.Should().Be(new TimeSpan(16, 30, 00));
+            comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -631,6 +631,13 @@ namespace MudBlazor.UnitTests.Components
             // and there are actions which are defined
             picker.Time.Should().Be(new TimeSpan(00, 45, 00));
 
+            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => timePicker.Instance.Clear());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+            await comp.InvokeAsync(() => timePicker.Instance.Close(false));
+
             // Change the value of autoclose
             timePicker.Instance.AutoClose = true;
 
@@ -651,6 +658,12 @@ namespace MudBlazor.UnitTests.Components
 
             // Check that the time should be equal to the selection this time!
             picker.Time.Should().Be(new TimeSpan(16, 30, 00));
+
+            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => timePicker.Instance.Clear());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(0));
         }
 
         public async Task CheckReadOnlyTest()

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -800,6 +800,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(null));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(null));
+
+            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             //When its disabled, keys should not work
             timePicker.Disabled = true;
             timePicker.FocusAsync().AndForget();

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -171,11 +171,15 @@ namespace MudBlazor
             _selectedDate = null;
         }
 
-        public override void Clear(bool close = true)
+        public override async void Clear(bool close = true)
         {
-            Date = null;
             _selectedDate = null;
-            base.Clear();
+            await SetDateAsync(null, true);
+
+            if (AutoClose == true)
+            {
+                Close(false);
+            }
         }
 
         protected override string GetTitleDateString()

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -337,11 +337,12 @@ namespace MudBlazor
             IsOpen = false;
 
             if (submit)
+            {
                 Submit();
-
-            StateHasChanged();
+            }
 
             OnClosed();
+            StateHasChanged();
         }
 
         public void Open()

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -194,11 +194,15 @@ namespace MudBlazor
             Time = TimeIntermediate;
         }
 
-        public override void Clear(bool close = true)
+        public override async void Clear(bool close = true)
         {
-            Time = null;
             TimeIntermediate = null;
-            base.Clear();
+            await SetTimeAsync(null, true);
+
+            if (AutoClose == true)
+            {
+                Close(false);
+            }
         }
 
         private string GetHourString()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4271.

Calling Clear() now didn't close picker if AutoClose is false.

And datepicker's AutoClose test misses the [Text] attribute and don't behave like a test, we added it.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->


https://user-images.githubusercontent.com/78308169/160247847-b95dad9e-d2ad-44e3-b082-3d36dc48fefc.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
