### PR TITLE
MudDrawerContainer: Call StateHasChanged after removing Drawer to ensure classes are updated (#4363)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>MudBlazor.UnitTests</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'MudBlazor.UnitTests.Viewer' " />
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.5.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.5.*" PrivateAssets="all" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDrawerContainer @ref="DrawerContainer">
+    @if (_isShown)
+    {
+        <MudDrawer Open="true" Variant="DrawerVariant.Responsive" ClipMode="DrawerClipMode.Always" Anchor="Anchor.Right"></MudDrawer>
+    }
+</MudDrawerContainer>
+<button @onclick="@HandleButtonClick" />
+
+@code {
+    public MudDrawerContainer DrawerContainer;
+
+    public bool _isShown = true;
+
+    public void HandleButtonClick()
+    {
+        _isShown = false;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -312,5 +312,18 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
         }
+
+        [Test]
+        public async Task DrawerContainer_RemoveDrawer_CheckStates()
+        {
+            var comp = Context.RenderComponent<DrawerContainerTest1>();
+
+            comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(1);
+
+            // Remove drawer
+            comp.Find("button").Click();
+
+            comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
+        }
     }
 }

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -45,7 +45,11 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        internal void Remove(MudDrawer drawer) => _drawers.Remove(drawer);
+        internal void Remove(MudDrawer drawer)
+        {
+            _drawers.Remove(drawer);
+            StateHasChanged();
+        }
 
         private string GetDrawerClass(MudDrawer drawer)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description

When a MudDrawer is shown, classes are added to its container to make space for it.  If the Drawer is removed from the page (not just closed) the classes are left behind.

This can be a problem if you have a layout component that includes MudLayout, and some pages with Drawers and some pages without.  When navigating from a page with a Drawer to a page without a Drawer, classes are left behind making space for a drawer that doesn't exist.

The fix is simply to call StateHasChanged after removing a MudDrawer from a MudDrawerContainer.  This updates the classes.

Fixes #4363

<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?

Added a new unit test.

Tested in my local project.

<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
