### PR TITLE
MudForm: Add FieldChanged event

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -5,7 +5,7 @@
 <MudGrid>
     <MudItem xs="12" sm="7">
         <MudPaper Class="pa-4">
-            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors" FieldChanged="((e) => Console.WriteLine(e.NewValue))">
+            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
                     <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!"/>
                     <MudTextField T="string" Label="Email" Required="true" RequiredError="Email is required!"
                                   Validation="@(new EmailAddressAttribute() {ErrorMessage = "The email address is invalid"})"/>

--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -5,7 +5,7 @@
 <MudGrid>
     <MudItem xs="12" sm="7">
         <MudPaper Class="pa-4">
-            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
+            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors" FieldChanged="((e) => Console.WriteLine(e.NewValue))">
                     <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!"/>
                     <MudTextField T="string" Label="Email" Required="true" RequiredError="Email is required!"
                                   Validation="@(new EmailAddressAttribute() {ErrorMessage = "The email address is invalid"})"/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedTest.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using MudBlazor.Utilities
+@using System.Text.RegularExpressions
+@using System.ComponentModel.DataAnnotations
+
+<MudForm @ref="form" FieldChanged="((v) => FormFieldChangedEventArgs = v)">
+    <MudTextField T="string" Label="Username" />
+    <MudTextField T="string" Label="Email" />
+    <MudNumericField T="int" />
+    <div class="d-flex">
+        <MudRadioGroup T="string" Required="true" RequiredError="Account type is required!">
+            <MudRadio Option="@("1")">Personal</MudRadio>
+            <MudRadio Option="@("2")">Professional</MudRadio>
+        </MudRadioGroup>
+    </div>
+</MudForm>
+
+@code {
+    MudForm form;
+
+    public FormFieldChangedEventArgs FormFieldChangedEventArgs;
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -337,6 +337,7 @@ namespace MudBlazor
                     await UpdateTextPropertyAsync(false);
                 await ValueChanged.InvokeAsync(Value);
                 BeginValidate();
+                Form?.FieldChanged(this, Value);
             }
         }
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -337,7 +337,7 @@ namespace MudBlazor
                     await UpdateTextPropertyAsync(false);
                 await ValueChanged.InvokeAsync(Value);
                 BeginValidate();
-                Form?.FieldChanged(this, Value);
+                FieldChanged(Value);
             }
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -67,6 +67,7 @@ namespace MudBlazor
                 Checked = value;
                 await CheckedChanged.InvokeAsync(value);
                 BeginValidate();
+                Form?.FieldChanged(this, Checked);
             }
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -67,7 +67,7 @@ namespace MudBlazor
                 Checked = value;
                 await CheckedChanged.InvokeAsync(value);
                 BeginValidate();
-                Form?.FieldChanged(this, Checked);
+                FieldChanged(Checked);
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -471,6 +471,15 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Notify the Form that a field has changed if Standalone is true
+        /// </summary>
+        protected void FieldChanged(object newValue)
+        {
+            if (Standalone)
+                Form?.FieldChanged(this, newValue);
+        }
+
+        /// <summary>
         /// Reset the value and the validation.
         /// </summary>
         public void Reset()

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -32,6 +32,12 @@ namespace MudBlazor
 
         protected HashSet<string> _errors = new HashSet<string>();
 
+
+        void IForm.FieldChanged(IFormComponent formControl, object newValue)
+        {
+            //implement in future for DataGrid
+        }
+
         void IForm.Add(IFormComponent formControl)
         {
             _formControls.Add(formControl);

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -101,6 +101,11 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<bool> IsTouchedChanged { get; set; }
 
+        /// <summary>
+        /// Raised when a contained IFormComponent changes its value
+        /// </summary>
+        [Parameter] public EventCallback<FormFieldChangedEventArgs> FieldChanged { get; set; }
+
         // keeps track of validation. if the input was validated at least once the value will be true
         protected HashSet<IFormComponent> _formControls = new();
         protected HashSet<string> _errors = new();
@@ -154,6 +159,11 @@ namespace MudBlazor
         private HashSet<MudForm> ChildForms { get; set; } = new HashSet<MudForm>();
 
         [CascadingParameter] private MudForm ParentMudForm { get; set; }
+
+        void IForm.FieldChanged(IFormComponent formControl, object newValue)
+        {
+            FieldChanged.InvokeAsync(new FormFieldChangedEventArgs { Field = formControl, NewValue = newValue }).AndForget();
+        }
 
         void IForm.Add(IFormComponent formControl)
         {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -327,6 +327,7 @@ namespace MudBlazor
                 if (callback)
                     await StringValueChanged(_text);
                 await TextChanged.InvokeAsync(_text);
+                Form?.FieldChanged(this, _text);
             }
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -327,7 +327,7 @@ namespace MudBlazor
                 if (callback)
                     await StringValueChanged(_text);
                 await TextChanged.InvokeAsync(_text);
-                Form?.FieldChanged(this, _text);
+                FieldChanged(_text);
             }
         }
 

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -50,6 +50,7 @@ namespace MudBlazor
                 await SelectedOptionChanged.InvokeAsync(_value);
 
                 BeginValidate();
+                Form?.FieldChanged(this, _value);
             }
         }
 

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -50,7 +50,7 @@ namespace MudBlazor
                 await SelectedOptionChanged.InvokeAsync(_value);
 
                 BeginValidate();
-                Form?.FieldChanged(this, _value);
+                FieldChanged(_value);
             }
         }
 

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -26,6 +26,11 @@ namespace MudBlazor
 
         protected HashSet<string> _errors = new();
 
+        void IForm.FieldChanged(IFormComponent formControl, object newValue)
+        {
+            //implement in future for table
+        }
+
         void IForm.Add(IFormComponent formControl)
         {
             _formControls.Add(formControl);

--- a/src/MudBlazor/Interfaces/IForm.cs
+++ b/src/MudBlazor/Interfaces/IForm.cs
@@ -7,6 +7,7 @@
 #nullable enable
         public object? Model { get; set; }
 #nullable disable
+        public void FieldChanged(IFormComponent formControl, object newValue);
         internal void Add(IFormComponent formControl);
         internal void Remove(IFormComponent formControl);
         internal void Update(IFormComponent formControl);

--- a/src/MudBlazor/Utilities/FormFieldChangedEventArgs.cs
+++ b/src/MudBlazor/Utilities/FormFieldChangedEventArgs.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MudBlazor.Interfaces;
+
+namespace MudBlazor.Utilities
+{
+    public class FormFieldChangedEventArgs
+    {
+        public IFormComponent Field { get; set; }
+        public object NewValue { get; set; }
+    }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a `FieldChanged` event to the MudForm. Example usage:
```csharp
<MudForm FieldChanged=@((e) => Console.WriteLine($"Value changed: {e.NewValue}. Component type: {e.Field}"))>
   <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!"/>
</MudForm>
```

It will fire whenever a `MudFormComponent` value changes. I believe I have accounted for all components which inherit `MudFormComponent`.

A few caveats:
* The Rating and Slider components do not inherit from `MudFormComponent` and are not covered by this PR.
* I needed to modify `IForm`, which means the `FieldChanged` method of that interface is ignored in the Table validators which inherit `IForm`. However, this was already the case for the `Update` method.

One potential issue: MudTextFields trigger the event twice, once with a MudTextField type and once with a MudInput type.

Lastly, this seems like a niche change and I have not written proper documentation for it. However, I can do so if desired.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I have written a unit test to cover the interaction with the most common fields and make sure the FieldChanged event fires correctly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
