### PR TITLE
DataGrid: Added functionality to disable user interaction with MudDataGridPager

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -9,7 +9,7 @@
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString
         </MudText>
-        <MudSelect T="string" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true">
+        <MudSelect T="string" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true" Disabled="@Disabled">
             @foreach (int pageSize in PageSizeOptions)
             {
                 <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -20,6 +20,12 @@ namespace MudBlazor
         [Parameter] public bool DisableRowsPerPage { get; set; }
 
         /// <summary>
+        /// Set true to disable user interaction with the backward/forward buttons
+        /// and the part of the pager which allows to change the page size.
+        /// </summary>
+        [Parameter] public bool Disabled { get; set; }
+
+        /// <summary>
         /// Define a list of available page size options for the user to choose from
         /// </summary>
         [Parameter] public int[] PageSizeOptions { get; set; } = new int[] { 10, 25, 50, 100 };
@@ -41,9 +47,9 @@ namespace MudBlazor
             .Replace("{last_item}", $"{Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount())}")
             .Replace("{all_items}", $"{DataGrid.GetFilteredItemsCount()}");
 
-        private bool BackButtonsDisabled => DataGrid == null ? false : DataGrid.CurrentPage == 0;
+        private bool BackButtonsDisabled => Disabled || (DataGrid == null ? false : DataGrid.CurrentPage == 0);
 
-        private bool ForwardButtonsDisabled => DataGrid == null ? false : (DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage >= DataGrid.GetFilteredItemsCount();
+        private bool ForwardButtonsDisabled => Disabled || (DataGrid == null ? false : (DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage >= DataGrid.GetFilteredItemsCount());
 
         protected string Classname =>
             new CssBuilder("mud-table-pagination-toolbar")


### PR DESCRIPTION
## Description
Added functionality to disable user interaction with `MudDataGridPager`. I have added a new `Disabled` property to `MudDataGridPager` which, when set to `true`, disables user interaction with the backward/forward buttons and the part of the pager which allows the user to change the page size. This is a useful setting to prevent users from changing pages at unintended times (for example, while data is already being retrieved from the server for a previous page request).

resolves #4984

## How Has This Been Tested?
Tested visually. There are no existing Unit Tests for the MudDataGridPager component, so I did not add or modify any.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
