### PR TITLE
Menu: Fix MouseEnter/MouseLeave event handler inconsistency

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
@@ -25,7 +25,7 @@
     </ChildContent>
 </MudMenu>
 
-<MudMenu FullWidth="true" ActivationEvent="@MouseEvent.MouseOver" OffsetY>
+<MudMenu FullWidth="true" ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
     <ActivatorContent>
         <MudChip Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Mouse over</MudChip>
     </ActivatorContent>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -98,6 +98,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MenuMouseLeave_MenuMouseEnter_CheckOpen()
+        {
+            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var pop = comp.FindComponent<MudPopover>();
+
+            // Mouse over to menu to open popover
+            var menu = comp.Find(".mud-menu");
+            await menu.TriggerEventAsync("onmouseenter", new MouseEventArgs());
+
+            // Popover open, captures mouse
+            await menu.TriggerEventAsync("onmouseleave", new MouseEventArgs());
+            await comp.FindAll("div.mud-list")[0].TriggerEventAsync("onmouseenter", new MouseEventArgs());
+
+            // Mouse moves to menu, still need to open
+            await comp.FindAll("div.mud-list")[0].TriggerEventAsync("onmouseleave", new MouseEventArgs());
+            await menu.TriggerEventAsync("onmouseenter", new MouseEventArgs());
+
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
+        }
+
+        [Test]
         public void ActivatorContent_Disabled_CheckDisabled()
         {
             var comp = Context.RenderComponent<MenuTestDisabledCustomActivator>();

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -4,7 +4,7 @@
 
 
 <div @attributes="UserAttributes" Class="@Classname" Style="@Style" 
-        @onmouseenter="@(ActivationEvent== MouseEvent.MouseOver ? OpenMenu : null)"
+        @onmouseenter="@MouseEnter"
         @onmouseleave="@MouseLeave"
         @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick ? true : false)">
     @if (ActivatorContent != null)
@@ -40,8 +40,8 @@
     <MudPopover Open="@_isOpen" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@PopoverStyle">
         <CascadingValue Value="@this">
             <MudList Class="@ListClass" Clickable="true" Dense="@Dense"  
-                @onmouseenter="@PopoverMouseEnter"
-                @onmouseleave="@(ActivationEvent== MouseEvent.MouseOver ? CloseMenu : null)">
+                @onmouseenter="@MouseEnter"
+                @onmouseleave="@MouseLeave">
                 @ChildContent
             </MudList>
         </CascadingValue>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -266,11 +266,6 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void PopoverMouseEnter()
-        {
-            _isMouseOver = true;
-        }
-
         // Sets the popover style ONLY when there is an activator
         private void SetPopoverStyle(MouseEventArgs args)
         {
@@ -319,9 +314,22 @@ namespace MudBlazor
             ToggleMenu(args);
         }
 
+        public void MouseEnter(EventArgs args)
+        {
+            _isMouseOver = true;
+
+            if (ActivationEvent == MouseEvent.MouseOver)
+            {
+                OpenMenu(args);
+            }
+        }
+
         public async void MouseLeave()
         {
+            _isMouseOver = false;
+
             await Task.Delay(100);
+
             if (ActivationEvent == MouseEvent.MouseOver && _isMouseOver == false)
             {
                 CloseMenu();


### PR DESCRIPTION
## Description
Inconsistent MouseEvent/MouseLeave event handler causes flickering (destroys element and recreates) while the mouse moves between menu and popover,
note the _isMouseOver is not set when entering the menu

## How Has This Been Tested?
All tests passed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
