### PR TITLE
Docs: fix links in Releases page

### DIFF
--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -49,6 +49,11 @@
         output = Regex.Replace(output, @"(^|\n)# .+", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">$&</h5>");
         output = Regex.Replace(output, @"(^|\n)## .+", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">$&</h5>");
         output = Regex.Replace(output, @"(^|\n)### .+", "<h6 class=\"mud-typography mud-typography-h6 mud-inherit-text\">$&</h6>");
+        // Markdown links
+        output = Regex.Replace(output, @"\[(.*?)\]\((.*?)\)", "<a target=\"_blank\" href=\"$2\">$1</a>");
+        // Http links
+        output = Regex.Replace(output, @"(?<!"")(?>https?:\/\/)[^\s<>]+(?:[\w\d]+|(?>[^[\p{P}\s]|\/))", "<a target=\"_blank\" href=\"$0\">$0</a>");
+        // Issue / PR links
         output = Regex.Replace(output, @"(#){1}([0-9]{4}){1}", "<a target=\"_blank\" href=\"https://github.com/MudBlazor/MudBlazor/pull/$2\">#$2</a>");
         output = output.Replace("- **", "<b class=\"mx-3\">•</b><b>").Replace("**:",":</b>");
         output = output.Replace("### ", "").Replace("## ","").Replace("# ","#");


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/15875066/177587403-76bcdfcd-b028-4376-9d4f-ecc37a82f321.png)

After:
![image](https://user-images.githubusercontent.com/15875066/177587481-11e0effd-474d-42e5-91c3-8b4519673cdd.png)

I tried my best regex skills (ie copy/pasting from stackoverflow 😂)