### PR TITLE
Move _scrollSpy creation into OnInitialized so it's available on time…

### DIFF
--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -139,6 +139,9 @@ namespace MudBlazor
         }
 
 
+        /// <summary>
+        /// Rerender the component
+        /// </summary>
         public void Update() => StateHasChanged();
         
         protected override void OnInitialized()
@@ -146,9 +149,7 @@ namespace MudBlazor
             _scrollSpy = ScrollSpyFactory.Create();
         }
         
-        /// <summary>
-        /// Rerender the component
-        /// </summary>
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -138,16 +138,22 @@ namespace MudBlazor
             }
         }
 
+
+        public void Update() => StateHasChanged();
+        
+        protected override void OnInitialized()
+        {
+            _scrollSpy = ScrollSpyFactory.Create();
+        }
+        
         /// <summary>
         /// Rerender the component
         /// </summary>
-        public void Update() => StateHasChanged();
-
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
-                _scrollSpy = ScrollSpyFactory.Create();
+                
                 _scrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
 
                 if (string.IsNullOrEmpty(SectionClassSelector) == false)


### PR DESCRIPTION
This fixes: #4849

What happened?

_scrollSpy gets initialized in the OnAfterRenderAsync of the of hte MudPageContentNavigation, which is fired after we are able to call AddSection.
Here is an existing Try that breaks: https://try.mudblazor.com/snippet/wEcGuROZAazxkebB

Here's the commit that introduced the issue:
https://github.com/MudBlazor/MudBlazor/blob/68a80de3e9be7646fe2b2c8ea0c076e615dcfaa9/src/MudBlazor.Docs/Components/
Expected behavior

Able to use/call AddSection in OnAfterRender without an exception and with a working menu.