### PR TITLE
Rework transient services

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -70,7 +70,7 @@ namespace MudBlazor.UnitTests.Components
         {
             _eventListener = new MockEventListener();
             base.Setup();
-            Context.Services.AddSingleton<IEventListener>(_eventListener);
+            Context.Services.AddSingleton<IEventListenerFactory>(new MockEventListenerFactory(_eventListener));
         }
 
         private void CheckColorRelatedValues(IRenderedComponent<SimpleColorPickerTest> comp, double expectedX, double expectedY, MudColor expectedColor, ColorPickerMode mode, bool checkInstanceValue = true, bool isRtl = false)

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -19,11 +19,15 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class DynamicTabsTests : BunitTest
     {
+        public override void Setup()
+        {
+            base.Setup();
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), new MockResizeObserverFactory()));
+        }
+
         [Test]
         public async Task DefaultValues()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<MudDynamicTabs>();
             var tabs = comp.Instance;
 
@@ -53,8 +57,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task BasicParameters()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
             //Console.WriteLine(comp.Markup);
 
@@ -92,8 +94,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task BasicParameters_WithToolTips()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<SimpleDynamicTabsTestWithToolTips>();
             //Console.WriteLine(comp.Markup);
 
@@ -157,7 +157,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestInteractions_AddTab()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
             var comp = Context.RenderComponent<SimpleDynamicTabsInteractionTest>();
 
             //Console.WriteLine(comp.Markup);
@@ -172,7 +171,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestInteractions_RemoveTab()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
             var comp = Context.RenderComponent<SimpleDynamicTabsInteractionTest>();
 
             //Console.WriteLine(comp.Markup);

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -12,11 +12,16 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class PageContentNavigationTests : BunitTest
     {
+        public override void Setup()
+        {
+            base.Setup();
+            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), new MockScrollSpyFactory()));
+
+        }
+
         [Test]
         public void DefaultValues()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), new MockScrollSpy()));
-
             var comp = Context.RenderComponent<MudPageContentNavigation>();
 
             comp.Instance.ActiveSection.Should().BeNull();
@@ -33,8 +38,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task AddSection(bool withUpdate)
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), new MockScrollSpy()));
-
             var comp = Context.RenderComponent<MudPageContentNavigation>();
 
             var section1 = new MudPageContentSection("my section", "my-id");
@@ -78,7 +81,8 @@ namespace MudBlazor.UnitTests.Components
                 CenteredSection = "my-id"
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), mockedScrollSpy));
+            var factory = new MockScrollSpyFactory(mockedScrollSpy);
+            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
             var comp = Context.RenderComponent<MudPageContentNavigation>();
 
@@ -110,7 +114,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var mockedScrollSpy = new MockScrollSpy();
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), mockedScrollSpy));
+            var factory = new MockScrollSpyFactory(mockedScrollSpy);
+            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
             var comp = Context.RenderComponent<MudPageContentNavigation>(p => p.Add(x => x.ActivateFirstSectionAsDefault, true));
 
@@ -143,7 +148,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var spyMock = new MockScrollSpy();
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), spyMock));
+            var factory = new MockScrollSpyFactory(spyMock);
+            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
             var comp = Context.RenderComponent<MudPageContentNavigation>();
 
@@ -180,7 +186,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var spyMock = new MockScrollSpy();
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), spyMock));
+            var factory = new MockScrollSpyFactory(spyMock);
+            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
             var comp = Context.RenderComponent<MudPageContentNavigation>(x => x.Add(y => y.SectionClassSelector, "my-section-class"));
 
@@ -223,10 +230,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task HideContentIfOnlyOneSectionIsAdded()
         {
-            var mockedScrollSpy = new MockScrollSpy();
-
-            Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), mockedScrollSpy));
-
             var comp = Context.RenderComponent<MudPageContentNavigation>();
 
             var section = new MudPageContentSection("my section", "my-id");

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -19,11 +19,15 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TabsTests : BunitTest
     {
+        public override void Setup()
+        {
+            base.Setup();
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), new MockResizeObserverFactory()));
+        }
+
         [Test]
         public async Task AddingAndRemovingTabPanels()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsAddingRemovingTabsTest>();
             //Console.WriteLine(comp.Markup);
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().BeEmpty();
@@ -80,8 +84,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeepTabsAliveTest()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsKeepAliveTest>();
             //Console.WriteLine(comp.Markup);
             // all panels should be evident in the markup:
@@ -140,8 +142,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeepTabs_Not_AliveTest()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsKeepAliveTest>(ComponentParameter.CreateParameter("KeepPanelsAlive", false));
             //Console.WriteLine(comp.Markup);
             // only one panel should be evident in the markup:
@@ -181,8 +181,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ScrollToItem_NoScrollingNeeded()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
 
@@ -216,7 +214,9 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = totalSize + 10,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -248,7 +248,9 @@ namespace MudBlazor.UnitTests.Components
                 IsVertical = true,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             comp.SetParametersAndRender(p => p.Add(x => x.Position, Position.Left));
