### PR TITLE
Select: Update Text when switching to MultiSelection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest5.razor
@@ -1,0 +1,28 @@
+@if (_posts != null)
+{
+    <MudSelect Label="Roles" T="string" SelectedValues="SelectedValues" MultiSelection="true">
+        @foreach (var role in _posts)
+        {
+            <MudSelectItem T="string" Value="@role">@role</MudSelectItem>
+        }
+    </MudSelect>
+}
+
+
+@code
+{
+    private IEnumerable<string> SelectedValues { get; set; } = new HashSet<string>()
+    { 
+        "Programista", "test"
+    };
+
+    private HashSet<string> _posts;
+
+    protected override void OnInitialized()
+    {
+        _posts = new HashSet<string>
+        {
+            "Programista", "Programista 2", "test", "Technik", "Tester", "Tester tester"
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1103,5 +1103,23 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => selectWithT.Validate());
             selectWithT.ValidationErrors.Count.Should().Be(0);
         }
+
+        /// <summary>
+        /// When MultiSelect attribute goes after SelectedValues, text should contain all selected values.
+        /// </summary>
+        [Test]
+        public async Task MultiSelectAttributesOrder()
+        {
+            var comp = Context.RenderComponent<MultiSelectTest5>();
+            var select = comp.FindComponent<MudSelect<string>>().Instance;
+            select.SelectedValues.Count().Should().Be(2);
+            select.Text.Should().Be("Programista, test");
+            await comp.InvokeAsync(() =>
+            {
+                select.SelectedValues = new List<string> { "test" };
+            });
+            select.SelectedValues.Count().Should().Be(1);
+            select.Text.Should().Be("test");
+        }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -411,12 +411,24 @@ namespace MudBlazor
 
         internal event Action<ICollection<T>> SelectionChangedFromOutside;
 
+        private bool _multiSelection;
         /// <summary>
         /// If true, multiple values can be selected via checkboxes which are automatically shown in the dropdown
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool MultiSelection { get; set; }
+        public bool MultiSelection
+        {
+            get => _multiSelection;
+            set
+            {
+                if (value != _multiSelection)
+                {
+                    _multiSelection = value;
+                    UpdateTextPropertyAsync(false).AndForget();
+                }
+            }
+        }
 
         /// <summary>
         /// The collection of items within this select


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #4848.

The MudSelect attributes are set in the same order as they are processed.
```razor
<MudSelect T="string" SelectedValues="SelectedValues" MultiSelection="true">
```

In this case (as noted in associated issue #4848), the SelectedValues setter sets the text when the MultiSelection attribute is still false.

This fix makes sure that MultiSelection property setter updates the text if needed.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
