### PR TITLE
MudDropZone: Fix NoDropClass not being removed after drop if ItemDropped handler is executed asynchronously (#4516)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanDropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanDropTest.razor
@@ -43,8 +43,11 @@
 	[Parameter]
 	public bool? SecondColumnAppliesClassesOnDragStarted { get; set; } = null;
 
-	private void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+	private async Task ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
 	{
+	    // simulate async/await and force re-rendering
+	    await Task.Delay(1);
+	    
 		dropItem.Item.ZoneIdentifier = dropItem.DropzoneIdentifier;
 	}
 

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -644,6 +644,40 @@ namespace MudBlazor.UnitTests.Components
             thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
             thirdDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
         }
+        
+        [Test]
+        public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragCancelled()
+        {
+            var comp = Context.RenderComponent<DropzoneCanDropTest>(p =>
+            {
+                p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, false);
+                p.Add(x => x.ApplyDropClassesOnDragStarted, true);
+            });
+
+            var firstDropZone = comp.Find(".first-drop-zone");
+            var secondDropZone = comp.Find(".second-drop-zone");
+            var thirdDropZone = comp.Find(".third-drop-zone");
+
+            var dragItem = firstDropZone.Children[1];
+
+            //start dragging
+            await dragItem.DragStartAsync(new DragEventArgs());
+            
+            //cancel drag transaction
+            await dragItem.DragEndAsync(new DragEventArgs());
+
+            //first zone, as source, should not have classes applied
+            firstDropZone.ClassList.Should().NotContain("can-drop-from-container");
+            firstDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
+
+            //second zone, should not have styles because it is explicit set to false
+            secondDropZone.ClassList.Should().NotContain("can-drop-from-zone");
+            secondDropZone.ClassList.Should().NotContain("no-drop-class-from-zone");
+
+            //third zone, should not have classes applied after cancellation
+            thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
+            thirdDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
+        }
 
         [Test]
         public void DropZone_CheckDropClasses_DisabledItems()

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -607,6 +607,43 @@ namespace MudBlazor.UnitTests.Components
             thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
             thirdDropZone.ClassList.Should().Contain("no-drop-class-from-container");
         }
+        
+        [Test]
+        public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragFinished()
+        {
+            var comp = Context.RenderComponent<DropzoneCanDropTest>(p =>
+            {
+                p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, false);
+                p.Add(x => x.ApplyDropClassesOnDragStarted, true);
+            });
+
+            var firstDropZone = comp.Find(".first-drop-zone");
+            var secondDropZone = comp.Find(".second-drop-zone");
+            var thirdDropZone = comp.Find(".third-drop-zone");
+
+            var dragItem = firstDropZone.Children[1];
+
+            //start dragging
+            await dragItem.DragStartAsync(new DragEventArgs());
+            
+            //enter second drop zone
+            await secondDropZone.DragEnterAsync(new DragEventArgs());
+            
+            //drop to second drop zone
+            await secondDropZone.DropAsync(new DragEventArgs());
+
+            //first zone, as source, should not have classes applied
+            firstDropZone.ClassList.Should().NotContain("can-drop-from-container");
+            firstDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
+
+            //second zone, should not have styles because it is explicit set to false
+            secondDropZone.ClassList.Should().NotContain("can-drop-from-zone");
+            secondDropZone.ClassList.Should().NotContain("no-drop-class-from-zone");
+
+            //third zone, should not have classes applied after drop
+            thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
+            thirdDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
+        }
 
         [Test]
         public void DropZone_CheckDropClasses_DisabledItems()

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -312,15 +312,17 @@ namespace MudBlazor
             }
 
             await ItemDropped.InvokeAsync(new MudItemDropInfo<T>(_transaction.Item, dropzoneIdentifier, index));
-            TransactionEnded?.Invoke(this, new MudDragAndDropTransactionFinishedEventArgs<T>(dropzoneIdentifier, true, _transaction));
+            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(dropzoneIdentifier, true, _transaction);
             _transaction = null;
+            TransactionEnded?.Invoke(this, transactionFinishedEventArgs);
         }
 
         public async Task CancelTransaction()
         {
             await _transaction.Cancel();
-            TransactionEnded?.Invoke(this, new MudDragAndDropTransactionFinishedEventArgs<T>(_transaction));
+            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(_transaction);
             _transaction = null;
+            TransactionEnded?.Invoke(this, transactionFinishedEventArgs);
         }
 
         public void UpdateTransactionIndex(int index)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This sets the _transaction to null in MudDropContainer.CommitTransaction and MudDropContainer.CancelTransaction before the TransactionEnded event is fired. This is changed because if the component is re-rendered, there is still an active transaction, but _canDrop is set to false by the handler method MudDropZone.Container_TransactionEnded (if ApplyDropClassesOnDragStarted is set to true). This is why the NoDrop css classes are getting applied.

Fixes #4516

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually in the Docs app + new unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
