### PR TITLE
DialogService: Fix for trimming

### DIFF
--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -57,9 +58,9 @@ namespace MudBlazor
             RenderFragment = rf;
         }
 
-        public async Task<T> GetReturnValueAsync<T>()
+        public async Task<T> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
         {
-            var result=await Result;
+            var result = await Result;
             try
             {
                 return (T)result.Data;

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -5,6 +5,7 @@
 // License: MIT
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -30,6 +31,6 @@ namespace MudBlazor
 
         void InjectDialog(object inst);
 
-        Task<T> GetReturnValueAsync<T>();
+        Task<T> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
     }
 }

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -6,6 +6,7 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -16,25 +17,25 @@ namespace MudBlazor
         public event Action<IDialogReference> OnDialogInstanceAdded;
         public event Action<IDialogReference, DialogResult> OnDialogCloseRequested;
 
-        IDialogReference Show<TComponent>() where TComponent : ComponentBase;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>() where TComponent : ComponentBase;
 
-        IDialogReference Show<TComponent>(string title) where TComponent : ComponentBase;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title) where TComponent : ComponentBase;
 
-        IDialogReference Show<TComponent>(string title, DialogOptions options) where TComponent : ComponentBase;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogOptions options) where TComponent : ComponentBase;
 
-        IDialogReference Show<TComponent>(string title, DialogParameters parameters) where TComponent : ComponentBase;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters) where TComponent : ComponentBase;
 
-        IDialogReference Show<TComponent>(string title, DialogParameters parameters = null, DialogOptions options = null) where TComponent : ComponentBase;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters, DialogOptions options) where TComponent : ComponentBase;
 
-        IDialogReference Show(Type component);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component);
 
-        IDialogReference Show(Type component, string title);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title);
 
-        IDialogReference Show(Type component, string title, DialogOptions options);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogOptions options);
 
-        IDialogReference Show(Type component, string title, DialogParameters parameters);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters);
 
-        IDialogReference Show(Type component, string title, DialogParameters parameters, DialogOptions options);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters, DialogOptions options);
 
         IDialogReference CreateReference();
 
@@ -44,7 +45,7 @@ namespace MudBlazor
         Task<bool?> ShowMessageBox(string title, MarkupString markupMessage, string yesText = "OK",
             string noText = null, string cancelText = null, DialogOptions options = null);
 
-        Task<bool?> ShowMessageBox(MessageBoxOptions mboxOptions, DialogOptions options = null);
+        Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions options = null);
 
         void Close(DialogReference dialog);
 

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -16,56 +16,56 @@ namespace MudBlazor
         public event Action<IDialogReference> OnDialogInstanceAdded;
         public event Action<IDialogReference, DialogResult> OnDialogCloseRequested;
 
-        public IDialogReference Show<T>() where T : ComponentBase
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : ComponentBase
         {
             return Show<T>(string.Empty, new DialogParameters(), new DialogOptions());
         }
 
-        public IDialogReference Show<T>(string title) where T : ComponentBase
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title) where T : ComponentBase
         {
             return Show<T>(title, new DialogParameters(), new DialogOptions());
         }
 
-        public IDialogReference Show<T>(string title, DialogOptions options) where T : ComponentBase
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogOptions options) where T : ComponentBase
         {
             return Show<T>(title, new DialogParameters(), options);
         }
 
-        public IDialogReference Show<T>(string title, DialogParameters parameters) where T : ComponentBase
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters) where T : ComponentBase
         {
             return Show<T>(title, parameters, new DialogOptions());
         }
 
-        public IDialogReference Show<T>(string title, DialogParameters parameters, DialogOptions options) where T : ComponentBase
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters, DialogOptions options) where T : ComponentBase
         {
             return Show(typeof(T), title, parameters, options);
         }
 
-        public IDialogReference Show(Type contentComponent)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent)
         {
             return Show(contentComponent, string.Empty, new DialogParameters(), new DialogOptions());
         }
 
