### PR TITLE
MudDialog:  Fix Dialog is null in IDialogReference

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
@@ -19,7 +19,7 @@
     {
         var parameters = new DialogParameters { ["server"]=server };
 
-        var dialog = DialogService.Show<DialogPassingDataExample_Dialog>("Delete Server", parameters);
+        var dialog = await DialogService.ShowAsync<DialogPassingDataExample_Dialog>("Delete Server", parameters);
         var result = await dialog.Result;
 
         if (!result.Cancelled)

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -466,6 +466,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("button").Click();
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
+
+        [Test]
+        public async Task ShowAsyncRenderCompleteTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+
+            var service = Context.Services.GetService<IDialogService>();
+
+            IDialogReference dialogReference = null;
+            await comp.InvokeAsync(async () => dialogReference = await service?.ShowAsync<DialogOkCancel>()!);
+
+            var result = await dialogReference.RenderCompleteTaskCompletionSource.Task;
+
+            result.Should().Be(true);
+        }
     }
 
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -38,6 +39,8 @@ namespace MudBlazor.UnitTests.Components
                 var result2 = await dialogReference.Result;
             });
             DialogRender.OnInitializedCount.Should().Be(2);
+            //Reset global value
+            DialogRender.OnInitializedCount = 0;
         }
 
         /// <summary>
@@ -467,6 +470,342 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
 
