### PR TITLE
MudDataGrid: Allow for disabling of toolbar

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridToolbarHiderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridToolbarHiderTest.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items" Hideable="true" DisableToolbar="true">
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public record Model(string Name, int Age);
+
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("John", 45), 
+        new Model("Johanna", 23), 
+        new Model("Steve", 32)
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1359,5 +1359,20 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dataGrid.Instance.ShowAllColumns());
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(2);
         }
+
+        [Test]
+        public async Task DataGridToolbarHiderTest()
+        {
+            // If DisableToolbar="true" we do not expect a mud-menu
+            var comp = Context.RenderComponent<DataGridToolbarHiderTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridToolbarHiderTest.Model>>();
+            dataGrid.FindAll(".mud-menu").Count.Should().Be(0);
+
+            // If DisableToolbar="false" we expect a mud-menu
+            var comp2 = Context.RenderComponent<DataGridColumnChooserTest>();
+            var dataGrid2 = comp2.FindComponent<MudDataGrid<DataGridColumnChooserTest.Model>>();
+            dataGrid2.FindAll(".mud-menu").Count.Should().Be(1);
+
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -9,20 +9,23 @@
     <div @attributes="UserAttributes" class="@_classname" style="@Style">
         @if (Items != null || ServerData != null)
         {
-            @if (ToolBarContent != null)
+            @if (!DisableToolbar)
             {
-                <MudToolBar Class="mud-table-toolbar">
-                    @ToolBarContent
-                    @ToolbarMenu(this)           
-                </MudToolBar>
-            }
-            else
-            {
+                @if (ToolBarContent != null)
+                {
+                    <MudToolBar Class="mud-table-toolbar">
+                        @ToolBarContent
+                        @ToolbarMenu(this)           
+                    </MudToolBar>
+                }
+                else
+                {
                 @*Add the default toolbar.*@
-                <MudToolBar Class="mud-table-toolbar">
-                    <MudSpacer />
-                    @ToolbarMenu(this) 
-                </MudToolBar>
+                    <MudToolBar Class="mud-table-toolbar">
+                        <MudSpacer />
+                        @ToolbarMenu(this) 
+                    </MudToolBar>
+                }
             }
             <div class="mud-table-container" style="@_tableStyle @(GetHorizontalScrollbarStyle())">
                 <table class="mud-table-root">

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -496,6 +496,10 @@ namespace MudBlazor
         /// CSS styles for the groups.
         /// </summary>
         [Parameter] public string GroupStyle { get; set; }
+        /// <summary>
+        /// If enabled, the Toolbar of the MudDataGrid will be disabled.
+        /// </summary>
+        [Parameter] public bool DisableToolbar { get; set; }
 
         #endregion
 


### PR DESCRIPTION
## Description
Adds a "DisableToolbar" boolean parameter to the MudDataGrid, which allows users to disable the default toolbar.
Change is based on the following discussion:
https://github.com/MudBlazor/MudBlazor/discussions/4794

## How Has This Been Tested?
This has been tested in a new unit test which tests whether or not a ".mud-menu" has been added to the component or not.
The test verifies that if DisableToolbar is true, then we expect 0 .mud-menus and otherwise 1.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
