### PR TITLE
MudTreeView: Changed TreeView to use ICollection<T> instead of HashSet<T>

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -20,7 +20,7 @@
 
         public int? Number { get; set; }
 
-        public HashSet<TreeItemData> TreeItems { get; set; }
+        public ICollection<TreeItemData> TreeItems { get; set; }
 
         public TreeItemData(string title, string icon, int? number = null)
         {
@@ -47,7 +47,7 @@
         TreeItems.Add(new TreeItemData("History", Icons.Filled.Label));
     }
 
-    public async Task<HashSet<TreeItemData>> LoadServerData(TreeItemData parentNode)
+    public async Task<ICollection<TreeItemData>> LoadServerData(TreeItemData parentNode)
     {
         await Task.Delay(500);
         return parentNode.TreeItems;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
@@ -17,7 +17,7 @@
 
         public int? Number { get; set; }
 
-        public HashSet<TreeItemData> TreeItems { get; set; }
+        public ICollection<TreeItemData> TreeItems { get; set; }
 
         public TreeItemData(string title, string icon, int? number = null)
         {
@@ -44,7 +44,7 @@
         TreeItems.Add(new TreeItemData("History", Icons.Filled.Label));
     }
 
-    public Task<HashSet<TreeItemData>> LoadServerData(TreeItemData parentNode)
+    public Task<ICollection<TreeItemData>> LoadServerData(TreeItemData parentNode)
     {
         return Task.FromResult(parentNode.TreeItems);
     }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -131,9 +131,12 @@ namespace MudBlazor
         [Category(CategoryTypes.TreeView.Behavior)]
         public bool Disabled { get; set; }
 
+        /// <summary>
+        /// Collection of items to render using ItemTemplate
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public HashSet<T> Items { get; set; }
+        public ICollection<T> Items { get; set; }
 
         [ExcludeFromCodeCoverage]
         [Obsolete("Use SelectedValueChanged instead.", true)]
@@ -171,7 +174,7 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public Func<T, Task<HashSet<T>>> ServerData { get; set; }
+        public Func<T, Task<ICollection<T>>> ServerData { get; set; }
 
         public MudTreeView()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -135,7 +135,7 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public HashSet<T> Items { get; set; }
+        public ICollection<T> Items { get; set; }
 
         /// <summary>
         /// Command executed when the user clicks on the CommitEdit Button.


### PR DESCRIPTION
## Description

fixes #4105

Changed TreeView `Items` and `ServerData` to use `ICollection<T>` instead of `HashSet<T>`.

Reason for the change:

1) `HashSet<T>` does not ensure order [(doc)](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1?view=net-6.0) and a TreeView should render its items in the correct order. It's only working by luck, not by implementation.
2) Using an interface like `ICollection<T>` will allow users to use any storage backend. Like `List<T>` or any custom-made class implementing `ICollection<T>` 
3) A `HashSet<T>` is a lot harder for people starting to understand versus a "collection" of items or a "list of items".
4) There's really no need for the UI component to force the use of a specific storage

This is not a breaking change for the `Items` property, since existing pieces of code using `HashSet<T>` can still plug it into the new `ICollection<T>`. 
It is a breaking change for the `ServerData` property, it won't compile on existing code, since `Task<HashSet<T>>` cannot be passed to a `Task<ICollection<T>>`.
The change only requires changing the returned type to `ICollection<T>`.

I can also re-do the change, with `IReadOnlyCollection<T>`, if we're 100% sure the TreeView will never need to manipulate in the provided list of items.

## How Has This Been Tested?
No new unit tests has been added. The documentation and existing unit tests already cover the changed code.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