+        ///-------------------------------
+        /// <summary>
+        /// Testing lifecycle of dialogs in dialogprovider
+        /// </summary>
+        [Test]
+        public async Task AsyncLifecycleTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            await comp.InvokeAsync(async () =>
+            {
+                var dialogReference = await service!.ShowAsync<DialogRender>();
+                await dialogReference.Result;
+                //The second Dialog is added here, but the first dialog is still in the _dialogs collection of the dialogprovider, as only the result task was set to completion.
+                //So DialogProvider will render again with 2 dialogs, but 1 is completed. This one needs to be excluded from rendering to prevent double initialize with no params.
+                dialogReference = await service.ShowAsync<DialogRender>();
+                await dialogReference.Result;
+            });
+            DialogRender.OnInitializedCount.Should().Be(2);
+            //Reset global value
+            DialogRender.OnInitializedCount = 0;
+        }
+
+        /// <summary>
+        /// Opening and closing a simple dialog
+        /// </summary>
+        [Test]
+        public async Task AsyncSimpleTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            //open simple test dialog
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            Console.WriteLine(comp.Markup);
+            comp.Find("div.mud-dialog-container").Should().NotBe(null);
+            comp.Find("p.mud-typography").TrimmedText().Should().Be("Wabalabadubdub!");
+            //close by click outside the dialog
+            comp.Find("div.mud-overlay").Click();
+            comp.Markup.Trim().Should().BeEmpty();
+            var result = await dialogReference.Result;
+            result.Cancelled.Should().BeTrue();
+            //open simple test dialog
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            dialogReference = await dialogReferenceLazy.Value;
+            //close by click on cancel button
+            comp.FindAll("button")[0].Click();
+            result = await dialogReference.Result;
+            result.Cancelled.Should().BeTrue();
+            //open simple test dialog
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            dialogReference = await dialogReferenceLazy.Value;
+            //close by click on ok button
+            comp.FindAll("button")[1].Click();
+            result = result = await dialogReference.Result;
+            result.Cancelled.Should().BeFalse();
+
+            //create 2 instances and dismiss all
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var cont = comp.FindAll("div.mud-dialog-container");
+            cont.Count.Should().Be(2);
+            await comp.InvokeAsync(() => comp.Instance.DismissAll());
+            cont = comp.FindAll("div.mud-dialog-container");
+            cont.Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Based on bug report #3128
+        /// Dialog Class and Style parameters should be honored for inline dialog
+        /// </summary>
+        [Test]
+        public async Task InlineAsyncDialogShouldHonorClassAndStyle()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<TestInlineDialog>());
+            // open simple test dialog
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            comp.WaitForAssertion(() => dialogReference.Should().NotBe(null));
+            comp.Find("button").Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-dialog").ClassList.Should().Contain("test-class"));
+            comp.Find("div.mud-dialog").Attributes["style"].Value.Should().Be("color: red;");
+            comp.Find("div.mud-dialog-content").Attributes["style"].Value.Should().Be("color: blue;");
+            comp.Find("div.mud-dialog-content").ClassList.Should().NotContain("test-class");
+            comp.Find("div.mud-dialog-content").ClassList.Should().Contain("content-class");
+            // check if tag is ok
+            var dialogInstance = comp.FindComponent<MudDialog>().Instance;
+            dialogInstance.Tag.Should().Be("test-tag");
+        }
+
+        /// <summary>
+        /// Based on bug report by Porkopek:
+        /// Updating values that are referenced in TitleContent render fragment won't result in an update of the dialog title
+        /// when they change. This is solved by allowing the user to call ForceRender() on DialogInstance
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task AsyncDialogShouldUpdateTitleContent()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogThatUpdatesItsTitle>());
+            // open simple test dialog
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            //Console.WriteLine(comp.Markup);
+            //comp.Find("div.mud-dialog-container").Should().NotBe(null);
+            comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body:");
+            comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
+            // click on ok button should set title and content
+            comp.FindAll("button")[1].Click();
+            comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body: Test123");
+            comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Test123");
+        }
+
+        /// <summary>
+        /// A test that ensures parameters are not overwritten when dialog is updated
+        /// </summary>
+        [Test]
+        public async Task AsyncDialogShouldNotOverwriteParameters()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+
+            var parameters = new DialogParameters();
+            parameters.Add("TestValue", "test");
+            parameters.Add("Color_Test", Color.Error); // !! comment me !!
+
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogWithParameters>(string.Empty, parameters));
+            await comp.InvokeAsync(()=> dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+
+            //Console.WriteLine("----------------------------------------");
+            //Console.WriteLine(comp.Markup);
+
+            var textField = comp.FindComponent<MudInput<string>>().Instance;
+            textField.Text.Should().Be("test");
+
+            comp.Find("input").Change("new_test");
+            comp.Find("input").Blur();
+            textField.Text.Should().Be("new_test");
+
+            comp.FindAll("button")[0].Click();
+            //Console.WriteLine("----------------------------------------");
+            //Console.WriteLine(comp.Markup);
+
+            ((DialogWithParameters)dialogReference.Dialog).TestValue.Should().Be("new_test");
+            ((DialogWithParameters)dialogReference.Dialog).ParamtersSetCounter.Should().Be(1);
+            textField.Text.Should().Be("new_test");
+        }
+
+        /// <summary>
+        /// Based on bug report #1385
+        /// Dialog Class and Style parameters should be honored
+        /// </summary>
+        [Test]
+        public async Task AsyncDialogShouldHonorClassAndStyle()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+            // open simple test dialog
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            //Console.WriteLine(comp.Markup);
+            comp.Find("div.mud-dialog").ClassList.Should().Contain("test-class");
+            comp.Find("div.mud-dialog").Attributes["style"].Value.Should().Be("color: red;");
+            comp.Find("div.mud-dialog-content").Attributes["style"].Value.Should().Be("color: blue;");
+            comp.Find("div.mud-dialog-content").ClassList.Should().NotContain("test-class");
+            comp.Find("div.mud-dialog-content").ClassList.Should().Contain("content-class");
+        }
+
+        [Test]
+        public async Task AsyncCustomDialogService()
+        {
+            //Remove default IDialogService so we can provide our custom implementation
+            //This is not necessary in normal cases, you would rather just not register all services in the beginning, but the test environment requires here to do so.
+            Context.Services.Remove(Context.Services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IDialogService)));
+            //Register our custom dialog service implementation as the new service instance behind IDialogService
+            Context.Services.AddScoped<IDialogService>(sp => new CustomDialogService());
+
+            //Render our dialog provider and make sure everything is fine
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+
+            //Try to get the current service instance for the type IDialogService and make sure it is our custom implementation
+            var service = Context.Services.GetService<IDialogService>();
+            service.Should().NotBe(null);
+            service.Should().BeAssignableTo(typeof(CustomDialogService));
+
+            //Show the dialog, create reference and make sure it is our custom dialog reference implementation
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogThatUpdatesItsTitle>());
+            //The type of the dialog does not really matter, for the sake of laziness I will re-use this existing one
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            dialogReference.Should().BeAssignableTo(typeof(CustomDialogReference));
+
+            //After above checks have passed, we can safely cast the generic reference into our specific implementation  
+            var customDialogReference = (CustomDialogReference)dialogReference;
+            //The custom property should be false by default otherwise the rest of the test logic would be incorrect
+            customDialogReference.AllowDismiss.Should().BeFalse();
+
+            //Dialog should not be closable through backdrop click
+            comp.Find("div.mud-overlay").Click();
+            comp.WaitForAssertion(() => comp.Markup.Trim().Should().NotBeEmpty(), TimeSpan.FromSeconds(5));
+
+            //Allow dismiss
+            customDialogReference.AllowDismiss = true;
+
+            //Dialog should now be closable through backdrop click
+            comp.Find("div.mud-overlay").Click();
+            comp.WaitForAssertion(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
+        }
+
+        /// <summary>
+        /// Getting return value from dialog
+        /// </summary>
+        [Test]
+        public async Task AsyncDialogShouldReturnTheReturnValue()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogWithReturnValue>());
+            // open dialog
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            // close by click on cancel button
+            comp.FindAll("button")[0].Click();
+            var rv = await dialogReference.GetReturnValueAsync<string>();
+            rv.Should().BeNull();
+            // open dialog
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogWithReturnValue>());
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            // close by click on ok button
+            comp.FindAll("button")[1].Click();
+            dialogReference = await dialogReferenceLazy.Value;
+            rv = await dialogReference.GetReturnValueAsync<string>();
+            rv.Should().Be("Closed via OK");
+        }
+
+        [Test]
+        public async Task AsyncDialogKeyboardNavigation()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = true }));
+            //dialog with clickable backdrop
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            dialogReferenceLazy.Value.Should().NotBe(null);
+            var dialogReference = await dialogReferenceLazy.Value;
+            var dialog1 = (DialogOkCancel)dialogReference.Dialog;
+            comp.Markup.Trim().Should().NotBeEmpty();
+            await comp.InvokeAsync(() => dialog1.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            comp.Markup.Trim().Should().BeEmpty();
+            //dialog with disabled backdrop click
+            dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            var dialog2 = (DialogOkCancel)dialogReference.Dialog;
+            comp.Markup.Trim().Should().NotBeEmpty();
+            await comp.InvokeAsync(() => dialog2.MudDialog.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            comp.Markup.Trim().Should().NotBeEmpty();
+        }
+
+        [Test]
+        public async Task AsyncDialogHandlesOnBackdropClickEvent()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogWithOnBackdropClickEvent>());
+
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+            comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
+
+            //Click on backdrop
+            comp.Find("div.mud-overlay").Click();
+
+            comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Backdrop clicked");
+        }
+
+        [Test]
+        public async Task AsyncDialogToggleFullscreenOptions()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogToggleFullscreen>());
+
+            await comp.InvokeAsync(() => dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
+            dialogReference.Should().NotBe(null);
+
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+            comp.Find("button").Click();
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
+            comp.Find("button").Click();
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+        }
+
         [Test]
         public async Task ShowAsyncRenderCompleteTest()
         {
@@ -474,8 +813,10 @@ namespace MudBlazor.UnitTests.Components
 
             var service = Context.Services.GetService<IDialogService>();
 
-            IDialogReference dialogReference = null;
-            await comp.InvokeAsync(async () => dialogReference = await service?.ShowAsync<DialogOkCancel>()!);
+            var dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service?.ShowAsync<DialogOkCancel>());
+
+            await comp.InvokeAsync(async () => await dialogReferenceLazy.Value);
+            var dialogReference = await dialogReferenceLazy.Value;
 
             var result = await dialogReference.RenderCompleteTaskCompletionSource.Task;
 

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -46,6 +46,8 @@ namespace MudBlazor
 
         public Task<DialogResult> Result => _resultCompletion.Task;
 
