### PR TITLE
Tooltip: Add ShowOnFocus parameter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/ToolTipPlacementPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/ToolTipPlacementPropertyTest.razor
@@ -3,7 +3,7 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudRTLProvider RightToLeft="@RightToLeft">
-	<MudTooltip Placement="@Placement">
+	<MudTooltip Placement="@Placement" ShowOnFocus="@ShowOnFocus">
 		<ChildContent>
 			<MudButton>My Buttion</MudButton>
 		</ChildContent>
@@ -19,5 +19,6 @@
 @code {
 	[Parameter] public Placement Placement { get; set; } = Placement.Bottom;
 	[Parameter] public bool RightToLeft { get; set; } = false;
+	[Parameter] public bool ShowOnFocus { get; set; } = false;
 
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipVisiblePropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipVisiblePropTest.razor
@@ -2,7 +2,7 @@
 
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudTooltip Text="Visible Property" @bind-IsVisible="TooltipVisible">
+<MudTooltip Text="Visible Property" @bind-IsVisible="TooltipVisible" ShowOnFocus="true">
 	<MudButton Variant="Variant.Filled" Color="Color.Secondary">My Button</MudButton>
 </MudTooltip>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
@@ -2,7 +2,7 @@
 
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudTooltip>
+<MudTooltip ShowOnFocus="true">
 	<ChildContent>
 	<MudButton>My Buttion</MudButton>
 	</ChildContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
@@ -2,7 +2,7 @@
 
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudTooltip Text="@TooltipTextContent" Touch="@EnableTouch" Placement="Placement.Start">
+<MudTooltip Text="@TooltipTextContent" Touch="@EnableTouch" ShowOnFocus="true" Placement="Placement.Start">
 	<MudButton>My Buttion</MudButton>
 </MudTooltip>
 

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -26,6 +26,7 @@ namespace MudBlazor.UnitTests.Components
             toolTip.Delay.Should().Be(0);
             toolTip.Placement.Should().Be(Placement.Bottom);
             toolTip.Inline.Should().BeTrue();
+            toolTip.ShowOnFocus.Should().BeFalse();
         }
 
         [Test]
@@ -46,7 +47,7 @@ namespace MudBlazor.UnitTests.Components
 
             button.ParentElement.ClassList.Should().Contain("mud-tooltip-root");
 
-            //the button [0] and [1] the popover npde
+            //the button [0] and [1] the popover node
             button.ParentElement.Children.Should().HaveCount(2);
 
             var popoverNode = button.ParentElement.Children[1];
@@ -266,21 +267,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Tooltip_On_Focus()
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public async Task Tooltip_On_Focus(bool showOnFocus, bool shouldBeVisible)
         {
-            var comp = Context.RenderComponent<ToolTipPlacementPropertyTest>();
+            var comp = Context.RenderComponent<ToolTipPlacementPropertyTest>(p => p
+                .Add(x => x.ShowOnFocus, showOnFocus));
 
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onfocusin", new FocusEventArgs());
 
-            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
+            var popoverContentNode = comp.FindAll("#my-tooltip-content").FirstOrDefault()?.ParentElement;
 
-            popoverContentNode.Should().NotBeNull();
+            if (shouldBeVisible)
+            {
+                popoverContentNode.Should().NotBeNull();
+            }
+            else
+            {
+                popoverContentNode.Should().BeNull();
+            }
         }
 
         [Test]
         [TestCase(true)]
-        [TestCase(false)]        
+        [TestCase(false)]
         public async Task Visible_ByDefault(bool usingFocusout)
         {
             var comp = Context.RenderComponent<TooltipVisiblePropTest>(p =>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@ContainerClass" style="@RootStyle" @onmouseenter="@HandleMouseOver" @onmouseleave="@HandleMouseOut" @onfocusin="@HandleMouseOver" @onfocusout="@HandleMouseOut" >
+<div @attributes="UserAttributes" class="@ContainerClass" style="@RootStyle" @onmouseenter="@HandleMouseOver" @onmouseleave="@HandleMouseOut" @onfocusin="@HandleFocusIn" @onfocusout="@HandleFocusOut" >
 	@ChildContent
 	@if (TooltipContent != null || string.IsNullOrEmpty(Text) == false)
 	{

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -139,14 +139,24 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// When true, also shows the tooltip onfocusin and hides it onfocusout
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Tooltip.Behavior)]
+        public bool ShowOnFocus { get; set; }
+
+        /// <summary>
         /// An event triggered when the state of IsVisible has changed
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public EventCallback<bool> IsVisibleChanged { get; set; }
 
-        private void HandleMouseOver() { IsVisible = true;}
-        private void HandleMouseOut() { IsVisible = false;}
+        private void HandleMouseOver() { IsVisible = true; }
+        private void HandleMouseOut() { IsVisible = false; }
+
+        private void HandleFocusIn() { if (ShowOnFocus) IsVisible = true; }
+        private void HandleFocusOut() { if (ShowOnFocus) IsVisible = false; }
 
         private Origin ConvertPlacement()
         {


### PR DESCRIPTION
## Description
Bear with me as this is my first PR for this repository. Please let me know anything I can do better ;-)

fixes #4319

This is about the MudTooltip component.

I have added a "ShowOnFocus" parameter (name is still up for debate... ;-)), which defaults to false and which controls the behaviour of showing/hiding the tooltip with the onfocusin and onfocusout events. When "ShowOnFocus" is false, the tooltip is not shown with those events, when it is true, the tooltip is shown with these events.

I understand if you wouldn't want to have it defaulted to false, as that is actually a breaking change, and I gladly change the PR if you want that... In that case the name should probably be negative in the way that the default would still be false like "NotOnFocus" for instance... not sure... naming is still hard ;-)

But OTOH, from what I have heard "in the field" (read: on the discord), people are not expecting the tooltip to appear on focus, plus it has the nasty side-effect of showing the tooltip when you come back from another tab or application. So IMO the breaking change would be justified.

## How Has This Been Tested?
I have updated the tests to accommodate for this change... please review ;-)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] The PR is submitted to the correct branch (`dev`).
- [ x ] My code follows the code style of this project.
- [ x ] I've added relevant tests.
