### PR TITLE
DatePicker: KeyInterceptor Crash Workaround 

### DIFF
--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -426,13 +426,26 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                _keyInterceptor = _keyInterceptorFactory.Create();
+                await ConnectKeyInterceptor();
+            }
 
-                await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
-                {
-                    //EnableLogging = true,
-                    TargetClass = "mud-input-slot",
-                    Keys =
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        private async Task ConnectKeyInterceptor()
+        {
+            if (_keyInterceptor != null)
+            {
+                return;
+            }
+
+            _keyInterceptor = _keyInterceptorFactory.Create();
+
+            await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+            {
+                //EnableLogging = true,
+                TargetClass = "mud-input-slot",
+                Keys =
                     {
                         new KeyOptions { Key = " ", PreventDown = "key+none" },
                         new KeyOptions { Key = "ArrowUp", PreventDown = "key+none" },
@@ -441,11 +454,8 @@ namespace MudBlazor
                         new KeyOptions { Key = "NumpadEnter", PreventDown = "key+none" },
                         new KeyOptions { Key = "/./", SubscribeDown = true, SubscribeUp = true }, // for our users
                     },
-                });
-                _keyInterceptor.KeyDown += HandleKeyDown;
-            }
-
-            await base.OnAfterRenderAsync(firstRender);
+            });
+            _keyInterceptor.KeyDown += HandleKeyDown;
         }
 
         protected internal void ToggleState()
@@ -474,6 +484,7 @@ namespace MudBlazor
                 await _pickerInlineRef.MudChangeCssAsync(PickerInlineClass);
             }
 
+            await ConnectKeyInterceptor();
             await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "key+none" });
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
A workaround about #4897 and #4853.

The issue is, when datepicker's popover opening, `_keyInterceptor` is null (despite being initialized in OnAfterRender) and application crashes with null reference.

Actually i don't know about exact problem, probably it may about transient #4631.

In this PR we only added that the code checks the _keyInterceptor again on opening and initialize it if its null.

This PR may not be the final solution, but i think we should solve this crashing datepicker, its unavoidable and common situation now.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Website doesn't crash with this PR when we click datepickers which has OpenTo="Year" parameter.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
