### PR TITLE
Tooltip: Add TabContent render fragment to MudTabPanel

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsContentExample.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs Elevation="1" Rounded="true" PanelClass="pa-6">
+    <MudTabPanel>
+        <ChildContent>
+            <MudText>Custom tab content only</MudText>
+        </ChildContent>
+        <TabContent>
+            Item One
+        </TabContent>
+    </MudTabPanel>
+    <MudTabPanel>
+        <ChildContent>
+            <MudText>Both custom tab and wrapper content</MudText>
+        </ChildContent>
+        <TabWrapperContent>
+            <MudTooltip Text="ToolTip Two">
+                @context
+            </MudTooltip>
+        </TabWrapperContent>
+        <TabContent>
+            <MudText Typo="Typo.h6">Item Two</MudText>
+        </TabContent>
+    </MudTabPanel>
+    <MudTabPanel Text="Item Three">
+        <ChildContent>
+            <MudText>Custom wrapper content only</MudText>
+        </ChildContent>
+        <TabWrapperContent>
+            <MudTooltip Text="ToolTip Three">
+                @context
+            </MudTooltip>
+        </TabWrapperContent>
+    </MudTabPanel>
+</MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -76,6 +76,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Tab Content">
+                <Description>Custom tab header content can be provided for special scenarios. Specify only <CodeInline>TabContent</CodeInline> top customize the tab content, or specify <CodeInline>TabWrapperContent</CodeInline> to provide a wrapper around the entire tab header.</Description>
+            </SectionHeader>
+            <SectionContent Code="TabsContentExample" ShowCode="false" HighLight="TabContent,TabWrapperContent">
+                <TabsContentExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Set Active Panel">
             </SectionHeader>
             <SectionContent Code="TabsSetActiveExample" ShowCode="false"  Block="true">

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -87,10 +87,18 @@ else
     public RenderFragment ChildContent { get; set; }
 
     /// <summary>
+    /// Tab content of component.
+    /// </summary>
+    [Parameter] 
+    [Category(CategoryTypes.Tabs.Behavior)]
+    public RenderFragment TabContent { get; set; }
+
+    /// <summary>
     /// TabPanel Tooltip
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]
+    [ObsoleteAttribute("Use the MudToolTip component inside <TabContent> instead.")]
     public string ToolTip { get; set; }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -94,11 +94,10 @@ else
     public RenderFragment TabContent { get; set; }
 
     /// <summary>
-    /// TabPanel Tooltip
+    /// TabPanel Tooltip. It will be ignored if TabContent is provided
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]
-    [ObsoleteAttribute("Use the MudToolTip component inside <TabContent> instead.")]
     public string ToolTip { get; set; }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -94,6 +94,13 @@ else
     public RenderFragment TabContent { get; set; }
 
     /// <summary>
+    /// Tab content wrapper of component. It is used with TabContent to entirely wrap the content of a tab heading
+    /// </summary>
+    [Parameter] 
+    [Category(CategoryTypes.Tabs.Behavior)]
+    public RenderFragment<RenderFragment> TabWrapperContent { get; set; }
+
+    /// <summary>
     /// TabPanel Tooltip. It will be ignored if TabContent is provided
     /// </summary>
     [Parameter]

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -94,14 +94,16 @@ else
     public RenderFragment TabContent { get; set; }
 
     /// <summary>
-    /// Tab content wrapper of component. It is used with TabContent to entirely wrap the content of a tab heading
+    /// Tab content wrapper of component. It is used to wrap the content of a tab heading in a user supplied div or component. 
+    /// Use @context in the TabWrapperContent to render the tab header within your custom wrapper. 
+    /// This is most useful with tooltips, which must wrap the entire content they refer to.
     /// </summary>
     [Parameter] 
     [Category(CategoryTypes.Tabs.Behavior)]
     public RenderFragment<RenderFragment> TabWrapperContent { get; set; }
 
     /// <summary>
-    /// TabPanel Tooltip. It will be ignored if TabContent is provided
+    /// TabPanel Tooltip. It will be ignored if TabContent is provided.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -5,13 +5,13 @@
     <CascadingValue Value="this" IsFixed="true">
         <div class="@ToolbarClassnames">
             <div class="mud-tabs-toolbar-inner" style="@MaxHeightStyles">
-                @if(HeaderPosition == TabHeaderPosition.Before && Header != null)
+                @if (HeaderPosition == TabHeaderPosition.Before && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
                         @Header(this)
                     </div>
                 }
