### PR TITLE
JsInteropSerivce: Centralizing JS error handling part one

### DIFF
--- a/src/MudBlazor.UnitTests/Services/IIJSRuntimeExtentionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/IIJSRuntimeExtentionsTests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
+using Moq;
+using MudBlazor.Services;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    public class IIJSRuntimeExtentionsTests
+    {
+        static object[] CatchedExceptions =
+        {
+            #if DEBUG
+#else
+            new object[] { new JSException("only testing") },
+#endif
+            new object[] { new TaskCanceledException() },
+            new object[] { new JSDisconnectedException("only testing") },
+        };
+
+        [Test]
+        public async Task InvokeVoidAsyncWithErrorHandling_NoException()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>()).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            await runtime.InvokeVoidAsyncWithErrorHandling("myMethod", 42, "blub");
+
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(CatchedExceptions))]
+        public async Task InvokeVoidAsyncWithErrorHandling_Exception<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .Throws(ex).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            await runtime.InvokeVoidAsyncWithErrorHandling("myMethod", 42, "blub");
+
+            runtimeMock.Verify();
+
+        }
+
+        [Test]
+        public void InvokeVoidAsyncWithErrorHandling_ThrowsForUncatchedExceptions()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .Throws(new InvalidOperationException("mhh that is odd")).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await runtime.InvokeVoidAsyncWithErrorHandling("myMethod", 42, "blub"));
+
+            ex.Message.Should().Be("mhh that is odd");
+            runtimeMock.Verify();
+        }
+
+        [Test]
+        public async Task InvokeAsyncWithErrorHandling_NoException()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<double>("myMethod", It.IsAny<object[]>()))
+                .ReturnsAsync(42.0).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var (success, value) = await runtime.InvokeAsyncWithErrorHandling<double>("myMethod", 42, "blub");
+
+            success.Should().Be(true);
+            value.Should().Be(42.0);
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(CatchedExceptions))]
+        public async Task InvokeAsyncWithErrorHandling_Exception_WithDefaultValue<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<double>("myMethod", It.IsAny<object[]>()))
+                .Throws(ex).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var (success, value) = await runtime.InvokeAsyncWithErrorHandling<double>("myMethod", 42, "blub");
+
+            success.Should().Be(false);
+            value.Should().Be(0.0);
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(CatchedExceptions))]
+        public async Task InvokeAsyncWithErrorHandling_Exception_WithFallbackValue<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<double>("myMethod", It.IsAny<object[]>()))
+                .Throws(ex).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var (success, value) = await runtime.InvokeAsyncWithErrorHandling<double>(37.5, "myMethod", 42, "blub");
+
+            success.Should().Be(false);
+            value.Should().Be(37.5);
+            runtimeMock.Verify();
+        }
+
+        [Test]
+        public void InvokeAsyncWithErrorHandling_ThrowsForUncatchedExceptions()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock.Setup(x => x.InvokeAsync<double>("myMethod", It.IsAny<object[]>()))
+                 .Throws(new InvalidOperationException("mhh that is odd")).Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await runtime.InvokeAsyncWithErrorHandling<double>("myMethod", 42, "blub"));
+
+            ex.Message.Should().Be("mhh that is odd");
+            runtimeMock.Verify();
+        }
+
+    }
+}

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -403,7 +403,7 @@ namespace MudBlazor
         {
             if (firstRender == true)
             {
-                await JsRuntime.InvokeVoidAsync("mudDragAndDrop.initDropZone", _id.ToString());
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudDragAndDrop.initDropZone", _id.ToString());
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -58,7 +58,7 @@ namespace MudBlazor
             Tag = componentBase.Tag;
             UserAttributes = componentBase.UserAttributes;
             ShowContent = showContent;
-            if(showContent == true)
+            if (showContent == true)
             {
                 ActivationDate = DateTime.Now;
             }
@@ -91,8 +91,7 @@ namespace MudBlazor
                     return;
                 }
 
-                await _runtime.InvokeVoidAsync("mudPopover.connect", Id);
-                IsConnected = true;
+                IsConnected = await _runtime.InvokeVoidAsyncWithErrorHandling("mudPopover.connect", Id); ;
             }
             finally
             {
@@ -109,11 +108,9 @@ namespace MudBlazor
 
                 if (IsConnected)
                 {
-                    await _runtime.InvokeVoidAsync("mudPopover.disconnect", Id);
+                    await _runtime.InvokeVoidAsyncWithErrorHandling("mudPopover.disconnect", Id);
                 }
             }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
             finally
             {
                 IsConnected = false;
@@ -150,11 +147,9 @@ namespace MudBlazor
                 await _semaphoreSlim.WaitAsync();
                 if (_isInitialized == true) { return; }
 
-                await _jsRuntime.InvokeVoidAsync("mudPopover.initialize", _options.ContainerClass, _options.FlipMargin);
+                await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.initialize", _options.ContainerClass, _options.FlipMargin);
                 _isInitialized = true;
             }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
             finally
             {
                 _semaphoreSlim.Release();
@@ -189,12 +184,7 @@ namespace MudBlazor
         {
             if (_isInitialized == false) { return; }
 
-            try
-            {
-                await _jsRuntime.InvokeVoidAsync("mudPopover.dispose");
-            }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
+            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.dispose");
         }
     }
 }

