### PR TITLE
MudMask: Ctrl+Backspace clears textfield #4510

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -642,6 +642,11 @@ namespace MudBlazor.UnitTests.Components
             // clear via clear button
             await comp.InvokeAsync(() => maskField.HandleClearButton(new MouseEventArgs()));
             comp.WaitForAssertion(() => maskField.Mask.ToString().Should().Be("|"));
+            // ctrl + backspace clears input
+            await comp.InvokeAsync(() => maskField.OnPaste("123"));
+            comp.WaitForAssertion(() => maskField.Mask.ToString().Should().Be("123 |"));
+            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
+            comp.WaitForAssertion(() => maskField.Mask.ToString().Should().Be("|"));
         }
 
         [Test]
@@ -691,6 +696,15 @@ namespace MudBlazor.UnitTests.Components
             //This gives error
             await comp.InvokeAsync(() => textField.SetText("123"));
             comp.WaitForAssertion(() => textField.Value.Should().Be("(123) "));
+
+            //ctrl+backspace
+            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => mask.OnPaste("1234567890"));
+            comp.WaitForAssertion(() => mask.Mask.ToString().Should().Be("(123) 456-7890|"));
+            comp.WaitForAssertion(() => textField.Text.Should().Be("(123) 456-7890"));
+            comp.WaitForAssertion(() => textField.Value.Should().Be("(123) 456-7890"));
+            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
+            comp.WaitForAssertion(() => textField.Value.Should().Be(""));
         }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -182,12 +182,18 @@ namespace MudBlazor
         {
             try
             {
-                if (e.CtrlKey || e.AltKey)
-                    return;
+                if ((e.CtrlKey && e.Key != "Backspace") || e.AltKey)
+                        return;
                 // Console.WriteLine($"HandleKeyDown: '{e.Key}'");
                 switch (e.Key)
                 {
                     case "Backspace":
+                        if (e.CtrlKey)
+                        {
+                            Mask.Clear();
+                            await Update();
+                            return;
+                        }
                         Mask.Backspace();
                         await Update();
                         return;


### PR DESCRIPTION
## Description: 
Fixed missing functionality on mudTextfield with mask and ctrl+backspace shortcut.

Issue fix #4510 


## How Has This Been Tested?
Unit Test added + visible on docs

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
