### PR TITLE
MudDrawer: Handle JSDisconnectedExceptions thrown when disposed.

### DIFF
--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -312,9 +312,9 @@ namespace MudBlazor
                     DrawerContainer?.Remove(this);
 
                     if (_mouseEnterListenerId != 0)
-                        _ = _drawerRef.MudRemoveEventListenerAsync("mouseenter", _mouseEnterListenerId);
+                        _drawerRef.MudRemoveEventListenerAsync("mouseenter", _mouseEnterListenerId).AndForget(TaskOption.Safe);
                     if (_mouseLeaveListenerId != 0)
-                        _ = _drawerRef.MudRemoveEventListenerAsync("mouseleave", _mouseLeaveListenerId);
+                        _drawerRef.MudRemoveEventListenerAsync("mouseleave", _mouseLeaveListenerId).AndForget(TaskOption.Safe);
 
                     var toDispose = _dotNetRef;
                     _dotNetRef = null;

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace MudBlazor
@@ -32,8 +33,8 @@ namespace MudBlazor
             {
                 if (option != TaskOption.Safe)
                     throw;
-
-                Console.WriteLine(ex);
+                
+                Debug.WriteLine(ex);
             }
         }
 
@@ -58,8 +59,8 @@ namespace MudBlazor
             {
                 if (option != TaskOption.Safe)
                     throw;
-
-                Console.WriteLine(ex);
+                
+                Debug.WriteLine(ex);
             }
         }
     }


### PR DESCRIPTION
## Description
Resolves #4608 by ignoring exceptions thrown during Dispose. Also changes the call to Console.WriteLine to Debug.WriteLine as these messages are not desirable in a release build of a production application -- Console.WriteLine mangles log outputs of other components and doesn't allow the user to control the format (e.g. JSON logging)

## How Has This Been Tested?
Visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
