### PR TITLE
Popover: fix endless render loop for recursive popups

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -529,9 +529,9 @@ namespace MudBlazor.UnitTests.Components
                 p.Add(x => x.Tag, "my tag");
 
             });
-
             handler.UpdateFragment(changedFragment, comp.Instance, "my-class", "my-style", true);
-            fragmentChangedCounter.Should().Be(2);
+            // counter doesn't change because UpdateFragment now only re-renders the updated fragment, without raising the FragmentsChanged event
+            fragmentChangedCounter.Should().Be(1);
         }
 
         [Test]

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
@@ -6,7 +6,7 @@
 	    @foreach (var handler in Service.Handlers)
 	    {
             <MudRender @ref="handler.ElementReference" @key="handler.Id">
-		        <div id="@($"popovercontent-{handler.Id}")" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
+		        <div id="@($"popovercontent-{handler.Id}")" data-ticks="@(handler.ActivationDate?.Ticks ?? 0)" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
 			        @if (handler.ShowContent == true)
 			        {
 				        @handler.Fragment

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
@@ -5,8 +5,8 @@
     <div class="mud-popover-provider">
 	    @foreach (var handler in Service.Handlers)
 	    {
-            <MudRender @ref="handler.ElementReference">
-		        <div @key="handler.Id" id="@($"popovercontent-{handler.Id}")" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
+            <MudRender @ref="handler.ElementReference" @key="handler.Id">
+		        <div id="@($"popovercontent-{handler.Id}")" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
 			        @if (handler.ShowContent == true)
 			        {
 				        @handler.Fragment

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
@@ -5,12 +5,14 @@
     <div class="mud-popover-provider">
 	    @foreach (var handler in Service.Handlers)
 	    {
-		    <div @key="handler.Id" id="@($"popovercontent-{handler.Id}")" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
-			    @if (handler.ShowContent == true)
-			    {
-				    @handler.Fragment
-			    }
-		    </div>
+            <MudRender @ref="handler.ElementReference">
+		        <div @key="handler.Id" id="@($"popovercontent-{handler.Id}")" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
+			        @if (handler.ShowContent == true)
+			        {
+				        @handler.Fragment
+			        }
+		        </div>
+            </MudRender>
 	    }
     </div>
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
 {
     public partial class MudPopoverProvider : IDisposable
     {
-        private bool _isConnectedToSerivce = false;
+        private bool _isConnectedToService = false;
 
         [Inject] public IMudPopoverService Service { get; set; }
 
@@ -38,28 +38,31 @@ namespace MudBlazor
             }
 
             Service.FragmentsChanged += Service_FragmentsChanged;
-            _isConnectedToSerivce = true;
+            _isConnectedToService = true;
         }
 
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
 
-            if (IsEnabled == false && _isConnectedToSerivce == true)
+            if (IsEnabled == false && _isConnectedToService == true)
             {
                 Service.FragmentsChanged -= Service_FragmentsChanged;
-                _isConnectedToSerivce = false;
+                _isConnectedToService = false;
             }
-            else if(IsEnabled == true && _isConnectedToSerivce == false)
+            else if (IsEnabled == true && _isConnectedToService == false)
             {
+                Service.FragmentsChanged -= Service_FragmentsChanged; // make sure to avoid multiple registration
                 Service.FragmentsChanged += Service_FragmentsChanged;
-                _isConnectedToSerivce = true;
+                _isConnectedToService = true;
             }
         }
 
         private void Service_FragmentsChanged(object sender, EventArgs e)
         {
-            InvokeAsync(StateHasChanged);
+            //Console.WriteLine("Rendering Popoverprovider");
+            StateHasChanged();
         }
+
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -60,8 +60,7 @@ namespace MudBlazor
 
         private void Service_FragmentsChanged(object sender, EventArgs e)
         {
-            //Console.WriteLine("Rendering Popoverprovider");
-            StateHasChanged();
+            InvokeAsync(StateHasChanged);
         }
 
     }

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -73,7 +73,6 @@ namespace MudBlazor
         {
             Fragment = fragment;
             SetComponentBaseParameters(componentBase, @class, @style, showContent);
-            //Console.WriteLine("PopoverHandler.UpdateFragment");
             // this basically calls StateHasChanged on the Popover
             ElementReference?.ForceRender();
             _updater?.Invoke(); // <-- this doesn't do anything anymore except making unit tests happy 

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -40,6 +40,7 @@ namespace MudBlazor
         public object Tag { get; private set; }
         public bool ShowContent { get; private set; }
         public Dictionary<string, object> UserAttributes { get; set; } = new Dictionary<string, object>();
+        public MudRender ElementReference { get; set; }
 
         public MudPopoverHandler(RenderFragment fragment, IJSRuntime jsInterop, Action updater)
         {
@@ -63,8 +64,10 @@ namespace MudBlazor
         {
             Fragment = fragment;
             SetComponentBaseParameters(componentBase, @class, @style, showContent);
+            //Console.WriteLine("PopoverHandler.UpdateFragment");
             // this basically calls StateHasChanged on the Popover
-            _updater.Invoke();
+            ElementReference?.ForceRender();
+            _updater?.Invoke(); // <-- this doesn't do anything anymore except making unit tests happy 
         }
 
         public async Task Initialize()
@@ -152,7 +155,7 @@ namespace MudBlazor
 
         public MudPopoverHandler Register(RenderFragment fragment)
         {
-            var handler = new MudPopoverHandler(fragment, _jsRuntime, () => FragmentsChanged?.Invoke(this, EventArgs.Empty));
+            var handler = new MudPopoverHandler(fragment, _jsRuntime, () => { /*not doing anything on purpose for now*/ });
             _handlers.Add(handler.Id, handler);
 
             FragmentsChanged?.Invoke(this, EventArgs.Empty);

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -39,6 +39,7 @@ namespace MudBlazor
         public string Style { get; private set; }
         public object Tag { get; private set; }
         public bool ShowContent { get; private set; }
+        public DateTime? ActivationDate { get; private set; }
         public Dictionary<string, object> UserAttributes { get; set; } = new Dictionary<string, object>();
         public MudRender ElementReference { get; set; }
 
@@ -57,6 +58,14 @@ namespace MudBlazor
             Tag = componentBase.Tag;
             UserAttributes = componentBase.UserAttributes;
             ShowContent = showContent;
+            if(showContent == true)
+            {
+                ActivationDate = DateTime.Now;
+            }
+            else
+            {
+                ActivationDate = null;
+            }
         }
 
         public void UpdateFragment(RenderFragment fragment,

--- a/src/MudBlazor/Components/Render/MudRender.razor
+++ b/src/MudBlazor/Components/Render/MudRender.razor
@@ -1,0 +1,25 @@
+﻿@namespace MudBlazor
+
+@* MudRender is a container component that only renders its content, so it really doesn't do anything other than giving you the ability to force a re-render of its content
+    This is especially useful if you don't want to render the whole tree for some reason. All you need to force a renderupdate of its content is to call ForceRender() on an 
+    ElementReference to MudRender
+*@
+
+@ChildContent
+
+@code {
+
+    /// <summary>
+    /// The content to render
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    /// <summary>
+    /// Re-render the content
+    /// </summary>
+    public void ForceRender()
+    {
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -308,18 +308,61 @@ class MudPopover {
         this.contentObserver = null;
         this.mainContainerClass = null;
     }
-
+    
     callback(id, mutationsList, observer) {
         for (const mutation of mutationsList) {
             if (mutation.type === 'attributes') {
                 const target = mutation.target
-                if (target.classList.contains('mud-popover-overflow-flip-onopen') &&
-                    target.classList.contains('mud-popover-open') == false) {
-                    target.mudPopoverFliped = null;
-                    target.removeAttribute('data-mudpopover-flip');
-                }
+                if (mutation.attributeName == 'class') {
+                    if (target.classList.contains('mud-popover-overflow-flip-onopen') &&
+                        target.classList.contains('mud-popover-open') == false) {
+                        target.mudPopoverFliped = null;
+                        target.removeAttribute('data-mudpopover-flip');
+                    }
 
-                window.mudpopoverHelper.placePopoverByNode(target);
+                    window.mudpopoverHelper.placePopoverByNode(target);
+                }
+                else if (mutation.attributeName == 'data-ticks') {
+                    const tickAttribute = target.getAttribute('data-ticks');
+                    console.log(target.id + " | " + tickAttribute);
+
+                    const parent = target.parentElement;
+                    const tickValues = [];
+                    let max = -1;
+                    for (let i = 0; i < parent.children.length; i++) {
+                        const childNode = parent.children[i];
+                        const tickValue = parseInt(childNode.getAttribute('data-ticks'));
+                        if (tickValue == 0) {
+                            continue;
+                        }
+
+                        if (tickValues.indexOf(tickValue) >= 0) {
+                            continue;
+                        }
+
+                        tickValues.push(tickValue);
+
+                        if (tickValue > max) {
+                            max = tickValue;
+                        }
+                    }
+
+                    if (tickValues.length == 0) {
+                        continue;
+                    }
+
+                    const sortedTickValues = tickValues.sort((x, y) => x - y);
+
+                    for (let i = 0; i < parent.children.length; i++) {
+                        const childNode = parent.children[i];
+                        const tickValue = parseInt(childNode.getAttribute('data-ticks'));
+                        if (tickValue == 0) {
+                            continue;
+                        }
+
+                        childNode.style['z-index'] = 'calc(var(--mud-zindex-popover) + ' + (sortedTickValues.indexOf(tickValue) + 3).toString() + ')';
+                    }
+                }
             }
         }
     }
@@ -360,7 +403,7 @@ class MudPopover {
 
             window.mudpopoverHelper.placePopover(popoverNode);
 
-            const config = { attributeFilter: ['class'] };
+            const config = { attributeFilter: ['class', 'data-ticks'] };
 
             const observer = new MutationObserver(this.callback.bind(this, id));
 
@@ -385,6 +428,8 @@ class MudPopover {
                 for (let entry of entries) {
                     var target = entry.target;
                     window.mudpopoverHelper.placePopoverByNode(target);
+
+
                 }
             });
 
@@ -439,4 +484,3 @@ window.addEventListener('scroll', () => {
 window.addEventListener('resize', () => {
     window.mudpopoverHelper.placePopoverByClassSelector();
 });
-

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -281,6 +281,7 @@ window.mudpopoverHelper = {
 
             if (window.getComputedStyle(popoverNode).getPropertyValue('z-index') != 'auto') {
                 popoverContentNode.style['z-index'] = window.getComputedStyle(popoverNode).getPropertyValue('z-index');
+                popoverContentNode.skipZIndex = true;
             }
         }
     },
@@ -357,6 +358,10 @@ class MudPopover {
                         const childNode = parent.children[i];
                         const tickValue = parseInt(childNode.getAttribute('data-ticks'));
                         if (tickValue == 0) {
+                            continue;
+                        }
+
+                        if (childNode.skipZIndex == true) {
                             continue;
                         }
 


### PR DESCRIPTION
Recursive popovers caused infinite render loop because the popup provider did re-render all popups when only a single popup requested to be re-rendered due to a fragment update. This could be seen in the dev.4 nuget or on https://dev.mudblazor.com/components/popover#popover-inception before this PR is merged.

The solution was to encapsulate every popup that is rendered as child of the popupprovider in a `<MudRender>` which is a new component with the sole purpose of allowing us to keep an element reference to it and force a render of only that popup when its fragment changed without re-rendering the entire popup provider and the other popups. 

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Caused by #4375 which fixes a bug that did mask this bug. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Manual

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

