### PR TITLE
MudForm: Option To Validate And Submit With Enter Key

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -1,53 +1,54 @@
-﻿@using System.Text.RegularExpressions
+﻿@inject ISnackbar Snackbar
+
+@using System.Text.RegularExpressions
 @using System.ComponentModel.DataAnnotations
 @namespace MudBlazor.Docs.Examples
 
-<MudGrid>
-    <MudItem xs="12" sm="7">
-        <MudPaper Class="pa-4">
-            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
-                    <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!"/>
-                    <MudTextField T="string" Label="Email" Required="true" RequiredError="Email is required!"
-                                  Validation="@(new EmailAddressAttribute() {ErrorMessage = "The email address is invalid"})"/>
-                    <MudTextField T="string" Label="Password" HelperText="Choose a strong password" @ref="pwField1"
-                                  InputType="InputType.Password"
-                                  Validation="@(new Func<string, IEnumerable<string>>(PasswordStrength))" Required="true"
-                                  RequiredError="Password is required!"/>
-                    <MudTextField T="string"
-                                  Label="Password" HelperText="Repeat the password" InputType="InputType.Password"
-                                  Validation="@(new Func<string, string>(PasswordMatch))"/>
-                    <div class="d-flex">
-                        <MudRadioGroup T="string" Required="true" RequiredError="Account type is required!">
-                            <MudRadio Option="@("Personal")">Personal</MudRadio>
-                            <MudRadio Option="@("Professional")">Professional</MudRadio>
-                        </MudRadioGroup>
-                    </div>
-                    <div class="d-flex align-center justify-space-between mt-6">
-                        <MudCheckBox T="bool" Required="true" RequiredError="You must agree" Class="ml-n2" Label="I agree!"/>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" Class="ml-auto">Register</MudButton>
-                    </div>
-            </MudForm>   
-        </MudPaper>
-        <MudPaper Class="pa-4 mt-4">
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" DisableElevation="true" OnClick="@(()=>form.Validate())">Validate</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Secondary" DisableElevation="true" OnClick="@(()=>form.Reset())" Class="mx-2">Reset</MudButton>
-            <MudButton Variant="Variant.Filled" DisableElevation="true" OnClick="@(()=>form.ResetValidation())">Reset Validation</MudButton>
-        </MudPaper>
-    </MudItem>
-    <MudItem xs="12" sm="5">
-        <MudPaper Class="pa-4 mud-height-full">
-            <MudText Typo="Typo.subtitle2">@($"Errors ({errors.Length})")</MudText>
-                @foreach (var error in errors)
-                {
-                    <MudText Color="@Color.Error">@error</MudText>
-                }
-        </MudPaper>
-    </MudItem>
-</MudGrid>
+
+<MudStack>
+    <MudPaper Class="pa-4">
+        <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors" SubmitOnEnter="submitOnEnter" OnEnterKey="EnterPressed">
+            <MudStack>
+                <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!" />
+                <MudTextField T="string" Label="Email" Required="true" RequiredError="Email is required!"
+                              Validation="@(new EmailAddressAttribute() {ErrorMessage = "The email address is invalid"})" />
+                <MudTextField T="string" Label="Password" HelperText="Choose a strong password" @ref="pwField1"
+                              InputType="InputType.Password"
+                              Validation="@(new Func<string, IEnumerable<string>>(PasswordStrength))" Required="true"
+                              RequiredError="Password is required!" />
+                <MudTextField T="string"
+                              Label="Password" HelperText="Repeat the password" InputType="InputType.Password"
+                              Validation="@(new Func<string, string>(PasswordMatch))" />
+                <MudRadioGroup T="string" Required="true" RequiredError="Account type is required!">
+                    <MudRadio Option="@("Personal")">Personal</MudRadio>
+                    <MudRadio Option="@("Professional")">Professional</MudRadio>
+                </MudRadioGroup>
+                <MudCheckBox T="bool" Required="true" RequiredError="You must agree" Label="I agree!" Style="width: fit-content" />
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" Class="ml-auto">Register</MudButton>
+            </MudStack>
+        </MudForm>
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mt-4">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" DisableElevation="true" OnClick="@(()=>form.Validate())">Validate</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Secondary" DisableElevation="true" OnClick="@(()=>form.Reset())" Class="mx-2">Reset</MudButton>
+        <MudButton Variant="Variant.Filled" DisableElevation="true" OnClick="@(()=>form.ResetValidation())">Reset Validation</MudButton>
+        <MudSwitch Class="ml-2" @bind-Checked="submitOnEnter" Color="Color.Primary" Label="Submit On Enter" />
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mud-height-full">
+        <MudText Typo="Typo.subtitle2">@($"Errors ({errors.Length})")</MudText>
+        @foreach (var error in errors)
+        {
+            <MudText Color="@Color.Error">@error</MudText>
+        }
+    </MudPaper>
+</MudStack>
 
 
 @code {
     bool success;
+    bool submitOnEnter;
     string[] errors = { };
     MudTextField<string> pwField1;
     MudForm form;
@@ -76,4 +77,9 @@
         return null;
     }
 
