### PR TITLE
Fix Form Reset Behavior

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7128;http://localhost:5128",
-      "launchUrl": "components/autocomplete",
+      "launchUrl": "components/form",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -7,7 +7,7 @@
         <MudPaper Class="pa-4">
             <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
                     <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!"/>
-                    <MudTextField T="string" Label="Email" Required="true" RequiredError="Email is required!"
+                    <MudTextField T="string" Label="Email" Required="true" @bind-Value="_emailValue" RequiredError="Email is required!"
                                   Validation="@(new EmailAddressAttribute() {ErrorMessage = "The email address is invalid"})"/>
                     <MudTextField T="string" Label="Password" HelperText="Choose a strong password" @ref="pwField1"
                                   InputType="InputType.Password"
@@ -23,7 +23,7 @@
                         </MudRadioGroup>
                     </div>
                     <div class="d-flex align-center justify-space-between mt-6">
-                        <MudCheckBox T="bool" Required="true" RequiredError="You must agree" Class="ml-n2" Label="I agree!"/>
+                        <MudCheckBox T="bool" Required="true" @bind-Checked="_checkedValue" RequiredError="You must agree" Class="ml-n2" Label="I agree!"/>
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" Class="ml-auto">Register</MudButton>
                     </div>
             </MudForm>   
@@ -49,6 +49,8 @@
 @code {
     bool success;
     string[] errors = { };
+    string _emailValue = "mud@mudblazor.com";
+    bool _checkedValue = false;
     MudTextField<string> pwField1;
     MudForm form;
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -11,6 +11,8 @@ namespace MudBlazor
     {
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
+        string _backUpText;
+
         /// <summary>
         /// If true, the input element will be disabled.
         /// </summary>
@@ -448,9 +450,13 @@ namespace MudBlazor
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             //Only focus automatically after the first render cycle!
-            if (firstRender && AutoFocus)
+            if (firstRender)
             {
-                await FocusAsync();
+                _backUpText = Text;
+                if (AutoFocus)
+                {
+                    await FocusAsync();
+                }
             }
         }
 
@@ -462,7 +468,7 @@ namespace MudBlazor
 
         protected override void ResetValue()
         {
-            SetTextAsync(null, updateValue: true).AndForget();
+            SetTextAsync(_backUpText, updateValue: true).AndForget();
             base.ResetValue();
         }
     }

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -8,6 +8,8 @@ namespace MudBlazor
     {
         public MudBooleanInput() : base(new BoolConverter<T>()) { }
 
+        T _backUpValue;
+
         /// <summary>
         /// If true, the input will be disabled.
         /// </summary>
@@ -86,5 +88,21 @@ namespace MudBlazor
         {
             return (BoolValue == true);
         }
+
+        protected override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                _backUpValue = _value;
+            }
+            return base.OnAfterRenderAsync(firstRender);
+        }
+
+        protected override void ResetValue()
+        {
+            SetBoolValueAsync(Converter.Set(_backUpValue)).AndForget();
+            base.ResetValue();
+        }
+
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
I think the initial `ResetValue` approach has a mistake.

It behaves like `Clear` and clears all value to all form components.

This may be true if we have a blank form. But if we have an already filled form (user want to edit values) calling reset clears all the values. But it should turn values to the initial ones.

This PR fixes this. We arranged both text based and bool based components, so when we reset form, the values turns the initial ones (the values when first onafterrender calls)

## How Has This Been Tested?
We changed the form docs a bit, so it can seen on docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This video shows, calling reset not clears the email textfield, instead of turns the initial value.

https://user-images.githubusercontent.com/78308169/173188577-109b7748-decd-4960-83a6-edb9d235137d.mp4



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