+        TaskCompletionSource<bool> IDialogReference.RenderCompleteTaskCompletionSource { get; } = new();
+
         public void InjectDialog(object inst)
         {
             Dialog = inst;

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -14,6 +14,7 @@ namespace MudBlazor
     public interface IDialogReference
     {
         Guid Id { get; }
+
         RenderFragment RenderFragment { get; set; }
 
         [Obsolete("This will always return true"), ExcludeFromCodeCoverage]
@@ -21,7 +22,10 @@ namespace MudBlazor
 
         Task<DialogResult> Result { get; }
 
+        internal TaskCompletionSource<bool> RenderCompleteTaskCompletionSource { get; }
+
         void Close();
+
         void Close(DialogResult result);
 
         bool Dismiss(DialogResult result);

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 
@@ -43,6 +44,19 @@ namespace MudBlazor
             _globalDialogOptions.Position = Position;
             _globalDialogOptions.FullWidth = FullWidth;
             _globalDialogOptions.MaxWidth = MaxWidth;
+        }
+
+        protected override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!firstRender)
+            {
+                foreach (var dialogReference in _dialogs.Where(x => !x.Result.IsCompleted))
+                {
+                    dialogReference.RenderCompleteTaskCompletionSource.TrySetResult(true);
+                }
+            }
+
+            return base.OnAfterRenderAsync(firstRender);
         }
 
         internal void DismissInstance(Guid id, DialogResult result)

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -163,11 +163,11 @@ namespace MudBlazor
                 [nameof(YesText)] = YesText,
                 [nameof(YesButton)] = YesButton,
             };
