### PR TITLE
MudDropZone: Fix NullReferenceException when dragging not tracked item onto MudDynamicDropItem (#4506)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -328,20 +328,18 @@ namespace MudBlazor.UnitTests.Components
         public async Task DropZone_DropItem_DragEnterNotTrackedItem()
         {
             var comp = Context.RenderComponent<DropzoneBasicTest>();
-            {
-                var tempContainer = comp.Find(".mud-drop-container");
-                tempContainer.Children.Should().HaveCount(2);
+            
+            var tempContainer = comp.Find(".mud-drop-container");
+            tempContainer.Children.Should().HaveCount(2);
 
-                var firstDropZone = tempContainer.Children[0];
-                var firstDropItem = firstDropZone.Children[1];
-                
-                await firstDropItem.DragEnterAsync(new DragEventArgs());
-            }
-
-            var container = comp.Find(".mud-drop-container");
-            container.Children.Should().HaveCount(2);
-            container.Children[0].Children.Should().HaveCount(2);
-            container.Children[1].Children.Should().HaveCount(3);
+            var firstDropZone = tempContainer.Children[0];
+            var firstDropItem = firstDropZone.Children[1];
+            
+            await firstDropItem.DragEnterAsync(new DragEventArgs());
+            
+            tempContainer.Children.Should().HaveCount(2);
+            tempContainer.Children[0].Children.Should().HaveCount(2);
+            tempContainer.Children[1].Children.Should().HaveCount(3);
         }
         
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -323,7 +323,27 @@ namespace MudBlazor.UnitTests.Components
             firstDropZone.ClassList.Should().NotContain("my-special-dragging-class");
             firstDropItem.ClassList.Should().NotContain("my-special-item-dragging-class");
         }
+        
+        [Test]
+        public async Task DropZone_DropItem_DragEnterNotTrackedItem()
+        {
+            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            {
+                var tempContainer = comp.Find(".mud-drop-container");
+                tempContainer.Children.Should().HaveCount(2);
 
+                var firstDropZone = tempContainer.Children[0];
+                var firstDropItem = firstDropZone.Children[1];
+                
+                await firstDropItem.DragEnterAsync(new DragEventArgs());
+            }
+
+            var container = comp.Find(".mud-drop-container");
+            container.Children.Should().HaveCount(2);
+            container.Children[0].Children.Should().HaveCount(2);
+            container.Children[1].Children.Should().HaveCount(3);
+        }
+        
         [Test]
         public async Task DropZone_DropNotTrackedItem()
         {

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -123,6 +123,8 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
 
     private void HandleDragEnter()
     {
+        if (Container == null || Container.TransactionInProgress() == false) { return; }
+        
         Container.UpdateTransactionIndex(Index);
     }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Adds check for transaction in progress in DragEnter handler in MudDynamicDropItem.

This fixes a NullReferenceException that is thrown when DragEnter is called by dragging a not tracked item onto MudDynamicDropItem.

Fixes #4506 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested with MudBlazor Docs app on local system and added unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
