### PR TITLE
Dialog: Fix error thrown when clicking dialog overlay

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -290,13 +290,13 @@ namespace MudBlazor
             if (DisableBackdropClick)
                 return;
 
-            if (_dialog.OnBackdropClick == null)
+            if (_dialog?.OnBackdropClick == null)
             {
                 Cancel();
                 return;
             }
 
-            _dialog.OnBackdropClick.Invoke();
+            _dialog?.OnBackdropClick.Invoke();
         }
 
         private MudDialog _dialog;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Clicking the overlay on a dialog that has been opened using `Show` may throw an error due to `_dialog` being null.

This is a regression from #4413.

As far as I can tell `_dialog` being null is not a bug, as the `Register` [method](https://github.com/MudBlazor/MudBlazor/blob/dev/src/MudBlazor/Components/Dialog/MudDialog.razor.cs#L198) is only called when using an inline `MudDialog`.

The original error can be reproduced here: https://try.mudblazor.com/snippet/mOcQOJvKVYHXdiox

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Manually, and tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
