### PR TITLE
Table: Fix KeyNotFoundException with records in MudTable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableContextRecordTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableContextRecordTest.razor
@@ -1,0 +1,36 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable @ref="MudTableRef" Items="items" T="Element" @bind-SelectedItem="selectedItem">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Value)">#</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Value</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField T="string" id="@context.Id" @bind-Value="@context.Value"></MudTextField>
+        </MudTd>
+    </RowEditingTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "identical record items should be stored as separate rows";
+    
+    private Element elementBeforeEditing = new();
+    private Element selectedItem = null;
+    public MudTable<Element> MudTableRef { get; private set; }
+
+    IEnumerable<Element> items = new List<Element> 
+    { 
+        new Element { Value = "A", Id = "Id1" }, 
+        new Element { Value = "A", Id = "Id1" }, 
+        new Element { Value = "B", Id = "Id2" }, 
+        new Element { Value = "C", Id = "Id3" }, 
+    };
+    public record Element
+    {
+        public string Id { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1541,5 +1541,19 @@ namespace MudBlazor.UnitTests.Components
             testComponent.WaitForAssertion(() => table.RowsPerPage.Should().Be(35));
         }
 
+        [Test]
+        public async Task TableContextRecordTest()
+        {
+            var comp = Context.RenderComponent<TableContextRecordTest>();
+            var table = comp.Instance.MudTableRef;
+            table.Context.Rows.Count.Should().Be(4);
+
+            var rows = table.Context.Rows.OrderBy(x => x.Value.Value).ToList(); //get a sorted list with the first two items
+
+            rows.Count.Should().Be(4);
+
+            rows[0].Value.Should().Be(rows[1].Value); //row values should match
+            rows[0].Should().NotBe(rows[1]); //but the presence of the row means the containing record is unique
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTrWithValue.cs
+++ b/src/MudBlazor/Components/Table/MudTrWithValue.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor
+{
+    public record MudTrWithValue<T>(T Value, MudTr Row);
+    //{
+    //    public MudTrWithValue(T value, MudTr row)
+    //    {
+    //        Value = value;
+    //        Row = row;
+    //    }
+
+    //    public T Value { get; set; }
+    //    public MudTr Row { get; set; }
+    //}
+}

--- a/src/MudBlazor/Components/Table/MudTrWithValue.cs
+++ b/src/MudBlazor/Components/Table/MudTrWithValue.cs
@@ -5,14 +5,4 @@
 namespace MudBlazor
 {
     public record MudTrWithValue<T>(T Value, MudTr Row);
-    //{
-    //    public MudTrWithValue(T value, MudTr row)
-    //    {
-    //        Value = value;
-    //        Row = row;
-    //    }
-
-    //    public T Value { get; set; }
-    //    public MudTr Row { get; set; }
-    //}
 }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -32,8 +32,7 @@ namespace MudBlazor
         private MudTr editedRow;
 
         public HashSet<T> Selection { get; set; } = new HashSet<T>();
-
-        public Dictionary<T, MudTr> Rows { get; set; } = new Dictionary<T, MudTr>();
+        public HashSet<MudTrWithValue<T>> Rows { get; set; } = new HashSet<MudTrWithValue<T>>();
         public List<MudTableGroupRow<T>> GroupRows { get; set; } = new List<MudTableGroupRow<T>>();
 
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new List<MudTableSortLabel<T>>();
@@ -45,8 +44,8 @@ namespace MudBlazor
             // update row checkboxes
             foreach (var pair in Rows.ToArray())
             {
-                var row = pair.Value;
-                var item = pair.Key;
+                var row = pair.Row;
+                var item = pair.Value;
                 row.SetChecked(Selection.Contains(item), notify: notify);
             }
             //update group checkboxes
@@ -90,7 +89,7 @@ namespace MudBlazor
             var t = item.As<T>();
             if (t is null)
                 return;
-            Rows[t] = row;
+            Rows.Add(new MudTrWithValue<T>(t, row));
         }
 
         public override void Remove(MudTr row, object item)
@@ -98,8 +97,7 @@ namespace MudBlazor
             var t = item.As<T>();
             if (t is null)
                 return;
-            if (Rows[t] == row) // Verify the row we wish to remove is the row stored for the key
-                Rows.Remove(t);
+            Rows.Remove(new MudTrWithValue<T>(t, row));
         }
 
         #region --> Sorting


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves #4691 and #4904 (duplicate).

Record types would break various table functions as identical records would be treated at the same object by the TableContext Dictionary. This PR resolves this by using a HashSet of records that uses both the T value and the MudTr row to determine equality.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

All existing tests pass. I could duplicate a handful of the existing tests and replace the class type with record types to specifically test records, but the existing tests cover the replacement of the Dictionary with a HashSet.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
