### PR TITLE
Table: Add "selective" multi-select

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSelectiveMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSelectiveMultiSelectExample.razor
@@ -1,0 +1,42 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable Items="@Elements" MultiSelection SelectItem="SelectItemFunc" @bind-SelectedItems="selectedItems1" Hover>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
+    </PagerContent>
+    <FooterContent>
+        <MudTd colspan="5">Select All</MudTd>
+    </FooterContent>
+</MudTable>
+
+<MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
+
+@code {
+    private HashSet<Element> selectedItems1 = new HashSet<Element>();
+
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    private Func<Element, bool> SelectItemFunc = x => x.Number % 2 == 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -82,6 +82,17 @@
                 <TableMultiSelectExample />
             </SectionContent>
         </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Selective Multi-Selection">
+                <Description>
+                    Setting a <CodeInline>SelectItem</CodeInline> Func will determine whether a row can be selected in multi-select mode.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="TableSelectiveMultiSelectExample" ShowCode="false" Block="true" FullWidth="true">
+                <TableSelectiveMultiSelectExample />
+            </SectionContent>
+        </DocsPageSection>
 
         <DocsPageSection>
             <SectionHeader Title="Fixed header and footer">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest8.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" SelectItem="SelectItemFunc">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "Selecting all items from the header should only select items that are enabled";
+
+    private Func<int, bool> SelectItemFunc = x => x % 2 == 0;
+
+    int[] items = new int[] { 0, 1, 2, 3, 4, 5, 6 };
+    HashSet<int> selectedItems = new HashSet<int>();
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -751,6 +751,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Selecting all items from the header should only select items that are enabled
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest8()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionTest8>();
+            // print the generated html
+            //Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var text = comp.FindComponent<MudText>();
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(8); // <-- one header, 7 rows
+            var th = comp.FindAll("th").ToArray();
+            th.Length.Should().Be(2); //  one for the checkbox, one for the header
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(14); // two td per row for multi selection
+            var inputs = comp.FindAll("input").ToArray();
+            inputs.Length.Should().Be(8); // one checkbox per row + one for the header
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+            // click header checkbox and verify selection text
+            inputs[0].Change(true);
+            table.SelectedItems.Count.Should().Be(4);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 2, 4, 6 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(5); //checked count (0, 2, 4, 6, and the header)
+            checkboxes.Sum(x => !x.Checked ? 1 : 0).Should().Be(3); //unchecked count (1, 3, 5)
+            inputs = comp.FindAll("input").ToArray();
+            inputs[0].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+        }
+
+        /// <summary>
         /// Checkbox click must not bubble up.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -84,7 +84,7 @@
                             <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
-                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" 
+                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" DisableCheckbox="!SelectItem(item)" IsCheckable="MultiSelection" IsEditable="IsEditable" 
                                       IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                                    @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
@@ -198,7 +198,7 @@
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, ! string.IsNullOrEmpty("mud-table-row-group-indented-1")).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
              } 
-             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
+             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" DisableCheckbox="!SelectItem(item)" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
                         IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -163,6 +163,13 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// A function that returns whether or not an item should be selectable when MultiSelection is true.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Selecting)]
+        public Func<T, bool> SelectItem { get; set; } = x => true;
+
+        /// <summary>
         /// A function that returns whether or not an item should be displayed in the table. You can use this to implement your own search function.
         /// </summary>
         [Parameter]
@@ -400,6 +407,13 @@ namespace MudBlazor
             return FilteredItems.Count();
         }
 
+        public override int GetFilteredSelectableItemsCount()
+        {
+            if (ServerData != null)
+                return _server_data.TotalItems;
+            return FilteredItems.Where(SelectItem).Count();
+        }
+
         public override void SetSelectedItem(object item)
         {
             SelectedItem = item.As<T>();
@@ -439,7 +453,7 @@ namespace MudBlazor
                 Context.Selection.Clear();
             else
             {
-                foreach (var item in FilteredItems)
+                foreach (var item in FilteredItems.Where(SelectItem))
                     Context.Selection.Add(item);
             }
             Context.UpdateRowCheckBoxes(false);

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -463,6 +463,8 @@ namespace MudBlazor
 
         public abstract int GetFilteredItemsCount();
 
+        public abstract int GetFilteredSelectableItemsCount();
+
         public abstract void SetSelectedItem(object item);
 
         public abstract void SetEditingItem(object item);

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -9,7 +9,7 @@
             <div class="d-flex" style="@ActionsStylename">
                 @if (IsCheckable)
                 {
-                    <MudCheckBox @bind-Checked="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
+                    <MudCheckBox @bind-Checked="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox" Disabled="DisableCheckbox"></MudCheckBox>
                 }
             </div>
         </MudElement>

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -26,6 +26,11 @@ namespace MudBlazor
 
         [Parameter] public object Item { get; set; }
 
+        /// <summary>
+        /// If true, disables the Checkbox. Has no effect if IsCheckable is false
+        /// </summary>
+        [Parameter] public bool DisableCheckbox { get; set; }
+
         [Parameter] public bool IsCheckable { get; set; }
 
         [Parameter] public bool IsEditable { get; set; }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -57,7 +57,7 @@ namespace MudBlazor
             }
             if (HeaderRows.Count > 0 || FooterRows.Count > 0)
             {
-                var itemsCount = Table.GetFilteredItemsCount();
+                var itemsCount = Table.GetFilteredSelectableItemsCount();
                 var b = Selection.Count == itemsCount && itemsCount != 0;
                 // update header checkbox
                 foreach (var header in HeaderRows)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a `SelectItem` Func to the `MudTable` which allows the user to determine which items should be selected when `MultiSelection` is enabled. The header and footer checkboxes will only select the items that pass the select `SelectItem` Func.

My only concern is the naming of `SelectItem` which is close to the existing `SelectedItem` parameter. An alterative could be `ShouldSelectItem`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I have added a unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
