### PR TITLE
MudDropZone: Fix keeping elements order when you drag one out of the MudDropZone (#4311)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDraggingTestCantDropSecondZoneTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDraggingTestCantDropSecondZoneTest.razor
@@ -6,7 +6,8 @@
 				  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
 				  ItemDropped="ItemUpdated">
 	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
+                     CanDrop=@( (x) => false)>
 			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -1055,5 +1055,36 @@ namespace MudBlazor.UnitTests.Components
             firstDropZone.Children[3].TextContent.Should().Be("Item 3");
             firstDropZone.Children[4].TextContent.Should().Be("Item 4");
         }
+        
+        [Test]
+        public async Task DropZone_DragFinished_DropNotAllowed_KeepOrder()
+        {
+            var comp = Context.RenderComponent<DropzoneDraggingTestCantDropSecondZoneTest>();
+        
+            var container = comp.Find(".mud-drop-container");
+            container.Children.Should().HaveCount(2);
+        
+            var firstDropZone = container.Children[0];
+            var secondDropZone = container.Children[1];
+        
+            secondDropZone.Children.Should().HaveCount(3);
+            var secondDropItem = secondDropZone.Children[1];
+            var secondDropItemText = secondDropItem.Children[0].TextContent;
+            
+            secondDropItemText.Should().Be("Second Item");
+            
+            await secondDropItem.DragStartAsync(new DragEventArgs());
+        
+            //drop item in first zone
+            await firstDropZone.DropAsync(new DragEventArgs());
+        
+            //reload DOM references
+            container = comp.Find(".mud-drop-container");
+            secondDropZone = container.Children[1];
+            secondDropItem = secondDropZone.Children[1];
+            secondDropItemText = secondDropItem.Children[0].TextContent;
+            
+            secondDropItemText.Should().Be("Second Item");
+        }
     }
 }

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -237,21 +237,24 @@ namespace MudBlazor
                 _canDrop = false;
             }
 
-            if (e.OriginatedDropzoneIdentifier == Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
+            if (e.Success)
             {
-                _indicies.Remove(e.Item);
-            }
-
-            if (e.OriginatedDropzoneIdentifier == Identifier || e.DestinationDropzoneIdentifier == Identifier)
-            {
-                int index = 0;
-
-                foreach (var item in _indicies.OrderBy(x => x.Value).ToArray())
+                if (e.OriginatedDropzoneIdentifier == Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
                 {
-                    _indicies[item.Key] = index++;
+                    _indicies.Remove(e.Item);
+                }
+
+                if (e.OriginatedDropzoneIdentifier == Identifier || e.DestinationDropzoneIdentifier == Identifier)
+                {
+                    int index = 0;
+
+                    foreach (var item in _indicies.OrderBy(x => x.Value).ToArray())
+                    {
+                        _indicies[item.Key] = index++;
+                    }
                 }
             }
-
+            
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -237,7 +237,7 @@ namespace MudBlazor
                 _canDrop = false;
             }
 
-            if (e.Success)
+            if (e.Success == true)
             {
                 if (e.OriginatedDropzoneIdentifier == Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
                 {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

The internal indices were always updated after a drag drop operation. Now they are only updated if the drag drop operation was successful.

Fixes #4311

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually in the local Docs app and by unit test.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
