### PR TITLE
MudPicker: Add clear button

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -156,6 +156,25 @@ namespace MudBlazor.UnitTests.Components
             picker.Text.Should().Be("26 10 2020");
         }
 
+        [Test]        
+        public async Task DatePicker_Should_Clear()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+            // select elements needed for the test
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+            comp.SetParam(p => p.Clearable, true);
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
+            picker.Date.Should().Be(new DateTime(2020, 10, 26));
+            picker.Text.Should().Be(new DateTime(2020, 10, 26).ToShortDateString());
+
+            comp.Find("button").Click(); //clear the input
+
+            picker.Text.Should().Be(""); //ensure the text and date are reset. Note this is an empty string rather than null due to how the reset works internally
+            picker.Date.Should().Be(null);
+        }
+
         [Test]
         public void Check_Intial_Date_Format()
         {

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -48,6 +48,26 @@ namespace MudBlazor.UnitTests.Components
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Time Picker");
         }
 
+
+        [Test]
+        public void TimePicker_Should_Clear()
+        {
+            var comp = Context.RenderComponent<MudTimePicker>();
+            // select elements needed for the test
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Time.Should().Be(null);
+            comp.SetParam(p => p.Clearable, true);
+            comp.SetParam(p => p.Time, new TimeSpan(637940935730000000));
+            picker.Time.Should().Be(new TimeSpan(637940935730000000));
+            picker.Text.Should().Be(new TimeSpan(637940935730000000).ToIsoString());
+
+            comp.Find("button").Click(); //clear the input
+
+            picker.Text.Should().Be(""); //ensure the text and time are reset. Note this is an empty string rather than null due to how the reset works internally
+            picker.Time.Should().Be(null);
+        }
+
         [Test]
         public void Open_ClickOutside_CheckClosed()
         {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -34,7 +34,7 @@
              RequiredError="@RequiredError" 
              Error="@Error" 
              ErrorText="@ErrorText"
-             Clearable="@Clearable"
+             Clearable="@(ReadOnly ? false : Clearable)"
              OnClearButtonClick="@(() => Clear())"
              @onclick="@(() => { if (!Editable) ToggleState(); })" 
              @onkeydown="HandleKeyDown" 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -33,7 +33,9 @@
              Required="@Required" 
              RequiredError="@RequiredError" 
              Error="@Error" 
-             ErrorText="@ErrorText" 
+             ErrorText="@ErrorText"
+             Clearable="@Clearable"
+             OnClearButtonClick="@(() => Clear())"
              @onclick="@(() => { if (!Editable) ToggleState(); })" 
              @onkeydown="HandleKeyDown" 
              />;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -164,6 +164,13 @@ namespace MudBlazor
         public string Label { get; set; }
 
         /// <summary>
+        /// Show clear button.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public bool Clearable { get; set; } = false;
+
+        /// <summary>
         /// If true, the picker will be disabled.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a clear button to the various MudPickers for consistency with the rest of the library.

**However, this makes it possible to clear a Readonly Picker.** Is this desired behavior?

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually, I can add a unit test if necessary.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

An example from the Basic Usage section of the Date Picker docs page:

![image](https://user-images.githubusercontent.com/26885142/178068873-6bf685e2-2004-478c-bab3-2564c86920da.png)

When empty, the clear button is not shown:
![image](https://user-images.githubusercontent.com/26885142/178068906-f368a753-6c89-4c5d-9948-de99135c07af.png)

It also works for the time picker and color picker:
![image](https://user-images.githubusercontent.com/26885142/178069247-508de5d4-a407-44a6-a1fe-846383e8b8e2.png)
![image](https://user-images.githubusercontent.com/26885142/178069214-0dd2690b-96af-4cf7-8196-0bc4c6346697.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