-                @if(_showScrollButtons)
+                @if (_showScrollButtons)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
@@ -21,43 +21,18 @@
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {
-                            <div class="d-inline-block" style="width: fit-content;">
-                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
-                                    @if (TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
-                                    {
-                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
-                                            @TabPanelHeader(panel)
-                                        </div>
-                                    }
-                                    @if (panel.TabContent != null)
-                                    {
-                                        @panel.TabContent
-                                    }
-                                    else if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" />
-                                    }
-                                    else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    @if (panel.BadgeData != null || panel.BadgeDot)
-                                    {
-                                        <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
-                                    }
-                                    @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
-                                    {
-                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
-                                            @TabPanelHeader(panel)
-                                        </div>
-                                    }
+                            @if(panel.TabContent == null)
+                            {
+                                <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
+                                    @RenderTab(panel)
+                                </MudTooltip>
+                            }
+                            else
+                            {
+                                <div class="d-inline-block" style="width: fit-content;">
+                                    @RenderTab(panel)
                                 </div>
-                            </div>
+                            }                            
                         }
                         @if (!HideSlider)
                         {
@@ -65,13 +40,13 @@
                         }
                     </div>
                 </div>
-                @if(_showScrollButtons)
+                @if (_showScrollButtons)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" />
                     </div>
                 }
-                @if(HeaderPosition == TabHeaderPosition.After && Header != null)
+                @if (HeaderPosition == TabHeaderPosition.After && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-after">
                         @Header(this)
@@ -88,3 +63,41 @@
         </div>
     </CascadingValue>
 </div>
+
+@code {
+    RenderFragment RenderTab(MudTabPanel panel) => @<div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
+        @if (TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
+            {
+                <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
+                    @TabPanelHeader(panel)
+                </div>
+            }
+            @if (panel.TabContent != null)
+            {
+                @panel.TabContent
+            }
+            else if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
+            {
+                @((MarkupString)panel.Text)
+            }
+            else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+            {
+                <MudIcon Icon="@panel.Icon" Color="@IconColor" />
+            }
+            else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+            {
+                <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
+                @((MarkupString)panel.Text)
+            }
+            @if (panel.BadgeData != null || panel.BadgeDot)
+            {
+                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+            }
+            @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
+            {
+                <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                    @TabPanelHeader(panel)
+                </div>
+            }
+        </div>;
+}

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -79,7 +79,7 @@
                 }
             </div>
         </div>
-        @i (PrePanelContent != null)
+        @if (PrePanelContent != null)
         {
             @PrePanelContent(ActivePanel)
         }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -21,7 +21,7 @@
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {
-                            @if(panel.TabContent == null)
+                            @if (panel.TabContent == null)
                             {
                                 <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
                                     @RenderTab(panel)
@@ -29,10 +29,19 @@
                             }
                             else
                             {
-                                <div class="d-inline-block" style="width: fit-content;">
-                                    @RenderTab(panel)
-                                </div>
-                            }                            
+                                if (panel.TabWrapperContent == null)
+                                {
+                                    <div class="d-inline-block" style="width: fit-content;">
+                                        @RenderTab(panel)
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="d-inline-block" style="width: fit-content;">
+                                        @panel.TabWrapperContent(RenderTab(panel))
+                                    </div>
+                                }
+                            }
                         }
                         @if (!HideSlider)
                         {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -8,7 +8,7 @@
                 @if(HeaderPosition == TabHeaderPosition.Before && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
-                       @Header(this)
+                        @Header(this)
                     </div>
                 }
                 @if(_showScrollButtons)
@@ -21,15 +21,19 @@
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {
-                            <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
+                            <div class="d-inline-block" style="width: fit-content;">
                                 <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
-                                    @if(TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
+                                    @if (TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
                                     {
                                         <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
                                             @TabPanelHeader(panel)
                                         </div>
                                     }
-                                    @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
+                                    @if (panel.TabContent != null)
+                                    {
+                                        @panel.TabContent
+                                    }
+                                    else if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
                                     {
                                         @((MarkupString)panel.Text)
                                     }
@@ -46,14 +50,14 @@
                                     {
                                         <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
                                     }
-                                    @if(TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
+                                    @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
                                     {
                                         <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
                                             @TabPanelHeader(panel)
                                         </div>
                                     }
                                 </div>
-                            </MudTooltip>
+                            </div>
                         }
                         @if (!HideSlider)
                         {
@@ -75,14 +79,12 @@
                 }
             </div>
         </div>
-		@if(PrePanelContent != null)
-		{
-			@PrePanelContent(ActivePanel)
-		}
+        @i (PrePanelContent != null)
+        {
+            @PrePanelContent(ActivePanel)
+        }
         <div class="@PanelsClassnames">
             @ChildContent
         </div>
     </CascadingValue>
 </div>
-
-


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

As discussed in #3913 and #4015, the existing "embedded" tooltip of the MudTabs component is limited as it is impossible to specify properties for the Tooltip, such as color. This PR is a demo/test of a possible solution to this problem that provides a `TabContent` render fragment on each `MudTabPanel`, which is rendered accordingly by the parent `MudTab` component if it exists.

This is the solution originally proposed by @Garderoben https://github.com/MudBlazor/MudBlazor/pull/3913#issuecomment-1036982747

This is a breaking change as it makes the existing `Tooltip` property obsolete and any text provided to this property will be ignored.

Other components that similarly use tooltips may need similar changes for consistency.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

This has been tested visually thus far, tests will ultimately need to be added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
