### PR TITLE
MudTable: Show loading indicator whenever table loads data from server

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -334,7 +334,7 @@ namespace MudBlazor
             {
                 if (IsEditing && _hasPreEditSort)
                     return _preEditSort;
-                if (ServerData != null)
+                if (HasServerData)
                 {
                     _preEditSort = _server_data.Items.ToList();
                     return _preEditSort;
@@ -356,7 +356,7 @@ namespace MudBlazor
             {
                 if (@PagerContent == null)
                     return FilteredItems; // we have no pagination
-                if (ServerData == null)
+                if (!HasServerData)
                 {
                     var filteredItemCount = GetFilteredItemsCount();
                     int lastPageNo;
@@ -376,7 +376,7 @@ namespace MudBlazor
             if (n < 0 || pageSize <= 0)
                 return Array.Empty<T>();
 
-            if (ServerData != null)
+            if (HasServerData)
                 return _server_data.Items;
 
             return FilteredItems.Skip(n * pageSize).Take(pageSize);
@@ -386,7 +386,7 @@ namespace MudBlazor
         {
             get
             {
-                if (ServerData != null)
+                if (HasServerData)
                     return (int)Math.Ceiling(_server_data.TotalItems / (double)RowsPerPage);
 
                 return (int)Math.Ceiling(FilteredItems.Count() / (double)RowsPerPage);
@@ -395,7 +395,7 @@ namespace MudBlazor
 
         public override int GetFilteredItemsCount()
         {
-            if (ServerData != null)
+            if (HasServerData)
                 return _server_data.TotalItems;
             return FilteredItems.Count();
         }
@@ -473,10 +473,11 @@ namespace MudBlazor
 
         internal override async Task InvokeServerLoadFunc()
         {
-            if (ServerData == null)
+            if (!HasServerData)
                 return;
 
             Loading = true;
+            await InvokeAsync(StateHasChanged);
             var label = Context.CurrentSortLabel;
 
             var state = new TableState


### PR DESCRIPTION
## Description
This PR attempts to resolve #4662 

## How Has This Been Tested?
Created a sample application derived from https://try.mudblazor.com/snippet/QEGmYJGodIwVIMvp.
Unfortunately I was not able to find any similar unit test to start from.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before
https://user-images.githubusercontent.com/3428860/170023301-4869ba7c-f453-4503-af8d-42472bfa76cc.mp4

## After
https://user-images.githubusercontent.com/3428860/170022706-88758db8-f6ea-4302-99a4-32301683c7e5.mp4

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
