### PR TITLE
NavMenu: Fix border stle for RTL layout

### DIFF
--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -19,19 +19,19 @@
                 <div class="d-flex">
                     @if (Error)
                     {
-                        <div class="mr-auto">
+                        <div class="me-auto">
                             @ErrorText
                         </div>
                     }
                     else if (!String.IsNullOrEmpty(HelperText))
                     {
-                        <div class="mr-auto">
+                        <div class="me-auto">
                             @HelperText
                         </div>
                     }
                     @if (!String.IsNullOrEmpty(CounterText))
                     {
-                        <div class="ml-auto">
+                        <div class="ms-auto">
                             @CounterText
                         </div>            
                     }

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -144,8 +144,8 @@
   &.mud-navmenu-bordered{
     .mud-nav-link{
       &.active:not(.mud-nav-link-disabled) {
-        border-right-style: solid;
-        border-right-width: 2px;
+        border-inline-end-style: solid;
+        border-inline-end-width: 2px;
       }
     }
   }


### PR DESCRIPTION
Fixed the border style alignment of the NavMenu


## Description
Border style was set to right edge by using 
`border-right-style: solid; border-right-width: 2px;`
It's now fixed by using inline styles of the border:
`border-inline-end-style: solid; border-inline-end-width: 2px;`

## How Has This Been Tested?
visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before: 
![image](https://user-images.githubusercontent.com/4676021/163444071-9b61282c-e562-4c29-964d-6fc674c3f1de.png)

After: 
![image](https://user-images.githubusercontent.com/4676021/163444259-f802b98b-5c8b-419e-aca5-3dd686d4fa5e.png)


- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
