### PR TITLE
MessageBox: Add Keyboard Navigation and Fix Initial Focus

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -42,8 +42,6 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button")[clickButtonIndex].Click();
             comp.Markup.Trim().Should().BeEmpty();
             yesNoCancel.Result.Should().Be(expectedResult);
-
-            
         }
 
         [Test, Timeout(3000)]
@@ -101,6 +99,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-dialog-actions div")[0].KeyDown(Key.Escape);
 
             comp.FindAll("button").Should().BeEmpty();
+            yesNoCancel.Result.Should().Be(null);
         }
 
     }

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -40,6 +42,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button")[clickButtonIndex].Click();
             comp.Markup.Trim().Should().BeEmpty();
             yesNoCancel.Result.Should().Be(expectedResult);
+
+            
         }
 
         [Test, Timeout(3000)]
@@ -72,6 +76,32 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Trim().Should().BeEmpty();
             yesNoCancel.Result.Should().Be(expectedResult);
         }
-    }
 
+        [Test]
+        public async Task MessageBox_KeyNavTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            // open mbox
+            Task<bool?> yesNoCancel = null;
+            await comp.InvokeAsync(() =>
+            {
+                yesNoCancel = service?.ShowMessageBox("Boom!", (MarkupString)$"I'm a pickle. What do you make of that?", "Great",
+                    "Whatever", "Go away!");
+            });
+            //Console.WriteLine(comp.Markup);
+            comp.Find("div.mud-dialog-container").Should().NotBe(null);
+            comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
+            comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Go away!");
+            comp.FindAll("button")[1].TrimmedText().Should().Be("Whatever");
+            comp.FindAll("button")[2].TrimmedText().Should().Be("Great");
+            comp.FindAll(".mud-dialog-actions div")[0].KeyDown(Key.Escape);
+
+            comp.FindAll("button").Should().BeEmpty();
+        }
+
+    }
 }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -23,35 +23,40 @@
         }
     </DialogContent>
     <DialogActions>
-        @if (CancelButton != null)
-        {
-            <CascadingValue Value="@_cancelCallback">
-                @CancelButton
-            </CascadingValue>
-        }
-        else if(!string.IsNullOrWhiteSpace(CancelText))
-        {
-            <MudButton OnClick="OnCancelClicked">@CancelText</MudButton>
-        }
-        @if (NoButton != null)
-        {
-            <CascadingValue Value="@_noCallback">
-                @NoButton
-            </CascadingValue>
-        }
-        else if(!string.IsNullOrWhiteSpace(NoText))
-        {
-            <MudButton OnClick="OnNoClicked">@NoText</MudButton>
-        }
-        @if (YesButton != null)
-        {
-            <CascadingValue Value="@_yesCallback">
-                @YesButton
-            </CascadingValue>
-        }
-        else if(!string.IsNullOrWhiteSpace(YesText))
-        {
-            <MudButton Color="Color.Primary" OnClick="OnYesClicked">@YesText</MudButton>
-        }
+        <div tabindex="-1" @onkeydown="HandleKeyDown">
+            <MudFocusTrap DefaultFocus="DefaultFocus.LastChild">
+                @if (CancelButton != null)
+                {
+                    <CascadingValue Value="@_cancelCallback">
+                        @CancelButton
+                    </CascadingValue>
+                }
+                else if (!string.IsNullOrWhiteSpace(CancelText))
+                {
+                    <MudButton OnClick="OnCancelClicked">@CancelText</MudButton>
+                }
+                @if (NoButton != null)
+                {
+                    <CascadingValue Value="@_noCallback">
+                        @NoButton
+                    </CascadingValue>
+                }
+                else if (!string.IsNullOrWhiteSpace(NoText))
+                {
+                    <MudButton OnClick="OnNoClicked">@NoText</MudButton>
+                }
+                @if (YesButton != null)
+                {
+                    <CascadingValue Value="@_yesCallback">
+                        @YesButton
+                    </CascadingValue>
+                }
+                else if (!string.IsNullOrWhiteSpace(YesText))
+                {
+                    <MudButton Color="Color.Primary" OnClick="OnYesClicked">@YesText</MudButton>
+                }
+            </MudFocusTrap>
+        </div>
+        
     </DialogActions>
 </MudDialog>

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -199,7 +199,14 @@ namespace MudBlazor
         private void OnNoClicked() => DialogInstance.Close(DialogResult.Ok(false));
 
         private void OnCancelClicked() => DialogInstance.Close(DialogResult.Cancel());
+
+        private void HandleKeyDown(KeyboardEventArgs args)
+        {
+            if (args.Key == "Escape")
+            {
+                OnCancelClicked();
+            }
+        }
+
     }
-
-
 }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -200,7 +200,7 @@ namespace MudBlazor
 
         private void OnCancelClicked() => DialogInstance.Close(DialogResult.Cancel());
 
-        internal void HandleKeyDown(KeyboardEventArgs args)
+        private void HandleKeyDown(KeyboardEventArgs args)
         {
             if (args.Key == "Escape")
             {

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -200,7 +200,7 @@ namespace MudBlazor
 
         private void OnCancelClicked() => DialogInstance.Close(DialogResult.Cancel());
 
-        private void HandleKeyDown(KeyboardEventArgs args)
+        internal void HandleKeyDown(KeyboardEventArgs args)
         {
             if (args.Key == "Escape")
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
MessageBox has a weird behavior before: when you open a messagebox, it still focus on the button which opens messagebox, so when you press enter, it doesn't confirm the messagebox, instead of open a second, third messagebox.

So we simply added a focustrap into messagebox actions, so now when messagebox opens, it directly focus on yes button.

Also we added a cancel option with pressing "Escape".

The left one is old, and the right one is new behavior.


https://user-images.githubusercontent.com/78308169/175053273-7bbb8dce-8f03-4d88-9448-35ecce2d8b59.mp4



## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