-            _reference = DialogService.Show<MudMessageBox>(parameters: parameters, options: options, title: Title);
+            _reference = await DialogService.ShowAsync<MudMessageBox>(parameters: parameters, options: options, title: Title);
             var result = await _reference.Result;
-            if (result.Cancelled || !(result.Data is bool))
+            if (result.Cancelled || result.Data is not bool data)
                 return null;
-            return (bool)result.Data;
+            return data;
         }
 
         public void Close()

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -37,6 +37,26 @@ namespace MudBlazor
 
         IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters, DialogOptions options);
 
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>() where TComponent : ComponentBase;
+
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title) where TComponent : ComponentBase;
+
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogOptions options) where TComponent : ComponentBase;
+
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters) where TComponent : ComponentBase;
+
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters, DialogOptions options) where TComponent : ComponentBase;
+
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component);
+
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title);
+
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogOptions options);
+
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters);
+
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters, DialogOptions options);
+
         IDialogReference CreateReference();
 
         Task<bool?> ShowMessageBox(string title, string message, string yesText = "OK",

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -126,6 +127,66 @@ namespace MudBlazor
             return dialogReference;
         }
 
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : ComponentBase
+        {
+            return ShowAsync<T>(string.Empty, new DialogParameters(), new DialogOptions());
+        }
+
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title) where T : ComponentBase
+        {
+            return ShowAsync<T>(title, new DialogParameters(), new DialogOptions());
+        }
+
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogOptions options) where T : ComponentBase
+        {
+            return ShowAsync<T>(title, new DialogParameters(), options);
+        }
+
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters) where T : ComponentBase
+        {
+            return ShowAsync<T>(title, parameters, new DialogOptions());
+        }
+
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters, DialogOptions options) where T : ComponentBase
+        {
+            return ShowAsync(typeof(T), title, parameters, options);
+        }
+
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent)
+        {
+            return ShowAsync(contentComponent, string.Empty, new DialogParameters(), new DialogOptions());
+        }
+
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title)
+        {
+            return ShowAsync(contentComponent, title, new DialogParameters(), new DialogOptions());
+        }
+
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogOptions options)
+        {
+            return ShowAsync(contentComponent, title, new DialogParameters(), options);
+        }
+
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters)
+        {
+            return ShowAsync(contentComponent, title, parameters, new DialogOptions());
+        }
+
+        public async Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters, DialogOptions options)
+        {
+            var dialogReference = Show(contentComponent, title, parameters, options);
+
+            //Do not wait forever, what if render fails because of some internal exception and we will never release the method.
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var token = cancellationTokenSource.Token;
+            await using (token.Register(() => dialogReference.RenderCompleteTaskCompletionSource.TrySetResult(false)))
+            {
+                await dialogReference.RenderCompleteTaskCompletionSource.Task;
+
+                return dialogReference;
+            }
+        }
+
         public Task<bool?> ShowMessageBox(string title, string message, string yesText = "OK",
             string noText = null, string cancelText = null, DialogOptions options = null)
         {
@@ -163,7 +224,7 @@ namespace MudBlazor
                 [nameof(MessageBoxOptions.NoText)] = messageBoxOptions.NoText,
                 [nameof(MessageBoxOptions.YesText)] = messageBoxOptions.YesText,
             };
-            var reference = Show<MudMessageBox>(parameters: parameters, options: options, title: messageBoxOptions.Title);
+            var reference = await ShowAsync<MudMessageBox>(parameters: parameters, options: options, title: messageBoxOptions.Title);
             var result = await reference.Result;
             if (result.Cancelled || result.Data is not bool data)
                 return null;


### PR DESCRIPTION
## Description
Resolves #1839

Check my comment for more details https://github.com/MudBlazor/MudBlazor/issues/1839#issuecomment-1211460905

I guess this is the best way to solve it without making drastic / breaking changes to dialogs system.

The `RenderCompleteTaskCompletionSource` was made internal on purpose so it wouldn't be visible to the end developer. Had no other choice but shove it inside `IDialogReference`.

I didn't mark `Show` with `Obsolete`, because current project settings wouldn't allow to compile when an obsolete method is used. It would require changing everything - tests and docs. Also some public methods that use `Show` are also not awaitable, for example `MudMessageBox.Show` is awaitable, and can be changed to `ShowAsync`, meanwhile `MudDialog.Show` is not awaitable, so I didn't want to risk changing too much.

## How Has This Been Tested?
Unit test and by checking DialogPassingDataExample
<img src="https://i.imgur.com/rjtMwnJ.png" width="400" />

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
