### PR TITLE
CheckBox, Radio, Switch: UnCheckedColor and CSS cleanup

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -18,6 +18,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Code="CheckboxColorExample">
+                <CheckboxColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Labels">
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxBasicExample.razor
@@ -2,11 +2,12 @@
 
 <MudCheckBox @bind-Checked="@Basic_CheckBox1"></MudCheckBox>
 <MudCheckBox @bind-Checked="@Basic_CheckBox2" Color="Color.Primary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox1" Color="Color.Secondary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox1" Disabled="true"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Basic_CheckBox3" Color="Color.Secondary"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Basic_CheckBox4" Disabled="true"></MudCheckBox>
 
 @code {
     public bool Basic_CheckBox1 { get; set; } = true;
     public bool Basic_CheckBox2 { get; set; } = false;
     public bool Basic_CheckBox3 { get; set; } = false;
+    public bool Basic_CheckBox4 { get; set; } = true;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxColorExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudCheckBox @bind-Checked="@Basic_CheckBox1" UnCheckedColor="Color.Error"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Basic_CheckBox2" Color="Color.Primary" UnCheckedColor="Color.Default"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Basic_CheckBox3" Color="Color.Secondary" UnCheckedColor="Color.Default"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Basic_CheckBox4" Disabled="true" UnCheckedColor="Color.Success"></MudCheckBox>
+
+@code {
+    public bool Basic_CheckBox1 { get; set; } = true;
+    public bool Basic_CheckBox2 { get; set; } = false;
+    public bool Basic_CheckBox3 { get; set; } = false;
+    public bool Basic_CheckBox4 { get; set; } = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupColorExample.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudRadioGroup T="int">
+    <MudRadio Option="1" Color="Color.Primary" UnCheckedColor="Color.Default">One</MudRadio>
+    <MudRadio Option="2" Color="Color.Secondary" UnCheckedColor="Color.Default">Two</MudRadio>
+    <MudRadio Option="3" Color="Color.Success" UnCheckedColor="Color.Error">Three</MudRadio>
+    <MudRadio Option="4" Color="Color.Primary" Disabled="true">Four</MudRadio>
+</MudRadioGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
@@ -14,6 +14,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Code="RadioGroupColorExample" ShowCode="false">
+                <RadioGroupColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Dense">
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchColorExample.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwitch @bind-Checked="@Basic_Switch1" Color="Color.Success" UnCheckedColor="Color.Error" />
+<MudSwitch @bind-Checked="@Basic_Switch2" Color="Color.Primary" UnCheckedColor="Color.Secondary" />
+<MudSwitch @bind-Checked="@Basic_Switch3" Color="Color.Info" UnCheckedColor="Color.Warning" />
+<MudSwitch T="bool" Disabled="true" UnCheckedColor="Color.Dark" />
+
+@code{
+    public bool Basic_Switch1 { get; set; } = false;
+    public bool Basic_Switch2 { get; set; } = true;
+    public bool Basic_Switch3 { get; set; } = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -14,6 +14,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Code="SwitchColorExample">
+                <SwitchColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Switch with label">
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -242,6 +243,34 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParam("Disabled", true);
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+        }
+
+        [Test]
+        [TestCase(Color.Default, Color.Primary)]
+        [TestCase(Color.Primary, Color.Secondary)]
+        [TestCase(Color.Secondary, Color.Info)]
+        [TestCase(Color.Tertiary, Color.Success)]
+        [TestCase(Color.Info, Color.Warning)]
+        [TestCase(Color.Success, Color.Error)]
+        [TestCase(Color.Warning, Color.Dark)]
+        [TestCase(Color.Error, Color.Primary)]
+        [TestCase(Color.Dark, Color.Primary)]
+        public void CheckBoxColorTest(Color color, Color uncheckedcolor)
+        {
+            var comp = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UnCheckedColor, uncheckedcolor));
+
+            var box = comp.Instance;
+            var input = comp.Find("input");
+
+            var checkboxClasses = comp.Find(".mud-button-root.mud-icon-button");
+            // check initial state
+            box.Checked.Should().Be(false);
+            checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
+
+            // click and check if it has new color
+            input.Change(true);
+            box.Checked.Should().Be(true);
+            checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -42,6 +43,34 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParam("Disabled", true);
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+        }
+
+        [Test]
+        [TestCase(Color.Default, Color.Primary)]
+        [TestCase(Color.Primary, Color.Secondary)]
+        [TestCase(Color.Secondary, Color.Info)]
+        [TestCase(Color.Tertiary, Color.Success)]
+        [TestCase(Color.Info, Color.Warning)]
+        [TestCase(Color.Success, Color.Error)]
+        [TestCase(Color.Warning, Color.Dark)]
+        [TestCase(Color.Error, Color.Primary)]
+        [TestCase(Color.Dark, Color.Primary)]
+        public void SwitchColorTest(Color color, Color uncheckedcolor)
+        {
+            var comp = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UnCheckedColor, uncheckedcolor));
+
+            var box = comp.Instance;
+            var input = comp.Find("input");
+
+            var checkboxClasses = comp.Find(".mud-button-root.mud-icon-button.mud-switch-base");
+            // check initial state
+            box.Checked.Should().Be(false);
+            checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
+
+            // click and check if it has new color
+            input.Change(true);
+            box.Checked.Should().Be(true);
+            checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -9,7 +9,7 @@ namespace MudBlazor
         protected string Classname =>
         new CssBuilder("mud-button-root mud-icon-button")
           .AddClass("mud-button", when: AsButton)
