### PR TITLE
Checkbox: Add LabelPosition property to specify the label's Start/End position

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -28,7 +28,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Labels">
-                <Description></Description>
+                <Description>
+                    Text can be added using the <CodeInline>Label</CodeInline> property and its
+                    position can be specified using the <CodeInline>LabelPosition</CodeInline> property
+                </Description>
             </SectionHeader>
             <SectionContent Code="CheckboxLabelExample">
                 <CheckboxLabelExample />

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxLabelExample.razor
@@ -2,8 +2,8 @@
 
 <MudCheckBox @bind-Checked="@Label_CheckBox1" Label="Default"></MudCheckBox>
 <MudCheckBox @bind-Checked="@Label_CheckBox2" Label="Primary" Color="Color.Primary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Label_CheckBox3" Label="Secondary" Color="Color.Secondary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Label_CheckBox1" Disabled="true" Label="Disabled"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Label_CheckBox3" Label="Secondary" LabelPosition="LabelPosition.Start" Color="Color.Secondary"></MudCheckBox>
+<MudCheckBox @bind-Checked="@Label_CheckBox1" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start"></MudCheckBox>
 
 @code {
     public bool Label_CheckBox1 { get; set; } = true;

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -1,10 +1,9 @@
-﻿
-using System;
+﻿using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Docs.Examples;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
@@ -322,6 +321,25 @@ namespace MudBlazor.UnitTests.Components
             input.Change(true);
             box.Checked.Should().Be(true);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
+        }
+
+        [Test]
+        public void CheckBoxDisabledTest()
+        {
+            var comp = Context.RenderComponent<CheckboxLabelExample>();
+            var switches = comp.FindAll("label.mud-checkbox");
+            switches[3].ClassList.Should().Contain("mud-disabled"); // 4rd checkbox
+        }
+
+        [Test]
+        public void CheckBoxLabelPositionTest()
+        {
+            var comp = Context.RenderComponent<CheckboxLabelExample>();
+            //Console.WriteLine(comp.Markup);
+            var switches = comp.FindAll("label.mud-checkbox");
+
+            switches[0].ClassList.Should().Contain("mud-ltr"); // 1st checkbox: (default) LabelPosition.End
+            switches[2].ClassList.Should().Contain("mud-rtl"); // 3rd checkbox: LabelPosition.Start
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -327,8 +327,8 @@ namespace MudBlazor.UnitTests.Components
         public void CheckBoxDisabledTest()
         {
             var comp = Context.RenderComponent<CheckboxLabelExample>();
-            var switches = comp.FindAll("label.mud-checkbox");
-            switches[3].ClassList.Should().Contain("mud-disabled"); // 4rd checkbox
+            var checkboxes = comp.FindAll("label.mud-checkbox");
+            checkboxes[3].ClassList.Should().Contain("mud-disabled"); // 4rd checkbox
         }
 
         [Test]
@@ -336,10 +336,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<CheckboxLabelExample>();
             //Console.WriteLine(comp.Markup);
-            var switches = comp.FindAll("label.mud-checkbox");
+            var checkboxes = comp.FindAll("label.mud-checkbox");
 
-            switches[0].ClassList.Should().Contain("mud-ltr"); // 1st checkbox: (default) LabelPosition.End
-            switches[2].ClassList.Should().Contain("mud-rtl"); // 3rd checkbox: LabelPosition.Start
+            checkboxes[0].ClassList.Should().Contain("mud-ltr"); // 1st checkbox: (default) LabelPosition.End
+            checkboxes[2].ClassList.Should().Contain("mud-rtl"); // 3rd checkbox: LabelPosition.Start
         }
     }
 }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -19,6 +19,7 @@ namespace MudBlazor
         new CssBuilder("mud-checkbox")
             .AddClass($"mud-disabled", Disabled)
             .AddClass($"mud-readonly", ReadOnly)
+            .AddClass(LabelPosition == LabelPosition.End ? "mud-ltr" : "mud-rtl", true)
         .Build();
 
         protected string CheckBoxClassname =>
@@ -46,11 +47,18 @@ namespace MudBlazor
         public Color? UnCheckedColor { get; set; } = null;
 
         /// <summary>
-        /// If applied the text will be added to the component.
+        /// The text/label will be displayed next to the checkbox if set.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string Label { get; set; }
+
+        /// <summary>
+        /// The position of the text/label.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public LabelPosition LabelPosition { get; set; } = LabelPosition.End;
 
         /// <summary>
         /// If true, the checkbox can be controlled with the keyboard.


### PR DESCRIPTION
Following up on PR #5152, `MudCheckBox` now also supports the `LabelPosition` property.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