@@ -276,7 +278,9 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 200 + 10,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -310,8 +314,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Scroll_NotEnabled_EnoughSpace()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
 
@@ -334,7 +336,9 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 200,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
 
@@ -360,7 +364,9 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 200,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
 
@@ -385,7 +391,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 200,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
 
@@ -418,7 +425,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 200,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
 
@@ -453,7 +461,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 300,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -480,7 +489,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 300,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -506,7 +516,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 300,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -544,7 +555,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 300,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -580,7 +592,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 300,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -622,7 +635,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 250.0,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<SimplifiedScrollableTabsTest>();
 
@@ -659,7 +673,8 @@ namespace MudBlazor.UnitTests.Components
                 PanelTotalSize = 250.0,
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<SimplifiedScrollableTabsTest>(p => p.Add(x => x.StartAmount, 5));
 
@@ -699,8 +714,6 @@ namespace MudBlazor.UnitTests.Components
                (x,y) => x.Instance.ActivateTab(y.Panel, false),
                (x,y) => x.Instance.ActivateTab(y.Tag, false),
             };
-
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             foreach (var invoker in activator)
             {
@@ -758,8 +771,6 @@ namespace MudBlazor.UnitTests.Components
                (x,y) => x.Instance.ActivateTab(y.Tag, true),
             };
 
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             foreach (var invoker in activator)
             {
                 var comp = Context.RenderComponent<ActivateDisabledTabsTest>();
@@ -792,8 +803,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectedIndex_Binding()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             //starting with index 1:
             var comp = Context.RenderComponent<SelectedIndexTabsTest>();
             comp.Instance.Tabs.ActivePanelIndex.Should().Be(1);
@@ -843,8 +852,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TabHeaderPosition.Before)]
         public async Task RenderHeaderBasedOnPosition(TabHeaderPosition position)
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, position));
             comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
@@ -875,8 +882,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RenderHeaderBasedOnPosition_None()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
@@ -893,8 +898,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TabHeaderPosition.Before)]
         public async Task RenderHeaderPanelBasedOnPosition(TabHeaderPosition position)
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, position));
@@ -930,8 +933,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RenderHeaderPanelBasedOnPosition_None()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
@@ -943,8 +944,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task HtmlTextTabs()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             // get the tab panels, we must have 2 tabs, one with html text and one without
             var comp = Context.RenderComponent<HtmlTextTabsTest>();
             //Console.WriteLine(comp.Markup);
@@ -966,8 +965,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ToggleTabsSliderAnimation()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<ToggleTabsSlideAnimationTest>();
 
             //Toggle DisableSliderAnimation to true
@@ -987,8 +984,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MenuInHeaderPanelCloseOnClickOutside()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithMenuInHeader>();
 
             //open the menu
@@ -1007,8 +1002,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PrePanelContent()
         {
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
-
             var comp = Context.RenderComponent<TabsWithPrePanelContent>(p => p.Add(x => x.SelectedIndex, 0));
 
             var content =  comp.Find(".pre-panel-content-custom");

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddTransient<IScrollSpy, MockScrollSpy>();
+            ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
             ctx.Services.AddTransient<IEventListener, MockEventListener>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
-            ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
+            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddTransient<IScrollSpy, MockScrollSpy>();
             ctx.Services.AddTransient<IEventListener, MockEventListener>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -31,7 +31,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
-            ctx.Services.AddTransient<IEventListener, MockEventListener>();
+            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
             ctx.Services.AddSingleton<IMenuService, MenuService>();

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -36,8 +36,8 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
             ctx.Services.AddSingleton<IMenuService, MenuService>();
             ctx.Services.AddSingleton<IMudPopoverService, MockPopoverService>();
-            ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEvent, MockJsEvent>();
+            ctx.Services.AddTransient<IKeyInterceptorFactory, MockKeyInterceptorServiceFactory>();
+            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
             ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddScoped(sp => new HttpClient());
         }

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
             ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddTransient<IScrollSpy, MockScrollSpy>();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -31,7 +31,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
-            ctx.Services.AddTransient<IEventListener, EventListener>();
+            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
             ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();
             ctx.Services.AddTransient<IJsEvent, MockJsEvent>();
             ctx.Services.AddSingleton<IMudPopoverService, MockPopoverService>();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
-            ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
+            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddTransient<IEventListener, EventListener>();
             ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -32,8 +32,8 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
-            ctx.Services.AddTransient<IKeyInterceptor, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEvent, MockJsEvent>();
+            ctx.Services.AddTransient<IKeyInterceptorFactory, MockKeyInterceptorServiceFactory>();
+            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
             ctx.Services.AddSingleton<IMudPopoverService, MockPopoverService>();
             ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddOptions();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
             ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());