-          .AddClass($"mud-icon-button-color-{Color.ToDescriptionString()}", !AsButton && Color != Color.Default)
+          .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !AsButton && Color != Color.Default)
           .AddClass($"mud-button-{Variant.ToDescriptionString()}", AsButton)
           .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}", AsButton)
           .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}", AsButton)

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -19,9 +19,10 @@ namespace MudBlazor
 
         protected string CheckBoxClassname =>
         new CssBuilder("mud-button-root mud-icon-button")
-            .AddClass($"mud-icon-button-color-{Color.ToDescriptionString()}")
+            .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", UnCheckedColor == null || (UnCheckedColor != null && BoolValue == true))
+            .AddClass($"mud-{UnCheckedColor?.ToDescriptionString()}-text hover:mud-{UnCheckedColor?.ToDescriptionString()}-hover", UnCheckedColor != null && BoolValue == false)
             .AddClass($"mud-checkbox-dense", Dense)
-            .AddClass($"mud-ripple mud-ripple-checkbox", !DisableRipple)
+            .AddClass($"mud-ripple mud-ripple-checkbox", !DisableRipple && !ReadOnly && !Disabled)
             .AddClass($"mud-disabled", Disabled)
             .AddClass($"mud-readonly", ReadOnly)
         .Build();
@@ -32,6 +33,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The base color of the component in its none active/unchecked state. It supports the theme colors.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public Color? UnCheckedColor { get; set; } = null;
 
         /// <summary>
         /// If applied the text will be added to the component.

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -21,8 +21,9 @@ namespace MudBlazor
 
         protected string ButtonClassname =>
         new CssBuilder("mud-button-root mud-icon-button")
-            .AddClass($"mud-ripple mud-ripple-radio", !DisableRipple)
-            .AddClass($"mud-icon-button-color-{Color.ToDescriptionString()}")
+            .AddClass($"mud-ripple mud-ripple-radio", !DisableRipple && !Disabled)
+            .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", UnCheckedColor == null || (UnCheckedColor != null && Checked == true))
+            .AddClass($"mud-{UnCheckedColor?.ToDescriptionString()}-text hover:mud-{UnCheckedColor?.ToDescriptionString()}-hover", UnCheckedColor != null && Checked == false)
             .AddClass($"mud-radio-dense", Dense)
             .AddClass($"mud-disabled", Disabled)
             .AddClass($"mud-checked", Checked)
@@ -80,6 +81,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The base color of the component in its none active/unchecked state. It supports the theme colors.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public Color? UnCheckedColor { get; set; } = null;
 
         /// <summary>
         /// The position of the child content.

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -15,7 +15,7 @@
                 </span>
             </span>
         </span>
