### PR TITLE
List: Added selected color & fixed parent null issue

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListColorExample.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudStack Row="true">
+    <MudPaper Width="300px">
+        <MudList Clickable="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue" Color="_color">
+            <MudListSubheader>
+                Select Your Character:
+            </MudListSubheader>
+            <MudListItem Text="Neutral" Value="1" />
+            <MudListItem Text="Good">
+                <NestedList>
+                    <MudListItem Text="Frodo Baggins" Value="2" />
+                    <MudListItem Text="Harry Potter" Value="3" />
+                </NestedList>
+            </MudListItem>
+            <MudListItem Text="Evil">
+                <NestedList>
+                    <MudListItem Text="Sauron" Value="5" />
+                    <MudListItem Text="Voldemort" Value="6" />
+                    <MudListItem Text="Mckaragoz" Value="7" />
+                </NestedList>
+            </MudListItem>
+            <MudListItem Disabled="true" Text="Im not hero" Value="7" />
+        </MudList>
+    </MudPaper>
+    <MudPaper Class="pe-4">
+        <MudRadioGroup T="Color" @bind-SelectedOption="_color" Class="d-flex flex-column">
+            <MudRadio Option="Color.Primary" Color="Color.Primary">Primary</MudRadio>
+            <MudRadio Option="Color.Secondary" Color="Color.Secondary">Secondary</MudRadio>
+            <MudRadio Option="Color.Tertiary" Color="Color.Tertiary">Tertiary</MudRadio>
+            <MudRadio Option="Color.Info" Color="Color.Info">Info</MudRadio>
+            <MudRadio Option="Color.Success" Color="Color.Success">Success</MudRadio>
+            <MudRadio Option="Color.Warning" Color="Color.Warning">Warning</MudRadio>
+        </MudRadioGroup>
+    </MudPaper>
+</MudStack>
+
+@code{
+    MudListItem selectedItem;
+    object selectedValue = 1;
+    Color _color = Color.Primary;
+}

--- a/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
@@ -53,5 +53,16 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description>
+                    In selectable MudList, you can also set the selected item's color.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ListColorExample">
+                <ListColorExample/>
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudList Clickable="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue">
+<MudList Clickable="true" Color="Color" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue">
     <MudListSubheader>
         Your drink:
         <MudChip Color="Color.Secondary">
@@ -26,6 +26,7 @@
 
 @code
 {
+    [Parameter] public Color Color { get; set; } = Color.Primary;
     public static string __description__ = "Sparkling Water should be selected initially.";
     MudListItem selectedItem;
     object selectedValue=1;

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -28,22 +28,22 @@ namespace MudBlazor.UnitTests.Components
             list.SelectedItem.Should().Be(null);
             // we have seven choices, none is active
             comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(0);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
             // click water
             comp.FindAll("div.mud-list-item")[0].Click();
             list.SelectedItem.Text.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-selected-item");
             // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
             comp.FindAll("div.mud-list-item")[4].Click();
             list.SelectedItem.Text.Should().Be("Pu'er");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-selected-item");
             // click Cafe Latte
             comp.FindAll("div.mud-list-item")[8].Click();
             list.SelectedItem.Text.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
         }
 
         /// <summary>
@@ -60,26 +60,26 @@ namespace MudBlazor.UnitTests.Components
             list.SelectedItem.Text.Should().Be("Sparkling Water");
             // we have seven choices, 1 is active because of the initial value of SelectedValue
             comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
             // set Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
             await comp.InvokeAsync(()=>comp.Instance.SetSelecedValue(4));
             list.SelectedItem.Text.Should().Be("Pu'er");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-selected-item");
             // set Cafe Latte via changing SelectedValue
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(7));
             list.SelectedItem.Text.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
             // set water
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(1));
             list.SelectedItem.Text.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-list-item-selected");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-selected-item");
             // set nothing
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(null));
             list.SelectedItem.Should().Be(null);
-            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(0);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace MudBlazor.UnitTests.Components
             var list = comp.FindComponent<MudList>().Instance;
             list.SelectedItem.Text.Should().Be("Sparkling Water");
 
-            var listItemClasses = comp.Find(".mud-list-item-selected");
+            var listItemClasses = comp.Find(".mud-selected-item");
             listItemClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"mud-{color.ToDescriptionString()}-hover" });
         }
     }

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -27,22 +28,22 @@ namespace MudBlazor.UnitTests.Components
             list.SelectedItem.Should().Be(null);
             // we have seven choices, none is active
             comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(0);
             // click water
             comp.FindAll("div.mud-list-item")[0].Click();
             list.SelectedItem.Text.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-list-item-selected");
             // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
             comp.FindAll("div.mud-list-item")[4].Click();
             list.SelectedItem.Text.Should().Be("Pu'er");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-list-item-selected");
             // click Cafe Latte
             comp.FindAll("div.mud-list-item")[8].Click();
             list.SelectedItem.Text.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-list-item-selected");
         }
 
         /// <summary>
