### PR TITLE
MudDropZone: fixed drag and drop events propagation for nested drop zones (#4602)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
@@ -4,14 +4,25 @@
 	<DocsPageHeader Title="Drop Zone" SubTitle="Drag and Drop"/>
 
 	<DocsPageContent>
-		<DocsPageSection>
-			<SectionHeader Title="Basic Usage">
+        <DocsPageSection>
+            <SectionHeader Title="Basic Usage">
+                <Description>
+
+                </Description>
+            </SectionHeader>
+            <SectionContent ShowCode="false" Code="DropZoneUsageExample">
+                <DropZoneUsageExample />
+            </SectionContent>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+			<SectionHeader Title="Nested DropZone Usage">
 				<Description>
 
 				</Description>
 			</SectionHeader>
-			<SectionContent ShowCode="false" Code="DropZoneUsageExample">
-				<DropZoneUsageExample />
+			<SectionContent ShowCode="false" Code="DropZoneNestedUsageExample">
+				<DropZoneNestedUsageExample />
 			</SectionContent>
 		</DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneNestedUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneNestedUsageExample.razor
@@ -1,0 +1,58 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDropContainer T="DropItem" Items="_items" ItemsSelector="@((item, dropzone) => item.ParentId.ToString() == dropzone)" ItemDropped="ItemUpdated">
+    <ChildContent>
+        <MudStack >
+            <MudText Typo="Typo.h6" Class="mb-2">First DropZone</MudText>
+            <MudDropZone T="DropItem" Identifier="@Guid.Empty.ToString()" AllowReorder="true" Class=" d-flex flex-row rounded mud-background-gray pa-2 ma-2">
+
+            </MudDropZone>
+        </MudStack>
+    </ChildContent>
+    <ItemRenderer>
+        <MudPaper Elevation="25" Class="pa-2 ma-2">
+            <MudStack >
+                <MudText Typo="Typo.h6" Class="mb-2">@context.Name</MudText>
+                <MudDropZone T="DropItem" Identifier="@context.Id.ToString()" AllowReorder="true" Class="rounded mud-background-gray pa-2 ma-2">
+
+                </MudDropZone>
+            </MudStack>
+        </MudPaper>
+    </ItemRenderer>
+</MudDropContainer>
+
+@code {
+
+    private static Guid _level1 = Guid.NewGuid();
+    private static Guid _level2 = Guid.NewGuid();
+    private static Guid _level3 = Guid.NewGuid();
+
+    private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
+    {
+        dropItem.Item.ParentId = Guid.Parse(dropItem.DropzoneIdentifier);
+    }
+
+    private List<DropItem> _items = new()
+    {
+        new DropItem() {Id = _level1, Name = "Drag me!"},
+        new DropItem() {Id = _level2, Name = "Or me!"},
+        new DropItem() {Id = _level3, Name = "Just Mud"},
+        new DropItem() {ParentId = _level1, Name = "Drag me! - child 1"},
+        new DropItem() {ParentId = _level2, Name = "Or me! - child 1"},
+        new DropItem() {ParentId = _level3, Name = "Just Mud - child 1"},
+        new DropItem() {ParentId = _level1, Name = "Drag me! - child 2"},
+        new DropItem() {ParentId = _level2, Name = "Or me! - child 2"},
+        new DropItem() {ParentId = _level3, Name = "Just Mud - child 2"},
+        new DropItem() {ParentId = _level1, Name = "Drag me! - child 3"},
+        new DropItem() {ParentId = _level2, Name = "Or me! - child 3"},
+        new DropItem() {ParentId = _level3, Name = "Just Mud - child 3"},
+    };
+
+    public class DropItem
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid ParentId { get; set; } = Guid.Empty;
+        public string Name { get; init; }
+    }
+
+}

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -4,66 +4,75 @@
 
 
 <div class="@Classname" style="@Style"
-	 id="@($"mud-drop-zone-{_id}")"
-	 @ondrop="HandleDrop"
-	 @ondragenter="HandleDragEnter"
-	 @ondragleave="HandleDragLeave"
-	 @attributes="UserAttributes">
+     id="@($"mud-drop-zone-{_id}")"
+     @ondrop="HandleDrop"
+     @ondragenter="HandleDragEnter"
+     @ondragleave="HandleDragLeave"
+     @ondragover:preventDefault
+     @ondragenter:preventDefault
+     @ondrop:preventDefault
+     @ondrop:stopPropagation
+     @ondragenter:stopPropagation
+     @ondragend:stopPropagation
+     @ondragover:stopPropagation
+     @ondragleave:stopPropagation
+     @ondragstart:stopPropagation
+     @attributes="UserAttributes">
 
