### PR TITLE
BreakpointService: Fix race condition causing invalid state

### DIFF
--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -23,7 +23,6 @@ namespace MudBlazor.Services
         private IBrowserWindowSizeProvider _browserWindowSizeProvider;
         private BrowserWindowSize _windowSize;
         private Breakpoint _breakpoint = Breakpoint.None;
-        private SemaphoreSlim _subscribeSemaphore = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// 
@@ -145,11 +144,12 @@ namespace MudBlazor.Services
                 DotNetRef = DotNetObjectReference.Create(this);
             }
 
-            var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
 
             try
             {
-                await _subscribeSemaphore.WaitAsync();
+                await Semaphore.WaitAsync();
+
+                var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
 
                 if (existingOptionId == default)
                 {
@@ -188,7 +188,7 @@ namespace MudBlazor.Services
             }
             finally
             {
-                _subscribeSemaphore.Release();
+                Semaphore.Release();
             }
         }
     }

--- a/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.Services
         where TSelf : class
         where TInfo : SubscriptionInfo<TAction, TaskOption>
     {
-        private SemaphoreSlim _unsubscribeSemaphore = new SemaphoreSlim(1, 1);
+        protected SemaphoreSlim Semaphore = new (1, 1);
 
         protected Dictionary<Guid, TInfo> Listeners { get; } = new();
         protected IJSRuntime JsRuntime { get; init; }
@@ -43,7 +43,7 @@ namespace MudBlazor.Services
 
             try
             {
-                await _unsubscribeSemaphore.WaitAsync();
+                await Semaphore.WaitAsync();
 
                 var isLastSubscriber = info.Value.RemoveSubscription(subscriptionId);
                 if (isLastSubscriber == true)
@@ -66,7 +66,7 @@ namespace MudBlazor.Services
             }
             finally
             {
-                _unsubscribeSemaphore.Release();
+                Semaphore.Release();
             }
 
             return true;


### PR DESCRIPTION
## Description

In a project, I recently encountered an issue regarding MudHidden. 

Currently, the code looks like

```csharp
var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
try
{
   await _semaphore.WaitAsync();
   ...calling js and do other stuff
}
finally
{
  _semaphore.Release();
}
```
Because the ``existingOptionId`` is read before entering the semaphore (and there is another semaphore for removing items from the dictionary ``Listeners`` it creates a condition where the option id once valid is invalid at the time, the value is read from the dictionary. Therefore the ``<MudHidden>`` relying on the service will fail with a message like

![image](https://user-images.githubusercontent.com/51370361/167148899-9a190a43-e67e-42fc-97ef-d8dde31be215.png)

I've restructured the service a bit. Firstly, there is only one semaphore for both subscribing (adding to the dictionary) and unsubscribing (removing from the dictionary). Besides, the relevant dictionary lookup takes place after locking the semaphore.

```csharp
try
{
   await Semaphore.WaitAsync();
   var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
   ... do stuff ...
 }
 finally
{
   Semaphore.Release();
}
```

## How Has This Been Tested?
I've included MudBlazor locally (not as a package reference) in the relevant project, fixed the issue there, and the error was gone. I've tried writing unit tests, but these conditions are challenging to reproduce in such a scenario,

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