-        <span class="mud-switch-track"></span>
+        <span class="@TrackClassname"></span>
     </span>
     @if (!String.IsNullOrEmpty(Label))
     {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -20,10 +20,17 @@ namespace MudBlazor
         protected string SwitchClassname =>
         new CssBuilder("mud-button-root mud-icon-button mud-switch-base")
             .AddClass($"mud-ripple mud-ripple-switch", !DisableRipple && !ReadOnly && !Disabled)
-            .AddClass($"mud-switch-{Color.ToDescriptionString()}")
+            .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", BoolValue == true)
+            .AddClass($"mud-{UnCheckedColor.ToDescriptionString()}-text hover:mud-{UnCheckedColor.ToDescriptionString()}-hover", BoolValue == false)
             .AddClass($"mud-switch-disabled", Disabled)
             .AddClass($"mud-readonly", ReadOnly)
             .AddClass($"mud-checked", BoolValue)
+        .Build();
+
+        protected string TrackClassname =>
+        new CssBuilder("mud-switch-track")
+            .AddClass($"mud-{Color.ToDescriptionString()}", BoolValue == true)
+            .AddClass($"mud-{UnCheckedColor.ToDescriptionString()}", BoolValue == false)
         .Build();
 
         //Excluded because not used
@@ -40,6 +47,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The base color of the component in its none active/unchecked state. It supports the theme colors.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public Color UnCheckedColor { get; set; } = Color.Default;
 
         /// <summary>
         /// The text/label will be displayed next to the switch if set.

--- a/src/MudBlazor/Styles/abstracts/_colors.scss
+++ b/src/MudBlazor/Styles/abstracts/_colors.scss
@@ -9,6 +9,16 @@
         color: var(--mud-palette-#{$color}) !important;
     }
 
+    .mud-#{$color}-hover {
+        background-color: var(--mud-palette-#{$color}-hover) !important;
+    }
+
+    .hover\:mud-#{$color}-hover {
+        &:hover, &:focus-visible {
+            background-color: var(--mud-palette-#{$color}-hover) !important;
+        }
+    }
+
     .mud-border-#{$color} {
         border-color: var(--mud-palette-#{$color}) !important;
     }

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -299,12 +299,6 @@
 }
 
 .mud-button-group-root {
-    @each $color in $mud-palette-colors {
-        .mud-button-root.mud-icon-button.mud-icon-button-color-#{$color} {
-            color: var(--mud-palette-#{$color});
-        }
-    }
-
     .mud-button-root.mud-icon-button {
         padding-right: 12px;
         padding-left: 12px;

--- a/src/MudBlazor/Styles/components/_checkbox.scss
+++ b/src/MudBlazor/Styles/components/_checkbox.scss
@@ -1,6 +1,4 @@
-﻿@import '../abstracts/variables';
-
-.mud-checkbox {
+﻿.mud-checkbox {
     cursor: pointer;
     display: inline-flex;
     align-items: center;
@@ -9,7 +7,7 @@
 
     &.mud-disabled, .mud-disabled:hover, .mud-disabled:focus-visible {
         cursor: default;
-        background-color: transparent;
+        background-color: transparent !important;
 
         & * {
             cursor: default;

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -1,6 +1,4 @@
-﻿@import '../abstracts/variables';
-
-.mud-icon-button {
+﻿.mud-icon-button {
     flex: 0 0 auto;
     padding: 12px;
     overflow: visible;
@@ -36,17 +34,6 @@
         background-color: var(--mud-palette-action-default-hover);
     }
 }
-
-@each $color in $mud-palette-colors {
-    .mud-icon-button-color-#{$color} {
-        color: var(--mud-palette-#{$color});
-
-        &:hover, &:focus-visible {
-            background-color: var(--mud-palette-#{$color}-hover);
-        }
-    }
-}
-
 
 .mud-icon-button-label {
     width: 100%;

--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -1,6 +1,4 @@
-﻿@import '../abstracts/variables';
-
-.mud-switch {
+﻿.mud-switch {
     cursor: pointer;
     display: inline-flex;
     align-items: center;
@@ -44,8 +42,6 @@
         background-color: var(--mud-palette-black);
     }
 }
-
-
 
 .mud-switch-base {
     padding: 9px;
@@ -106,22 +102,5 @@
         box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);
         border-radius: 50%;
         background-color: currentColor;
-    }
-}
-
-
-@each $color in $mud-palette-colors {
-    .mud-switch-#{$color} {
-        &.mud-checked {
-            color: var(--mud-palette-#{$color});
-
-            &:hover, &:focus-visible {
-                background-color: var(--mud-palette-#{$color}-hover);
-            }
-
-            & + .mud-switch-track {
-                background-color: var(--mud-palette-#{$color});
-            }
-        }
     }
 }

--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -10,13 +10,13 @@
     -webkit-tap-highlight-color: transparent;
 
     &.mud-disabled {
-        color: var(--mud-palette-text-disabled);
+        color: var(--mud-palette-text-disabled) !important;
         cursor: default;
     }
 
     &.mud-readonly, .mud-readonly:hover {
         cursor: default;
-        background-color: transparent;
+        background-color: transparent !important;
     }
 }
 
@@ -65,15 +65,15 @@
     }
 
     &.mud-switch-disabled {
-        color: var(--mud-palette-grey-default);
+        color: var(--mud-palette-grey-default) !important;
 
         & + .mud-switch-track {
-            opacity: 0.12;
+            opacity: 0.12 !important;
         }
 
         &:hover, &:focus-visible {
             cursor: default;
-            background-color: transparent;
+            background-color: transparent !important;
         }
     }
 }


### PR DESCRIPTION
## Description
Added parameter to control the "`UnCheckedColor`" of `MudCheckBox`, `MudSwitch` and `MudRadio` i took the opportunity to kickstart the CSS class cleanup and removed all component specific color classes and instead use the provided CSS utility theme classes.

This could be done before by simply changing the Color of the component by the users but not for `MudSwitch` so i decided to add it to `MudCheckBoix `and `MudRadio `as well to streamline the form/input components.

To not break things `UnCheckedColor` is null by default for `MudCheckBox` and `MudRadio` but set to `Color.Default` for `MudSwitch`.

fixes #4340


### CheckBox
![CheckBox](https://user-images.githubusercontent.com/10367109/163013634-70244594-f57a-4738-a8f7-5b0528438e0b.gif)

### Radio
![Radio](https://user-images.githubusercontent.com/10367109/163013651-aec7ef24-1a51-4e5e-b8de-e1298357658b.gif)

### Switch
![Switch](https://user-images.githubusercontent.com/10367109/163013659-234a89a7-351a-4802-925e-29b8f6d04042.gif)

## How Has This Been Tested?
Visual/manually in docs.
Tests are coming...

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
