### PR TITLE
Treeview: Fix conflicting iconbutton css selectors

### DIFF
--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -44,7 +44,7 @@
 }
 
 .mud-switch-base {
-    padding: 9px!important;
+    padding: 9px;
     top: 0;
     left: 0;
     color: #fafafa;

--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -44,7 +44,7 @@
 }
 
 .mud-switch-base {
-    padding: 9px;
+    padding: 9px!important;
     top: 0;
     left: 0;
     color: #fafafa;

--- a/src/MudBlazor/Styles/components/_treeview.scss
+++ b/src/MudBlazor/Styles/components/_treeview.scss
@@ -45,8 +45,10 @@
     align-items: center;
     -webkit-tap-highlight-color: transparent;
 
-    .mud-icon-button {
-        padding: 4px;
+    .mud-treeview-item-arrow, .mud-treeview-item-checkbox {
+        .mud-icon-button {
+            padding: 4px;
+        }
     }
 }
 


### PR DESCRIPTION
Conflict with .mud-treeview-item .mud-icon-button {
    padding: 4px;
}
![image](https://user-images.githubusercontent.com/6291948/186322700-2954ac09-4384-4e9d-81f5-3d47174a080b.png)