--- a/src/MudBlazor/Services/EventManager/EventManager.cs
+++ b/src/MudBlazor/Services/EventManager/EventManager.cs
@@ -102,7 +102,7 @@ namespace MudBlazor
             var (type, properties) = GetTypeInformation<T>();
             var key = RegisterCallBack(type, callback);
 
-            await _jsRuntime.InvokeVoidAsync("mudThrottledEventManager.subscribe", eventName, elementId, projectionName, throotleInterval, key, properties, _dotNetRef);
+            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudThrottledEventManager.subscribe", eventName, elementId, projectionName, throotleInterval, key, properties, _dotNetRef);
 
             return key;
         }
@@ -112,7 +112,7 @@ namespace MudBlazor
             var (type, properties) = GetTypeInformation<T>();
             var key = RegisterCallBack(type, callback);
 
-            await _jsRuntime.InvokeVoidAsync("mudThrottledEventManager.subscribeGlobal", eventName, throotleInterval, key, properties, _dotNetRef);
+            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudThrottledEventManager.subscribeGlobal", eventName, throotleInterval, key, properties, _dotNetRef);
 
             return key;
         }
@@ -123,7 +123,7 @@ namespace MudBlazor
 
             try
             {
-                await _jsRuntime.InvokeVoidAsync("mudThrottledEventManager.unsubscribe", key);
+                await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudThrottledEventManager.unsubscribe", key);
                 return true;
             }
             catch (Exception)
