### PR TITLE
MudNumericField: Clearable with Min

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
@@ -55,9 +55,16 @@
 				 Margin="Margin.Dense" />
 <br/>
 <MudNumericField T="decimal?"
-				 Label="decimal?"
-				 Variant="Variant.Outlined"
-				 Margin="Margin.Dense" />
+                 Label="decimal?"
+                 Variant="Variant.Outlined"
+                 Margin="Margin.Dense" />
+<br/>
+<MudNumericField T="int?"
+                 Label="int? clearable with min/max"
+                 Variant="Variant.Outlined"
+                 Margin="Margin.Dense"
+                 Clearable="true"
+                 Min="1" Max="10" />
 
 @code {
 	public static string __description__ = "The textfield should be changed by up/down arrows";

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -624,5 +624,23 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => numericField.Text.Should().Be("€1234"));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234));
         }
+
+        /// <summary>
+        /// NumericField with min/max set and nullable int can be cleared
+        /// </summary>
+        [TestCase(10, 20, 15)]
+        [TestCase(-20, -10, -15)]
+        public async Task NumericFieldCanBeCleared(int min, int max, int value)
+        {
+            var comp = Context.RenderComponent<MudNumericField<int?>>();
+            comp.SetParam(x => x.Min, min);
+            comp.SetParam(x => x.Max, max);
+            comp.SetParam(x => x.Value, value);
+            
+            comp.Find("input").Change("");
+            comp.Find("input").Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().BeNull());
+        }
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -194,19 +194,17 @@ namespace MudBlazor
         /// <returns>Returns a valid value and if it has been changed.</returns>
         protected (T value, bool changed) ConstrainBoundaries(T v)
         {
+            if (v is null)
+                return (default, false);
+
             var value = Num.From(v);
             var max = Num.From(Max);
             var min = Num.From(Min);
             //check if Max/Min has value, if not use MaxValue/MinValue for that data type
             if (value > max)
                 return (Max, true);
-            else if (value < min)
+            if (value < min)
                 return (Min, true);
-            //return T default (null) when there is no value
-            else if (v == null)
-            {
-                return (default(T), true);
-            }
 
             return (Num.To<T>(value), false);
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #3884
MudNumericField could not be cleared if Min property was set (or negative Max).

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
New unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