--- a/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
@@ -32,6 +32,13 @@ namespace MudBlazor.UnitTests.Mocks
 
         public Dictionary<Guid, string> ElementIdMapper { get; private set; } = new();
 
+        public ValueTask DisposeAsync()
+        {
+            Callbacks.Clear();
+            ElementIdMapper.Clear();
+            return ValueTask.CompletedTask;
+        }
+
         public Task<Guid> Subscribe<T>(string eventName, string elementId, string projection, int throttleInterval, Func<object, Task> callback)
         {
             var id = Guid.NewGuid();

--- a/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockEventListener.cs
@@ -9,6 +9,23 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor.UnitTests.Mocks
 {
+    public class MockEventListenerFactory : IEventListenerFactory
+    {
+        private readonly MockEventListener _listener;
+
+        public MockEventListenerFactory(MockEventListener listener)
+        {
+            _listener = listener;
+        }
+
+        public MockEventListenerFactory()
+        {
+
+        }
+
+        public IEventListener Create() => _listener ?? new MockEventListener();
+    }
+
     public class MockEventListener : IEventListener
     {
         public Dictionary<Guid, Func<object, Task>> Callbacks { get; private set; } = new();

--- a/src/MudBlazor.UnitTests/Mocks/MockJsEvent.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockJsEvent.cs
@@ -11,6 +11,23 @@ namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998
 #pragma warning disable CS0067
+    public class MockJsEventFactory : IJsEventFactory
+    {
+        private readonly MockJsEvent _jsEvent;
+
+        public MockJsEventFactory(MockJsEvent jsEvent)
+        {
+            _jsEvent = jsEvent;
+        }
+
+        public MockJsEventFactory()
+        {
+
+        }
+
+        public IJsEvent Create() => _jsEvent ?? new MockJsEvent();
+    }
+
     public class MockJsEvent : IJsEvent
     {
         public void Dispose()

--- a/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockKeyInterceptor.cs
@@ -7,6 +7,23 @@ namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998
 #pragma warning disable CS0067
+    public class MockKeyInterceptorServiceFactory : IKeyInterceptorFactory
+    {
+        private readonly MockKeyInterceptorService _interceptorService;
+
+        public MockKeyInterceptorServiceFactory(MockKeyInterceptorService interceptorService)
+        {
+            _interceptorService = interceptorService;
+        }
+
+        public MockKeyInterceptorServiceFactory()
+        {
+
+        }
+
+        public IKeyInterceptor Create() => _interceptorService ?? new MockKeyInterceptorService();
+    }
+
     public class MockKeyInterceptorService : IKeyInterceptor
     {
         public void Dispose()

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
@@ -9,6 +9,24 @@ using MudBlazor.Services;
 
 namespace MudBlazor.UnitTests.Mocks
 {
+    public class MockResizeObserverFactory : IResizeObserverFactory
+    {
+        private MockResizeObserver _observer;
+
+        public MockResizeObserverFactory()
+        {
+
+        }
+
+        public MockResizeObserverFactory(MockResizeObserver observer)
+        {
+            _observer = observer;
+        }
+
+        public IResizeObserver Create(ResizeObserverOptions options) => _observer ?? new MockResizeObserver();
+        public IResizeObserver Create() => Create(new ResizeObserverOptions());
+    }
+
     public class MockResizeObserver : IResizeObserver, IDisposable
     {
         private Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -5,6 +5,7 @@ namespace MudBlazor.UnitTests.Mocks
 {
     public class MockScrollListenerFactory : IScrollListenerFactory
     {
+
         public IScrollListener Create(string selector) =>
             new MockScrollListener()
             {

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -3,6 +3,15 @@ using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Mocks
 {
+    public class MockScrollListenerFactory : IScrollListenerFactory
+    {
+        public IScrollListener Create(string selector) =>
+            new MockScrollListener()
+            {
+                Selector = selector,
+            };
+    }
+
     /// <summary>
     /// Mock for scroll listener
     /// </summary>
@@ -15,6 +24,11 @@ namespace MudBlazor.UnitTests.Mocks
         public MockScrollListener()
         {
             OnScroll?.Invoke(this, new ScrollEventArgs());
+        }
+
+        public void Dispose()
+        {
+           
         }
     }
 

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
@@ -4,6 +4,23 @@ using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Mocks
 {
+    public class MockScrollSpyFactory : IScrollSpyFactory
+    {
+        private readonly MockScrollSpy _spy;
+
+        public MockScrollSpyFactory(MockScrollSpy spy)
+        {
+            _spy = spy;
+        }
+
+        public MockScrollSpyFactory()
+        {
+
+        }
+
+        public IScrollSpy Create() => _spy ?? new MockScrollSpy();
+    }
+
     /// <summary>
     /// Mock for scroll spy
     /// </summary>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -185,7 +185,8 @@ namespace MudBlazor
             }
         }
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        private IKeyInterceptor _keyInterceptor;
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
         private string _elementId = "checkbox" + Guid.NewGuid().ToString().Substring(0, 8);
 
@@ -193,6 +194,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = _keyInterceptorFactory.Create();
+
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -207,6 +210,16 @@ namespace MudBlazor
                 _keyInterceptor.KeyDown += HandleKeyDown;
             }
             await base.OnAfterRenderAsync(firstRender);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _keyInterceptor?.Dispose();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -575,6 +575,8 @@ namespace MudBlazor
 
         public async ValueTask DisposeAsync()
         {
+           if(_throttledEventManager == null) { return; }
+
             await _throttledEventManager.Unsubscribe(_throttledMouseOverEventId);
         }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -577,7 +577,7 @@ namespace MudBlazor
         {
            if(_throttledEventManager == null) { return; }
 
-            await _throttledEventManager.Unsubscribe(_throttledMouseOverEventId);
+            await _throttledEventManager.DisposeAsync();
         }
 
         #endregion

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -52,7 +52,8 @@ namespace MudBlazor
         private readonly Guid _id = Guid.NewGuid();
         private Guid _throttledMouseOverEventId;
 
-        [Inject] IEventListener ThrottledEventManager { get; set; }
+        private IEventListener _throttledEventManager;
+        [Inject] IEventListenerFactory ThrottledEventManagerFactory { get; set; }
 
         #endregion
 
@@ -551,8 +552,13 @@ namespace MudBlazor
         {
             if (DisableDragEffect == true) { return; }
 
+            if(_throttledEventManager == null)
+            {
+                _throttledEventManager = ThrottledEventManagerFactory.Create();
+            }
+
             _throttledMouseOverEventId = await
-                ThrottledEventManager.Subscribe<MouseEventArgs>("mousemove", _id.ToString(), "mudEventProjections.correctOffset", 10, async (x) =>
+                _throttledEventManager.Subscribe<MouseEventArgs>("mousemove", _id.ToString(), "mudEventProjections.correctOffset", 10, async (x) =>
                 {
                     var e = x as MouseEventArgs;
                     await InvokeAsync(() => OnMouseOver(e));
@@ -564,12 +570,12 @@ namespace MudBlazor
         {
             if (_throttledMouseOverEventId == default) { return Task.CompletedTask; }
 
-            return ThrottledEventManager.Unsubscribe(_throttledMouseOverEventId);
+            return _throttledEventManager.Unsubscribe(_throttledMouseOverEventId);
         }
 
         public async ValueTask DisposeAsync()
         {
-            await ThrottledEventManager.Unsubscribe(_throttledMouseOverEventId);
+            await _throttledEventManager.Unsubscribe(_throttledMouseOverEventId);
         }
 
         #endregion

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -11,12 +11,14 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudDialogInstance : MudComponentBase
+    public partial class MudDialogInstance : MudComponentBase, IDisposable
     {
         private DialogOptions _options = new();
         private string _elementId = "dialog_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private IKeyInterceptor _keyInterceptor;
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
+
         [CascadingParameter] public bool RightToLeft { get; set; }
         [CascadingParameter] private MudDialogProvider Parent { get; set; }
         [CascadingParameter] private DialogOptions GlobalDialogOptions { get; set; } = new DialogOptions();
@@ -79,6 +81,8 @@ namespace MudBlazor
                 //Since CloseOnEscapeKey is the only thing to be handled, turn interceptor off
                 if (CloseOnEscapeKey)
                 {
+                    _keyInterceptor = _keyInterceptorFactory.Create();
+
                     await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                     {
                         TargetClass = "mud-dialog",
@@ -300,6 +304,8 @@ namespace MudBlazor
         }
 
         private MudDialog _dialog;
+        private bool _disposedValue;
+
         public void Register(MudDialog dialog)
         {
             if (dialog == null)
@@ -314,6 +320,25 @@ namespace MudBlazor
         public void ForceRender()
         {
             StateHasChanged();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _keyInterceptor?.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -15,7 +15,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudMask : MudBaseInput<string>
+    public partial class MudMask : MudBaseInput<string>, IDisposable
     {
         public MudMask()
         {
@@ -65,9 +65,12 @@ namespace MudBlazor
 
         private ElementReference _elementReference;
         private ElementReference _elementReference1;
+        private IJsEvent _jsEvent;
+        private IKeyInterceptor _keyInterceptor;
+        
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
-        [Inject] private IJsEvent _jsEvent { get; set; }
+        [Inject] private IJsEventFactory _jsEventFactory { get; set; }
         [Inject] private IJsApiService _jsApiService { get; set; }
 
         private string _elementId = "mask_" + Guid.NewGuid().ToString().Substring(0, 8);
@@ -141,6 +144,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _jsEvent = _jsEventFactory.Create();
+
                 await _jsEvent.Connect(_elementId,
                     new JsEventOptions
                     {
@@ -151,6 +156,9 @@ namespace MudBlazor
                 _jsEvent.CaretPositionChanged += OnCaretPositionChanged;
                 _jsEvent.Paste += OnPaste;
                 _jsEvent.Select += OnSelect;
+
+                _keyInterceptor = _keyInterceptorFactory.Create();
+
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -415,6 +423,17 @@ namespace MudBlazor
                 Mask.Delete();
             await Update();
             //Console.WriteLine($"OnCut: '{Mask}'");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _jsEvent?.Dispose();
+                _keyInterceptor?.Dispose();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -16,6 +16,8 @@ namespace MudBlazor
 {
     public partial class MudNumericField<T> : MudDebouncedInput<T>
     {
+        private IKeyInterceptor _keyInterceptor;
+
         public MudNumericField() : base()
         {
             Validation = new Func<T, Task<bool>>(ValidateInput);
@@ -109,7 +111,7 @@ namespace MudBlazor
                 .Build();
 
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
         private string _elementId = "numericField_" + Guid.NewGuid().ToString().Substring(0, 8);
 
@@ -213,6 +215,7 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = _keyInterceptorFactory.Create();
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -379,6 +382,16 @@ namespace MudBlazor
                 return f.ToString(TagFormat, CultureInfo.InvariantCulture.NumberFormat);
             else
                 return null;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _keyInterceptor?.Dispose();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -14,8 +14,9 @@ namespace MudBlazor
     public partial class MudPageContentNavigation : IAsyncDisposable
     {
         private List<MudPageContentSection> _sections = new();
+        private IScrollSpy _scrollSpy;
 
-        [Inject] IScrollSpy ScrollSpy { get; set; }
+        [Inject] IScrollSpyFactory ScrollSpyFactory { get; set; }
 
         /// <summary>
         /// The displayed section within the MudPageContentNavigation
@@ -55,7 +56,7 @@ namespace MudBlazor
         private Task OnNavLinkClick(string id)
         {
             SelectActiveSection(id);
-            return ScrollSpy.ScrollToSection(id);
+            return _scrollSpy.ScrollToSection(id);
         }
 
         private void ScrollSpy_ScrollSectionSectionCentered(object sender, ScrollSectionCenteredEventArgs e) =>
@@ -92,7 +93,7 @@ namespace MudBlazor
         /// </summary>
         /// <param name="uri">The uri containing the fragment to scroll</param>
         /// <returns>A task that completes when the viewport has scrolled</returns>
-        public Task ScrollToSection(Uri uri) => ScrollSpy.ScrollToSection(uri);
+        public Task ScrollToSection(Uri uri) => _scrollSpy.ScrollToSection(uri);
 
         /// <summary>
         /// Add a section to the content navigation
@@ -121,14 +122,14 @@ namespace MudBlazor
                 counter += diffRootLevel;
             }
 
-            if (section.Id == ScrollSpy.CenteredSection)
+            if (section.Id == _scrollSpy.CenteredSection)
             {
                 section.Activate();
             }
             else if (_sections.Count == 1 && ActivateFirstSectionAsDefault == true)
             {
                 section.Activate();
-                ScrollSpy.SetSectionAsActive(section.Id).AndForget();
+                _scrollSpy.SetSectionAsActive(section.Id).AndForget();
             }
 
             if (forceUpdate == true)
@@ -146,21 +147,24 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                ScrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
+                _scrollSpy = ScrollSpyFactory.Create();
+                _scrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
 
                 if (string.IsNullOrEmpty(SectionClassSelector) == false)
                 {
-                    await ScrollSpy.StartSpying(SectionClassSelector);
+                    await _scrollSpy.StartSpying(SectionClassSelector);
                 }
 
-                SelectActiveSection(ScrollSpy.CenteredSection);
+                SelectActiveSection(_scrollSpy.CenteredSection);
             }
         }
 
         public ValueTask DisposeAsync()
         {
-            ScrollSpy.ScrollSectionSectionCentered -= ScrollSpy_ScrollSectionSectionCentered;
-            return ScrollSpy.DisposeAsync();
+            if (_scrollSpy == null) { return ValueTask.CompletedTask; }
+
+            _scrollSpy.ScrollSectionSectionCentered -= ScrollSpy_ScrollSectionSectionCentered;
+            return _scrollSpy.DisposeAsync();
         }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -11,10 +11,12 @@ namespace MudBlazor
 {
     public partial class MudPicker<T> : MudFormComponent<T, string>
     {
+        private IKeyInterceptor _keyInterceptor;
+
         public MudPicker() : base(new Converter<T, string>()) { }
         protected MudPicker(Converter<T, string> converter) : base(converter) { }
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
         private string _elementId = "picker" + Guid.NewGuid().ToString().Substring(0, 8);
 
@@ -421,6 +423,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = _keyInterceptorFactory.Create();
+
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -474,7 +478,7 @@ namespace MudBlazor
         {
             OnPickerClosed();
 
-            _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "none" });
+            _keyInterceptor?.UpdateKey(new() { Key = "Escape", StopDown = "none" });
         }
 
         protected virtual void OnPickerOpened()
@@ -508,5 +512,16 @@ namespace MudBlazor
                     break;
             }
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _keyInterceptor?.Dispose();
+            }
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -190,9 +190,11 @@ namespace MudBlazor
         public void Dispose()
         {
             MudRadioGroup?.UnregisterRadio(this);
+            _keyInterceptor?.Dispose();
         }
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        private IKeyInterceptor _keyInterceptor;
+        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
         private string _elementId = "radio" + Guid.NewGuid().ToString().Substring(0, 8);
 
@@ -200,6 +202,7 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = _keyInterceptorFactory.Create();
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -214,5 +217,6 @@ namespace MudBlazor
             }
             await base.OnAfterRenderAsync(firstRender);
         }
+
     }
 }

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -6,6 +6,8 @@ namespace MudBlazor
 {
     public partial class MudScrollToTop : IDisposable
     {
+        private IScrollListener _scrollListener;
+
         protected string Classname =>
         new CssBuilder("mud-scroll-to-top")
             .AddClass("visible", Visible && string.IsNullOrWhiteSpace(VisibleCssClass))
@@ -15,7 +17,8 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
-        [Inject] IScrollListener ScrollListener { get; set; }
+        [Inject] IScrollListenerFactory ScrollListenerFactory { get; set; }
+
         [Inject] IScrollManager ScrollManager { get; set; }
 
         [Parameter]
@@ -74,13 +77,15 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+
                 var selector = !string.IsNullOrWhiteSpace(Selector)
                     ? Selector
                     : null;// null is defaulted to document element in JS function
-                ScrollListener.Selector = selector;
+
+                _scrollListener = ScrollListenerFactory.Create(selector);
 
                 //subscribe to event
-                ScrollListener.OnScroll += ScrollListener_OnScroll;
+                _scrollListener.OnScroll += ScrollListener_OnScroll;
             }
         }
 
@@ -115,7 +120,7 @@ namespace MudBlazor
         /// </summary>
         private void OnClick()
         {
-            ScrollManager.ScrollToTopAsync(ScrollListener.Selector, ScrollBehavior);
+            ScrollManager.ScrollToTopAsync(_scrollListener.Selector, ScrollBehavior);
         }
 
         /// <summary>
@@ -123,7 +128,10 @@ namespace MudBlazor
         /// </summary>
         public void Dispose()
         {
-            ScrollListener.OnScroll -= ScrollListener_OnScroll;
+            if(_scrollListener == null) { return; }
+
+            _scrollListener.OnScroll -= ScrollListener_OnScroll;
+            _scrollListener.Dispose();
         }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,14 +22,14 @@ namespace MudBlazor
         private bool _dense;
         private string multiSelectionText;
         private bool? _selectAllChecked;
+        private IKeyInterceptor _keyInterceptor;
 
         protected string Classname =>
             new CssBuilder("mud-select")
             .AddClass(Class)
             .Build();
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
-
+        [Inject] private IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
         [Inject] IScrollManager ScrollManager { get; set; }
 
         private string _elementId = "select_" + Guid.NewGuid().ToString().Substring(0, 8);
@@ -722,6 +722,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = KeyInterceptorFactory.Create();
+
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -1030,11 +1032,12 @@ namespace MudBlazor
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _keyInterceptor.Dispose();
-            }
             base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _keyInterceptor?.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -39,7 +39,8 @@ namespace MudBlazor
         new CssBuilder("mud-switch-span mud-flip-x-rtl")
         .Build();
 
-        [Inject] private IKeyInterceptor _keyInterceptor { get; set; }
+        private IKeyInterceptor _keyInterceptor;
+        [Inject] private IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
 
         /// <summary>
         /// The color of the component. It supports the theme colors.
@@ -117,6 +118,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                _keyInterceptor = KeyInterceptorFactory.Create();
+
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
                     //EnableLogging = true,
@@ -130,6 +133,16 @@ namespace MudBlazor
                 _keyInterceptor.KeyDown += HandleKeyDown;
             }
             await base.OnAfterRenderAsync(firstRender);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing == true)
+            {
+                _keyInterceptor?.Dispose();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -31,10 +31,11 @@ namespace MudBlazor
         private double _allTabsSize;
         private double _scrollPosition;
 
+        private IResizeObserver _resizeObserver;
 
         [CascadingParameter] public bool RightToLeft { get; set; }
 
-        [Inject] private IResizeObserver _resizeObserver { get; set; }
+        [Inject] private IResizeObserverFactory _resizeObserverFactory { get; set; }
 
         /// <summary>
         /// If true, render all tabs and hide (display:none) every non-active.
@@ -279,8 +280,19 @@ namespace MudBlazor
             Panels = _panels.AsReadOnly();
         }
 
+        protected override void OnInitialized()
+        {
+            _resizeObserver = _resizeObserverFactory.Create();
+            base.OnInitialized();
+        }
+
         protected override void OnParametersSet()
         {
+            if (_resizeObserver == null)
+            {
+                _resizeObserver = _resizeObserverFactory.Create();
+            }
+
             Rerender();
         }
 

--- a/src/MudBlazor/Services/EventManager.cs
+++ b/src/MudBlazor/Services/EventManager.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
             new EventListener(_provider.GetRequiredService<IJSRuntime>());
     }
 
-    public interface IEventListener
+    public interface IEventListener : IAsyncDisposable
     {
         /// <summary>
         /// Listing to a javascript event

--- a/src/MudBlazor/Services/EventManager.cs
+++ b/src/MudBlazor/Services/EventManager.cs
@@ -7,10 +7,29 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace MudBlazor
 {
+    public interface IEventListenerFactory
+    {
+        IEventListener Create();
+    }
+
+    public class EventListenerFactory : IEventListenerFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public EventListenerFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IEventListener Create() =>
+            new EventListener(_provider.GetRequiredService<IJSRuntime>());
+    }
+
     public interface IEventListener
     {
         /// <summary>

--- a/src/MudBlazor/Services/JsEvent/JsEvent.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEvent.cs
@@ -14,7 +14,7 @@ using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-    public interface IJsEvent
+    public interface IJsEvent : IDisposable
     {
         Task Connect(string elementId, JsEventOptions options);
         Task Disconnect();
@@ -26,7 +26,7 @@ namespace MudBlazor.Services
     /// <summary>
     /// Subscribe JS events of any element by html id
     /// </summary>
-    public class JsEvent : IJsEvent, IDisposable
+    public class JsEvent : IJsEvent
     {
         private bool _isDisposed = false;
 

--- a/src/MudBlazor/Services/JsEvent/JsEventFactory.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEventFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+    public interface IJsEventFactory
+    {
+        IJsEvent Create();
+    }
+
+    public class JsEventFactory : IJsEventFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public JsEventFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IJsEvent Create() =>
+            new JsEvent(_provider.GetRequiredService<IJSRuntime>());
+    }
+
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorFactory.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+    public interface IKeyInterceptorFactory
+    {
+        public IKeyInterceptor Create();
+    }
+
+    public class KeyInterceptorFactory : IKeyInterceptorFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public KeyInterceptorFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IKeyInterceptor Create() =>
+            new KeyInterceptor(_provider.GetRequiredService<IJSRuntime>());
+    }
+}

--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserverFactory.cs
@@ -3,5 +3,6 @@
     public interface IResizeObserverFactory
     {
         IResizeObserver Create(ResizeObserverOptions options);
+        IResizeObserver Create();
     }
 }

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
@@ -52,7 +52,7 @@ namespace MudBlazor.Services
                 _cachedValueIds.Add(id, item);
             }
 
-            var result = await _jsRuntime.InvokeAsync<IEnumerable<BoundingClientRect>>("mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options);
+            var result = await _jsRuntime.InvokeAsync<IEnumerable<BoundingClientRect>>("mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options) ?? Array.Empty<BoundingClientRect>();
             var counter = 0;
             foreach (var item in result)
             {

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserverFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
 namespace MudBlazor.Services
@@ -15,5 +16,11 @@ namespace MudBlazor.Services
 
         public IResizeObserver Create(ResizeObserverOptions options) =>
             new ResizeObserver(_provider.GetRequiredService<IJSRuntime>(), options);
+         
+        public IResizeObserver Create()
+        {
+            var options = _provider.GetService<IOptions<ResizeObserverOptions>>();
+            return Create(options?.Value ?? new ResizeObserverOptions());
+        }
     }
 }

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace MudBlazor
 {
-    public interface IScrollListener
+
+
+    public interface IScrollListener : IDisposable
     {
         /// <summary>
         /// The CSS selector to which the scroll event will be attached
@@ -24,9 +27,14 @@ namespace MudBlazor
         /// </summary>
         public string Selector { get; set; } = null;
 
-        public ScrollListener(IJSRuntime js)
+        public ScrollListener(IJSRuntime js) : this(string.Empty, js)
+        {
+        }
+
+        public ScrollListener(string selector, IJSRuntime js)
         {
             _js = js;
+            Selector = selector;
         }
 
         private EventHandler<ScrollEventArgs> _onScroll;

--- a/src/MudBlazor/Services/Scroll/ScrollListenerFactory.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListenerFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor
+{
+    public interface IScrollListenerFactory
+    {
+        IScrollListener Create(string selector);
+    }
+
+    public class ScrollListenerFactory : IScrollListenerFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public ScrollListenerFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IScrollListener Create(string selector) =>
+            new ScrollListener(selector, _provider.GetRequiredService<IJSRuntime>());
+    }
+}

--- a/src/MudBlazor/Services/Scroll/ScrollSpyFactory.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpyFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor
+{
+    public interface IScrollSpyFactory
+    {
+        IScrollSpy Create();
+    }
+
+    public class ScrollSpyFactory : IScrollSpyFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public ScrollSpyFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IScrollSpy Create() =>
+            new ScrollSpy(_provider.GetRequiredService<IJSRuntime>());
+    }
+}

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -91,7 +91,6 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorResizeObserver(this IServiceCollection services, Action<ResizeObserverOptions> options)
         {
             services.TryAddTransient<IResizeObserver, ResizeObserver>();
-            services.TryAddScoped<IResizeObserverFactory, ResizeObserverFactory>();
             services.Configure(options);
             return services;
         }
@@ -113,13 +112,31 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
-        /// Adds a IResizeObserverFactory as a Singelton instance.
+        /// Adds a IResizeObserverFactory as a scoped dependency.
         /// </summary>
         /// <param name="services">IServiceCollection</param>
+        /// <param name="options">Defines ResizeObserverOptions for this instance</param>
         /// <returns>Continues the IServiceCollection chain.</returns>
-        public static IServiceCollection AddMudBlazorResizeObserverFactory(this IServiceCollection services)
+        public static IServiceCollection AddMudBlazorResizeObserverFactory(this IServiceCollection services, Action<ResizeObserverOptions> options)
         {
-            services.TryAddSingleton<IResizeObserverFactory, ResizeObserverFactory>();
+            services.TryAddScoped<IResizeObserverFactory, ResizeObserverFactory>();
+            services.Configure(options);
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a IResizeObserverFactory as a scoped dependency.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <param name="options">Defines ResizeObserverOptions for this instance</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorResizeObserverFactory(this IServiceCollection services, ResizeObserverOptions options = null)
+        {
+            options ??= new ResizeObserverOptions();
+            services.AddMudBlazorResizeObserverFactory(o =>
+            {
+                o = options;
+            });
             return services;
         }
 
@@ -189,6 +206,8 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorScrollListener(this IServiceCollection services)
         {
             services.TryAddTransient<IScrollListener, ScrollListener>();
+            services.TryAddScoped<IScrollListenerFactory, ScrollListenerFactory>();
+
             return services;
         }
 
@@ -265,7 +284,7 @@ namespace MudBlazor.Services
                 .AddMudBlazorSnackbar(options.SnackbarConfiguration)
                 .AddMudBlazorResizeListener(options.ResizeOptions)
                 .AddMudBlazorResizeObserver(options.ResizeObserverOptions)
-                .AddMudBlazorResizeObserverFactory()
+                .AddMudBlazorResizeObserverFactory(options.ResizeObserverOptions)
                 .AddMudBlazorKeyInterceptor()
                 .AddMudBlazorJsEvent()
                 .AddMudBlazorScrollManager()

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -91,6 +91,7 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorResizeObserver(this IServiceCollection services, Action<ResizeObserverOptions> options)
         {
             services.TryAddTransient<IResizeObserver, ResizeObserver>();
+            services.TryAddScoped<IResizeObserverFactory, ResizeObserverFactory>();
             services.Configure(options);
             return services;
         }

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -240,6 +240,8 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudEventManager(this IServiceCollection services)
         {
             services.TryAddTransient<IEventListener, EventListener>();
+            services.TryAddScoped<IEventListenerFactory, EventListenerFactory>();
+
             return services;
         }
 

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -219,6 +219,7 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorScrollSpy(this IServiceCollection services)
         {
             services.TryAddTransient<IScrollSpy, ScrollSpy>();
+            services.TryAddScoped<IScrollSpyFactory, ScrollSpyFactory>();
             return services;
         }
 

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -148,6 +148,8 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorKeyInterceptor(this IServiceCollection services)
         {
             services.TryAddTransient<IKeyInterceptor, KeyInterceptor>();
+            services.TryAddScoped<IKeyInterceptorFactory, KeyInterceptorFactory>();
+
             return services;
         }
 
@@ -159,6 +161,8 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorJsEvent(this IServiceCollection services)
         {
             services.TryAddTransient<IJsEvent, JsEvent>();
+            services.TryAddScoped<IJsEventFactory, JsEventFactory>();
+
             return services;
         }
 


### PR DESCRIPTION

## Description
Based on the discussion in #4544 this is the implementation with factories. All components that used transient services are now using factories and disposing of the instances correctly.  

I **haven't** changed the service registration. So all transient services can still be injected into own components. However, we should mark this behavior internally as absolute and remove them from the service collection in future releases.  

## How Has This Been Tested?
+ updating the existing unit tests
+ trying the examples in docs (server and wasm) to see if there are any "hidden" errors. 

However, it would be great if you could inspect the pages and components to see if any behavior has changed, so I can correct it.  

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] ~~I've added relevant tests.~~ I've updated relevant tests
