### PR TITLE
MudBreadcrumbs: Change from List to IReadOnlyList

### DIFF
--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Breadcrumbs.Behavior)]
-        public List<BreadcrumbItem>? Items { get; set; }
+        public IReadOnlyList<BreadcrumbItem>? Items { get; set; }
 
         /// <summary>
         /// Specifies the separator between the items.


### PR DESCRIPTION
## Description
This PR improves the usage of Breadcrumbs. Opening the collection-type for the items allows developers to use eg. `IReadOnlyCollection<BreadcrumbItem>`, `ObservableCollection<BreadcrumbItem>`.

## How Has This Been Tested?
No logic has been changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
