### PR TITLE
DatePicker: Update date when clicking on days in static picker with picker actions

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
@@ -1,0 +1,14 @@
+﻿<MudPopoverProvider></MudPopoverProvider>
+
+<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" PickerVariant="PickerVariant.Static" @bind-Date="date">
+    <PickerActions>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+    </PickerActions>
+</MudDatePicker>
+
+@code {
+    MudDatePicker _picker;
+    DateTime? date = DateTime.Today;
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -338,6 +338,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DatePickerStaticWithPickerActionsDayClick_Test()
+        {
+            var comp = Context.RenderComponent<DatePickerStaticTest>();
+            var picker = comp.FindComponent<MudDatePicker>();
+            comp.FindAll("button.mud-picker-calendar-day")
+                .Where(x => x.TrimmedText().Equals("23")).First().Click();
+            picker.Instance.Date.Should().Be(new DateTime(DateTime.Now.Year, DateTime.Now.Month, 23));
+        }
+
+        [Test]
         public void OpenTo12thMonth_NavigateBack_CheckMonth()
         {
             var comp = OpenTo12thMonth();

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -85,7 +85,7 @@ namespace MudBlazor
         protected override async void OnDayClicked(DateTime dateTime)
         {
             _selectedDate = dateTime;
-            if (PickerActions == null || AutoClose)
+            if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
                 Submit();
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
With basic static picker we have no problem. But when static picker has picker actions render fragment, clicking on days has no effect. As a workaround need to add `AutoClose="true"` but autoclose parameter has no sense with static picker.

Before (Date doesn't change on first picker)

https://user-images.githubusercontent.com/78308169/170724404-ea3a7306-0a6c-43d5-8ad6-71360cb06f7c.mp4

After


https://user-images.githubusercontent.com/78308169/170724504-0d61daf3-f38a-41a6-b135-039064b70968.mp4




## How Has This Been Tested?
Unit test added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
