### PR TITLE
Fix transient services memory leak (#4240)

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
@@ -42,5 +42,11 @@ namespace MudBlazor.UnitTests.Mocks
                 item.Invoke(args);
             }
         }
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -16,6 +16,10 @@ namespace MudBlazor.UnitTests.Mocks
         {
             OnScroll?.Invoke(this, new ScrollEventArgs());
         }
+
+        public void Dispose()
+        {
+        }
     }
 
 
@@ -39,7 +43,7 @@ namespace MudBlazor.UnitTests.Mocks
         public ValueTask ScrollToListItemAsync(string elementId) => ValueTask.CompletedTask;
 
         public Task ScrollToTop(ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => Task.CompletedTask;
-        
+
         public ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => ValueTask.CompletedTask;
 
         public ValueTask ScrollToBottomAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => ValueTask.CompletedTask;

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -208,5 +208,13 @@ namespace MudBlazor
             }
             await base.OnAfterRenderAsync(firstRender);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor.Dispose();
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -570,6 +570,7 @@ namespace MudBlazor
         public async ValueTask DisposeAsync()
         {
             await ThrottledEventManager.Unsubscribe(_throttledMouseOverEventId);
+            await ThrottledEventManager.DisposeAsync();
         }
 
         #endregion

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -11,7 +11,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudDialogInstance : MudComponentBase
+    public partial class MudDialogInstance : MudComponentBase, IDisposable
     {
         private DialogOptions _options = new();
         private string _elementId = "dialog_" + Guid.NewGuid().ToString().Substring(0, 8);
@@ -94,7 +94,7 @@ namespace MudBlazor
 
         internal void HandleKeyDown(KeyboardEventArgs args)
         {
-             switch (args.Key)
+            switch (args.Key)
             {
                 case "Escape":
                     if (CloseOnEscapeKey)
@@ -300,6 +300,8 @@ namespace MudBlazor
         }
 
         private MudDialog _dialog;
+        private bool _isDisposed;
+
         public void Register(MudDialog dialog)
         {
             if (dialog == null)
@@ -314,6 +316,23 @@ namespace MudBlazor
         public void ForceRender()
         {
             StateHasChanged();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || _isDisposed)
+                return;
+
+            _keyInterceptor?.Dispose();
+            _isDisposed = true;
+        }
+
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -414,7 +414,10 @@ namespace MudBlazor
         protected override void Dispose(bool disposing)
         {
             if (disposing)
+            {
                 _keyInterceptor?.Dispose();
+                _jsEvent?.Dispose();
+            }
 
             base.Dispose(disposing);
         }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -145,7 +145,7 @@ namespace MudBlazor
                     new JsEventOptions
                     {
                         //EnableLogging = true,
-                        TargetClass = "mud-input-slot", 
+                        TargetClass = "mud-input-slot",
                         TagName = "INPUT"
                     });
                 _jsEvent.CaretPositionChanged += OnCaretPositionChanged;
@@ -315,7 +315,7 @@ namespace MudBlazor
             var text = Text;
             if (Mask.Selection != null)
             {
-                (_, text, _)=BaseMask.SplitSelection(text, Mask.Selection.Value);
+                (_, text, _) = BaseMask.SplitSelection(text, Mask.Selection.Value);
             }
             _jsApiService.CopyToClipboardAsync(text);
         }
@@ -405,10 +405,18 @@ namespace MudBlazor
 
         private async void OnCut(ClipboardEventArgs obj)
         {
-            if (_selection!=null)
+            if (_selection != null)
                 Mask.Delete();
             await Update();
             //Console.WriteLine($"OnCut: '{Mask}'");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor?.Dispose();
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -380,5 +380,13 @@ namespace MudBlazor
             else
                 return null;
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor?.Dispose();
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -508,5 +508,13 @@ namespace MudBlazor
                     break;
             }
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor?.Dispose();
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -187,14 +187,10 @@ namespace MudBlazor
                 await MudRadioGroup.RegisterRadioAsync(this);
         }
 
-        public void Dispose()
-        {
-            MudRadioGroup?.UnregisterRadio(this);
-        }
-
         [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
 
         private string _elementId = "radio" + Guid.NewGuid().ToString().Substring(0, 8);
+        private bool _isDisposed;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
@@ -213,6 +209,23 @@ namespace MudBlazor
                 });
             }
             await base.OnAfterRenderAsync(firstRender);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed || !disposing)
