### PR TITLE
add `MudGetSelectionStart` and `MudGetSelectionEnd` extensions to `ElementReference`

### DIFF
--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -49,6 +49,12 @@ namespace MudBlazor
 
         public static ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
+
+        public static ValueTask<ulong> MudGetSelectionStart(this ElementReference elementReference) =>
+            elementReference.GetJSRuntime()?.InvokeAsync<ulong>("mudElementRef.getSelectionStart", elementReference) ?? ValueTask.FromResult(0ul);
+
+        public static ValueTask<ulong> MudGetSelectionEnd(this ElementReference elementReference) =>
+            elementReference.GetJSRuntime()?.InvokeAsync<ulong>("mudElementRef.getSelectionEnd", elementReference) ?? ValueTask.FromResult(0ul);
 
         /// <summary>
         /// Gets the client rect of the element 

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -114,6 +114,18 @@ class MudElementReference {
         rect.windowHeight = window.innerHeight;
         rect.windowWidth = window.innerWidth;
         return rect;
+    }
+
+    getSelectionStart(element) {
+        if (!element) return 0;
+        // The index of the beginning of selected text. When nothing is selected,
+        // this is also the caret position inside of the < input > element.
+        return element.selectionStart || 0;
+    }
+
+    getSelectionEnd(element) {
+        if (!element) return 0;
+        return element.selectionEnd || 0;
     }
 
     /**


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This PR adds two extensions methods to `ElementReference` in the same line of `MudGetBoundingClientRectAsync`.

My motivation to add these two extensions is that I need a way to get the caret position from `MudTextField` (I was implementing a mention system), and the way to get the caret position is using js `selectionStart`

> selectionStart: The index of the beginning of selected text. When nothing is selected, this is also the caret position inside of the <input> element.

I realized that the extensions are consistent with the names used in `js` so I keep the name consistent as well. I also implemented the extension to `selectionEnd` to keep the api aligned.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I could not find how you guys test theses extensions, so I create a new file in `MudBlazor.UnitTests.Viewer` and tested it visually (after a key down I render the caret position calling `MudGetSelectionStart` in the `MudTextField<string>.InputReference.ElementReference`) which worked just fine as expected.

I didn't commit this test file because I'm not sure if this is the right place to test it. Let me know how you guys test this kind of extension.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