@@ -158,7 +158,7 @@ namespace MudBlazor
             {
                 try
                 {
-                    await _jsRuntime.InvokeVoidAsync("mudThrottledEventManager.unsubscribe", item.Key);
+                    await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudThrottledEventManager.unsubscribe", item.Key);
                 }
                 catch (Exception)
                 {

--- a/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace MudBlazor
+{
+    public static class IIJSRuntimeExtentions
+    {
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation and resolves to true in case no exception has occured ohterwise false.</returns>
+        public static async ValueTask<bool> InvokeVoidAsyncWithErrorHandling(this IJSRuntime jsRuntime, string identifier, params object[] args)
+        {
+            try
+            {
+                await jsRuntime.InvokeVoidAsync(identifier, args);
+                return true;
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+                return false;
+            }
+#endif
+            catch (JSDisconnectedException)
+            {
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException. In case an exception occured the default value of <typeparamref name="TValue"/> is returned
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value into a tuple. The first item (sucess) is true in case where there was no exception, otherwise fall.</returns>
+        public static async ValueTask<(bool success, TValue value)> InvokeAsyncWithErrorHandling<TValue>(this IJSRuntime jsRuntime, string identifier, params object[] args)
+            => await jsRuntime.InvokeAsyncWithErrorHandling(default(TValue), identifier, args);
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="fallbackValue">The value that should be returned in case an exception occured</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value into a tuple. The first item (sucess) is true in case where there was no exception, otherwise fall.</returns>
+        public static async ValueTask<(bool success, TValue value)> InvokeAsyncWithErrorHandling<TValue>(this IJSRuntime jsRuntime, TValue fallbackValue, string identifier, params object[] args)
+        {
+            try
+            {
+                var result = await jsRuntime.InvokeAsync<TValue>(identifier: identifier, args: args);
+                return (true, result);
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
+            catch (JSDisconnectedException)
+            {
+                return (false, fallbackValue);
+            }
+            catch (TaskCanceledException)
+            {
+                return (false, fallbackValue);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Services/JsEvent/JsEvent.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEvent.cs
@@ -57,13 +57,7 @@ namespace MudBlazor.Services
             if (_isObserving || _isDisposed)
                 return;
             _elementId = elementId;
-            try
-            {
-                await _jsRuntime.InvokeVoidAsync("mudJsEvent.connect", _dotNetRef, elementId, options);
-                _isObserving = true;
-            }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
+            _isObserving = await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudJsEvent.connect", _dotNetRef, elementId, options); ;
         }
 
         /// <summary>
@@ -115,7 +109,7 @@ namespace MudBlazor.Services
                 return;
             try
             {
-                foreach(var eventName in _subscribedEvents)
+                foreach (var eventName in _subscribedEvents)
                     await _jsRuntime.InvokeVoidAsync($"mudJsEvent.unsubscribe", _elementId, eventName);
             }
             catch (Exception) {  /*ignore*/ }

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -51,14 +51,7 @@ namespace MudBlazor.Services
             if (_isObserving || _isDisposed)
                 return;
             _elementId = elementId;
-            try
-            {
-                await _jsRuntime.InvokeVoidAsync("mudKeyInterceptor.connect", _dotNetRef, elementId, options);
-                _isObserving = true;
-            }
-            catch (JSException) { } //navigating quickly can throw "element not found" errors
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
+            _isObserving = await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudKeyInterceptor.connect", _dotNetRef, elementId, options);
         }
 
         /// <summary>
@@ -79,20 +72,21 @@ namespace MudBlazor.Services
             try
             {
                 await _jsRuntime.InvokeVoidAsync($"mudKeyInterceptor.disconnect", _elementId);
-            } catch (Exception) {  /*ignore*/ }
+            }
+            catch (Exception) {  /*ignore*/ }
             _isObserving = false;
         }
 
         [JSInvokable]
         public void OnKeyDown(KeyboardEventArgs args)
         {
-            KeyDown?.Invoke( args);
+            KeyDown?.Invoke(args);
         }
 
         [JSInvokable]
         public void OnKeyUp(KeyboardEventArgs args)
         {
-            KeyUp?.Invoke( args);
+            KeyUp?.Invoke(args);
         }
 
         public event KeyboardEvent KeyDown;

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserver.cs
@@ -71,7 +71,7 @@ namespace MudBlazor.Services
             var elementId = _cachedValueIds.FirstOrDefault(x => x.Value.Id == element.Id).Key;
             if (elementId == default) { return; }
 
-            //if the ubobserve happen during a component teardown, the try-catch is a safe guard to prevent a "pseudo" exception
+            //if the unobserve happens during a component teardown, the try-catch is a safe guard to prevent a "pseudo" exception
             try { await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.disconnect", _id, elementId); } catch (Exception) { }
 
             _cachedValueIds.Remove(elementId);

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -14,7 +14,7 @@ using Microsoft.JSInterop;
 
 namespace MudBlazor.Services
 {
-  
+
     public class BreakpointService :
         ResizeBasedService<BreakpointService, BreakpointServiceSubscriptionInfo, Breakpoint, ResizeOptions>,
         IBreakpointService
@@ -161,24 +161,19 @@ namespace MudBlazor.Services
 
                     Listeners.Add(listenerId, subscriptionInfo);
 
-                    try
+                    var interopResult = await JsRuntime.InvokeVoidAsyncWithErrorHandling
+                        ("mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
+                    
+                    if (interopResult == true)
                     {
-                        await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
                         if (_breakpoint == Breakpoint.None)
                         {
                             _breakpoint = await GetBreakpoint();
 
                         }
-                        return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
                     }
-                    catch (JSDisconnectedException)
-                    {
-                        return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
-                    }
+
+                    return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
                 }
                 else
                 {
@@ -218,7 +213,7 @@ namespace MudBlazor.Services
         /// <param name="reference">The reference breakpoint (xs,sm,md,lg,xl)</param>
         /// <returns>True if the media size is meet, false otherwise. For instance if the reference size is sm and the breakpoint is SmAndSmaller, this method returns true</returns>
         bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference);
-        
+
         /// <summary>
         /// Get the current breakpoint
         /// </summary>

--- a/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.Services
         where TSelf : class
         where TInfo : SubscriptionInfo<TAction, TaskOption>
     {
-        protected SemaphoreSlim Semaphore = new (1, 1);
+        protected SemaphoreSlim Semaphore = new(1, 1);
 
         protected Dictionary<Guid, TInfo> Listeners { get; } = new();
         protected IJSRuntime JsRuntime { get; init; }
@@ -50,12 +50,7 @@ namespace MudBlazor.Services
                 {
                     Listeners.Remove(info.Key);
 
-                    try
-                    {
-                        await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.cancelListener", info.Key);
-                    }
-                    catch (JSDisconnectedException) { }
-                    catch (TaskCanceledException) { }
+                    await JsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListenerFactory.cancelListener", info.Key);
                 }
 
                 if (Listeners.Count == 0)
@@ -80,12 +75,7 @@ namespace MudBlazor.Services
             var ids = Listeners.Keys.ToArray();
             Listeners.Clear();
 
-            try
-            {
-                await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.cancelListeners", ids);
-            }
-            catch (JSDisconnectedException) { }
-            catch (TaskCanceledException) { }
+            await JsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListenerFactory.cancelListeners", ids);
 
             DotNetRef.Dispose();
         }

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -78,7 +78,7 @@ namespace MudBlazor.Services
         {
             if (_onResized == null || _onBreakpointChanged == null)
             {
-                await _jsRuntime.InvokeVoidAsync($"mudResizeListener.listenForResize", _dotNetRef, _options);
+                await _jsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListener.listenForResize", _dotNetRef, _options);
             }
         }
 
@@ -88,7 +88,7 @@ namespace MudBlazor.Services
             {
                 if (_onResized == null && _onBreakpointChanged == null)
                 {
-                    await _jsRuntime.InvokeVoidAsync($"mudResizeListener.cancelListener");
+                    await _jsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListener.cancelListener");
                 }
                 else if (_onResized == null && _onBreakpointChanged != null && !_options.NotifyOnBreakpointOnly)
                 {

--- a/src/MudBlazor/Services/ResizeListener/ResizeService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeService.cs
@@ -90,12 +90,7 @@ namespace MudBlazor.Services
 
                 Listeners.Add(listenerId, subscriptionInfo);
 
-                try
-                {
-                    await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
-                }
-                catch (JSDisconnectedException) { }
-                catch (TaskCanceledException) { }
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
 
                 return subscriptionId;
             }

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -83,10 +83,10 @@ namespace MudBlazor
         /// <summary>
         /// Subscribe to scroll event in JS
         /// </summary>        
-        private ValueTask Start()
+        private ValueTask<bool> Start()
         {
             _dotNetRef = DotNetObjectReference.Create(this);
-            return _js.InvokeVoidAsync
+            return _js.InvokeVoidAsyncWithErrorHandling
                 ("mudScrollListener.listenForScroll",
                            _dotNetRef,
                            Selector);

--- a/src/MudBlazor/Services/Scroll/ScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpy.cs
@@ -84,14 +84,14 @@ namespace MudBlazor
         public async Task ScrollToSection(string id)
         {
             CenteredSection = id;
-            await _js.InvokeVoidAsync
+            await _js.InvokeVoidAsyncWithErrorHandling
             ("mudScrollSpy.scrollToSection", id.Trim('#'));
         }
 
         public async Task SetSectionAsActive(string id)
         {
             CenteredSection = id;
-            await _js.InvokeVoidAsync
+            await _js.InvokeVoidAsyncWithErrorHandling
             ("mudScrollSpy.activateSection", id.Trim('#'));
         }
 
@@ -102,7 +102,7 @@ namespace MudBlazor
             try
             {
                 _dotNetRef?.Dispose();
-                await _js.InvokeVoidAsync("mudScrollSpy.unspy");
+                await _js.InvokeVoidAsyncWithErrorHandling("mudScrollSpy.unspy");
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Description
Before this PR, each service handled exceptions for JS interop separately. This PR tries to start the process of centralizing it and providing a single point for future changes. 

There have been two options for the implementation: Either the creation of a new service or extension methods. For service, I need to create it and wrap the calls, announce it to the DI container and replace ``IJSRuntime`` throughout the library with this new service.  With the Extention method approach, I still need to write the wrapper, but that's about it. Besides, users can use this method more quickly and effectively in their own code. 
 
The wrapper itself is quite simple

```csharp
try
{
	await jsRuntime.InvokeVoidAsync(identifier, args);
	return true;
}
catch (JSException)
{
	return false;
}
catch (JSDisconnectedException)
{
	return false;
}
catch (TaskCanceledException)
{
	return false;
}
```

I haven't replaced all calls of ``.InvokeVoidAsync`` with ``InvokeVoidAsyncWithErrorHandling``, because sometimes this method return ``ValueTask`` and ``ValueTask<bool>`` can't be casted to ``ValueTask``. In other scenarios like dispose, the error handling was simple ``catch(Exception)``. Therefore, I see this PR as the first step towards more unified handling of JS interop error within Mudblazor.  

## How Has This Been Tested?
I've added relevant unit tests. I've inspected the docs page briefly and didn't find a difference. However, the PR touches many components, so additional pairs of eyes are very much appreciated. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refractoring (increasing code quality without changing functionality or fixing bugs) 

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
