### PR TITLE
MudDialog: Fix dialog not closing when using multiple layouts (#4508)

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -86,6 +86,12 @@ namespace MudBlazor
         {
             if (NavigationManager != null)
                 NavigationManager.LocationChanged -= LocationChanged;
+
+            if (DialogService != null)
+            {
+                DialogService.OnDialogInstanceAdded -= AddInstance;
+                DialogService.OnDialogCloseRequested -= DismissInstance;
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Disconnect event handlers in Dispose method of MudDialogProvider.

This fixes a problem that dialogs do not close when using multiple layouts within an application.  When using multiple layouts and at least one includes <MudDialogProvider/> then multiple instances of MudDialogProvider are created during the lifetime of the app.  Previously these instances weren't being disposed correctly which is what causes the issue.

Fixes #4508

## How Has This Been Tested?
Tested with MudBlazor app on local system.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
