### PR TITLE
DataGrid - QuickFilter in GetItemsOfPage

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataQuickFilterTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataQuickFilterTest.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid T="Item" Filterable="true" QuickFilter="this.QuickFilterFunc" ServerData="this.ServerDataFunc">
+    <Columns>
+        <Column T="Item" Field="@nameof(Item.Name)" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("B"), 
+        new Item("A"), 
+        new Item("C"),
+        new Item("C")
+    };
+
+    private bool QuickFilterFunc(Item item)
+    {
+        return item.Name == "A";
+    }
+
+    private async Task<GridData<Item>> ServerDataFunc(GridState<Item> gridState)
+    {
+        await Task.CompletedTask;
+        return new GridData<Item>
+        {
+            Items = this._items,
+            TotalItems = this._items.Count()
+        };
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public Item(string name)
+        {
+            Name = name;
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1297,6 +1297,15 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridServerDataQuickFilterTest()
+        {
+            var comp = Context.RenderComponent<DataGridServerDataQuickFilterTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataQuickFilterTest.Item>>();
+
+            dataGrid.FindAll("tr").Count.Should().Be(3);
+        }
+
+        [Test]
         public async Task DataGridServerPaginationTest()
         {
             var comp = Context.RenderComponent<DataGridServerPaginationTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -591,9 +591,9 @@ namespace MudBlazor
 
         #region Methods
 
-        protected IEnumerable<T> GetItemsOfPage(int n, int pageSize)
+        protected IEnumerable<T> GetItemsOfPage(int page, int pageSize)
         {
-            if (n < 0 || pageSize <= 0)
+            if (page < 0 || pageSize <= 0)
                 return Array.Empty<T>();
 
             if (ServerData != null)
@@ -603,7 +603,7 @@ namespace MudBlazor
                     : _server_data.Items;
             }
 
-            return FilteredItems.Skip(n * pageSize).Take(pageSize);
+            return FilteredItems.Skip(page * pageSize).Take(pageSize);
         }
 
         internal async Task InvokeServerLoadFunc()

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -530,8 +530,8 @@ namespace MudBlazor
         {
             get
             {
-                var items = ServerData != null 
-                    ? _server_data.Items 
+                var items = ServerData != null
+                    ? _server_data.Items
                     : Items;
 
                 // Quick filtering
@@ -597,7 +597,11 @@ namespace MudBlazor
                 return Array.Empty<T>();
 
             if (ServerData != null)
-                return _server_data.Items;
+            {
+                return QuickFilter != null
+                    ? _server_data.Items.Where(QuickFilter)
+                    : _server_data.Items;
+            }
 
             return FilteredItems.Skip(n * pageSize).Take(pageSize);
         }


### PR DESCRIPTION
Fixed the issue with ServerData not been filtered properly.
Renamed name of variable, from `n` to `page` to give it more semantic meaning.

Also fixed some whitespaces.

Note: This isn't fixing the issue with multiple QuickFilters been executed multiple times. I will take a look in the future.