### PR TITLE
Add a type of EnumConverter<T> for conversion between DescriptionAttribute.Description and value of enum.

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -138,7 +138,15 @@ namespace MudBlazor.UnitTests.Utilities
             c9.Get(null).Should().Be(null);
         }
 
-        public enum YesNoMaybe { Maybe, Yes, No }
+        public enum YesNoMaybe
+        {
+            [System.ComponentModel.Description("may be")]
+            Maybe,
+            [System.ComponentModel.Description("yes")]
+            Yes,
+            [System.ComponentModel.Description("no")]
+            No
+        }
 
         [Test]
         public void DefaultConverterTest2()
@@ -457,6 +465,20 @@ namespace MudBlazor.UnitTests.Utilities
             conv.Get("nada").Should().Be(null);
             conv.Set(18).Should().Be("18");
             conv.Get("18").Should().Be(18);
+        }
+
+        [Test]
+        public void EnumConverterTest()
+        {
+            var conv = new EnumConverter<YesNoMaybe>();
+            conv.Set(YesNoMaybe.Yes).Should().Be("yes");            
+            conv.Set(YesNoMaybe.Maybe).Should().Be("may be");
+            conv.Set(YesNoMaybe.No).Should().Be("no");
+            conv.Get("No").Should().Be(YesNoMaybe.No);
+            conv.Get("no").Should().Be(YesNoMaybe.No);
+            conv.Get("may be").Should().Be(YesNoMaybe.Maybe);
+            conv.Get("Maybe").Should().Be(YesNoMaybe.Maybe);
+            conv.Get(null).Should().Be(YesNoMaybe.Maybe);
         }
 
         // a custom converter used only in test cases

--- a/src/MudBlazor/Utilities/BindingConverters/EnumConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/EnumConverter.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MudBlazor.Utilities.BindingConverters
+{
+    [ExcludeFromCodeCoverage]
+    public class EnumConverter<T> : Converter<T, string> where T : Enum
+    {
+        public EnumConverter()
+        {
+            SetFunc = OnSet;
+            GetFunc = OnGet;
+        }
+
+        private T OnGet(string value)
+        {
+            try
+            {
+                foreach (var fieldInfo in typeof(T).GetFields())
+                {
+                    if (Attribute.GetCustomAttribute(fieldInfo, typeof(DescriptionAttribute)) is DescriptionAttribute descAttr)
+                    {
+                        if (descAttr.Description == value)
+                        {
+                            return (T)fieldInfo.GetValue(null);
+                        }
+                    }
+                    else
+                    {
+                        if (fieldInfo.Name == value)
+                        {
+                            return (T)fieldInfo.GetValue(null);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                UpdateGetError("Conversion error: " + e.Message);
+                return default;
+            }
+
+            return default;
+        }
+
+        private string OnSet(T value)
+        {
+            try
+            {
+                var fi = value.GetType().GetField(value.ToString());
+                if (Attribute.GetCustomAttribute(fi, typeof(DescriptionAttribute)) is DescriptionAttribute descAttr && !string.IsNullOrEmpty(descAttr.Description))
+                {
+                    return descAttr.Description;
+                }
+                else
+                {
+                    return value.ToString();
+                }
+            }
+            catch (FormatException ex)
+            {
+                UpdateSetError("Conversion error: " + ex.Message);
+                return default;
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Utilities/BindingConverters/EnumConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/EnumConverter.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
-namespace MudBlazor.Utilities.BindingConverters
+namespace MudBlazor
 {
     [ExcludeFromCodeCoverage]
     public class EnumConverter<T> : Converter<T, string> where T : Enum
@@ -21,7 +21,7 @@ namespace MudBlazor.Utilities.BindingConverters
                 {
                     if (Attribute.GetCustomAttribute(fieldInfo, typeof(DescriptionAttribute)) is DescriptionAttribute descAttr)
                     {
-                        if (descAttr.Description == value)
+                        if (descAttr.Description == value || fieldInfo.Name == value)
                         {
                             return (T)fieldInfo.GetValue(null);
                         }
@@ -48,8 +48,8 @@ namespace MudBlazor.Utilities.BindingConverters
         {
             try
             {
-                var fi = value.GetType().GetField(value.ToString());
-                if (Attribute.GetCustomAttribute(fi, typeof(DescriptionAttribute)) is DescriptionAttribute descAttr && !string.IsNullOrEmpty(descAttr.Description))
+                var fieldInfo = value.GetType().GetField(value.ToString());
+                if (Attribute.GetCustomAttribute(fieldInfo, typeof(DescriptionAttribute)) is DescriptionAttribute descAttr && !string.IsNullOrEmpty(descAttr.Description))
                 {
                     return descAttr.Description;
                 }


### PR DESCRIPTION
## Description
Sometimes display enums use DescriptionAttribute.Description instead of its value.

## How Has This Been Tested?
unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
