### PR TITLE
Table: Fix check-all not selecting all items after filtering in multiselect mode.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest7.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest7.razor
@@ -1,0 +1,36 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" Filter="new Func<int,bool>(FilterFunc)">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+<MudTextField @bind-Value="searchString"></MudTextField>
+
+@code {
+    public static string __description__ = "the selected items (check-box click or row click) should be represented in SelectedItems.";
+    
+    public string searchString = "";
+    int[] items = new int[] { 0, 1, 2 };
+    HashSet<int> selectedItems = new HashSet<int>();
+
+    private bool FilterFunc(int element)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+        {
+            return true;
+        }
+
+        if (element == int.Parse(searchString))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -703,6 +703,54 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Filtering and cancelling the filter should not change checking the header checkbox, which should select all items (all checkboxes on, all items in SelectedItems)
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest7()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionTest7>();
+            // print the generated html
+            //Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(4); // <-- one header, three rows
+            var th = comp.FindAll("th").ToArray();
+            th.Length.Should().Be(2); //  one for the checkbox, one for the header
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(6); // two td per row for multi selection
+            var inputs = comp.FindAll("input").ToArray();
+            inputs.Length.Should().Be(5); // one checkbox per row + one for the header
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+
+            inputs[4].Change("1"); // search for 1
+            checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+
+            // click header checkbox and verify selection text
+            inputs[0].Change(true);
+            table.SelectedItems.Count.Should().Be(1);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }"); // only "1" should be present
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(2);
+            inputs[0].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+
+            inputs[4].Change(""); // reset to default
+            checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+
+            // click header checkbox and verify selection text
+            inputs[0].Change(true);
+            table.SelectedItems.Count.Should().Be(3);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }"); // we reset search, so all three numbers should be searched
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(4);
+            inputs[0].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+        }
+
+        /// <summary>
         /// Checkbox click must not bubble up.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -98,7 +98,8 @@ namespace MudBlazor
             var t = item.As<T>();
             if (t is null)
                 return;
-            Rows.Remove(t);
+            if (Rows[t] == row) // Verify the row we wish to remove is the row stored for the key
+                Rows.Remove(t);
         }
 
         #region --> Sorting


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This fixes #3320. See this comment on that issue for more details on the results of the bug: https://github.com/MudBlazor/MudBlazor/issues/3320#issuecomment-1067634856

This is due to how the TableContext handles subscribing and disposing of table row instances. In short, the issue resulted because rows are disposed after their replacements are subscribed. This PR adds a check to ensure the `MudTr` passed to the `Remove` method on `TableContext` is indeed the instance currently stored in the Rows dictionary.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Unit tests + manually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
