### PR TITLE
DefaultConverter: Add AllowThousands flag to all integer type TryParse calls

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -632,13 +632,13 @@ namespace MudBlazor.UnitTests.Components
         public async Task NumericFieldThousandsSeparator()
         {
             var comp = Context.RenderComponent<MudNumericField<int?>>();
-            comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
-
             var numericField = comp.Instance;
+
             numericField.Value.Should().Be(null);
             numericField.Text.Should().Be(null);
 
             // comma separator
+            comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
             comp.FindAll("input").First().Change("1,000");
             comp.FindAll("input").First().Blur();
             comp.WaitForAssertion(() => numericField.Text.Should().Be("1000"));

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -645,7 +645,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1000));
 
             // period separator
-            comp.SetParam(x => x.Culture, new CultureInfo("de-DE"));
+            comp.SetParam(x => x.Culture, new CultureInfo("de-DE", false));
             comp.FindAll("input").First().Change("1.000");
             comp.FindAll("input").First().Blur();
             comp.WaitForAssertion(() => numericField.Text.Should().Be("1000"));

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -624,5 +624,32 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => numericField.Text.Should().Be("€1234"));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234));
         }
+
+        /// <summary>
+        /// Test that thousands separator is parsed properly
+        /// </summary>
+        [Test]
+        public async Task NumericFieldThousandsSeparator()
+        {
+            var comp = Context.RenderComponent<MudNumericField<int?>>();
+            comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
+
+            var numericField = comp.Instance;
+            numericField.Value.Should().Be(null);
+            numericField.Text.Should().Be(null);
+
+            // comma separator
+            comp.FindAll("input").First().Change("1,000");
+            comp.FindAll("input").First().Blur();
+            comp.WaitForAssertion(() => numericField.Text.Should().Be("1000"));
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1000));
+
+            // period separator
+            comp.SetParam(x => x.Culture, new CultureInfo("de-DE"));
+            comp.FindAll("input").First().Change("1.000");
+            comp.FindAll("input").First().Blur();
+            comp.WaitForAssertion(() => numericField.Text.Should().Be("1000"));
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(1000));
+        }
     }
 }

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -47,56 +47,56 @@ namespace MudBlazor
                 // sbyte
                 else if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(sbyte?))
                 {
-                    if (sbyte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (sbyte.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // byte
                 else if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
                 {
-                    if (byte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (byte.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // short
                 else if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
                 {
-                    if (short.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (short.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // ushort
                 else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
                 {
-                    if (ushort.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (ushort.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // int
                 else if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
                 {
-                    if (int.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (int.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // uint
                 else if (typeof(T) == typeof(uint) || typeof(T) == typeof(uint?))
                 {
-                    if (uint.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (uint.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // long
                 else if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
                 {
-                    if (long.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (long.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }
                 // ulong
                 else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
                 {
-                    if (ulong.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                    if (ulong.TryParse(value, NumberStyles.Integer | NumberStyles.AllowThousands, Culture, out var parsedValue))
                         return (T)(object)parsedValue;
                     UpdateGetError("Not a valid number");
                 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #4945

By default `int.TryParse` (and others) do not accept the thousands separator where float/double do accept them, I think we should have parity between them.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
