### PR TITLE
Select: Multiselect Touch Fix

### DIFF
--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -23,6 +23,8 @@ namespace MudBlazor
 
         [CascadingParameter] protected MudList MudList { get; set; }
 
+        private bool _onClickHandlerPreventDefault = false;
+
         /// <summary>
         /// The text to display
         /// </summary>
@@ -196,6 +198,14 @@ namespace MudBlazor
         [Category(CategoryTypes.List.Behavior)]
         public RenderFragment ChildContent { get; set; }
 
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool OnClickHandlerPreventDefault
+        {
+            get => _onClickHandlerPreventDefault;
+            set => _onClickHandlerPreventDefault = value;
+        }
+
         /// <summary>
         /// Add child list items here to create a nested list.
         /// </summary>
@@ -211,7 +221,7 @@ namespace MudBlazor
 
         protected void OnClickHandler(MouseEventArgs ev)
         {
-            if (Disabled)
+            if (Disabled || _onClickHandlerPreventDefault)
                 return;
             if (NestedList != null)
             {

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -221,26 +221,33 @@ namespace MudBlazor
 
         protected void OnClickHandler(MouseEventArgs ev)
         {
-            if (Disabled || _onClickHandlerPreventDefault)
+            if (Disabled)
                 return;
-            if (NestedList != null)
+            if (!_onClickHandlerPreventDefault)
             {
-                Expanded = !Expanded;
-            }
-            else if (Href != null)
-            {
-                MudList?.SetSelectedValue(this.Value);
-                OnClick.InvokeAsync(ev);
-                UriHelper.NavigateTo(Href, ForceLoad);
+                if (NestedList != null)
+                {
+                    Expanded = !Expanded;
+                }
+                else if (Href != null)
+                {
+                    MudList?.SetSelectedValue(this.Value);
+                    OnClick.InvokeAsync(ev);
+                    UriHelper.NavigateTo(Href, ForceLoad);
+                }
+                else
+                {
+                    MudList?.SetSelectedValue(this.Value);
+                    OnClick.InvokeAsync(ev);
+                    if (Command?.CanExecute(CommandParameter) ?? false)
+                    {
+                        Command.Execute(CommandParameter);
+                    }
+                }
             }
             else
             {
-                MudList?.SetSelectedValue(this.Value);
                 OnClick.InvokeAsync(ev);
-                if (Command?.CanExecute(CommandParameter) ?? false)
-                {
-                    Command.Execute(CommandParameter);
-                }
             }
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -27,7 +27,7 @@
 						<MudList Clickable="true" Dense="@Dense" @bind-SelectedValue="_activeItemId">
                             @if (MultiSelection && SelectAll)
 							{
-								<MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" @onmousedown="SelectAllClickAsync" OnClickHandlerPreventDefault="true" Dense="@Dense" Class="mb-2" />
+								<MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" OnClick="SelectAllClickAsync" OnClickHandlerPreventDefault="true" Dense="@Dense" Class="mb-2" />
                                 <MudDivider />
 							}
 							@ChildContent
@@ -46,4 +46,4 @@
 
 </CascadingValue>
 <!-- mousedown instead of click needed to close the menu before OnLostFocus runs -->
-<MudOverlay Visible="_isOpen" @onmousedown="@(() => CloseMenu(false))" @ontouchstart="@(() => CloseMenu(false))" LockScroll="@LockScroll" />
+<MudOverlay Visible="_isOpen" @onmousedown="@(() => CloseMenu(false))" LockScroll="@LockScroll" />

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -27,7 +27,7 @@
 						<MudList Clickable="true" Dense="@Dense" @bind-SelectedValue="_activeItemId">
                             @if (MultiSelection && SelectAll)
 							{
-								<MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" OnClick="SelectAllClickAsync" Dense="@Dense" Class="mb-2" />
+								<MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" @onmousedown="SelectAllClickAsync" OnClickHandlerPreventDefault="true" Dense="@Dense" Class="mb-2" />
                                 <MudDivider />
 							}
 							@ChildContent

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -586,9 +586,9 @@ namespace MudBlazor
                 _elementReference.SetText(Text).AndForget();
                 _selectedValues.Clear();
                 _selectedValues.Add(value);
-                HilightItemForValue(value);
             }
 
+            HilightItemForValue(value);
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
                 await SetValueAsync((T)(object)Text, updateText: false);

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -574,7 +574,8 @@ namespace MudBlazor
             else
             {
                 // single selection
-                await CloseMenu();
+                // CloseMenu(true) doesn't close popover in BSS
+                await CloseMenu(false);
 
                 if (EqualityComparer<T>.Default.Equals(Value, value))
                 {
@@ -592,7 +593,7 @@ namespace MudBlazor
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
                 await SetValueAsync((T)(object)Text, updateText: false);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         private async void HilightItemForValue(T value)

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor
@@ -4,7 +4,7 @@
 
 @if (HideContent == false)
 {
-	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" @onclick="@OnClicked" @ontouchend="@OnClicked" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
+	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" @onmousedown="@OnClicked" OnClickHandlerPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
 		@if (ChildContent != null)
 		{
 			@ChildContent

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor
@@ -4,7 +4,7 @@
 
 @if (HideContent == false)
 {
-	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" @onmousedown="@OnClicked" OnClickHandlerPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
+	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" OnClick="@OnClicked" OnClickHandlerPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
 		@if (ChildContent != null)
 		{
 			@ChildContent


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4284.

## What we did?
MudSelect has MudList inside itself, but select and list both have their own onclick implementations. Something deep of the click we have conflicts and select didn't work on touch. So we did:

1. Added OnClickHandlerPreventDefault parameter to MudListItem (not onClickPreventDefault, we prevent Mud code). If its true we bypass the list click code and directly continue with OnClick event.
2. In MudSelect set all ListItems prevent to true (to be sure just work select code)
3. Removed all touch events on select (they caused to fire events twice)

Tested both BSS and WASM

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


https://user-images.githubusercontent.com/78308169/160392996-9d87d8cb-88d2-43f3-957e-018874345451.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
