### PR TITLE
MudDropZone: Add support for Chromium based browsers on Mobile

### DIFF
--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -151,6 +151,8 @@ namespace MudBlazor
     {
         private MudDragAndDropItemTransaction<T> _transaction;
 
+        internal Dictionary<string, MudDropZone<T>> MudDropZones { get; set; } = new Dictionary<string, MudDropZone<T>>();
+
         protected string Classname =>
         new CssBuilder("mud-drop-container")
             .AddClass(Class)
@@ -342,6 +344,18 @@ namespace MudBlazor
             TransactionIndexChanged?.Invoke(this, new MudDragAndDropIndexChangedEventArgs(_transaction.CurrentZone, oldValue, _transaction.Index));
         }
 
+        internal bool RegisterDropZone(MudDropZone<T> dropZone)
+        {
+            return MudDropZones.TryAdd(dropZone.Identifier, dropZone);
+        }
+        internal void RemoveDropZone(string identifier)
+        {
+            MudDropZones.Remove(identifier);
+        }
+        internal MudDropZone<T> GetDropZone(string identifier)
+        {
+            return MudDropZones.TryGetValue(identifier, out var dropZone) ? dropZone : null;
+        }
 
         /// <summary>
         /// Refreshes the dropzone and all items within. This is neded in case of adding items to the collection or changed values of items

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -7,7 +7,9 @@
 	 id="@($"mud-drop-zone-{_id}")"
 	 @ondrop="HandleDrop"
 	 @ondragenter="HandleDragEnter"
+     
 	 @ondragleave="HandleDragLeave"
+    
 	 @attributes="UserAttributes">
 
 	@ChildContent

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -5,6 +5,7 @@
 
 <div class="@Classname" style="@Style"
 	 id="@($"mud-drop-zone-{_id}")"
+     identifier="@Identifier"
 	 @ondrop="HandleDrop"
 	 @ondragenter="HandleDragEnter"
      

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -307,7 +307,7 @@ namespace MudBlazor
             }
         }
 
-        private async Task HandleDrop()
+        internal async Task HandleDrop()
         {
             var (context, isValidZone) = ItemCanBeDropped();
             if (context == null)
@@ -387,6 +387,7 @@ namespace MudBlazor
                 Container.TransactionEnded += Container_TransactionEnded;
                 Container.RefreshRequested += Container_RefreshRequested;
                 Container.TransactionIndexChanged += Container_TransactionIndexChanged;
+                Container.RegisterDropZone(this);
             }
 
             base.OnParametersSet();
@@ -421,7 +422,7 @@ namespace MudBlazor
                         Container.TransactionEnded -= Container_TransactionEnded;
                         Container.RefreshRequested -= Container_RefreshRequested;
                         Container.TransactionIndexChanged -= Container_TransactionIndexChanged;
-
+                        Container.RemoveDropZone(Identifier);
                     }
                 }
 

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
@@ -2,10 +2,17 @@
 @inherits MudComponentBase
 @typeparam T
 
-<div class="@Classname" style="@Style"
+<div class="@Classname" style="@($"{Style};touch-action:none;transform: translate3d(0px, 0px, 0px);")"
+     id="@($"mud-drop-item-{_id}")"
 	 @attributes="UserAttributes"
 	 draggable="@(Disabled == false ? "true" : "false")"
+
 	 @ondragstart="DragStarted"
+
+     @ontouchstart="TouchStarted"
+     @ontouchend="TouchEnded"
+     @ontouchmove="TouchMoved"
+
 	 @ondragend="DragEnded"
 	 @ondragenter="HandleDragEnter"
 	 @ondragleave="HandleDragLeave">

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
@@ -4,6 +4,7 @@
 
 <div class="@Classname" style="@($"{Style};touch-action:none;transform: translate3d(0px, 0px, 0px);")"
      id="@($"mud-drop-item-{_id}")"
+     index="@Index"
 	 @attributes="UserAttributes"
 	 draggable="@(Disabled == false ? "true" : "false")"
 

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -155,7 +155,12 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
         //Send to JS to move DOM element
         await JsRuntime.InvokeVoidAsync("mudDragAndDrop.moveItemByDifference", _id.ToString(), x, y);
 
+        if (Container == null || Container.TransactionInProgress() == false) { return; }
 
