### PR TITLE
 NumericField: Fix decimal precision and overflows

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         /// Here we are open the first, then the third and then the second
         /// </summary>
         [Test]
-        public void MudExpansionPanel_Respects_Collapsing_Order()
+        public async Task MudExpansionPanel_Respects_Collapsing_Order()
         {
             var comp = Context.RenderComponent<ExpansionPanelExpansionsTest>();
             //the order in which the panels are going to be clicked
@@ -24,8 +24,7 @@ namespace MudBlazor.UnitTests.Components
             var sequence = new List<int> { 0, 2, 1 };
             foreach (var item in sequence)
             {
-                var header = comp.FindAll(".mud-expand-panel-header")[item];
-                header.Click();
+                await comp.InvokeAsync(() => comp.FindAll(".mud-expand-panel-header")[item].Click());
 
                 var panels = comp.FindAll(".mud-expand-panel").ToList();
 

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -236,6 +236,26 @@ namespace MudBlazor.UnitTests.Components
             //Console.WriteLine("Error message: " + numericField.ErrorText);
             numericField.ErrorText.Should().BeNullOrEmpty();
         }
+        
+        /// <summary>
+        /// Validate handling of decimal support & precision kept
+        /// </summary>
+        [Test]
+        public async Task NumericField_HandleDecimalPrecisionAndValues()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal>>();
+            var numericField = comp.Instance;
+
+            // first try set max decimal value
+            comp.Find("input").Change(decimal.MaxValue);
+            numericField.Value.Should().Be(decimal.MaxValue);
+            numericField.ErrorText.Should().BeNullOrEmpty();
+
+            // next try set minimum decimal value
+            comp.Find("input").Change(decimal.MinValue);
+            numericField.Value.Should().Be(decimal.MinValue);
+            numericField.ErrorText.Should().BeNullOrEmpty();
+        }
 
         /// <summary>
         /// An unstable converter should not cause an infinite update loop. This test must complete in under 1 sec!
@@ -594,6 +614,27 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
             await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
             comp.Instance.Value.Should().Be(value);
