### PR TITLE
Autocomplete: Add MoreItemsTemplate RenderFragment.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest6.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
+    <MoreItemsTemplate>
+        <MudText>Not all items are shown</MudText>
+    </MoreItemsTemplate>
+</MudAutocomplete>
+
+@code {
+    public static string __description__ = "There are more than 10 items, so the more items template should render";
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -222,6 +222,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// MoreItemsTemplate should render when there are more items than the MaxItems limit
+        /// </summary>
+        [Test]
+        public async Task AutocompleteTest6()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest6>();
+
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var mudText = comp.Find("p.mud-typography");
+            mudText.InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
+        }
+
+        /// <summary>
         /// After press Enter key down, the selected value should be shown in the input value
         /// </summary>
 
@@ -655,7 +671,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_ChangeBoundValue()
         {
-            await ImproveChanceOfSuccess(async () => { 
+            await ImproveChanceOfSuccess(async () =>
+            {
                 var comp = Context.RenderComponent<AutocompleteChangeBoundObjectTest>();
                 var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
                 var autocomplete = autocompletecomp.Instance;

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -233,8 +233,8 @@ namespace MudBlazor.UnitTests.Components
             inputControl.Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            var mudText = comp.Find("p.mud-typography");
-            mudText.InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -9,7 +9,7 @@
             <InputContent>
                 <MudInput @ref="_elementReference" @key="_elementKey" InputType="InputType.Text"
                           Class="mud-select-input" Margin="@Margin"
-                          Variant="@Variant" 
+                          Variant="@Variant"
                           TextUpdateSuppression="@TextUpdateSuppression"
                           Value="@Text" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
@@ -52,6 +52,12 @@
                                         @ItemTemplate(item)
                                     }
                                 </MudListItem>
+                            }
+                            @if (MoreItemsTemplate != null && _itemsReturned > MaxItems)
+                            {
+                                <div class="pa-1">
+                                    @MoreItemsTemplate
+                                </div>
                             }
                         </MudList>
                     }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -387,9 +387,9 @@ namespace MudBlazor
             {
                 Console.WriteLine("The search function failed to return results: " + e.Message);
             }
+            _itemsReturned = searched_items.Count();
             if (MaxItems.HasValue)
             {
-                _itemsReturned = searched_items.Count();
                 searched_items = searched_items.Take(MaxItems.Value);
             }
             _items = searched_items.ToArray();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -184,6 +184,13 @@ namespace MudBlazor
         public RenderFragment<T> ItemDisabledTemplate { get; set; }
 
         /// <summary>
+        /// Optional template when more items were returned from the Search function than the MaxItems limit
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment MoreItemsTemplate { get; set; }
+
+        /// <summary>
         /// On drop-down close override Text with selected Value. This makes it clear to the user
         /// which list value is currently selected and disallows incomplete values in Text.
         /// </summary>
@@ -356,6 +363,8 @@ namespace MudBlazor
 
         private void OnTimerComplete(object stateInfo) => InvokeAsync(OnSearchAsync);
 
+        private int _itemsReturned; //the number of items returned by the search function
+
         /// <remarks>
         /// This async method needs to return a task and be awaited in order for
         /// unit tests that trigger this method to work correctly.
@@ -379,7 +388,10 @@ namespace MudBlazor
                 Console.WriteLine("The search function failed to return results: " + e.Message);
             }
             if (MaxItems.HasValue)
+            {
+                _itemsReturned = searched_items.Count();
                 searched_items = searched_items.Take(MaxItems.Value);
+            }
             _items = searched_items.ToArray();
 
             _enabledItemIndices = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true).Select(tuple => tuple.idx).ToList();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a `<MoreItemsTemplate>` render fragment to the autocomplete. The component has a means of limiting the items displayed but provides no indication to the user that the list of items may be truncated. This PR provides a means of displaying a render fragment in the number of items returned from the `SearchFunc` is greater than the `MaxItems` count.

For example:
```csharp
<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1"
ResetValueOnEmptyText="@resetValueOnEmptyText"
CoerceText="@coerceText" CoerceValue="@coerceValue" MaxItems="10">
    <MoreItemsTemplate>
        <MudText Align="Align.Center">
        Not all items are shown.
        </MudText>
    </MoreItemsTemplate>
</MudAutocomplete>
```
![image](https://user-images.githubusercontent.com/26885142/167214599-a05d290e-426e-4678-86a4-afe3ec89f7b7.png)


My biggest caveat is the items `IEnumerable` must be enumerated twice, once to get the count of items, and once to take the appropriate number according to MaxItems. There may be a way to better optimize this (I don't care how long the items `IEnumberable` is, provided it is longer than MaxItems).

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I have added a unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
