### PR TITLE
Disable AggressiveAttributeTrimming for MudBlazor.Docs.Wasm

### DIFF
--- a/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
+++ b/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
@@ -5,6 +5,10 @@
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true'">
+    <_AggressiveAttributeTrimming>false</_AggressiveAttributeTrimming>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.7.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.7.*" PrivateAssets="all" />


### PR DESCRIPTION
## Description
Resolves #5019.

I still think that Docs shouldn't be published as trimmed to production since it uses a lot of reflection, but if it's someone's use case, then we should disable `System.AggressiveAttributeTrimming`, because Docs relies on `System.ObsoleteAttribute` for documentation.
Disabling `AggressiveAttributeTrimming` in `MudBlazor.Docs.Wasm` also influences `MudBlazor.Docs.WasmHost`.

The rest technical description is in the issue ticket.

## How Has This Been Tested?
Compiling with `PublishTrimmed` and checking the docs visually.
<img src="https://i.imgur.com/ou6BeXF.png"  width="200" />

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
