### PR TITLE
Autocomplete: Add NoItemsTemplate render fragment

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -47,6 +47,17 @@
                 <AutocompleteClrObjectsExample />
             </SectionContent>
         </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Presentation Extras">
+                <Description>
+                    You can also define a <CodeInline Tag="true">MoreItemsTemplate</CodeInline> or a <CodeInline Tag="true">NoItemsTemplate</CodeInline> for special scenarios.
+                </Description>
+            </SectionHeader>
+            <SectionContent ShowCode="false" Code="AutocompletePresentationExtrasExample">
+                <AutocompletePresentationExtrasExample />
+            </SectionContent>
+        </DocsPageSection>
 
         <DocsPageSection>
             <SectionHeader Title="Validation">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
@@ -1,0 +1,42 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="Element" Label="Periodic Table Element" @bind-Value="value1"
+                         SearchFunc="@Search" ToStringFunc="@(e=> e==null?null : $"{e.Name} ({e.Sign})")">
+            <MoreItemsTemplate>
+                <MudText Align="Align.Center" Class="px-4 py-1">
+                    Only the first 10 items are shown
+                </MudText>
+            </MoreItemsTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="Element" Label="Periodic Table Element" @bind-Value="value2"
+                         SearchFunc="@SearchEmpty" ToStringFunc="@(e=> e==null?null : $"{e.Name} ({e.Sign})")">
+            <NoItemsTemplate>
+                <MudText Align="Align.Center" Class="px-4 py-1">
+                    No items found
+                </MudText>
+            </NoItemsTemplate>
+        </MudAutocomplete>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private Element value1, value2;
+
+    private async Task<IEnumerable<Element>> Search(string value)
+    {
+        return await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}");
+    }
+
+    private async Task<IEnumerable<Element>> SearchEmpty(string value)
+    {
+        await Task.Delay(5);
+        return Array.Empty<Element>();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest7.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest7.razor
@@ -1,0 +1,40 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
+    <NoItemsTemplate>
+        <MudText>No items found, try another search</MudText>
+    </NoItemsTemplate>
+</MudAutocomplete>
+
+@code {
+    public static string __description__ = "There are no items after filtering, so the no items template should render";
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
+        return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -238,6 +238,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// NoItemsTemplate should render when there are no items
+        /// </summary>
+        [Test]
+        public async Task AutocompleteTest7()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest7>();
+
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("No items found, try another search"); //ensure the text is shown
+        }
+
+        /// <summary>
         /// After press Enter key down, the selected value should be shown in the input value
         /// </summary>
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -46,6 +46,7 @@
                                             @ItemTemplate(item)
                                         else
                                             @ItemSelectedTemplate(item)
+
                                     }
                                     else
                                     {
@@ -60,6 +61,12 @@
                                 </div>
                             }
                         </MudList>
+                    }
+                    else if (NoItemsTemplate != null)
+                    {
+                        <div class="pa-1">
+                            @NoItemsTemplate
+                        </div>
                     }
                 </MudPopover>
             </InputContent>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -184,11 +184,18 @@ namespace MudBlazor
         public RenderFragment<T> ItemDisabledTemplate { get; set; }
 
         /// <summary>
-        /// Optional template when more items were returned from the Search function than the MaxItems limit
+        /// Optional presentation template for when more items were returned from the Search function than the MaxItems limit
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public RenderFragment MoreItemsTemplate { get; set; }
+
+        /// <summary>
+        /// Optional presentation template for when no items were returned from the Search function
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment NoItemsTemplate { get; set; }
 
         /// <summary>
         /// On drop-down close override Text with selected Value. This makes it clear to the user


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a `NoItemsTemplate` that is shown when no items are returned from the `Search` function. Example:

```csharp
<MudAutocomplete T="Element" Label="Periodic Table Element" @bind-Value="value2"
    SearchFunc="@SearchEmpty" ToStringFunc="@(e=> e==null?null : $"{e.Name} ({e.Sign})")"> 
   <NoItemsTemplate>
        <MudText Align="Align.Center" Class="px-4 py-1">
           No items found
        </MudText>
    </NoItemsTemplate>
</MudAutocomplete>
```
![image](https://user-images.githubusercontent.com/26885142/171448720-0a462d8e-36ba-493f-8352-210ed09a2e0e.png)

I have also added a docs section for both the `NoItemsTemplate` and the `MoreItemsTemplate` (#4566) render fragments.

This PR additionally closes #4668.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
