### PR TITLE
MudTextField with mask should respect Readonly property

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/ReadonlyMaskedTextFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/ReadonlyMaskedTextFieldTest.razor
@@ -1,0 +1,12 @@
+<MudTextField
+    Mask="@(new PatternMask("0000 0000 0000 0000"))"
+    @bind-Value=Text
+    ReadOnly=ReadOnly/>
+
+@code
+{
+    [Parameter]
+    public bool ReadOnly { get; set; } = true;
+
+    private string Text { get; set; } = "1234 1234 1234 1234";
+}

--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -12,6 +12,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.TestComponents.Mask;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -705,6 +706,41 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => textField.Value.Should().Be("(123) 456-7890"));
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
             comp.WaitForAssertion(() => textField.Value.Should().Be(""));
+        }
+
+        /// <summary>
+        /// A readonly masked text should not react to any edit/delete event
+        /// </summary>
+        [Test]
+        public async Task MaskTest_Readonly()
+        {
+            var comp = Context.RenderComponent<ReadonlyMaskedTextFieldTest>();
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var mask = comp.FindComponent<MudMask>().Instance;
+            var originalValue = textField.Text;
+
+            originalValue.Should().Be("1234 1234 1234 1234");
+
+            // paste
+            await comp.InvokeAsync(() => {
+                mask.OnSelect(0, mask.Text.Length - 1);
+                mask.OnPaste("1234567890");
+            });
+            comp.WaitForAssertion(() => textField.Value.Should().Be(originalValue));
+            // backspace
+            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            comp.WaitForAssertion(() => textField.Value.Should().Be(originalValue));
+
+            comp.SetParam(p => p.ReadOnly, false);
+            // paste
+            await comp.InvokeAsync(async () => {
+                mask.OnSelect(0, mask.Text.Length - 1);
+                mask.OnPaste("2222 2222 2222 2222");
+            });
+            comp.WaitForAssertion(() => textField.Value.Should().Be("2222 2222 2222 2222"));
+            // backspace
+            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            comp.WaitForAssertion(() => textField.Value.Should().Be("2222 2222 2222 222"));
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -717,30 +717,45 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<ReadonlyMaskedTextFieldTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var mask = comp.FindComponent<MudMask>().Instance;
+            var maskInput = comp.Find("input");
             var originalValue = textField.Text;
 
             originalValue.Should().Be("1234 1234 1234 1234");
 
             // paste
             await comp.InvokeAsync(() => {
-                mask.OnSelect(0, mask.Text.Length - 1);
+                mask.OnSelect(0, mask.Text.Length);
                 mask.OnPaste("1234567890");
             });
             comp.WaitForAssertion(() => textField.Value.Should().Be(originalValue));
             // backspace
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             comp.WaitForAssertion(() => textField.Value.Should().Be(originalValue));
+            // cut
+            await comp.InvokeAsync(() =>
+            {
+                mask.OnSelect(0, mask.Text.Length);
+                maskInput.CutAsync(new ClipboardEventArgs { Type = "cut" });
+            });
+            comp.WaitForAssertion(() => textField.Value.Should().Be(originalValue));
 
             comp.SetParam(p => p.ReadOnly, false);
             // paste
             await comp.InvokeAsync(async () => {
-                mask.OnSelect(0, mask.Text.Length - 1);
+                mask.OnSelect(0, mask.Text.Length);
                 mask.OnPaste("2222 2222 2222 2222");
             });
             comp.WaitForAssertion(() => textField.Value.Should().Be("2222 2222 2222 2222"));
             // backspace
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             comp.WaitForAssertion(() => textField.Value.Should().Be("2222 2222 2222 222"));
+            // cut
+            await comp.InvokeAsync(() =>
+            {
+                mask.OnSelect(0, textField.Value.Length);
+                maskInput.Cut(new ClipboardEventArgs { Type = "cut" });
+            });
+            comp.WaitForAssertion(() => textField.Value.Should().Be(""));
         }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -190,7 +190,7 @@ namespace MudBlazor
         {
             try
             {
-                if ((e.CtrlKey && e.Key != "Backspace") || e.AltKey)
+                if ((e.CtrlKey && e.Key != "Backspace") || e.AltKey || ReadOnly)
                         return;
                 // Console.WriteLine($"HandleKeyDown: '{e.Key}'");
                 switch (e.Key)
@@ -337,7 +337,7 @@ namespace MudBlazor
         internal async void OnPaste(string text)
         {
             //Console.WriteLine($"Paste: {text}");
-            if (text == null)
+            if (text == null || ReadOnly)
                 return;
             Mask.Insert(text);
             await Update();
@@ -419,6 +419,9 @@ namespace MudBlazor
 
         private async void OnCut(ClipboardEventArgs obj)
         {
+            if (ReadOnly)
+                return;
+            
             if (_selection!=null)
                 Mask.Delete();
             await Update();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
MudTextField with mask should respect Readonly property.
If readonly is true, no paste/keyboard backspace events should work.

Problem seems to be located inside MudMask, some events do not check Readonly value.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #4866.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
