### PR TITLE
RadioGroup: Add InputClass and InputStyle for backward compatibility

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup T="string">
+<MudRadioGroup T="string" Class="some-main-class" InputClass="some-input-class">
     <MudRadio Option="@("1")" Placement="Placement.Left" />
     <MudRadio Option="@("2")" Placement="Placement.Top" />
     <MudRadio Option="@("3")" />

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -14,6 +14,25 @@ namespace MudBlazor.UnitTests.Components
     public class RadioTests : BunitTest
     {
         [Test]
+        public void RadiGroup_CheckClassTest()
+        {
+            var comp = Context.RenderComponent<RadioGroupTest1>();
+
+            var inputControl = comp.FindComponent<MudInputControl>();
+            inputControl.Instance.InputContent.Should().NotBeNull();
+
+            comp.Markup.Should().Contain("mud-radio-group");
+            comp.FindAll("div.mud-radio-group").Count.Should().Be(1);
+            comp.FindAll("div.some-main-class").Count.Should().Be(1);
+            comp.FindAll("div.some-input-class").Count.Should().Be(1);
+            comp.FindAll(".some-main-class .some-input-class").Count.Should().Be(1);
+            comp.FindAll(".mud-radio").Count.Should().Be(3);
+            // Input content should not have main class (Classname), but should have input class (InputClass)
+            comp.Markup.Should().NotContain("mud-radio-group some-main-class");
+            comp.Markup.Should().Contain("mud-radio-group some-input-class");
+        }
+
+        [Test]
         public void RadioGroupTest1()
         {
             var comp = Context.RenderComponent<RadioGroupTest1>();

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -21,15 +21,14 @@ namespace MudBlazor.UnitTests.Components
             var inputControl = comp.FindComponent<MudInputControl>();
             inputControl.Instance.InputContent.Should().NotBeNull();
 
-            comp.Markup.Should().Contain("mud-radio-group");
-            comp.FindAll("div.mud-radio-group").Count.Should().Be(1);
-            comp.FindAll("div.some-main-class").Count.Should().Be(1);
-            comp.FindAll("div.some-input-class").Count.Should().Be(1);
-            comp.FindAll(".some-main-class .some-input-class").Count.Should().Be(1);
+            comp.FindAll("div.mud-radio-group").Should().ContainSingle();
+            comp.FindAll("div.some-main-class").Should().ContainSingle();
+            comp.FindAll("div.some-input-class").Should().ContainSingle();
+            comp.FindAll(".some-main-class .some-input-class").Should().ContainSingle();
             comp.FindAll(".mud-radio").Count.Should().Be(3);
             // Input content should not have main class (Classname), but should have input class (InputClass)
-            comp.Markup.Should().NotContain("mud-radio-group some-main-class");
-            comp.Markup.Should().Contain("mud-radio-group some-input-class");
+            comp.FindAll(".mud-radio-group.some-main-class").Should().BeEmpty();
+            comp.FindAll(".mud-radio-group.some-input-class").Should().ContainSingle();
         }
 
         [Test]

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -5,7 +5,7 @@
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
-            <div role="radiogroup" @attributes="UserAttributes" class="@InputClass" style="@InputStyle">
+            <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
                 @ChildContent
             </div>
         </CascadingValue>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -5,7 +5,7 @@
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
-            <div role="radiogroup" @attributes="UserAttributes" >
+            <div role="radiogroup" @attributes="UserAttributes" class="@InputClass" style="@InputStyle">
                 @ChildContent
             </div>
         </CascadingValue>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -21,6 +21,11 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
+        private string GetInputClass() =>
+        new CssBuilder("mud-radio-group")
+            .AddClass(InputClass)
+            .Build();
+
         /// <summary>
         /// User class names for the input, separated by space
         /// </summary>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -21,6 +21,20 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
+        /// <summary>
+        /// User class names for the input, separated by space
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public string InputClass { get; set; }
+
+        /// <summary>
+        /// User style definitions for the input
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public string InputStyle { get; set; }
+
         [Parameter]
         [Category(CategoryTypes.Radio.Behavior)]
         public RenderFragment ChildContent { get; set; }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4916.

With #4084, class and style parameters moved to another element in the component. Now we added extra InputClass and and InputStyle parameters the previous place.

So if a user already had their custom classes or styles (if its about flex or etc), only need change:

Class => InputClass
Style => InputStyle

The upper radiogroup has Class and below radiogroup has InputClass `d-flex justify-space-between`

![Ekran görüntüsü 2022-07-23 230048](https://user-images.githubusercontent.com/78308169/180621279-7b73713a-1637-4096-971e-bbaa7364ccf3.png)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
