### PR TITLE
DataGrid: prevent trimming of FilterOperator

### DIFF
--- a/src/MudBlazor/Components/DataGrid/FilterOperator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterOperator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 
@@ -95,7 +96,7 @@ namespace MudBlazor
             return new string[] { };
         }
 
-        internal static string[] GetFields(Type type)
+        internal static string[] GetFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             List<string> fields = new List<string>();
 
@@ -135,12 +136,12 @@ namespace MudBlazor
             typeof(BigInteger?),
         };
 
-        internal static bool IsNumber(Type type)
+        internal static bool IsNumber([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             return NumericTypes.Contains(type);
         }
 
-        internal static bool IsEnum(Type type)
+        internal static bool IsEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             if (null == type)
                 return false;
@@ -152,7 +153,7 @@ namespace MudBlazor
             return (u != null) && u.IsEnum;
         }
 
-        internal static bool IsDateTime(Type type)
+        internal static bool IsDateTime([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             if (type == typeof(System.DateTime))
                 return true;
@@ -161,13 +162,13 @@ namespace MudBlazor
             return (u != null) && u == typeof(System.DateTime);
         }
 
-        internal static bool IsBoolean(Type type)
+        internal static bool IsBoolean([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
-            if (type == typeof(System.Boolean))
+            if (type == typeof(bool))
                 return true;
 
             Type u = Nullable.GetUnderlyingType(type);
-            return (u != null) && u == typeof(System.Boolean);
+            return (u != null) && u == typeof(bool);
         }
     }
 }


### PR DESCRIPTION
## Description
@henon another trimming issue
Fixes #5131

Usually this would **not** happen, since `type.GetFields()` has annotation with `DynamicallyAccessedMemberTypes.PublicFields`, but those are not working with literals...

NB! In ticket I mentioned one more issue that is not related to trimming.

## How Has This Been Tested?
By hands with trimming mode enabled on the wasm project.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
