### PR TITLE
Fix Title property for MudIconButton

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
@@ -1,0 +1,16 @@
+﻿<MudIconButton Icon="@Icons.Material.Filled.Favorite"
+			   Color="Color.Secondary"
+			   Title="This should appear when hovering over the button, not just the icon" />
+
+<MudFab Icon="@Icons.Material.Filled.Sailing"
+		Color="Color.Secondary"
+		Title="This should appear when hovering over the button, not just the icon" />
+
+		
+<MudFab Icon="@Icons.Material.Filled.RestoreFromTrash"
+		Color="Color.Secondary" />
+		
+@code
+{
+	public static string __description__ = "Test icon button title and visual behaviour.";
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -174,13 +174,11 @@ namespace MudBlazor.UnitTests.Components
             var icon = Parameter(nameof(MudIconButton.Icon), Icons.Filled.Add);
             var titleParam = Parameter(nameof(MudIconButton.Title), title);
             var comp = Context.RenderComponent<MudIconButton>(icon, titleParam);
-            comp.Find("svg Title").TextContent.Should().Be(title);
+            comp.Find($"button[title=\"{title}\"]");
 
             icon = Parameter(nameof(MudIconButton.Icon), "customicon");
             comp.SetParametersAndRender(icon, titleParam);
-            comp.Find("button span.mud-icon-button-label").InnerHtml.Trim().Should().StartWith("<span")
-                .And.Contain("customicon")
-                .And.Contain($"title=\"{title}\"");
+            comp.Find($"button[title=\"{title}\"]");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -65,11 +65,11 @@ namespace MudBlazor.UnitTests.Components
             var titleParam = Parameter(nameof(MudToggleIconButton.Title), title);
             var toggledTitleParam = Parameter(nameof(MudToggleIconButton.ToggledTitle), toggledTitle);
             var comp = Context.RenderComponent<MudToggleIconButton>(icon, toggledIcon, titleParam, toggledTitleParam);
-            comp.Find("svg Title").TextContent.Should().Be(title);
+            comp.Find($"button[title=\"{title}\"]");
             comp.Find("button").Click();
-            comp.Find("svg Title").TextContent.Should().Be(toggledTitle);
+            comp.Find($"button[title=\"{toggledTitle}\"]");
             comp.Find("button").Click();
-            comp.Find("svg Title").TextContent.Should().Be(title);
+            comp.Find($"button[title=\"{title}\"]");
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -12,16 +12,17 @@
             href="@Href"
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
-            disabled="@Disabled">
+            disabled="@Disabled"
+			title="@Title">
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {
-            <MudIcon Icon="@StartIcon" Color="@IconColor" Size="@IconSize"></MudIcon>
+            <MudIcon Icon="@StartIcon" Color="@IconColor" Size="@IconSize" />
         }
         @Label
         @if (!string.IsNullOrWhiteSpace(EndIcon))
         {
-            <MudIcon Icon="@EndIcon" Color="@IconColor" Size="@IconSize"></MudIcon>
+            <MudIcon Icon="@EndIcon" Color="@IconColor" Size="@IconSize" />
         }
     </span>
 </MudElement>

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -70,5 +70,12 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public string Label { get; set; }
+
+        /// <summary>
+        /// Title of the icon used for accessibility.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Button.Behavior)]
+        public string Title { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -12,11 +12,12 @@
             href="@Href" 
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
-            disabled="@Disabled">
+            disabled="@Disabled"
+			title="@Title">
     @if (!String.IsNullOrEmpty(Icon))
     {
         <span class="mud-icon-button-label">
-            <MudIcon Icon="@Icon" Size="@Size" Title="@Title" />
+            <MudIcon Icon="@Icon" Size="@Size" />
         </span>
     }
     else


### PR DESCRIPTION
Add and fixes the Title property for Icons.

## Description
Fixes issue #2818 and adds the Title property to MudFab.
The affected components are:

- MudFab
- MudIconButton (and all components that rely on it, passing a Title property)
- MudToggleIconButton

## How Has This Been Tested?
Update unit tests to look for the title property on the button tag instead of the SVG, as well as visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
