### PR TITLE
MudRadio: Added mudchecked class to use as selector for css

### DIFF
--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -16,6 +16,7 @@ namespace MudBlazor
         new CssBuilder("mud-radio")
             .AddClass($"mud-disabled", Disabled)
             .AddClass($"mud-radio-content-placement-{ConvertPlacement(Placement).ToDescriptionString()}")
+            .AddClass($"mud-checked", Checked)
             .AddClass(Class)
             .Build();
 


### PR DESCRIPTION
## Description
Needs a class one markup element higher to be able to select the active label of a radio button without code.

## How Has This Been Tested?
I checked that it doesn't look different in the documentation.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
