### PR TITLE
TablePager: Add default English aria-labels

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1468,6 +1468,37 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Tests the aria-labels for the pager control buttons
+        /// </summary>
+        /// <param name="controlButton">The type of the control button. Page.First for the navigate-to-first-page button.</param>
+        /// <param name="expectedButtonAriaLabel">The expected value in the aria-label.</param>
+        [TestCase(Page.First, "First page")]
+        [TestCase(Page.Previous, "Previous page")]
+        [TestCase(Page.Next, "Next page")]
+        [TestCase(Page.Last, "Last page")]
+        [Test]
+        public void TablePagerControlButtonAriaLabelTest(Page controlButton, string expectedButtonAriaLabel)
+        {
+            var tableComponent = Context.RenderComponent<TablePagerInfoTextTest>();
+            //Console.WriteLine(comp.Markup);
+
+            //get control button
+            var buttons = tableComponent.FindAll("div.mud-table-pagination-actions button");
+            var button = controlButton switch
+            {
+                Page.First => buttons[0],
+                Page.Previous => buttons[1],
+                Page.Next => buttons[^2],
+                Page.Last => buttons[^1],
+                _ => throw new ArgumentOutOfRangeException(nameof(controlButton), controlButton,
+                    "This control button type is not supported!")
+            };
+
+            //Expected values
+            button.GetAttribute("aria-label")?.Should().Be(expectedButtonAriaLabel);
+        }
+
+        /// <summary>
         /// Tests checks that RowsPerPage Parameter is two-way bindable
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -32,10 +32,10 @@
     @if (!HidePagination)
     {
         <div class="mud-table-pagination-actions">
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@FirstIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@BeforeIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@NextIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@LastIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@FirstIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))" aria-label="First page" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@BeforeIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))" aria-label="Previous page" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@NextIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))" aria-label="Next page" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@LastIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))" aria-label="Last page" />
         </div>
     }
     @if (HorizontalAlignment == HorizontalAlignment.Start ||


### PR DESCRIPTION
Added default English aria-labels for TablePager.

### Description

Simply added aria-label attributes for the table pager buttons for WCAG compliance. The changes made were basically the same as the changes that were made to the Pagination component in the [4120](https://github.com/MudBlazor/MudBlazor/pull/4120) pull request.

### How Has This Been Tested?

Manual inspection of test files

### Types of changes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:


- [x]  The PR is submitted to the correct branch (dev).
- [x]  My code follows the code style of this project.
- [x]  I've added relevant tests.