### PR TITLE
MudTooltip - removed invisible overlay rectangle when not visible

### DIFF
--- a/src/MudBlazor/Styles/components/_popover.scss
+++ b/src/MudBlazor/Styles/components/_popover.scss
@@ -18,6 +18,7 @@
     }
 
     &:not(.mud-popover-open ) {
+        pointer-events: none;
         transition-duration:0ms !important;
         transition-delay:0ms !important;
     }

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -8,6 +8,7 @@
 }
 
 .mud-tooltip {
+    padding: 4px 8px;
     text-align: center;
     align-items: center;
     justify-content: center;
@@ -16,10 +17,6 @@
     line-height: 1.4em;
     border-radius: var(--mud-default-borderradius);
     z-index: var(--mud-zindex-tooltip);
-
-    &.mud-popover-open {
-        padding: 4px 8px;
-    }
 
     &.mud-tooltip-default {
         color: var(--mud-palette-dark-text);

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -8,7 +8,6 @@
 }
 
 .mud-tooltip {
-    padding: 4px 8px;
     text-align: center;
     align-items: center;
     justify-content: center;
@@ -17,6 +16,10 @@
     line-height: 1.4em;
     border-radius: var(--mud-default-borderradius);
     z-index: var(--mud-zindex-tooltip);
+
+    &.mud-popover-open {
+        padding: 4px 8px;
+    }
 
     &.mud-tooltip-default {
         color: var(--mud-palette-dark-text);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
I noticed some weird behaviour that prevents clicking or triggering the hover state on some parts of elements only.
I boiled it down to some tooltip's invisible elements (`<div id="popovercontent-[id]">`) that are always on top of other elements sometimes.
This is frustrating for users as it happens that some 5% of the times one of the clickable elements (that randomly has this popover invisible on top) is clicked, the app does nothing so the final app seems unresponsive for no reason.

<!-- Note any issues that are resolved by this PR -->
Fixes  #4345

## How Has This Been Tested?
This is a CSS only fix, it was tested in the browser, as per the screenshots below, it can be seen that the rectangle does not block the button any more.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
It's hard to depict in pictures but the invisible square can be seen when inspecting the element in chrome:
![image](https://user-images.githubusercontent.com/20947919/161827146-a9e3f900-516b-4aa0-9fa3-2e0af74cd523.png)

And after the fix (I was hovering on the same area):
![image](https://user-images.githubusercontent.com/20947919/161827097-d258b63e-6e14-4d01-b621-429bd56396ae.png)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. (CSS Only - no tests needed)
