### PR TITLE
Breadcrumbs: Fix MaxItems collapsing logic

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/Examples/BreadcrumbsCollapsedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/Examples/BreadcrumbsCollapsedExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudBreadcrumbs Items="_items" MaxItems="5"></MudBreadcrumbs>
+<MudBreadcrumbs Items="_items" MaxItems="4"></MudBreadcrumbs>
 
 @code {
     private List<BreadcrumbItem> _items = new List<BreadcrumbItem>

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudBreadcrumbs_ShouldCollapseWhenMaxItemsIsReached()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(Parameter("MaxItems", (byte)5), Parameter("Items", new List<BreadcrumbItem>
+            var comp = Context.RenderComponent<MudBreadcrumbs>(Parameter("MaxItems", (byte)4), Parameter("Items", new List<BreadcrumbItem>
             {
                 new BreadcrumbItem("Link 1", "link1"),
                 new BreadcrumbItem("Link 2", "link2"),
@@ -58,7 +58,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudBreadcrumbs_Other()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(Parameter("MaxItems", (byte)5), Parameter("Items", new List<BreadcrumbItem>
+            var comp = Context.RenderComponent<MudBreadcrumbs>(Parameter("MaxItems", (byte)4), Parameter("Items", new List<BreadcrumbItem>
             {
                 new BreadcrumbItem("Link 1", "link1"),
                 new BreadcrumbItem("Link 2", "link2"),

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
@@ -9,7 +9,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
     <ul @attributes="UserAttributes" class=@Classname style="@Style">
-        @if (MaxItems != null && Collapsed && Items.Count >= MaxItems)
+        @if (MaxItems != null && Collapsed && Items.Count > MaxItems)
         {
             <BreadcrumbLink Item="Items[0]"></BreadcrumbLink>
             <BreadcrumbSeparator></BreadcrumbSeparator>


### PR DESCRIPTION
## Description
Change breadcrumb logic with `MaxItems` set so that it only collapses is max items is exceeded and not collapse when items count is equal to it.

## How Has This Been Tested?
Updated existing unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
