### PR TITLE
MudAutocomplete: add InputClass and InputStyle (#4926)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -851,5 +851,58 @@ namespace MudBlazor.UnitTests.Components
             var markupAfter = comp.Find("svg.mud-icon-root").Children.ToMarkup().Trim();
             markupAfter.Should().NotBe(markupBefore);
         }
+
+        /// <summary>
+        /// Setting InputClass should add the class(es) to the element in addition to the existing "mud-input" class
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_AppendInputClassToExistingInputClass()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            await comp.InvokeAsync(() => autocomplete.FocusAsync());
+
+            // check initial state
+            comp.Find("input").ClassList.Should().Contain("mud-input-root");
+
+            // add a class
+            autocompletecomp.SetParametersAndRender(parameters => parameters.Add(p => p.InputClass, "px-6"));
+
+            // check if classlist now contains newly added class
+            comp.WaitForAssertion(() => comp.Find("input").ClassList.Should().Contain("px-6"));
+
+            // check if classlist still contains default "mud-input-root" (did not overwrite)
+            comp.Find("input").ClassList.Should().Contain("mud-input-root");
+
+        }
+
+        /// <summary>
+        /// Setting InputStyle should add the style(s) to the element in addition to the existing "mud-select-input" style
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_AppendInputStyleToExistingInputStyle()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            await comp.InvokeAsync(() => autocomplete.FocusAsync());
+
+            // check initial state
+            var inputElement = comp.Find("input");
+            var styles = inputElement.ComputeCurrentStyle();
+
+            var curColor = styles.FirstOrDefault(x => x.Name == "color");
+            var curCursor = styles.FirstOrDefault(x => x.Name == "cursor");
+
+            autocompletecomp.SetParametersAndRender(parameters => parameters.Add(p => p.InputStyle, "color: red"));
+
+
+            // check if style now has new color and still retains existing cursor
+            comp.WaitForAssertion(() => comp.Find("input").Attributes.FirstOrDefault(x => x.Name == "color")?.Value.Should().Be("red"));
+            comp.WaitForAssertion(() => comp.Find("input").Attributes.FirstOrDefault(x => x.Name == "cursor")?.Value.Should().Be(curCursor.Value));
+        }
+
+
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -8,7 +8,7 @@
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required" ForId="@FieldId">
             <InputContent>
                 <MudInput @ref="_elementReference" @key="_elementKey" InputType="InputType.Text"
-                          Class="mud-select-input" Margin="@Margin"
+                          Class="@InputClass" Style="@InputStyle" Margin="@Margin"
                           Variant="@Variant"
                           TextUpdateSuppression="@TextUpdateSuppression"
                           Value="@Text" DisableUnderLine="@DisableUnderLine"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -86,7 +86,10 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public string InputStyle { get; set; }
+        public string InputStyle { get; set; } =
+            new StyleBuilder()
+            .AddStyle("mud-select-input")
+            .Build();
 
         /// <summary>
         /// The underlying Input element Class

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -82,6 +82,23 @@ namespace MudBlazor
         public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
+        /// The underlying Input element Style
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string InputStyle { get; set; }
+
+        /// <summary>
+        /// The underlying Input element Class
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string InputClass { get; set; } =
+            new CssBuilder("mud-input")
+            .Build();
+
+
+        /// <summary>
         /// The Close Autocomplete Icon
         /// </summary>
         [Parameter]
@@ -235,7 +252,7 @@ namespace MudBlazor
                 if (value == _isOpen)
                     return;
                 _isOpen = value;
-                
+
                 IsOpenChanged.InvokeAsync(_isOpen).AndForget();
             }
         }

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -6,7 +6,7 @@
         @InputContent
         @if (!String.IsNullOrEmpty(Label))
         {
-            <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" 
+            <MudInputLabel Style="@Style" Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" 
                            Margin="@Margin" ForId="@ForId">
                 @Label
             </MudInputLabel>


### PR DESCRIPTION
MudInputControl: make MudInputLabel respect parent Style instead of static style (#4926)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Add separate InputClass and InputStyle so that the underlying input field of the Autocomplete component can be styled. Currently, styling the Autocomplete component (for example, changing the font color) is not reflected in the input field. If you have an Autocomplete in a dark background, you cannot adjust the font color so it is visible (the current code by default uses the static CSS entry, which chooses theme.secondary).

Resolves #4926 

## How Has This Been Tested?
1. Ran through all the unit tests
2. Used the autocomplete component in a separate project. Was able to modify the InputStyle and change the font color.

No new tests created.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