-        public IDialogReference Show(Type contentComponent, string title)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title)
         {
             return Show(contentComponent, title, new DialogParameters(), new DialogOptions());
         }
 
-        public IDialogReference Show(Type contentComponent, string title, DialogOptions options)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogOptions options)
         {
             return Show(contentComponent, title, new DialogParameters(), options);
         }
 
-        public IDialogReference Show(Type contentComponent, string title, DialogParameters parameters)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters)
         {
             return Show(contentComponent, title, parameters, new DialogOptions());
         }
 
-        public IDialogReference Show(Type contentComponent, string title, DialogParameters parameters, DialogOptions options)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters, DialogOptions options)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(contentComponent))
             {
-                throw new ArgumentException($"{contentComponent.FullName} must be a Blazor Component");
+                throw new ArgumentException($"{contentComponent?.FullName} must be a Blazor Component");
             }
             var dialogReference = CreateReference();
 
@@ -133,22 +133,22 @@ namespace MudBlazor
             }, options);
         }
 
-        public async Task<bool?> ShowMessageBox(MessageBoxOptions mboxOptions, DialogOptions options = null)
+        public async Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions options = null)
         {
             var parameters = new DialogParameters()
             {
-                [nameof(MessageBoxOptions.Title)] = mboxOptions.Title,
-                [nameof(MessageBoxOptions.Message)] = mboxOptions.Message,
-                [nameof(MessageBoxOptions.MarkupMessage)] = mboxOptions.MarkupMessage,
-                [nameof(MessageBoxOptions.CancelText)] = mboxOptions.CancelText,
-                [nameof(MessageBoxOptions.NoText)] = mboxOptions.NoText,
-                [nameof(MessageBoxOptions.YesText)] = mboxOptions.YesText,
+                [nameof(MessageBoxOptions.Title)] = messageBoxOptions.Title,
+                [nameof(MessageBoxOptions.Message)] = messageBoxOptions.Message,
+                [nameof(MessageBoxOptions.MarkupMessage)] = messageBoxOptions.MarkupMessage,
+                [nameof(MessageBoxOptions.CancelText)] = messageBoxOptions.CancelText,
+                [nameof(MessageBoxOptions.NoText)] = messageBoxOptions.NoText,
+                [nameof(MessageBoxOptions.YesText)] = messageBoxOptions.YesText,
             };
-            var reference = Show<MudMessageBox>(parameters: parameters, options: options, title: mboxOptions.Title);
+            var reference = Show<MudMessageBox>(parameters: parameters, options: options, title: messageBoxOptions.Title);
             var result = await reference.Result;
-            if (result.Cancelled || !(result.Data is bool))
+            if (result.Cancelled || result.Data is not bool data)
                 return null;
-            return (bool)result.Data;
+            return data;
         }
 
         public void Close(DialogReference dialog)


### PR DESCRIPTION
## Description
Fixes #4822

Few notes:
I have added annotation for both `IDialogService` and `DialogService`. This might sound counterintuitive, but if you only mark your implementation with `DynamicallyAccessedMembers` and will use an interface that doesn't have it, then your type will be trimmed. This works vice-versa, if you mark your interface, but someone will cast it to the implantation class and call a method that doesn't have it, your type will get trimmed. At this point, the trimming analyzer is really dummy, so I played it safe and put it everywhere.

I did some cosmetic changes. Also, I removed default parameters for this signature
```CSharp
IDialogReference Show<TComponent>(string title, DialogParameters parameters = null, DialogOptions options = null) where TComponent : ComponentBase;
```
because this overload is **always hidden** by this ones
```CSharp
IDialogReference Show<TComponent>(string title) where TComponent : ComponentBase;

IDialogReference Show<TComponent>(string title, DialogParameters parameters) where TComponent : ComponentBase;
```
It wasn't making much sense to have default parameters there, and it's not a breaking change.

## How Has This Been Tested?
By hands with trimming mode enabled on the wasm project.
Tested all overloads (Show / ShowDialog) both IDialogService and DialogService.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
