### PR TITLE
PopoverProvider: Throw exception when duplicate providers detected

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDuplicationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDuplicationTest.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+<MudPopoverProvider></MudPopoverProvider>
+
+<div class="popoverparent">
+    <p>Some Text</p>
+    <MudPopover @ref="_popover" Open="_isOpen">
+        <MudText>Popover content</MudText>
+    </MudPopover>
+</div>
+
+@code {
+    public static string __description__ = "Duplicate MudPopoverProviders should throw";
+    private MudPopover _popover;
+
+    private bool _isOpen;
+
+    public async Task Open()
+    {
+        _isOpen = true;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task Close()
+    {
+        _isOpen = false;
+        await InvokeAsync(StateHasChanged);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -28,6 +28,7 @@ namespace MudBlazor.UnitTests.Components
 
             options.ContainerClass.Should().Be("mudblazor-main-content");
             options.FlipMargin.Should().Be(0);
+            options.ThrowOnDuplicateProvider.Should().Be(true);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -8,10 +8,12 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Popover;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -879,6 +881,31 @@ namespace MudBlazor.UnitTests.Components
 
             //Console.WriteLine(comp.Markup);
             Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task MudPopoverProvider_ThrowOnDuplicate(bool ThrowOnDuplicateProvider)
+        {
+            var options = new PopoverOptions
+            {
+                ThrowOnDuplicateProvider = ThrowOnDuplicateProvider
+            };
+
+            Context.Services.Configure<PopoverOptions>(x => x.ThrowOnDuplicateProvider = ThrowOnDuplicateProvider);
+            Context.JSInterop.Setup<int>("mudpopoverHelper.countProviders").SetResult(ThrowOnDuplicateProvider == true ? 2 : 1);
+
+            if (ThrowOnDuplicateProvider == true)
+            {
+                var ex = Assert.Throws<InvalidOperationException>(() => Context.RenderComponent<PopoverDuplicationTest>());
+                ex.Message.Should().StartWith("Duplicate MudPopoverProvider detected");
+            }
+            else
+            {
+                var comp = Context.RenderComponent<PopoverDuplicationTest>();
+                await comp.Instance.Open();
+                await comp.Instance.Close();
+            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Mocks/MockPopoverService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockPopoverService.cs
@@ -16,6 +16,8 @@ namespace MudBlazor.UnitTests.Mocks
         private static RenderFragment DefaultFragment = (builder) => { };
         public IEnumerable<MudPopoverHandler> Handlers => _handlers;
 
+        public bool ThrowOnDuplicateProvider => throw new NotImplementedException();
+
         public event EventHandler FragmentsChanged;
 
         public Task InitializeIfNeeded() => Task.FromResult(true);
@@ -26,5 +28,10 @@ namespace MudBlazor.UnitTests.Mocks
         });
 
         public Task<bool> Unregister(MudPopoverHandler handler) => Task.FromResult(true);
+
+        public ValueTask<int> CountProviders()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Mocks/MockPopoverService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockPopoverService.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Mocks
         private static RenderFragment DefaultFragment = (builder) => { };
         public IEnumerable<MudPopoverHandler> Handlers => _handlers;
 
-        public bool ThrowOnDuplicateProvider => throw new NotImplementedException();
+        public bool ThrowOnDuplicateProvider => false;
 
         public event EventHandler FragmentsChanged;
 
@@ -29,9 +29,6 @@ namespace MudBlazor.UnitTests.Mocks
 
         public Task<bool> Unregister(MudPopoverHandler handler) => Task.FromResult(true);
 
-        public ValueTask<int> CountProviders()
-        {
-            throw new NotImplementedException();
-        }
+        public ValueTask<int> CountProviders() => ValueTask.FromResult(0);
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -58,6 +58,19 @@ namespace MudBlazor
             }
         }
 
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender && IsEnabled && Service.ThrowOnDuplicateProvider)
+            {
+                await Service.InitializeIfNeeded();
+                if (await Service.CountProviders() > 1)
+                {
+                    throw new Exception("Duplicate MudPopoverProvider detected. Please ensure there is only one provider, or disable this warning with PopoverOptions.ThrowOnDuplicateProvider.");
+                }
+            }
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
         private void Service_FragmentsChanged(object sender, EventArgs e)
         {
             InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -65,7 +65,7 @@ namespace MudBlazor
                 await Service.InitializeIfNeeded();
                 if (await Service.CountProviders() > 1)
                 {
-                    throw new Exception("Duplicate MudPopoverProvider detected. Please ensure there is only one provider, or disable this warning with PopoverOptions.ThrowOnDuplicateProvider.");
+                    throw new InvalidOperationException("Duplicate MudPopoverProvider detected. Please ensure there is only one provider, or disable this warning with PopoverOptions.ThrowOnDuplicateProvider.");
                 }
             }
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -184,15 +184,11 @@ namespace MudBlazor
         public async ValueTask<int> CountProviders()
         {
             if (!_isInitialized) { return -1; }
-            var value = 0;
 
-            try
-            {
-                value = await _jsRuntime.InvokeAsync<int>("mudpopoverHelper.countProviders");
-            }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
-            return value;
+            var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling<int>("mudpopoverHelper.countProviders");
+            if (success)
+                return value;
+            return 0;
         }
 
         //TO DO add js test

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -20,6 +20,8 @@ namespace MudBlazor
     {
         MudPopoverHandler Register(RenderFragment fragment);
         Task<bool> Unregister(MudPopoverHandler hanlder);
+        ValueTask<int> CountProviders();
+        bool ThrowOnDuplicateProvider { get; }
         IEnumerable<MudPopoverHandler> Handlers { get; }
         Task InitializeIfNeeded();
         event EventHandler FragmentsChanged;
@@ -58,7 +60,7 @@ namespace MudBlazor
             Tag = componentBase.Tag;
             UserAttributes = componentBase.UserAttributes;
             ShowContent = showContent;
-            if(showContent == true)
+            if (showContent == true)
             {
                 ActivationDate = DateTime.Now;
             }
@@ -133,6 +135,7 @@ namespace MudBlazor
 
         public event EventHandler FragmentsChanged;
 
+        public bool ThrowOnDuplicateProvider => _options.ThrowOnDuplicateProvider;
         public IEnumerable<MudPopoverHandler> Handlers => _handlers.Values.AsEnumerable();
 
         public MudPopoverService(IJSRuntime jsInterop, IOptions<PopoverOptions> options = null)
@@ -181,6 +184,20 @@ namespace MudBlazor
             FragmentsChanged?.Invoke(this, EventArgs.Empty);
 
             return true;
+        }
+
+        public async ValueTask<int> CountProviders()
+        {
+            if (!_isInitialized) { return -1; }
+            var value = 0;
+
+            try
+            {
+                value = await _jsRuntime.InvokeAsync<int>("mudpopoverHelper.countProviders");
+            }
+            catch (JSDisconnectedException) { }
+            catch (TaskCanceledException) { }
+            return value;
         }
 
         //TO DO add js test

--- a/src/MudBlazor/Components/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Components/Popover/PopoverOptions.cs
@@ -14,5 +14,6 @@ namespace MudBlazor
     {
         public string ContainerClass { get; set; } = "mudblazor-main-content";
         public int FlipMargin { get; set; } = 0;
+        public bool ThrowOnDuplicateProvider { get; set; } = true;
     }
 }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -299,6 +299,10 @@ window.mudpopoverHelper = {
         const id = target.id.substr(15);
         const popoverNode = document.getElementById('popover-' + id);
         window.mudpopoverHelper.placePopover(popoverNode);
+    },
+
+    countProviders: function () {
+        return document.querySelectorAll(".mud-popover-provider").length;
     }
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

resolves #5064

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Adding multiple `MudPopoverProviders` can lead to issues such as #5064. This PR will check for duplicate `.mud-popover-provider` tags and throw an error if two or more are found. This feature can be disabled with `PopoverOptions.ThrowOnDuplicateProvider`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Tested manually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
