### PR TITLE
Autocomplete: Fix menu staying open on BSS and mobiles

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7128;http://localhost:5128",
-      "launchUrl": "components/dropzone",
+      "launchUrl": "components/autocomplete",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -31,7 +31,7 @@
                                 var item = _items[index];
                                 bool is_selected = index == _selectedListItemIndex;
                                 bool is_disabled = !_enabledItemIndices.Contains(index);
-                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(async() => await ListItemOnClick(item))" @ontouchend="@(async() => await ListItemTouchEnd(item))" OnClickHandlerPreventDefault="true" Class="@(is_selected ? "mud-selected-item" : "")">
                                     @if (ItemTemplate == null)
                                     {
                                         @GetItemString(item)
@@ -61,4 +61,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="IsOpen" OnClick="@ToggleMenu" LockScroll="false" />
+<MudOverlay Visible="IsOpen" OnClick="@(() => ToggleMenu())" @ontouchstart="@(() => ToggleMenu())" LockScroll="false" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -61,4 +61,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="IsOpen" OnClick="@(() => ToggleMenu())" @ontouchstart="@(() => ToggleMenu())" LockScroll="false" />
+<MudOverlay Visible="IsOpen" OnClick="@ToggleMenu" @ontouchstart="@ToggleMenu" LockScroll="false" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -644,5 +644,29 @@ namespace MudBlazor
             await SetTextAsync(text, true);
         }
 
+        private bool _touchState = false;
+
+        private async Task ListItemOnClick(T item)
+        {
+            //Touchend works before click, so prevent the SelectOption method run twice
+            if (_touchState)
+            {
+                _touchState = false;
+                return;
+            }
+            await SelectOption(item);
+        }
+
+        private async Task ListItemTouchEnd(T item)
+        {
+            //In WASM we should prevent this method and continue with classic click method, otherwise it bubbles to other elements
+            if (RuntimeLocation.IsClientSide)
+            {
+                return;
+            }
+            _touchState = true;
+            await SelectOption(item);
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -174,11 +174,12 @@ namespace MudBlazor
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            
-            // Only update the fragment if the popover is currently shown or will show
-            // This prevents unnecessary renders and popover handle locking
-            if (!_handler.ShowContent && !Open)
-                return;
+
+            // henon: this change by PR #3776 caused problems on BSS (#4303)
+            //// Only update the fragment if the popover is currently shown or will show
+            //// This prevents unnecessary renders and popover handle locking
+            //if (!_handler.ShowContent && !Open)
+            //    return;
 
             _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4303.

First of all this is the not final solution about this issue. There is really a deeper bug when occures complex things happened.

I believe this bug is about timing. So we can fix it with control event timing.

So;

1. Added `ontouchend` event both list item and overlay in autocomplete. I don't know the exact reason, but ontouchend fires before onclick and helps the timing problem.
2. You can ask why we didn't use ontouchstart. Because if we use touchstart, it fires first and closes the popover in autocomplete. And then click event starts and if there is something behind the popover, clicks it. We don't want this.
3. The only problem about touchend is calling same method twice with click event. So we checked the touch event and if user touches the component, the code understand it and skips click event.
4. This look like fix server side touch problem, but have some unwanted side effects on WASM-touch. The current WASM-touch is already working properly, so we skipped this touch events if runtime location is WASM.
This PR also supports direct click between autocompletes without touch again.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Autocomplete server side-touch

https://user-images.githubusercontent.com/78308169/161313616-68474404-7dcb-4692-a105-55b4ba254deb.mp4

Autocomplete direct touch (in mobile no need to touch somewhere to close overlay and touch other component again, now user can directly touch and interact another component)


https://user-images.githubusercontent.com/78308169/161313930-8c4a9e9c-14b1-4482-9037-5caf30d0332f.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests. (Test it if you can 🙂 )
