### PR TITLE
MudAutocomplete: Fix server side issue where Reset would reopen item Popover

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -270,6 +270,10 @@ namespace MudBlazor
         /// This boolean will keep track if the clear function is called too keep the set text function to be called.
         /// </summary>
         private bool _isCleared;
+        /// <summary>
+        /// This boolean will keep track if the clear function is called with SuppressOpen = true.
+        /// </summary>
+        private bool _suppressOpen;
 
         private MudInput<string> _elementReference;
 
@@ -373,6 +377,11 @@ namespace MudBlazor
         /// </remarks>
         private async Task OnSearchAsync()
         {
+            if (_suppressOpen)
+            {
+                _suppressOpen = false;
+                return;
+            }
             if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
             {
                 IsOpen = false;
@@ -416,9 +425,10 @@ namespace MudBlazor
         /// <summary>
         /// Clears the autocomplete's text
         /// </summary>
-        public async Task Clear()
+        public async Task Clear(bool suppressOpen = false)
         {
             _isCleared = true;
+            _suppressOpen = suppressOpen;
             IsOpen = false;
             await SetTextAsync(string.Empty, updateValue: false);
             await CoerceValueToText();
@@ -430,7 +440,7 @@ namespace MudBlazor
 
         protected override async void ResetValue()
         {
-            await Clear();
+            await Clear(true);
             base.ResetValue();
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
In some instances on Blazor Server, calling `Reset` on an autocomplete will cause the item Popover to open.

![MudAutocompleteServerIssue](https://user-images.githubusercontent.com/26885142/184366300-0a3e117b-42b5-4aaf-97f4-c42ba945a49e.gif)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

All existing unit tests pass. This particular issue would be difficult to test for as it is server only (latency induced?).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
