### PR TITLE
MudList: Nested Lists inherit Dense setting (#4861)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListDenseInheritanceTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListDenseInheritanceTest.razor
@@ -1,0 +1,31 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudList Dense="Dense">
+    <MudListSubheader>
+        Drinks
+    </MudListSubheader>
+    <MudListItem Text="Sparkling Water" />
+    <MudListItem Text="Teas" InitiallyExpanded="true">
+        <NestedList>
+            <MudListItem Text="Earl Grey"/>
+            <MudListItem Text="Matcha" />
+            <MudListItem Text="Pu'er" />
+        </NestedList>
+    </MudListItem>
+    <MudListItem Text="Coffees" Dense="InnerListDense">
+        <NestedList>
+            <MudListItem Text="Irish Coffee" />
+            <MudListItem Text="Double Espresso" />
+            <MudListItem Text="Cafe Latte" />
+        </NestedList>
+    </MudListItem>
+</MudList>
+
+@code
+{
+    [Parameter] public bool Dense { get; set; }
+
+    [Parameter] public bool? InnerListDense { get; set; }
+
+    public static string __description__ = "The child lists are dense when the parent list is dense.";
+}

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -102,5 +102,24 @@ namespace MudBlazor.UnitTests.Components
             var listItemClasses = comp.Find(".mud-selected-item");
             listItemClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"mud-{color.ToDescriptionString()}-hover" });
         }
+
+        /// <summary>
+        /// The child lists should honor the Dense property of their parent list if not overriden.
+        /// </summary>
+        [Test]
+        [TestCase(true, null, 9)]
+        [TestCase(false, null, 0)]
+        [TestCase(true, true, 9)]
+        [TestCase(false, false, 0)]
+        [TestCase(true, false, 5)]
+        [TestCase(false, true, 4)]
+        public async Task ListDenseInheritanceTest(bool dense, bool? innerListDense, int expectedDenseClassCount)
+        {
+            var comp = Context.RenderComponent<ListDenseInheritanceTest>(x => x.Add(c => c.Dense, dense).Add(c => c.InnerListDense, innerListDense));
+            var list = comp.FindComponent<MudList>().Instance;
+
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-list-item-dense").Count.Should().Be(expectedDenseClassCount); // 7 choices, 2 groups
+        }
     }
 }

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -36,7 +36,7 @@
 @if (NestedList != null)
 {
     <MudCollapse Expanded="@Expanded">
-        <MudList Clickable="MudList?.Clickable ?? false" Color="MudList?.Color ?? Color.Primary" DisablePadding="true" Class="mud-nested-list" Disabled="@Disabled">
+        <MudList Clickable="MudList?.Clickable ?? false" Color="MudList?.Color ?? Color.Primary" DisablePadding="true" Class="mud-nested-list" Disabled="@Disabled" Dense="(Dense ??  MudList?.Dense) ?? false">
             @NestedList
         </MudList>
     </MudCollapse>

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     {
         protected string Classname =>
         new CssBuilder("mud-list-item")
-          .AddClass("mud-list-item-dense", Dense || MudList?.Dense == true)
+          .AddClass("mud-list-item-dense", (Dense ?? MudList?.Dense) ?? false)
           .AddClass("mud-list-item-gutters", !DisableGutters && !(MudList?.DisableGutters == true))
           .AddClass("mud-list-item-clickable", MudList?.Clickable)
           .AddClass("mud-ripple", MudList?.Clickable == true && !DisableRipple && !Disabled)
@@ -139,7 +139,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool Dense { get; set; }
+        public bool? Dense { get; set; }
 
         /// <summary>
         /// If true, the left and right padding is removed.
@@ -266,11 +266,11 @@ namespace MudBlazor
         private Typo _textTypo;
         private void OnListParametersChanged()
         {
-            if (Dense || MudList?.Dense == true)
+            if ((Dense ?? MudList?.Dense) ?? false)
             {
                 _textTypo = Typo.body2;
             }
-            else if (!Dense || !MudList?.Dense == true)
+            else if (!((Dense ?? MudList?.Dense) ?? false))
             {
                 _textTypo = Typo.body1;
             }


### PR DESCRIPTION
## Description
Fixes #4861 

> When specifying Dense="true" for MudList, the items in the NestedList are not dense.

The issue comes from the fact that the MudListItem adds the `mud-list-item-dense` CSS class only if its `Dense` parameter or the parent MudList `Dense` parameter value is `true`, but since the NestedList is encapsulated in a new MudList which don't define the `Dense` parameter, all the MudListItem's in the NestedList are ignoring it.

### Correction
I defined the `Dense` parameter of the new `MudList` using the exact same logic that is used to add the `mud-list-item-dense` CSS class to the MudListItem

### Additionnal remark
By correcting this issue, I may have found something more about the `Dense` parameter and maybe other properties like that in general.
By the way the CSS class is added (which I used to fix the issue just to be consistent) and the fact that the `Dense` parameter is a boolean which has a default value of `false`, I have the impression you can't override a `Dense=True` of a MudList parent in a MudListItem child (with a `Dense=False`) since the condition is an OR between its own `Dense` value and its MudList parent `Dense` value (`Dense || MudList?.Dense == true`).
Maybe this is known and and considered as the expected behavior ?
I suppose this should be discussed in an individual issue but I thought it was appropriate to at least make a point about it here because my fix intensifies that behavior (just so you know).

## How Has This Been Tested?
Unit test and visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Before:**
![Before](https://user-images.githubusercontent.com/25689385/183268689-71d806b3-cd98-48a4-ada7-14443253ecfc.png)

**After:**
![After](https://user-images.githubusercontent.com/25689385/183268690-62021318-2ebf-4d92-9985-7927b7d51cce.png)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project. => I Hope so, wasn't completely sure about the naming for the unit test part though
- [x] I've added relevant tests.