+                return;
+
+            _keyInterceptor?.Dispose();
+            MudRadioGroup?.UnregisterRadio(this);
+            _isDisposed = true;
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -124,6 +124,7 @@ namespace MudBlazor
         public void Dispose()
         {
             ScrollListener.OnScroll -= ScrollListener_OnScroll;
+            ScrollListener?.Dispose();
         }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -77,7 +77,7 @@ namespace MudBlazor
             await ScrollToItemAsync(item);
         }
         private ValueTask ScrollToItemAsync(MudSelectItem<T> item)
-            =>item != null? ScrollManager.ScrollToListItemAsync(item.ItemId): ValueTask.CompletedTask;
+            => item != null ? ScrollManager.ScrollToListItemAsync(item.ItemId) : ValueTask.CompletedTask;
         private async Task SelectFirstItem(string startChar = null)
         {
             if (_items == null || _items.Count == 0)
@@ -1040,6 +1040,14 @@ namespace MudBlazor
                 return SelectedValues?.Count() > 0;
             else
                 return base.HasValue(value);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor?.Dispose();
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -131,5 +131,13 @@ namespace MudBlazor
             }
             await base.OnAfterRenderAsync(firstRender);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _keyInterceptor?.Dispose();
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -309,6 +309,7 @@ namespace MudBlazor
         {
             if (_isDisposed == true)
                 return;
+
             _isDisposed = true;
             _resizeObserver.OnResized -= OnResized;
             await _resizeObserver.DisposeAsync();
@@ -630,7 +631,7 @@ namespace MudBlazor
         {
             var x = 0D;
             var count = 0;
-            
+
             var toolbarContentSize = GetRelevantSize(_tabsContentSize);
 
             foreach (var panel in _panels)

--- a/src/MudBlazor/Services/EventManager.cs
+++ b/src/MudBlazor/Services/EventManager.cs
@@ -31,9 +31,12 @@ namespace MudBlazor
         /// <param name="key">The unique event identifier</param>
         /// <returns>true for if the event listener was detached, false if not</returns>
         Task<bool> Unsubscribe(Guid key);
+
+        ValueTask DisposeAsync(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
+        void Dispose(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
     }
 
-    public class EventListener : IEventListener, IAsyncDisposable, IDisposable
+    public class EventListener : IEventListener
     {
         private readonly IJSRuntime _jsRuntime;
         private readonly DotNetObjectReference<EventListener> _dotNetRef;

--- a/src/MudBlazor/Services/JsEvent/JsEvent.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEvent.cs
@@ -21,12 +21,13 @@ namespace MudBlazor.Services
         event Action<int> CaretPositionChanged;
         event Action<string> Paste;
         event Action<int, int> Select;
+        void Dispose(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
     }
 
     /// <summary>
     /// Subscribe JS events of any element by html id
     /// </summary>
-    public class JsEvent : IJsEvent, IDisposable
+    public class JsEvent : IJsEvent
     {
         private bool _isDisposed = false;
 
@@ -70,7 +71,7 @@ namespace MudBlazor.Services
                 return;
             await UnsubscribeAll();
             try
-            {                
+            {
                 await _jsRuntime.InvokeVoidAsync($"mudJsEvent.disconnect", _elementId);
             }
             catch (Exception) {  /*ignore*/ }
@@ -110,7 +111,7 @@ namespace MudBlazor.Services
                 return;
             try
             {
-                foreach(var eventName in _subscribedEvents)
+                foreach (var eventName in _subscribedEvents)
                     await _jsRuntime.InvokeVoidAsync($"mudJsEvent.unsubscribe", _elementId, eventName);
             }
             catch (Exception) {  /*ignore*/ }

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptor.cs
@@ -14,15 +14,15 @@ namespace MudBlazor.Services
 
     public delegate void KeyboardEvent(KeyboardEventArgs args);
 
-    public interface IKeyInterceptor : IDisposable
+    public interface IKeyInterceptor
     {
         Task Connect(string elementId, KeyInterceptorOptions options);
         Task Disconnect();
         Task UpdateKey(KeyOptions option);
+        void Dispose(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
 
         event KeyboardEvent KeyDown;
         event KeyboardEvent KeyUp;
-
     }
 
 }

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.Services
     /// It can call preventDefault or stopPropagation directly on the JavaScript side for single key strokes / key combinations as per configuration.
     /// Furthermore, you can precisely subscribe single keystrokes or combinations and only the subscribed ones will be forwarded into .NET
     /// </summary>
-    public class KeyInterceptor : IKeyInterceptor, IDisposable
+    public class KeyInterceptor : IKeyInterceptor
     {
         private bool _isDisposed = false;
 
@@ -71,20 +71,21 @@ namespace MudBlazor.Services
             try
             {
                 await _jsRuntime.InvokeVoidAsync($"mudKeyInterceptor.disconnect", _elementId);
-            } catch (Exception) {  /*ignore*/ }
+            }
+            catch (Exception) {  /*ignore*/ }
             _isObserving = false;
         }
 
         [JSInvokable]
         public void OnKeyDown(KeyboardEventArgs args)
         {
-            KeyDown?.Invoke( args);
+            KeyDown?.Invoke(args);
         }
 
         [JSInvokable]
         public void OnKeyUp(KeyboardEventArgs args)
         {
-            KeyUp?.Invoke( args);
+            KeyUp?.Invoke(args);
         }
 
         public event KeyboardEvent KeyDown;

--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
@@ -9,7 +9,7 @@ namespace MudBlazor.Services
 
     public delegate void SizeChanged(IDictionary<ElementReference, BoundingClientRect> changes);
 
-    public interface IResizeObserver : IAsyncDisposable, IDisposable
+    public interface IResizeObserver
     {
         Task<BoundingClientRect> Observe(ElementReference element);
         Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);
@@ -22,5 +22,8 @@ namespace MudBlazor.Services
         event SizeChanged OnResized;
 
         bool IsElementObserved(ElementReference reference);
+
+        void Dispose(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
+        ValueTask DisposeAsync(); // Transient services can't be IAsyncDisposable but the service must still be (manually) deallocated
     }
 }

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
@@ -9,7 +9,7 @@ using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-    public class ResizeObserver : IResizeObserver, IDisposable, IAsyncDisposable
+    public class ResizeObserver : IResizeObserver
     {
         private Boolean _isDisposed = false;
 

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -12,9 +12,10 @@ namespace MudBlazor
         string Selector { get; set; }
 
         event EventHandler<ScrollEventArgs> OnScroll;
+        void Dispose(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
     }
 
-    internal class ScrollListener : IScrollListener, IDisposable
+    internal class ScrollListener : IScrollListener
     {
         private readonly IJSRuntime _js;
         private DotNetObjectReference<ScrollListener> _dotNetRef;
@@ -30,6 +31,7 @@ namespace MudBlazor
         }
 
         private EventHandler<ScrollEventArgs> _onScroll;
+        private bool _isDisposed;
 
         /// <summary>
         /// OnScroll event. Fired when a element is scrolled
@@ -95,9 +97,22 @@ namespace MudBlazor
             catch { /* ignore */ }
         }
 
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed || !disposing)
+                return;
+
+            Cancel().AndForget(TaskOption.Safe);
+            _dotNetRef?.Dispose();
+            _isDisposed = true;
+        }
+
         public void Dispose()
         {
-            _dotNetRef?.Dispose();
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MudBlazor/Services/Scroll/ScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpy.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
         public string Id { get; init; }
     }
 
-    public interface IScrollSpy : IAsyncDisposable
+    public interface IScrollSpy
     {
         /// <summary>
         /// Start spying for scroll events for elements with the specified classes
@@ -53,6 +53,8 @@ namespace MudBlazor
         /// Get the current position of the centered section
         /// </summary>
         string CenteredSection { get; }
+
+        ValueTask DisposeAsync(); // Transient services can't be IDisposable but the service must still be (manually) deallocated
     }
 
     public class ScrollSpy : IScrollSpy


### PR DESCRIPTION
## Description
All transient services implementing IDisposable or IAsyncDisposable will create memory leaks when injected by Blazor. The DI container will keep references to all disposable transients until the scope is disposed, see https://blazor-university.com/dependency-injection/dependency-lifetimes-and-scopes/transient-dependencies/#avoiding-memory-leaks for more information.
This was resolved by removing the formal IDisposable and/or IAsyncDisposable interfaces from all transient services and making sure the injecting components properly calls the services' (informal) Dispose()/DisposeAsync().

Resolves #4240.
Resolves #4060

Note that only the IKeyInterceptor service was reported leaking in #4240 but further analysis confirmed all disposable transient services were leaking in similar ways. This PR includes fixes for all of them.

## How Has This Been Tested?
Existing unit tests passed.
Memory profiling confirms the leaks are gone.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Care has been taken to not break public API's but IDisposable has been removed from service interfaces and their implementing classes, in theory creating breaking changes in the unlikely event that affected services are cast to IDisposable in user code.


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
