### PR TITLE
Autocomplete: Fix Closing For Touch Devices (Server Side)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -633,8 +633,10 @@ namespace MudBlazor.UnitTests.Components
 
             // define the event-args for arrow-down
             var arrowDownKeyboardEventArgs = new KeyboardEventArgs { Key = Key.Down.Value, Type = "keyup" };
-
+            
+            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeFalse());
             // invoke directly (but twice)
+            onInputKeyUpMemberInfo.Invoke(autocompleteInstance, new[] { arrowDownKeyboardEventArgs }); //first one is for open popover
             onInputKeyUpMemberInfo.Invoke(autocompleteInstance, new[] { arrowDownKeyboardEventArgs });
             onInputKeyUpMemberInfo.Invoke(autocompleteInstance, new[] { arrowDownKeyboardEventArgs });
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -31,7 +31,7 @@
                                 var item = _items[index];
                                 bool is_selected = index == _selectedListItemIndex;
                                 bool is_disabled = !_enabledItemIndices.Contains(index);
-                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(() => SelectOption(item))" OnClickHandlerPreventDefault="true" Class="@(is_selected ? "mud-selected-item" : "")">
                                     @if (ItemTemplate == null)
                                     {
                                         @GetItemString(item)
@@ -61,4 +61,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="IsOpen" OnClick="@ToggleMenu" LockScroll="false" />
+<MudOverlay Visible="IsOpen" @onmousedown="@(() => ChangeMenu(false))" LockScroll="@LockScroll" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -250,6 +250,13 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
+        /// <summary>
+        /// If true, prevent scrolling while dropdown is open.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public bool LockScroll { get; set; } = false;
+
         private string _currentIcon;
 
         /// <summary>
@@ -274,7 +281,16 @@ namespace MudBlazor
             if (!_isCleared)
                 await SetTextAsync(optionText, false);
             _timer?.Dispose();
+            // Not proud of this task delays, but there is no other option for now. This needs to close popover properly on server side.
+            if (RuntimeLocation.IsServerSide)
+            {
+                await Task.Delay(1);
+            }
             IsOpen = false;
+            if (RuntimeLocation.IsServerSide)
+            {
+                await Task.Delay(1);
+            }
             BeginValidate();
             if (!_isCleared)
                 _elementReference?.SetText(optionText);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #3958.

Same with select, autocomplete didn't close in Server Side when touch an item.

Not the best solution, but at least solves most of async situations and can use as a workaround safely.

Also added LockScroll parameter the same as Select.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


https://user-images.githubusercontent.com/78308169/160583865-09299653-54ab-4697-98f7-f74f0045db6b.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
