### PR TITLE
CellContext: add 'CommitItemChanges' action

### DIFF
--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -32,9 +32,10 @@ namespace MudBlazor
             Item = item;
             Actions = new CellContext<T>.CellActions
             {
-                SetSelectedItem = async (x) => await dataGrid.SetSelectedItemAsync(x, item),
-                StartEditingItem = async () => await dataGrid.SetEditingItemAsync(item),
+                SetSelectedItem = async (x) => await dataGrid.SetSelectedItemAsync(x, this.Item),
+                StartEditingItem = async () => await dataGrid.SetEditingItemAsync(this.Item),
                 CancelEditingItem = async () => await dataGrid.CancelEditingItemAsync(),
+                CommitItemChanges = async () => await dataGrid.CommitItemChangesAsync(this.Item),
             };
         }
 
@@ -43,6 +44,7 @@ namespace MudBlazor
             public Action<bool> SetSelectedItem { get; internal set; }
             public Action StartEditingItem { get; internal set; }
             public Action CancelEditingItem { get; internal set; }
+            public Action CommitItemChanges { get; internal set; }
         }
     }
 }


### PR DESCRIPTION
## Description
When an `EditTemplate` is provided for a `Column` there is currently no way to hook into `MudDataGrid`'s event callback for `CommittedItemChanges`.  This change adds the relevant action to `CellContext`.  

## How Has This Been Tested?
Manually tested as no unit tests were available for the existing actions.  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