+        }
+
+        [TestCaseSource(nameof(TypeCases))]
+        public async Task NumericField_Increment_Decrement_OverflowHandled<T>(T value)
+        {
+            var comp = Context.RenderComponent<MudNumericField<T>>();
+            var max = Convert.ChangeType(10, typeof(T));
+            var min = Convert.ChangeType(0, typeof(T));
+            comp.SetParam(x => x.Max, max);
+            comp.SetParam(x => x.Min, min);
+            comp.SetParam(x => x.Step, value);
+            
+            // test max overflow
+            comp.SetParam(x => x.Value, max);
+            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
+            comp.Instance.Value.Should().Be(max);
+
+            // test min overflow
+            comp.SetParam(x => x.Value, min);
+            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            comp.Instance.Value.Should().Be(min);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -38,7 +38,17 @@ namespace MudBlazor.UnitTests.Components
             new object[] { (float)5 },
             new object[] { (double)5 },
             new object[] { (decimal)5 },
-            new object[] { (int?)5 }
+            new object[] { (byte?)5 },
+            new object[] { (sbyte?)5 },
+            new object[] { (short?)5 },
+            new object[] { (ushort?)5 },
+            new object[] { (int?)5 },
+            new object[] { (uint?)5 },
+            new object[] { (long?)5 },
+            new object[] { (ulong?)5 },
+            new object[] { (float?)5 },
+            new object[] { (double?)5 },
+            new object[] { (decimal?)5 }
         };
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -15,7 +15,6 @@ using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.Components;
 using MudBlazor.UnitTests.TestComponents.NumericField;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -25,7 +24,8 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class NumericFieldTests : BunitTest
     {
-        static object[] TypeCases =
+        // TestCaseSource does not know about "Nullable<T>" so having values as Nullable<T> does not make sense here
+        static object[] TypeCases = 
         {
             new object[] { (byte)5 },
             new object[] { (sbyte)5 },
@@ -37,18 +37,7 @@ namespace MudBlazor.UnitTests.Components
             new object[] { (ulong)5 },
             new object[] { (float)5 },
             new object[] { (double)5 },
-            new object[] { (decimal)5 },
-            new object[] { (byte?)5 },
-            new object[] { (sbyte?)5 },
-            new object[] { (short?)5 },
-            new object[] { (ushort?)5 },
-            new object[] { (int?)5 },
-            new object[] { (uint?)5 },
-            new object[] { (long?)5 },
-            new object[] { (ulong?)5 },
-            new object[] { (float?)5 },
-            new object[] { (double?)5 },
-            new object[] { (decimal?)5 }
+            new object[] { (decimal)5 }
         };
 
         /// <summary>
@@ -105,11 +94,56 @@ namespace MudBlazor.UnitTests.Components
         /// Setting the value to null should not cause a validation error
         /// </summary>
         [Test]
-        public async Task NumericFieldWithNullableTypes()
+        public async Task IntNumericFieldWithNullableTypes()
         {
             var comp = Context.RenderComponent<MudNumericField<int?>>(ComponentParameter.CreateParameter("Value", 17));
             // print the generated html
             //Console.WriteLine(comp.Markup);
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+            comp.Find("input").Change("");
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+        
+        /// <summary>
+        /// Setting the value to null should not cause a validation error
+        /// </summary>
+        [Test]
+        public async Task DecimalNumericFieldWithNullableTypes()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal?>>(ComponentParameter.CreateParameter("Value", 17M));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+            comp.Find("input").Change("");
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Setting the value to null should not cause a validation error
+        /// </summary>
+        [Test]
+        public async Task Int64NumericFieldWithNullableTypes()
+        {
+            var comp = Context.RenderComponent<MudNumericField<long?>>(ComponentParameter.CreateParameter("Value", 17L));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+            comp.Find("input").Change("");
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Setting the value to null should not cause a validation error
+        /// </summary>
+        [Test]
+        public async Task UInt64NumericFieldWithNullableTypes()
+        {
+            var comp = Context.RenderComponent<MudNumericField<ulong?>>(ComponentParameter.CreateParameter("Value", 17UL));
             comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
             comp.Find("input").Blur();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
@@ -396,7 +430,44 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
-
+        }
+        
+        /// <summary>
+        /// Keydown disabled, should not do anything
+        /// </summary>
+        [Test]
+        public async Task NumericFieldTest_KeyboardInput_Disabled()
+        {
+            var comp = Context.RenderComponent<MudNumericField<double>>();
+            comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
+            comp.SetParam(x => x.Format, "F2");
+            comp.SetParam(x => x.Value, 1234.56);
+            comp.SetParam(x => x.Disabled, true);
+            comp.Instance.Value.Should().Be(1234.56);
+            comp.Instance.Text.Should().Be("1234.56");
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(1234.56));
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(1234.56));
+        }
+        
+        /// <summary>
+        /// Keydown readonly, should not do anything
+        /// </summary>
+        [Test]
+        public async Task NumericFieldTest_KeyboardInput_Readonly()
+        {
+            var comp = Context.RenderComponent<MudNumericField<double>>();
+            comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
+            comp.SetParam(x => x.Format, "F2");
+            comp.SetParam(x => x.Value, 1234.56);
+            comp.SetParam(x => x.ReadOnly, true);
+            comp.Instance.Value.Should().Be(1234.56);
+            comp.Instance.Text.Should().Be("1234.56");
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(1234.56));
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -630,21 +701,17 @@ namespace MudBlazor.UnitTests.Components
         public async Task NumericField_Increment_Decrement_OverflowHandled<T>(T value)
         {
             var comp = Context.RenderComponent<MudNumericField<T>>();
-            var max = Convert.ChangeType(10, typeof(T));
-            var min = Convert.ChangeType(0, typeof(T));
-            comp.SetParam(x => x.Max, max);
-            comp.SetParam(x => x.Min, min);
             comp.SetParam(x => x.Step, value);
-            
+
             // test max overflow
-            comp.SetParam(x => x.Value, max);
+            comp.SetParam(x => x.Value, comp.Instance.Max);
             await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
-            comp.Instance.Value.Should().Be(max);
+            comp.Instance.Value.Should().Be(comp.Instance.Max);
 
             // test min overflow
-            comp.SetParam(x => x.Value, min);
+            comp.SetParam(x => x.Value, comp.Instance.Min);
             await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
-            comp.Instance.Value.Should().Be(min);
+            comp.Instance.Value.Should().Be(comp.Instance.Min);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix decimal precision and overflows when using increment / decrement

## Description
To resolve issue #4971
Added support to handle Decimal differently as it has support more precision with bigger numbers, but we must keep double as default since of the floating precision of double.
Resolved unhandled exceptions when "stepping" up a value above or below the MIN/MAX value of the primitive data type

## How Has This Been Tested?
New units tests has been added to verify the changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.