@@ -59,26 +60,47 @@ namespace MudBlazor.UnitTests.Components
             list.SelectedItem.Text.Should().Be("Sparkling Water");
             // we have seven choices, 1 is active because of the initial value of SelectedValue
             comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
             // set Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
             await comp.InvokeAsync(()=>comp.Instance.SetSelecedValue(4));
             list.SelectedItem.Text.Should().Be("Pu'er");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[4].Markup.Should().Contain("mud-list-item-selected");
             // set Cafe Latte via changing SelectedValue
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(7));
             list.SelectedItem.Text.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[8].Markup.Should().Contain("mud-list-item-selected");
             // set water
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(1));
             list.SelectedItem.Text.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(1);
+            comp.FindComponents<MudListItem>()[0].Markup.Should().Contain("mud-list-item-selected");
             // set nothing
             await comp.InvokeAsync(() => comp.Instance.SetSelecedValue(null));
             list.SelectedItem.Should().Be(null);
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            comp.FindAll("div.mud-list-item-selected").Count.Should().Be(0);
+        }
+
+        [Test]
+        [TestCase(Color.Default)]
+        [TestCase(Color.Primary)]
+        [TestCase(Color.Secondary)]
+        [TestCase(Color.Tertiary)]
+        [TestCase(Color.Info)]
+        [TestCase(Color.Success)]
+        [TestCase(Color.Warning)]
+        [TestCase(Color.Error)]
+        [TestCase(Color.Dark)]
+        public void ListColorTest(Color color)
+        {
+            var comp = Context.RenderComponent<ListSelectionInitialValueTest>(x => x.Add(c => c.Color, color));
+
+            var list = comp.FindComponent<MudList>().Instance;
+            list.SelectedItem.Text.Should().Be("Sparkling Water");
+
+            var listItemClasses = comp.Find(".mud-list-item-selected");
+            listItemClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"mud-{color.ToDescriptionString()}-hover" });
         }
     }
 }

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -17,6 +17,13 @@ namespace MudBlazor
         [CascadingParameter] protected MudList ParentList { get; set; }
 
         /// <summary>
+        /// The color of the selected List Item.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public Color Color { get; set; } = Color.Primary;
+
+        /// <summary>
         /// Child content of component.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -36,7 +36,7 @@
 @if (NestedList != null)
 {
     <MudCollapse Expanded="@Expanded">
-        <MudList Clickable="@MudList.Clickable" DisablePadding="true" Class="mud-nested-list" Disabled="@Disabled">
+        <MudList Clickable="MudList?.Clickable ?? false" Color="MudList?.Color ?? Color.Primary" DisablePadding="true" Class="mud-nested-list" Disabled="@Disabled">
             @NestedList
         </MudList>
     </MudCollapse>

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -2,6 +2,7 @@
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -14,7 +15,7 @@ namespace MudBlazor
           .AddClass("mud-list-item-gutters", !DisableGutters && !(MudList?.DisableGutters == true))
           .AddClass("mud-list-item-clickable", MudList?.Clickable)
           .AddClass("mud-ripple", MudList?.Clickable == true && !DisableRipple && !Disabled)
-          .AddClass("mud-selected-item", _selected && !Disabled)
+          .AddClass($"mud-list-item-selected mud-{MudList?.Color.ToDescriptionString()}-text mud-{MudList?.Color.ToDescriptionString()}-hover", _selected && !Disabled)
           .AddClass("mud-list-item-disabled", Disabled)
           .AddClass(Class)
         .Build();

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
           .AddClass("mud-list-item-gutters", !DisableGutters && !(MudList?.DisableGutters == true))
           .AddClass("mud-list-item-clickable", MudList?.Clickable)
           .AddClass("mud-ripple", MudList?.Clickable == true && !DisableRipple && !Disabled)
-          .AddClass($"mud-list-item-selected mud-{MudList?.Color.ToDescriptionString()}-text mud-{MudList?.Color.ToDescriptionString()}-hover", _selected && !Disabled)
+          .AddClass($"mud-selected-item mud-{MudList?.Color.ToDescriptionString()}-text mud-{MudList?.Color.ToDescriptionString()}-hover", _selected && !Disabled)
           .AddClass("mud-list-item-disabled", Disabled)
           .AddClass(Class)
         .Build();

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -45,11 +45,6 @@
     margin-top: -21px;
 }
 
-.mud-selected-item {
-    color: var(--mud-palette-primary);
-    background-color: var(--mud-palette-primary-hover);
-}
-
 .mud-select-all {
     margin-top: 10px;
     border-bottom: 1px solid lightgrey;


### PR DESCRIPTION
## Description
I remade @mckaragoz PR #4329 as it broke the hover and had wrong selected color by default. But mostly i did it to implement the usage the utility classes instead of adding more component specific CSS that we already have.

The docs Example is copied from @mckaragoz PR.
Also fixes a null issue with MudListItem when using Nested list and no parent List is present.

@mckaragoz sorry that i highjacked your PR but after i reviewed it and tested it, it was just so much faster for me to do it myself than show you/explain, please take your time and see what i did differently and especially for the ColorTest i added.

![ListColor](https://user-images.githubusercontent.com/10367109/163096244-47cdc608-d861-457a-a0c6-4ce62b2e2693.gif)



## How Has This Been Tested?
unit | visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