+        if (int.TryParse(await JsRuntime.InvokeAsync<string>("mudDragAndDrop.getDropIndexOnPosition", _onTouchLastX, _onTouchLastY, _id), out var dropIndex))
+        {
+            Container.UpdateTransactionIndex(dropIndex);
+        }
         //JS.InvokeVoidAsync("draggableTouch");
     }
 

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -102,6 +102,9 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
 
     private async Task TouchStarted(TouchEventArgs e)
     {
+        if (Index == -1) return; //the -1 item shoudn't be ever moved.
+        if (Disabled) return; //disabled items shouldn't be moved.
+
         _onTouchStartX = e.ChangedTouches[0].ClientX;
         _onTouchStartY = e.ChangedTouches[0].ClientY;
         _onTouchLastX = _onTouchStartX;
@@ -145,6 +148,8 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
     }
     private async void TouchMoved(TouchEventArgs e)
     {
+        if (Index == -1 || Disabled) return;
+
         //Calculate change from last Move event
         var x = e.ChangedTouches[0].ClientX - _onTouchLastX;
         var y = e.ChangedTouches[0].ClientY - _onTouchLastY;
@@ -166,6 +171,8 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
 
     private async Task TouchEnded(TouchEventArgs e)
     {
+        if (Index == -1 || Disabled) return;
+
         if (_dragOperationIsInProgress == true)
         {
             _onTouchLastX = e.ChangedTouches[0].ClientX;
@@ -187,7 +194,7 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
                 StateHasChanged();
             }
         }
-        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.makeDropZonesRelative");
+        //await JsRuntime.InvokeVoidAsync("mudDragAndDrop.makeDropZonesRelative");
     }
     /// <summary>
     /// This allows us to know if an item can be dropped on a given drop zone.

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -8,5 +8,45 @@ window.mudDragAndDrop = {
         const elem = document.getElementById('mud-drop-zone-' + id);
         elem.addEventListener('dragover',() => event.preventDefault());
         elem.addEventListener('dragstart', () => event.dataTransfer.setData('', event.target.id));
+    },
+    makeDropZonesNotRelative: () => {
+        const dropZones = document.getElementsByClassName('mud-drop-zone');
+        for (let dropZone of dropZones) {
+            dropZone.style.position = 'unset';
+        }
+    },
+    makeDropZonesRelative: () => {
+        const dropZones = document.getElementsByClassName('mud-drop-zone');
+        for (let dropZone of dropZones) {
+            dropZone.style.position = 'relative';
+        }
+    },
+    moveItemByDifference: (id, dx, dy) => {
+        const elem = document.getElementById('mud-drop-item-' + id);
+        
+
+
+        // keep the ACCUMULATED dragged position in the data-x/data-y attributes
+        var tx = (parseFloat(elem.getAttribute('data-x')) || 0) + dx;
+        var ty = (parseFloat(elem.getAttribute('data-y')) || 0) + dy;
+
+
+        // translate the element
+        elem.style.webkitTransform =
+            elem.style.transform =
+            'translate3d(' + tx + 'px, ' + ty + 'px, 10px)';
+        
+        // update the posiion attributes
+        elem.setAttribute('data-x', tx);
+        elem.setAttribute('data-y', ty);
+    },
+    resetItem: (id) => {
+        const elem = document.getElementById('mud-drop-item-' + id);
+        // translate the element
+        elem.style.webkitTransform =
+            elem.style.transform = '';
+        // update the posiion attributes
+        elem.setAttribute('data-x', 0);
+        elem.setAttribute('data-y', 0);
     }
 };

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -10,6 +10,11 @@ window.mudDragAndDrop = {
         elem.addEventListener('dragstart', () => event.dataTransfer.setData('', event.target.id));
     },
     makeDropZonesNotRelative: () => {
+        var firstDropItems = Array.from(document.getElementsByClassName('mud-drop-item')).filter(x => x.getAttribute('index') == "-1");
+        for (let dropItem of firstDropItems) {
+            dropItem.style.position = 'static';
+        }
+
         const dropZones = document.getElementsByClassName('mud-drop-zone');
         for (let dropZone of dropZones) {
             dropZone.style.position = 'unset';
@@ -25,7 +30,10 @@ window.mudDragAndDrop = {
         return "";
     },
     getDropIndexOnPosition: (x, y, id) => {
+        //const selfItem = document.getElementById('mud-drop-item-' + id);
+
         const elems = document.elementsFromPoint(x, y);
+
         const dropItems = elems.filter(e => e.classList.contains('mud-drop-item') && e.id != ('mud-drop-item-' + id))
         const dropItem = dropItems[0];
         if (dropItem) {
@@ -37,6 +45,10 @@ window.mudDragAndDrop = {
         const dropZones = document.getElementsByClassName('mud-drop-zone');
         for (let dropZone of dropZones) {
             dropZone.style.position = 'relative';
+        }
+        var firstDropItems = Array.from(document.getElementsByClassName('mud-drop-item')).filter(x => x.getAttribute('index') == "-1");
+        for (let dropItem of firstDropItems) {
+            dropItem.style.position = 'relative';
         }
     },
     moveItemByDifference: (id, dx, dy) => {

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -15,6 +15,15 @@ window.mudDragAndDrop = {
             dropZone.style.position = 'unset';
         }
     },
+    getDropZoneIdentifierOnPosition: (x, y) => {
+        const elems = document.elementsFromPoint(x, y);
+        const dropZones = elems.filter(e => e.classList.contains('mud-drop-zone'))
+        const dropZone = dropZones[0];
+        if (dropZone) {
+            return dropZone.getAttribute('identifier') || "";
+        }
+        return "";
+    },
     makeDropZonesRelative: () => {
         const dropZones = document.getElementsByClassName('mud-drop-zone');
         for (let dropZone of dropZones) {
@@ -42,11 +51,14 @@ window.mudDragAndDrop = {
     },
     resetItem: (id) => {
         const elem = document.getElementById('mud-drop-item-' + id);
-        // translate the element
-        elem.style.webkitTransform =
-            elem.style.transform = '';
-        // update the posiion attributes
-        elem.setAttribute('data-x', 0);
-        elem.setAttribute('data-y', 0);
+        if (elem) {
+            // translate the element
+            elem.style.webkitTransform =
+                elem.style.transform = '';
+            // update the posiion attributes
+            elem.setAttribute('data-x', 0);
+            elem.setAttribute('data-y', 0);
+        }
+        
     }
 };

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -24,6 +24,15 @@ window.mudDragAndDrop = {
         }
         return "";
     },
+    getDropIndexOnPosition: (x, y, id) => {
+        const elems = document.elementsFromPoint(x, y);
+        const dropItems = elems.filter(e => e.classList.contains('mud-drop-item') && e.id != ('mud-drop-item-' + id))
+        const dropItem = dropItems[0];
+        if (dropItem) {
+            return dropItem.getAttribute('index') || "";
+        }
+        return "";
+    },
     makeDropZonesRelative: () => {
         const dropZones = document.getElementsByClassName('mud-drop-zone');
         for (let dropZone of dropZones) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4817 adding support for drag on mobile. This is still WIP.

The code adds a few new things to port this feature which is based on HTML5 drag events which are mostly unavailable on mobile. This means a little more JS.

moveItemByDifference allows the item to be moved around using translate3d.

The main difficulty I am facing is that DragEnter is not triggered anymore which means that I need to use JS to figure out which drop zone I am dropping on, since I cannot just edit the index as soon as the DragEnter event is triggered since that won't fire anymore on mobile.

Instead I attached to `@ontouchstart` and `@ontouchend` in order to know when the dragging starts and when it ends. I use JS to obtain the drop zone in those final coordinates.

Now the issue here is that it's possible to have the `_id` by reading the div's id but that won't give me any useful info. I needed the `Identifier`, so to solve this I added an `identifier=@Identifier` to the div corresponding to the drop zone. Now I can get that attribute and pass it to the C# code using JS Interop.

But how can I check if I can drop the item? After all now I no longer have access to the drop zone itself to check the `CanDrop` property! So I had to modify the Container a little.

I added a `RegisterDropZone` method that adds the drop zone to a dictionary in the Container.

I added also a method to remove the drop zone given an identifier, and a way to get it from the Container.

I made a few methods internal though in the DropZone because I need to be able to call them from the `MudDynamicDropItem`.

I can now properly verify if the item can be drop and the logic continues as it used to before.

For now I have been able to get the simple drop zone behavior working. i.e. multiple dropzones without reorder.

I need more time to get the reordering working as well.


## How Has This Been Tested?
This is been tested visually with Chrome's emulation.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
