### PR TITLE
MudMask: Fix crash when navigating quickly on a page containing a mask

### DIFF
--- a/src/MudBlazor/Services/JsEvent/JsEvent.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEvent.cs
@@ -54,7 +54,7 @@ namespace MudBlazor.Services
         /// <param name="options">Define here the descendant(s) by setting TargetClass and the keystrokes to be monitored</param>
         public async Task Connect(string elementId, JsEventOptions options)
         {
-            if (_isObserving)
+            if (_isObserving || _isDisposed)
                 return;
             _elementId = elementId;
             try
@@ -75,7 +75,7 @@ namespace MudBlazor.Services
                 return;
             await UnsubscribeAll();
             try
-            {                
+            {
                 await _jsRuntime.InvokeVoidAsync($"mudJsEvent.disconnect", _elementId);
             }
             catch (Exception) {  /*ignore*/ }
@@ -86,7 +86,7 @@ namespace MudBlazor.Services
         {
             if (_elementId == null)
                 throw new InvalidOperationException("Call Connect(...) before attaching events!");
-            if (_subscribedEvents.Contains(eventName))
+            if (_subscribedEvents.Contains(eventName) || _isDisposed)
                 return;
             try
             {

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.Services
         /// <param name="options">Define here the descendant(s) by setting TargetClass and the keystrokes to be monitored / suppressed</param>
         public async Task Connect(string elementId, KeyInterceptorOptions options)
         {
-            if (_isObserving)
+            if (_isObserving || _isDisposed)
                 return;
             _elementId = elementId;
             try
@@ -56,6 +56,7 @@ namespace MudBlazor.Services
                 await _jsRuntime.InvokeVoidAsync("mudKeyInterceptor.connect", _dotNetRef, elementId, options);
                 _isObserving = true;
             }
+            catch (JSException) { } //navigating quickly can throw "element not found" errors
             catch (JSDisconnectedException) { }
             catch (TaskCanceledException) { }
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This resolves the issue discussed in #4565. What I have done is added a check on `_isDisposed` in both `JSEvent.cs` and `KeyInterceptor.cs` before `Connect` and `Subscribe` calls. I additionally caught all `JSException`s on KeyInterceptor as the `_isDisposed` check was insufficient to stop the error in #4565.

I think this a clean way of handling this edge case.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

All existing tests pass and the issue in #4565 is resolved.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
