### PR TITLE
Inputs: Add BlurAsync()

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -228,6 +228,8 @@ namespace MudBlazor
         /// <returns>The ValueTask</returns>
         public virtual ValueTask FocusAsync() { return new ValueTask(); }
 
+        public virtual ValueTask BlurAsync() { return new ValueTask(); }
+
         public virtual ValueTask SelectAsync() { return new ValueTask(); }
 
         public virtual ValueTask SelectRangeAsync(int pos1, int pos2) { return new ValueTask(); }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -635,6 +635,14 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Blur from the input in the Autocomplete component.
+        /// </summary>
+        public override ValueTask BlurAsync()
+        {
+            return _elementReference.BlurAsync();
+        }
+
+        /// <summary>
         /// Select all text within the Autocomplete input.
         /// </summary>
         public override ValueTask SelectAsync()

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -86,6 +86,11 @@ namespace MudBlazor
             }
         }
 
+        public override ValueTask BlurAsync()
+        {
+            return ElementReference.MudBlurAsync();
+        }
+
         public override ValueTask SelectAsync()
         {
             return ElementReference.MudSelectAsync();

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -124,6 +124,12 @@ namespace MudBlazor
         }
 
         [ExcludeFromCodeCoverage]
+        public override ValueTask BlurAsync()
+        {
+            return _elementReference.BlurAsync();
+        }
+
+        [ExcludeFromCodeCoverage]
         public override ValueTask SelectAsync()
         {
             return _elementReference.SelectAsync();

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -385,6 +385,8 @@ namespace MudBlazor
 
         public virtual ValueTask FocusAsync() => _inputReference?.FocusAsync() ?? ValueTask.CompletedTask;
 
+        public virtual ValueTask BlurAsync() => _inputReference?.BlurAsync() ?? ValueTask.CompletedTask;
+
         public virtual ValueTask SelectAsync() => _inputReference?.SelectAsync() ?? ValueTask.CompletedTask;
 
         public virtual ValueTask SelectRangeAsync(int pos1, int pos2) =>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -760,6 +760,11 @@ namespace MudBlazor
             return _elementReference.FocusAsync();
         }
 
+        public override ValueTask BlurAsync()
+        {
+            return _elementReference.BlurAsync();
+        }
+
         public override ValueTask SelectAsync()
         {
             return _elementReference.SelectAsync();

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -47,6 +47,14 @@ namespace MudBlazor
                 return _maskReference.FocusAsync();
         }
 
+        public override ValueTask BlurAsync()
+        {
+            if (_mask == null)
+                return InputReference.BlurAsync();
+            else
+                return _maskReference.BlurAsync();
+        }
+
         public override ValueTask SelectAsync()
         {
             if (_mask == null)

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -38,6 +38,9 @@ namespace MudBlazor
         public static ValueTask MudRestoreFocusAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.restoreFocus", elementReference) ?? ValueTask.CompletedTask;
 
+        public static ValueTask MudBlurAsync(this ElementReference elementReference) =>
+            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.blur", elementReference) ?? ValueTask.CompletedTask;
+
         public static ValueTask MudSelectAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.select", elementReference) ?? ValueTask.CompletedTask;
 

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -15,6 +15,12 @@ class MudElementReference {
         }
     }
 
+    blur(element) {
+        if (element) {
+            element.blur();
+        }
+    }
+
     focusFirst (element, skip = 0, min = 0) {
         if (element)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
We have `FocusAsync` method to focus on inputs. But we doesn't have the opposite method, blur.

Programmatically blur on element can only be done with js. So we need to add 6 lines of js code. I think we really need this, because blur is one of the most common methods and implementing blur outside of Mud code is really needs lots of work.

With this PR users can call `BlurAsync` and can lose focus programmatically.

This PR primarily affects text field and numeric field. It also can used with autocomplete, select and pickers, but users should be careful of using blur with them. An example, blur only blurs from input, so users also need to write code that closes the autocomplete's popover by manually.

Example 1: The left text field blurs when mouse out

https://user-images.githubusercontent.com/78308169/180099094-f95fa68b-4603-462f-aa12-21af7480409b.mp4


Example 2: The left Autocomplete blurs when user presses "a" key

https://user-images.githubusercontent.com/78308169/180099144-48b17bba-5d0e-477f-a38c-617f5f28431e.mp4




## How Has This Been Tested?
Js code can't be tested directly, but manually tried for common situations. Actually blur doesn't affect other methods, so the only risk is a bad working blur method. This doesn't break any event or something like.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
