### PR TITLE
MudCard: Set max width of MudCardHeaderContent

### DIFF
--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -18,6 +18,7 @@
 
     & .mud-card-header-content {
         flex: 1 1 auto;
+        max-width: 100%;
 
         & .mud-typography {
             margin-bottom: 0;


### PR DESCRIPTION
## Description
CardHeaderContent might exceed the cards width under certain circumstances. If, for example, are very long text is combined with "text-truncate", the text will simply exceed the Card and overflow.
Set max-width of CardHeaderContent to 100% to avoid this.

```
<MudGrid Spacing="2">
    <MudItem lg="2">
        <MudCard Class="m-4">
            <MudCardHeader>
                <CardHeaderContent>
                    <MudText Typo="Typo.h6" Class="text-truncate">This might be some long text</MudText>
                </CardHeaderContent>
            </MudCardHeader>
            <MudCardContent>
                <MudText>This is the card content with even more text</MudText>
            </MudCardContent>
        </MudCard>
    </MudItem>
</MudGrid>
```

## How Has This Been Tested?
visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![before](https://user-images.githubusercontent.com/16814491/172490273-95e10ecb-d281-4558-a43b-ac485f1f6ee0.png)

After:
![after](https://user-images.githubusercontent.com/16814491/172490295-c4eb41f3-23ea-4840-8eed-53d59a414839.png)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
