### PR TITLE
Select: Required now also works when MultiSelection="true" (#4328, #4346)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTestRequiredValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTestRequiredValue.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudSelect @bind-Value="value" Label="String Binding" MultiSelection="true" IsPreRendered="true" Required="true" Clearable="true">
+    <MudSelectItem Value="@("1")">1</MudSelectItem>
+    <MudSelectItem Value="@("2")">2</MudSelectItem>
+    <MudSelectItem Value="@("3")">3</MudSelectItem>
+</MudSelect>
+
+<MudSelect T=TestClass Label="Object Binding" MultiSelection="true" Required="true" @bind-SelectedValues="SelectedRoles" Clearable="true">
+    @foreach(var role in Roles)
+    {
+        <MudSelectItem T="TestClass" Value=@role/>
+    }
+</MudSelect>
+
+@code {
+
+	public static string __description__ = "Multi-Select Required Should Recognize Values";
+
+    string value=null;
+
+    public class TestClass
+    {
+        public string Name { get; set; }
+        public string NameTranslated { get; set; }
+        public override string ToString() => Name;
+    }
+
+
+    public List<TestClass> Roles {get; set; } = new();
+    public IEnumerable<TestClass> SelectedRoles = new List<TestClass>();
+
+    Func<TestClass, string> converter = p => p?.NameTranslated;
+    
+	protected override void OnInitialized()
+    {
+        Roles.Add(new TestClass() { Name ="Admin", NameTranslated="Administrator"});
+        Roles.Add(new TestClass() { Name ="Customer", NameTranslated="Kunde"});
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1064,12 +1064,14 @@ namespace MudBlazor.UnitTests.Components
 
             sut.Instance.Items.Should().HaveCountGreaterOrEqualTo(4);
         }
+
         /// <summary>
         /// When MultiSelection and Required are True with no selected values, required validation should fail.
         /// </summary>
         [Test]
         public async Task MultiSelectWithRequiredValue()
         {
+            //1a. Check When SelectedItems is empty - Validation Should Fail
             //Check on String type
             var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
@@ -1077,12 +1079,29 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => select.Validate());
             select.ValidationErrors.First().Should().Be("Required");
 
-            //Check on T type - MultiSelect of T(e.g. class object) 
-            comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            //1b. Check on T type - MultiSelect of T(e.g. class object) 
             var selectWithT = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
             selectWithT.Required.Should().BeTrue();
+            await comp.InvokeAsync(() => selectWithT.Validate());
+            selectWithT.ValidationErrors.First().Should().Be("Required");
+
+            //2a. Now check when SelectedItems is greater than one - Validation Should Pass
+            var inputs = comp.FindAll("div.mud-input-control");
+            Console.WriteLine(comp.Markup);
+            inputs[0].Click();//The 2nd one is the 
+            var items = comp.FindAll("div.mud-list-item").ToArray();
+            items[1].Click();
             await comp.InvokeAsync(() => select.Validate());
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.Count.Should().Be(0);
+            
+            //2b.
+            inputs[1].Click();//selectWithT 
+            //wait for render and it will find 5 items from the component
+            comp.WaitForState(() => comp.FindAll("div.mud-list-item").Count == 5);
+            items = comp.FindAll("div.mud-list-item").ToArray();
+            items[3].Click();
+            await comp.InvokeAsync(() => selectWithT.Validate());
+            selectWithT.ValidationErrors.Count.Should().Be(0);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1064,5 +1064,25 @@ namespace MudBlazor.UnitTests.Components
 
             sut.Instance.Items.Should().HaveCountGreaterOrEqualTo(4);
         }
+        /// <summary>
+        /// When MultiSelection and Required are True with no selected values, required validation should fail.
+        /// </summary>
+        [Test]
+        public async Task MultiSelectWithRequiredValue()
+        {
+            //Check on String type
+            var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            var select = comp.FindComponent<MudSelect<string>>().Instance;
+            select.Required.Should().BeTrue();
+            await comp.InvokeAsync(() => select.Validate());
+            select.ValidationErrors.First().Should().Be("Required");
+
+            //Check on T type - MultiSelect of T(e.g. class object) 
+            comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            var selectWithT = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
+            selectWithT.Required.Should().BeTrue();
+            await comp.InvokeAsync(() => select.Validate());
+            select.ValidationErrors.First().Should().Be("Required");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -336,8 +336,8 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Text.Should().Be("1");
             text.Should().Be("1");
             string.Join(",", selectedValues).Should().Be("1");
-            selectedValuesChangedCount.Should().Be(3);
-            textChangedCount.Should().Be(2);
+            comp.WaitForAssertion(() => selectedValuesChangedCount.Should().Be(3));
+            comp.WaitForAssertion(() => textChangedCount.Should().Be(2));
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1027,5 +1027,19 @@ namespace MudBlazor
             }
             base.OnBlur.InvokeAsync(obj);
         }
+
+        /// <summary>
+        /// Fixes issue #4328
+        /// Returns true when MultiSelection is true and it has selected values(Since Value property is not used when MultiSelection=true
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>True when component has a value</returns>
+        protected override bool HasValue(T value)
+        {
+            if (MultiSelection)
+                return SelectedValues?.Count() > 0;
+            else
+                return base.HasValue(value);
+        }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #4328
MudSelect When Required=true and MultiSelection=true Required Value check now works. Fixed by overriding `HasValue` method in MudSelect.
## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Test Added To SelectTests
`MultiSelectWithRequiredValue`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
