### PR TITLE
MudInput: Hide Clear Button When Readonly

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFormPropsReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFormPropsReadOnlyExample.razor
@@ -2,7 +2,7 @@
 
 <MudTextField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Text" />
 <MudTextField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Filled" />
-<MudTextField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Outlined" />
+<MudTextField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Outlined" Clearable="true" />
 
 @code {
     public string ReadOnly { get; set; } = "Can't change me";

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -388,6 +388,16 @@ namespace MudBlazor
             return changed;
         }
 
+        protected virtual async Task ClearButtonClickHandlerAsync(MouseEventArgs e)
+        {
+            if (ReadOnly)
+            {
+                return;
+            }
+
+            await SetTextAsync(string.Empty, updateValue: true);
+        }
+
         protected override Task ValidateValue()
         {
             if (Standalone)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -170,6 +170,11 @@ namespace MudBlazor
 
         protected virtual async Task ClearButtonClickHandlerAsync(MouseEventArgs e)
         {
+            if (ReadOnly)
+            {
+                return;
+            }
+
             await SetTextAsync(string.Empty, updateValue: true);
             await OnClearButtonClick.InvokeAsync(e);
         }

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -168,14 +168,9 @@ namespace MudBlazor
                 UpdateClearable(Value);
         }
 
-        protected virtual async Task ClearButtonClickHandlerAsync(MouseEventArgs e)
+        protected override async Task ClearButtonClickHandlerAsync(MouseEventArgs e)
         {
-            if (ReadOnly)
-            {
-                return;
-            }
-
-            await SetTextAsync(string.Empty, updateValue: true);
+            await base.ClearButtonClickHandlerAsync(e);
             await OnClearButtonClick.InvokeAsync(e);
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -772,6 +772,11 @@ namespace MudBlazor
         /// </summary>
         protected async ValueTask SelectClearButtonClickHandlerAsync(MouseEventArgs e)
         {
+            if (ReadOnly)
+            {
+                return;
+            }
+
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedValues.Clear();

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -772,11 +772,6 @@ namespace MudBlazor
         /// </summary>
         protected async ValueTask SelectClearButtonClickHandlerAsync(MouseEventArgs e)
         {
-            if (ReadOnly)
-            {
-                return;
-            }
-
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedValues.Clear();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4275.

If a component is disabled, clearable button even doesn't show. But we didn't prepared anything about readonly.

When we set readonly true, clearable button still shows, but when user click it, nothing happens.

In docs, added a clearable reanonly textfield component in readonly textfield example to test it manually.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->


https://user-images.githubusercontent.com/78308169/160248655-2656943c-4801-45fe-85c8-66fb7ae19fa9.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