+    private async void EnterPressed()
+    {
+        await form.Validate();
+        Snackbar.Add("Enter key pressed and form validated.", Severity.Info);
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest.razor
@@ -1,9 +1,10 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudForm ValidationDelay="0">
+<MudForm @ref="_form" ValidationDelay="0" OnEnterKey="@(async() => await _form.Validate())">
     <MudTextField T="string" Required="true" RequiredError="Enter a rock star"></MudTextField>
 </MudForm>
 
 @code {
     public static string __description__ = "Clearing the value of a required textfield should set form's isvalid to false.";
+    MudForm _form;
 }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Form;
@@ -59,6 +60,22 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task FormEnterKeyTest()
+        {
+            var comp = Context.RenderComponent<FormIsValidTest>();
+            //Console.WriteLine(comp.Markup);
+            var form = comp.FindComponent<MudForm>().Instance;
+            await comp.InvokeAsync(() => form.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => form.IsValid.Should().Be(false));
+            comp.WaitForAssertion(() => form.Errors.Length.Should().Be(0));
+#pragma warning disable BL0005
+            await comp.InvokeAsync(() => form.SubmitOnEnter = true);
+            await comp.InvokeAsync(() => form.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => form.IsValid.Should().Be(false));
+            comp.WaitForAssertion(() => form.Errors.Length.Should().Be(1));
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Form/MudForm.razor
+++ b/src/MudBlazor/Components/Form/MudForm.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 
-<form @attributes="UserAttributes" class="@Classname" style="@Style">
+<form @attributes="UserAttributes" class="@Classname" style="@Style" @onkeydown="HandleKeyDown" tabindex="-1">
     @if (SuppressImplicitSubmission)
     {
         <!-- Prevent implicit submission of the form -->

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
@@ -14,7 +15,7 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-form")
             .AddClass(Class)
-       .Build();
+            .Build();
 
         /// <summary>
         /// Child content of component.
@@ -22,6 +23,17 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Form.ValidatedData)]
         public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Form.ValidationResult)]
+        public bool SubmitOnEnter { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.Form.ValidationResult)]
+        public EventCallback OnEnterKey { get; set; }
 
         /// <summary>
         /// Validation status. True if the form is valid and without errors. This parameter is two-way bindable.
@@ -318,6 +330,20 @@ namespace MudBlazor
             }
 
             base.OnInitialized();
+        }
+
+        internal async Task HandleKeyDown(KeyboardEventArgs arg)
+        {
+            switch (arg.Key)
+            {
+                case "Enter":
+                case "NumpadEnter":
+                    if (SubmitOnEnter == true)
+                    {
+                        await OnEnterKey.InvokeAsync();
+                    }
+                    break;
+            }
         }
 
         public void Dispose()

--- a/src/MudBlazor/Styles/components/_form.scss
+++ b/src/MudBlazor/Styles/components/_form.scss
@@ -1,5 +1,3 @@
 ﻿.mud-form {
-   
+    outline: none;
 }
-
-  


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
With this PR users can use enter (or numpad enter) key to call their validate and submit methods.

Especially useful for login and signup forms that are commonly expected to submit with enter.

Also redesign the form example on docs (remove unnecessary grid and add stack)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


https://user-images.githubusercontent.com/78308169/164909606-000c5789-d03c-45c0-b15e-e8387a06e908.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