-	@ChildContent
+    @ChildContent
 
-	@if (OnlyZone != true)
-	{
-		int index = 0;
-		var transactionIndex = Container?.GetTransactionIndex() ?? -1;
-		var items = GetItems();
+    @if (OnlyZone != true)
+    {
+        int index = 0;
+        var transactionIndex = Container?.GetTransactionIndex() ?? -1;
+        var items = GetItems();
 
-		@if (AllowReorder == true)
-		{
-		    @if (items.Any() == false)
-		    {
-		        <div class="@PlaceholderClassname"></div>
-		    }
-		    else
-		    {
-		        if (transactionIndex == -1)
-		        {
-		            <div class="@PlaceholderClassname"></div>
-		        }
-		        <MudDynamicDropItem @key="_id" T="T"
+        @if (AllowReorder == true)
+        {
+            @if (items.Any() == false)
+            {
+                <div class="@PlaceholderClassname"></div>
+            }
+            else
+            {
+                if (transactionIndex == -1)
+                {
+                    <div class="@PlaceholderClassname"></div>
+                }
+                <MudDynamicDropItem @key="_id" T="T"
                                     Item="default"
                                     ZoneIdentifier="@Identifier"
                                     Disabled="true" HideContent="false"
                                     Class="mud-drop-item-preview-start"/>
-		    }
-		}
-	    @foreach (var item in items)
-		{
-			var indexCopy = index;
+            }
+        }
+        @foreach (var item in items)
+        {
+            var indexCopy = index;
 
-			<MudDynamicDropItem @key="@(item.GetHashCode())" T="T" DraggingClass="@GetItemDraggingClass()"
-						Item="item"
-						OnDragStarted="DragOperationStarted"
-						OnDragEnded="FinishedDragOperation"
-						ZoneIdentifier="@Identifier"
-						Disabled="@GetItemDisabledStatus(item)"
-						Index="indexCopy"
-						DisabledClass="@(DisabledClass ?? Container?.DisabledClass)">
-				@{
-					var renderer = GetItemTemplate();
-				}
+            <MudDynamicDropItem @key="@(item.GetHashCode())" T="T" DraggingClass="@GetItemDraggingClass()"
+                                Item="item"
+                                OnDragStarted="DragOperationStarted"
+                                OnDragEnded="FinishedDragOperation"
+                                ZoneIdentifier="@Identifier"
+                                Disabled="@GetItemDisabledStatus(item)"
+                                Index="indexCopy"
+                                DisabledClass="@(DisabledClass ?? Container?.DisabledClass)">
+                @{
+                    var renderer = GetItemTemplate();
+                }
 
-				@renderer(item)
+                @renderer(item)
 
-			</MudDynamicDropItem>
+            </MudDynamicDropItem>
 
 
-			if (transactionIndex == indexCopy && IsOrign(indexCopy) == false )
-			{
-				<div class="@PlaceholderClassname"></div>
-			}
+            if (transactionIndex == indexCopy && IsOrign(indexCopy) == false)
+            {
+                <div class="@PlaceholderClassname"></div>
+            }
 
-			index++;
-		}
-	}
+            index++;
+        }
+    }
 </div>


### PR DESCRIPTION
…s  (#4602)

When using "Nested Drop Zone" because of drag and drop events propagation, it didn't work.
so made a quick and effective fix.

## Description
I only added following attributes to drop zone div tag :

-      @ondragover:preventDefault
-      @ondragenter:preventDefault
-      @ondrop:preventDefault
-      @ondrop:stopPropagation
-      @ondragenter:stopPropagation
-      @ondragend:stopPropagation
-      @ondragover:stopPropagation
-      @ondragleave:stopPropagation
-      @ondragstart:stopPropagation

and I made Nested Drop Zone usage example at documentation projects under  "/components/dropzone" page

## How Has This Been Tested?
As there was just a fix, and  nothing more. I made sure that existing unit tests are working fine and nothing is broken.
There were no need to create tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
