### PR TITLE
fix/MudMask-ReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/MaskedTextReadOnlyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/MaskedTextReadOnlyTest.razor
@@ -1,0 +1,10 @@
+<MudText Typo="Typo.h6">Example of Mask</MudText>
+
+<MudSwitch @bind-Checked="_readOnly" Label="Read Only" />
+<MudTextField @bind-Value="@Date" Mask="@(new PatternMask("00.00.00"))" Label="Date" ReadOnly="_readOnly" />
+
+@code {
+    public static string __description__ = "If ReadOnly true, date should not be editable.";
+    public string Date { get; set; } = string.Empty;
+    private bool _readOnly = false;
+}

--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -706,5 +706,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
             comp.WaitForAssertion(() => textField.Value.Should().Be(""));
         }
+
+         [Test]
+        public async Task MaskTest_ReadOnly()
+        {
+            // Load the component
+            var comp = Context.RenderComponent<MudMask>();
+            comp.SetParam(x => x.Mask, new PatternMask("00.00.00"));
+            comp.SetParam(x => x.Text, "00.00.0");
+            comp.Instance.Text.Should().Be("00.00.0");
+
+            // Set ReadOnly true and try to modify the text
+            comp.SetParam(x => x.ReadOnly, true );
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() =>comp.Instance.OnPaste("0"));
+            /// await comp.InvonkeAsync()...  -> Test the OnCut function.
+            comp.Instance.Text.Should().Be("00.00.0");
+
+
+
+        }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -190,7 +190,7 @@ namespace MudBlazor
         {
             try
             {
-                if ((e.CtrlKey && e.Key != "Backspace") || e.AltKey)
+                if ((e.CtrlKey && e.Key != "Backspace") || e.AltKey || ReadOnly)
                         return;
                 // Console.WriteLine($"HandleKeyDown: '{e.Key}'");
                 switch (e.Key)
@@ -337,7 +337,7 @@ namespace MudBlazor
         internal async void OnPaste(string text)
         {
             //Console.WriteLine($"Paste: {text}");
-            if (text == null)
+            if (text == null || ReadOnly)
                 return;
             Mask.Insert(text);
             await Update();
@@ -419,8 +419,14 @@ namespace MudBlazor
 
         private async void OnCut(ClipboardEventArgs obj)
         {
-            if (_selection!=null)
-                Mask.Delete();
+              if(ReadOnly)
+            {
+                return;
+            }
+            else if (_selection!=null)
+            {
+                   Mask.Delete();
+            }
             await Update();
             //Console.WriteLine($"OnCut: '{Mask}'");
         }


### PR DESCRIPTION
Bug type
Component

Component name
MudTextField

What happened?
When creating a MudTextField component and adding a mask to it through the Mask property and setting this component to ReadOnly = true, it still allows to change the field content, the typing cursor is not shown, but it is allowed to type and change the content.

Expected behavior
It is expected that when informing the ReadOnly=true property, the component will no longer allow its content to be changed, regardless of whether it has a mask or not.

Reproduction link
https://try.mudblazor.com/snippet/wawQuBFuBDrOMyjC

Reproduction steps
Create a MudTaskField
Add Mask
Add values to field on execution
Set fields to Read Only
Focus on the masked field
Type backspace key or add new values (numbers) on the field
Value as changed
...
Relevant log output
No logs were generated in the console.
Version (bug)
6.0.11

Version (working)
No response

What browsers are you seeing the problem on?
Firefox, Chrome, Microsoft Edge

On what operating system are you experiencing the issue?
Windows

Pull Request
✅ I would like to do a Pull Request
Code of Conduct
✅ I agree to follow this project's Code of Conduct