### PR TITLE
[Breaking-change] Refactor: MudScrollToTop & ScrollListener

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Mocks
 {
     public class MockScrollListenerFactory : IScrollListenerFactory
     {
-
         public IScrollListener Create(string selector) =>
             new MockScrollListener()
             {
@@ -18,18 +19,30 @@ namespace MudBlazor.UnitTests.Mocks
     /// </summary>
     public class MockScrollListener : IScrollListener
     {
+        private readonly Subject<ScrollEventArgs> _scrollEventSubject;
+
         public string Selector { get; set; }
 
-        public event EventHandler<ScrollEventArgs> OnScroll;
+        public ValueTask SubscribeOnScrollAsync(Func<ScrollEventArgs, Task> onNext)
+        {
+            _scrollEventSubject.Select(onNext).Subscribe();
+            return ValueTask.CompletedTask;
+        }
 
         public MockScrollListener()
         {
-            OnScroll?.Invoke(this, new ScrollEventArgs());
+            _scrollEventSubject = new Subject<ScrollEventArgs>();
         }
 
         public void Dispose()
         {
-           
+            _scrollEventSubject.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _scrollEventSubject.Dispose();
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/src/MudBlazor/Reactive/AnonymousObserver.cs
+++ b/src/MudBlazor/Reactive/AnonymousObserver.cs
@@ -1,0 +1,73 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
+
+// ReSharper disable CheckNamespace
+namespace System.Reactive
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// Create an <see cref="IObserver{T}"/> instance from delegate-based implementations 
+    /// of the On* methods.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
+    [ExcludeFromCodeCoverage]
+    internal class AnonymousObserver<T> : IObserver<T>
+    {
+        // ReSharper disable StaticMemberInGenericType
+        // ReSharper disable once InconsistentNaming
+        private static readonly Action<Exception> rethrow = e => ExceptionDispatchInfo.Capture(e).Throw();
+        // ReSharper disable once InconsistentNaming
+        private static readonly Action nop = () => { };
+        // ReSharper restore StaticMemberInGenericType
+
+        private readonly Action<T> _onNext;
+        private readonly Action<Exception> _onError;
+        private readonly Action _onCompleted;
+
+        /// <summary>
+        /// Creates the observable providing just the <paramref name="onNext"/> action.
+        /// </summary>
+        public AnonymousObserver(Action<T> onNext)
+            : this(onNext, rethrow, nop) { }
+
+        /// <summary>
+        /// Creates the observable providing both the <paramref name="onNext"/> and 
+        /// <paramref name="onError"/> actions.
+        /// </summary>
+        public AnonymousObserver(Action<T> onNext, Action<Exception> onError)
+            : this(onNext, onError, nop) { }
+
+        /// <summary>
+        /// Creates the observable providing both the <paramref name="onNext"/> and 
+        /// <paramref name="onCompleted"/> actions.
+        /// </summary>
+        public AnonymousObserver(Action<T> onNext, Action onCompleted)
+            : this(onNext, rethrow, onCompleted) { }
+
+        /// <summary>
+        /// Creates the observable providing all three <paramref name="onNext"/>, 
+        /// <paramref name="onError"/> and <paramref name="onCompleted"/> actions.
+        /// </summary>
+        public AnonymousObserver(Action<T> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            _onNext = onNext;
+            _onError = onError;
+            _onCompleted = onCompleted;
+        }
+
+        /// <summary>
+        /// Calls the action implementing <see cref="IObserver{T}.OnCompleted()"/>.
+        /// </summary>
+        public void OnCompleted() => _onCompleted();
+
+        /// <summary>
+        /// Calls the action implementing <see cref="IObserver{T}.OnError(Exception)"/>.
+        /// </summary>
+        public void OnError(Exception error) => _onError(error);
+
+        /// <summary>
+        /// Calls the action implementing <see cref="IObserver{T}.OnNext(T)"/>.
+        /// </summary>
+        public void OnNext(T value) => _onNext(value);
+    }
+}

--- a/src/MudBlazor/Reactive/ObservableExtensions.OfType.cs
+++ b/src/MudBlazor/Reactive/ObservableExtensions.OfType.cs
@@ -1,10 +1,12 @@
-﻿using System.Reactive.Subjects;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Subjects;
 
 #nullable enable
 // ReSharper disable CheckNamespace
 namespace System.Reactive.Linq
 // ReSharper restore CheckNamespace
 {
+    [ExcludeFromCodeCoverage]
     internal static partial class ObservableExtensions
     {
         /// <summary>

--- a/src/MudBlazor/Reactive/ObservableExtensions.OfType.cs
+++ b/src/MudBlazor/Reactive/ObservableExtensions.OfType.cs
@@ -1,0 +1,43 @@
+﻿using System.Reactive.Subjects;
+
+#nullable enable
+// ReSharper disable CheckNamespace
+namespace System.Reactive.Linq
+// ReSharper restore CheckNamespace
+{
+    internal static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// Filters the elements of an observable sequence based on the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to filter the elements in the source sequence on.</typeparam>
+        /// <param name="source">The sequence that contains the elements to be filtered.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        public static IObservable<T> OfType<T>(this IObservable<object> source)
+            => new OfTypeSubject<T>(source ?? throw new ArgumentNullException(nameof(source)));
+
+        private class OfTypeSubject<T> : Subject<T>
+        {
+            private IDisposable? _subscription;
+
+            public OfTypeSubject(IObservable<object> source)
+            {
+                _subscription = source.Subscribe(
+                    next =>
+                    {
+                        if (next is T result)
+                            OnNext(result);
+                    },
+                    OnError,
+                    OnCompleted);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                _subscription?.Dispose();
+                _subscription = null;
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Reactive/ObservableExtensions.Select.cs
+++ b/src/MudBlazor/Reactive/ObservableExtensions.Select.cs
@@ -1,0 +1,45 @@
+﻿using System.Reactive.Subjects;
+
+#nullable enable
+// ReSharper disable CheckNamespace
+namespace System.Reactive.Linq
+// ReSharper restore CheckNamespace
+{
+    internal static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// Projects each element of a sequence into a new form.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TResult">The type of the elements in the result sequence, obtained by running the selector function for each element in the source sequence.</typeparam>
+        /// <param name="source">A sequence of elements to invoke a transform function on.</param>
+        /// <param name="selector">A transform function to apply to each source element.</param>
+        /// <returns>An sequence whose elements are the result of invoking the transform function on each element of source.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null.</exception>
+        public static IObservable<TResult> Select<TSource, TResult>(this IObservable<TSource> source, Func<TSource, TResult> selector)
+            => new SelectorSubject<TSource, TResult>(source ?? throw new ArgumentNullException(nameof(source)), selector ?? throw new ArgumentNullException(nameof(selector)));
+
+        private class SelectorSubject<TSource, TResult> : Subject<TResult>
+        {
+            private IDisposable? _subscription;
+            private Func<TSource, TResult>? _selector;
+
+            public SelectorSubject(IObservable<TSource> source, Func<TSource, TResult> selector)
+            {
+                _selector = selector;
+                _subscription = source.Subscribe(
+                    next => OnNext(_selector(next)),
+                    OnError,
+                    OnCompleted);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                _subscription?.Dispose();
+                _subscription = null;
+                _selector = null;
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Reactive/ObservableExtensions.Where.cs
+++ b/src/MudBlazor/Reactive/ObservableExtensions.Where.cs
@@ -1,0 +1,47 @@
+﻿using System.Reactive.Subjects;
+
+#nullable enable
+// ReSharper disable CheckNamespace
+namespace System.Reactive.Linq
+// ReSharper restore CheckNamespace
+{
+    internal static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// Filters the elements of an observable sequence based on the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to filter the elements in the source sequence on.</typeparam>
+        /// <param name="source">The sequence that contains the elements to be filtered.</param>
+        /// <param name="predicate">Predicate to apply to elements in <paramref name="source"/> for filtering.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        public static IObservable<T> Where<T>(this IObservable<T> source, Func<T, bool> predicate)
+            => new WhereSubject<T>(source ?? throw new ArgumentNullException(nameof(source)), predicate ?? throw new ArgumentNullException(nameof(predicate)));
+
+        private class WhereSubject<T> : Subject<T>
+        {
+            private IDisposable? _subscription;
+            private Func<T, bool>? _predicate;
+
+            public WhereSubject(IObservable<T> source, Func<T, bool> predicate)
+            {
+                _predicate = predicate;
+                _subscription = source.Subscribe(
+                    next =>
+                    {
+                        if (_predicate(next))
+                            OnNext(next);
+                    },
+                    OnError,
+                    OnCompleted);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                _subscription?.Dispose();
+                _subscription = null;
+                _predicate = null;
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Reactive/ObservableExtensions.cs
+++ b/src/MudBlazor/Reactive/ObservableExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+
+#nullable enable
+// ReSharper disable CheckNamespace
+namespace System
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// Provides a set of static methods for subscribing delegates to observables.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal static partial class ObservableExtensions
+    {
+        /// <summary>
+        /// Subscribes to the observable sequence without specifying any handlers.
+        /// This method can be used to evaluate the observable sequence for its side-effects only.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the source sequence.</typeparam>
+        /// <param name="source">Observable sequence to subscribe to.</param>
+        /// <returns><see cref="IDisposable"/> object used to unsubscribe from the observable sequence.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+        public static IDisposable Subscribe<T>(this IObservable<T> source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return source.Subscribe(new AnonymousObserver<T>(Stubs<T>.Ignore, Stubs.Throw, Stubs.Nop));
+        }
+
+        /// <summary>
+        /// Subscribes to the observable providing just the <paramref name="onNext"/> delegate.
+        /// </summary>
+        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(onNext);
+
+            return source.Subscribe(new AnonymousObserver<T>(onNext, Stubs.Throw, Stubs.Nop));
+        }
+
+        /// <summary>
+        /// Subscribes to the observable providing both the <paramref name="onNext"/> and 
+        /// <paramref name="onError"/> delegates.
+        /// </summary>
+        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(onNext);
+            ArgumentNullException.ThrowIfNull(onError);
+
+            return source.Subscribe(new AnonymousObserver<T>(onNext, onError, Stubs.Nop));
+        }
+
+        /// <summary>
+        /// Subscribes to the observable providing both the <paramref name="onNext"/> and 
+        /// <paramref name="onCompleted"/> delegates.
+        /// </summary>
+        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action onCompleted)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(onNext);
+            ArgumentNullException.ThrowIfNull(onCompleted);
+
+            return source.Subscribe(new AnonymousObserver<T>(onNext, Stubs.Throw, onCompleted));
+        }
+
+        /// <summary>
+        /// Subscribes to the observable providing all three <paramref name="onNext"/>, 
+        /// <paramref name="onError"/> and <paramref name="onCompleted"/> delegates.
+        /// </summary>
+        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(onNext);
+            ArgumentNullException.ThrowIfNull(onError);
+            ArgumentNullException.ThrowIfNull(onCompleted);
+
+            return source.Subscribe(new AnonymousObserver<T>(onNext, onError, onCompleted));
+        }
+    }
+}

--- a/src/MudBlazor/Reactive/Stubs.cs
+++ b/src/MudBlazor/Reactive/Stubs.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+
+// https://github.com/dotnet/reactive/blob/main/Rx.NET/Source/src/System.Reactive/Internal/Stubs.cs
+// https://github.com/dotnet/reactive/blob/main/LICENSE
+
+using System.Runtime.ExceptionServices;
+
+// ReSharper disable CheckNamespace
+namespace System.Reactive
+// ReSharper restore CheckNamespace
+{
+    internal static class Stubs<T>
+    {
+        public static readonly Action<T> Ignore = static _ => { };
+        public static readonly Func<T, T> I = static _ => _;
+    }
+
+    internal static class Stubs
+    {
+        public static readonly Action Nop = static () => { };
+        public static readonly Action<Exception> Throw = e => ExceptionDispatchInfo.Capture(e).Throw();
+    }
+}

--- a/src/MudBlazor/Reactive/Subject.cs
+++ b/src/MudBlazor/Reactive/Subject.cs
@@ -1,0 +1,264 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+
+// https://github.com/dotnet/reactive/blob/main/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+// https://github.com/dotnet/reactive/blob/main/LICENSE
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+#nullable enable
+// ReSharper disable CheckNamespace
+namespace System.Reactive.Subjects
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// Represents an object that is both an observable sequence as well as an observer.
+    /// Each notification is broadcasted to all subscribed observers.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    [ExcludeFromCodeCoverage]
+    internal class Subject<T> : IObserver<T>, IObservable<T>, IDisposable
+    {
+        // ReSharper disable InconsistentNaming
+        // ReSharper disable UseArrayEmptyMethod //do not use Array.Empty or it will break
+        private static readonly SubjectDisposable[] Terminated = new SubjectDisposable[0];
+        private static readonly SubjectDisposable[] Disposed = new SubjectDisposable[0];
+        // ReSharper restore UseArrayEmptyMethod
+        // ReSharper restore InconsistentNaming
+
+        private SubjectDisposable[] _observers;
+        private Exception? _exception;
+
+        /// <summary>
+        /// Creates a subject.
+        /// </summary>
+        public Subject() => _observers = Array.Empty<SubjectDisposable>();
+
+        /// <summary>
+        /// Indicates whether the subject has observers subscribed to it.
+        /// </summary>
+        public virtual bool HasObservers => Volatile.Read(ref _observers).Length != 0;
+
+        /// <summary>
+        /// Indicates whether the subject has been disposed.
+        /// </summary>
+        public virtual bool IsDisposed => Volatile.Read(ref _observers) == Disposed;
+
+        static void ThrowDisposed() => throw new ObjectDisposedException(string.Empty);
+
+        /// <summary>
+        /// Notifies all subscribed observers about the end of the sequence.
+        /// </summary>
+        public virtual void OnCompleted()
+        {
+            for (; ;)
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.Observer?.OnCompleted();
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the specified exception.
+        /// </summary>
+        /// <param name="error">The exception to send to all currently subscribed observers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="error"/> is null.</exception>
+        public virtual void OnError(Exception error)
+        {
+            ArgumentNullException.ThrowIfNull(nameof(error));
+
+            for (; ;)
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                _exception = error;
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.Observer?.OnError(error);
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the arrival of the specified element in the sequence.
+        /// </summary>
+        /// <param name="value">The value to send to all currently subscribed observers.</param>
+        public virtual void OnNext(T value)
+        {
+            var observers = Volatile.Read(ref _observers);
+            if (observers == Disposed)
+            {
+                _exception = null;
+                ThrowDisposed();
+                return;
+            }
+            foreach (var observer in observers)
+            {
+                observer.Observer?.OnNext(value);
+            }
+        }
+
+        /// <summary>
+        /// Subscribes an observer to the subject.
+        /// </summary>
+        /// <param name="observer">Observer to subscribe to the subject.</param>
+        /// <returns>Disposable object that can be used to unsubscribe the observer from the subject.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observer"/> is null.</exception>
+        public virtual IDisposable Subscribe(IObserver<T> observer)
+        {
+            ArgumentNullException.ThrowIfNull(nameof(observer));
+
+            var disposable = default(SubjectDisposable);
+            for (; ;)
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    var ex = _exception;
+                    if (ex != null)
+                    {
+                        observer.OnError(ex);
+                    }
+                    else
+                    {
+                        observer.OnCompleted();
+                    }
+                    break;
+                }
+
+                disposable ??= new SubjectDisposable(this, observer);
+
+                var n = observers.Length;
+                var b = new SubjectDisposable[n + 1];
+
+                Array.Copy(observers, 0, b, 0, n);
+
+                b[n] = disposable;
+                if (Interlocked.CompareExchange(ref _observers, b, observers) == observers)
+                {
+                    return disposable;
+                }
+            }
+
+            return Disposable.Empty;
+        }
+
+        void Unsubscribe(SubjectDisposable observer)
+        {
+            for (; ;)
+            {
+                var a = Volatile.Read(ref _observers);
+                var n = a.Length;
+                if (n == 0)
+                {
+                    break;
+                }
+
+                var j = Array.IndexOf(a, observer);
+
+                if (j < 0)
+                {
+                    break;
+                }
+
+                SubjectDisposable[] b;
+
+                if (n == 1)
+                {
+                    b = Array.Empty<SubjectDisposable>();
+                }
+                else
+                {
+                    b = new SubjectDisposable[n - 1];
+                    Array.Copy(a, 0, b, 0, j);
+                    Array.Copy(a, j + 1, b, j, n - j - 1);
+                }
+                if (Interlocked.CompareExchange(ref _observers, b, a) == a)
+                {
+                    break;
+                }
+            }
+        }
+
+        private class Disposable : IDisposable
+        {
+            public static IDisposable Empty { get; } = new Disposable();
+
+            Disposable() { }
+
+            public void Dispose() { }
+        }
+
+        private sealed class SubjectDisposable : IDisposable
+        {
+            private Subject<T> _subject;
+            private volatile IObserver<T>? _observer;
+
+            public SubjectDisposable(Subject<T> subject, IObserver<T> observer)
+            {
+                _subject = subject;
+                _observer = observer;
+            }
+
+            public IObserver<T>? Observer => _observer;
+
+            public void Dispose()
+            {
+                var observer = Interlocked.Exchange(ref _observer, null);
+                if (observer == null)
+                {
+                    return;
+                }
+
+                _subject.Unsubscribe(this);
+                _subject = null!;
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="Subject{T}"/> class and unsubscribes all observers.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            Interlocked.Exchange(ref _observers, Disposed);
+            _exception = null;
+        }
+    }
+}

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -1,12 +1,11 @@
-﻿
-
-#nullable enable
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
+
+#nullable enable
 namespace MudBlazor
 {
     public interface IScrollListener : IAsyncDisposable, IDisposable

--- a/src/MudBlazor/Services/Scroll/ScrollListenerFactory.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListenerFactory.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace MudBlazor
@@ -15,14 +13,13 @@ namespace MudBlazor
 
     public class ScrollListenerFactory : IScrollListenerFactory
     {
-        private readonly IServiceProvider _provider;
+        private readonly IJSRuntime _jsRuntime;
 
-        public ScrollListenerFactory(IServiceProvider provider)
+        public ScrollListenerFactory(IJSRuntime jsRuntime)
         {
-            _provider = provider;
+            _jsRuntime = jsRuntime;
         }
 
-        public IScrollListener Create(string selector) =>
-            new ScrollListener(selector, _provider.GetRequiredService<IJSRuntime>());
+        public IScrollListener Create(string selector) => new ScrollListener(selector, _jsRuntime);
     }
 }

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -38,7 +38,6 @@ namespace MudBlazor
         public ScrollManager(IJSRuntime jSRuntime)
         {
             _jSRuntime = jSRuntime;
-
         }
 
         /// <summary>

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -7,6 +7,8 @@ class MudScrollListener {
 
     constructor() {
         this.throttleScrollHandlerId = -1;
+        //needed as variable to remove the event listeners
+        this.handlerRef = null;
     }
 
     // subscribe to throttled scroll event
@@ -16,10 +18,11 @@ class MudScrollListener {
             ? document.querySelector(selector)
             : document;
 
+        this.handlerRef = this.throttleScrollHandler.bind(this, dotnetReference);
         // add the event listener
         element.addEventListener(
             'scroll',
-            this.throttleScrollHandler.bind(this, dotnetReference),
+            this.handlerRef,
             false
         );
     }
@@ -54,7 +57,6 @@ class MudScrollListener {
             //data to pass
             let firstChild = element.firstElementChild;
             let firstChildBoundingClientRect = firstChild.getBoundingClientRect();
-
             //invoke C# method
             dotnetReference.invokeMethodAsync('RaiseOnScroll', {
                 firstChildBoundingClientRect,
@@ -73,9 +75,9 @@ class MudScrollListener {
     cancelListener(selector) {
         let element = selector
             ? document.querySelector(selector)
-            : document.documentElement;
+            : document;
 
-        element.removeEventListener('scroll', this.throttleScrollHandler);
+        element.removeEventListener('scroll', this.handlerRef);
     }
 };
 window.mudScrollListener = new MudScrollListener();


### PR DESCRIPTION
## Description
fixes #5015
When doing the fix, I couldn't help myself but to **experiment** and replace the event to observer.
This PR is more like a _showcase_, if teams decide that such refactor is totally unnecessary then I will just make a lil fix for #5015
From a customer perspective, only `IScrollListener` changed, which I believe is not widely used.

In `ScrollListener` I replaced
``` Csharp
event EventHandler<ScrollEventArgs> OnScroll;
```
to
```Csharp
ValueTask SubscribeOnScrollAsync(Func<ScrollEventArgs, Task> onNext);
```
**Pros:**
1. Less `async void`, they are gone in `MudScrollToTop` and `ScrollListener`.
2. In future other `event`(not EventCallback!) can be replaced with this where it suits.
3. Subject's have better disposing for unsubscription: `subject.Dispose()` vs `onScoll -= Handle`.
4. It's just pure my opinion, but this pattern makes much more sense here and more readable.
```Csharp
public event EventHandler<ScrollEventArgs> OnScroll
{
	add => Subscribe(value);
	remove => Unsubscribe(value);
}

private async void Subscribe(EventHandler<ScrollEventArgs> value)
{
	if (_onScroll == null)
	{
		await Start();
	}
	_onScroll += value;
}
```
vs
```Csharp
public ValueTask SubscribeOnScrollAsync(Func<ScrollEventArgs, Task> onNext)
{
	_dotNetRef = DotNetObjectReference.Create(this);
	_scrollEventSubject.Select(onNext).Subscribe();
	return _js.InvokeVoidAsync("mudScrollListener.listenForScroll", _dotNetRef, Selector);
}
```

**Cons**
1. Still a Breaking change
2. New primitive IObserver / IObservable in code(in this case not visible to end client)

I didn't won't to bring the whole Rx.Net because its too heavy, it's just an overkill, so I brought own **internal** mini reactive.
 
## How Has This Been Tested?
Don't think there is need to test IObserver / IObservable. The rest was tested by hands.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
