### PR TITLE
MudHighlighter: Support multiple highligted texts

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterUntilNextBoundaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterUntilNextBoundaryExample.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
+
 <MudTextField Style="max-width:250px" @bind-Value="@highlightedText" Immediate="true" Label="Highlighted Text" />
 <MudPaper Class="pa-4 mt-4" Elevation="0">
     @foreach (var paragraph in paragraphs)
@@ -22,10 +23,9 @@
     bool untilNextBoundary;
     bool caseSensitive;
     IEnumerable<string> paragraphs = new List<string>
-{
+    {
         "MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure.",
         "MudLists are easily customizable and scrollable lists. Make them suit your needs with avatars, icons, or something like checkboxes.",
         "Use mud-* classes to customize your MudBlazor components."
     };
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithCustomStyleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithCustomStyleExample.razor
@@ -25,6 +25,4 @@
     {
         "This is the first item", "This is the second item", "This is the third item"
     };
-
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithListExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithListExample.razor
@@ -22,6 +22,4 @@
     {
         "This is the first item", "This is the second item", "This is the third item"
     };
-
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithListMultipleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithListMultipleExample.razor
@@ -1,0 +1,32 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Elevation="0">
+    <MudList>
+        <MudListSubheader>
+            <MudTextField @bind-Value="searchTerm" AdornmentIcon="@Icons.Filled.People"
+                          Adornment="Adornment.End" Immediate="true" Variant="Variant.Outlined"
+                          Label="Names to search"/>
+        </MudListSubheader>
+
+        @{
+            string[] searchTerms = searchTerm.Split(split);
+            for (int i = 0; i < searchTerms.Length; i++)
+                searchTerms[i] = searchTerms[i].Trim();
+        }
+        @foreach (var name in names)
+        {
+            <MudListItem @key="name" Icon="@Icons.Filled.Person">
+                <MudHighlighter Text="@name" HighlightedTexts="@searchTerms" />
+            </MudListItem>
+        }
+    </MudList>
+</MudPaper>
+
+@code {
+    string searchTerm = "William Jordan, Oliver";
+    IEnumerable<string> names = new List<string>
+    {
+        "William Jordan", "Oliver Jones", "William Johnson", "Daniel Williams", "Oliver Simpson"
+    };
+    static readonly char[] split = new char[] { ';', ',', '.' };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/HighlighterPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/HighlighterPage.razor
@@ -10,7 +10,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Usage">
-                <Description>The highlighter cand be used in combination with any other component.</Description>
+                <Description>The highlighter can be used in combination with any other component.</Description>
             </SectionHeader>
             <SectionSubGroups>
                 <DocsPageSection>
@@ -47,6 +47,15 @@
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="HighlighterUntilNextBoundaryExample" ShowCode="false">
                 <HighlighterUntilNextBoundaryExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Multiple Highlights">
+                <Description>In addition to <code class="docs-code docs-code-primary">HighlightedText</code> property which accepts a single text fragment in the form of an string, the <code class="docs-code docs-code-primary">HighlightedTexts</code> property accepts an enumerable of strings which can be used to highlight several text fragments.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="HighlighterWithListMultipleExample" ShowCode="false">
+                <HighlighterWithListMultipleExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -14,30 +14,73 @@ namespace MudBlazor.UnitTests.Components
         private const string TEXT = "This is the first item";
 
         [Test]
-        public void ShouldSplitTest()
+        public void ShouldSplitUsingHighlightedTextParameterTest()
         {
             var highlightedText = "item";
-            var result = GetFragments(TEXT, highlightedText);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex);
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
+            regex.Should().Be("((?:item))");
+        }
+
+        [Test]
+        public void ShouldSplitUsingHighlightedTextsParameterWithOneElementTest()
+        {
+            var highlightedTexts = new string[] { "item" };
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            result.Should().HaveCount(2);
+            result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
+            regex.Should().Be("((?:item))");
+        }
+
+        [Test]
+        public void ShouldSplitUsingHighlightedTextsParameterWithMultipleElementsTest()
+        {
+            var highlightedTexts = new string[] { "item", "the" };
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            result.Should().HaveCount(4);
+            result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " first ", "item" });
+            regex.Should().Be("((?:item)|(?:the))");
+        }
+
+        [Test]
+        public void ShouldSplitUsingHighlightedTextParameterAndHighlightedTextsParameterWithOneElementTest()
+        {
+            var highlightedTexts = new string[] { "the" };
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            result.Should().HaveCount(4);
+            result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " first ", "item" });
+            regex.Should().Be("((?:item)|(?:the))");
+        }
+
+        [Test]
+        public void ShouldSplitUsingHighlightedTextParameterAndHighlightedTextsParameterWithMultipleElementsTest()
+        {
+            var highlightedTexts = new string[] { "first", "the" };
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            result.Should().HaveCount(6);
+            result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " ", "first", " ", "item" });
+            regex.Should().Be("((?:item)|(?:first)|(?:the))");
         }
 
         [Test]
         public void ShouldUseUntilNextBoundaryTest()
         {
             var highlightedText = "it";
-            var result = GetFragments(TEXT, highlightedText, false, true);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, false, true);
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
+            regex.Should().Be("((?:it.*?\\b))");
         }
 
         [Test]
         public void ShouldBeCaseSensitiveTest()
         {
             var highlightedText = "It";
-            var result = GetFragments(TEXT, highlightedText, true, false);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false);
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
+            regex.Should().Be("((?:It))");
         }
 
         [Test]
@@ -45,9 +88,30 @@ namespace MudBlazor.UnitTests.Components
         {
             //regex characters are properly escaped in GetFragments
             var highlightedText = ".";
-            var result = GetFragments(TEXT, highlightedText, true, false);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false);
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
+            regex.Should().Be("((?:\\.))");
+        }
+
+        [Test]
+        public void DontMessWithDuplicatedHighlightPatternsInHighlightedTextsParameterTest()
+        {
+            var highlightedTexts = new string[] { "item", "item" };
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            result.Should().HaveCount(2);
+            result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
+            regex.Should().Be("((?:item)|(?:item))");
+        }
+
+        [Test]
+        public void DontMessWithDuplicatedHighlightPatternsInHighlightedTextParameterAndHighlightedTextsParameterTest()
+        {
+            var highlightedTexts = new string[] { "item" };
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            result.Should().HaveCount(2);
+            result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
+            regex.Should().Be("((?:item)|(?:item))");
         }
     }
 
@@ -60,12 +124,62 @@ namespace MudBlazor.UnitTests.Components
         /// Check markup with regular text, no regex
         /// </summary>
         [Test]
-        public void MudHighlighterMarkupTest()
+        public void MudHighlighterMarkupUsingHighlightedTextParameterTest()
         {
             var text = Parameter(nameof(MudHighlighter.Text), TEXT);
             var highlightedText = Parameter(nameof(MudHighlighter.HighlightedText), "item");
             var comp = Context.RenderComponent<MudHighlighter>(text, highlightedText);
             comp.MarkupMatches("This is the first <mark>item</mark>");
+        }
+
+        /// <summary>
+        /// Check markup with multiple regular texts, no regex
+        /// </summary>
+        [Test]
+        public void MudHighlighterMarkupUsingHighlightedTextsParameterWithOneElementTest()
+        {
+            var text = Parameter(nameof(MudHighlighter.Text), TEXT);
+            var highlightedTexts = Parameter(nameof(MudHighlighter.HighlightedTexts), new string[] { "item" });
+            var comp = Context.RenderComponent<MudHighlighter>(text, highlightedTexts);
+            comp.MarkupMatches("This is the first <mark>item</mark>");
+        }
+
+        /// <summary>
+        /// Check markup with multiple regular texts, no regex
+        /// </summary>
+        [Test]
+        public void MudHighlighterMarkupUsingHighlightedTextsParameterWithMultipleElementsTest()
+        {
+            var text = Parameter(nameof(MudHighlighter.Text), TEXT);
+            var highlightedTexts = Parameter(nameof(MudHighlighter.HighlightedTexts), new string[] { "item", "This" });
+            var comp = Context.RenderComponent<MudHighlighter>(text, highlightedTexts);
+            comp.MarkupMatches("<mark>This</mark> is the first <mark>item</mark>");
+        }
+
+        /// <summary>
+        /// Check markup with multiple regular text and a single regular text, no regex
+        /// </summary>
+        [Test]
+        public void MudHighlighterMarkupUsingHighlightedTextParameterAndHighlightedTextsParameterWithOneElementTest()
+        {
+            var text = Parameter(nameof(MudHighlighter.Text), TEXT);
+            var highlightedTexts = Parameter(nameof(MudHighlighter.HighlightedTexts), new string[] { "item" });
+            var highlightedText = Parameter(nameof(MudHighlighter.HighlightedText), "This");
+            var comp = Context.RenderComponent<MudHighlighter>(text, highlightedText, highlightedTexts);
+            comp.MarkupMatches("<mark>This</mark> is the first <mark>item</mark>");
+        }
+
+        /// <summary>
+        /// Check markup with multiple regular text and a single regular text, no regex
+        /// </summary>
+        [Test]
+        public void MudHighlighterMarkupUsingHighlightedTextParameterAndHighlightedTextsParameterWithMultipleElementsTest()
+        {
+            var text = Parameter(nameof(MudHighlighter.Text), TEXT);
+            var highlightedTexts = Parameter(nameof(MudHighlighter.HighlightedTexts), new string[] { "item", "first" });
+            var highlightedText = Parameter(nameof(MudHighlighter.HighlightedText), "This");
+            var comp = Context.RenderComponent<MudHighlighter>(text, highlightedText, highlightedTexts);
+            comp.MarkupMatches("<mark>This</mark> is the <mark>first</mark> <mark>item</mark>");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextParameterTest()
         {
             var highlightedText = "item";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item))");
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextsParameterWithOneElementTest()
         {
             var highlightedTexts = new string[] { "item" };
-            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item))");
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextsParameterWithMultipleElementsTest()
         {
             var highlightedTexts = new string[] { "item", "the" };
-            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(4);
             result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " first ", "item" });
             regex.Should().Be("((?:item)|(?:the))");
@@ -47,7 +47,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextParameterAndHighlightedTextsParameterWithOneElementTest()
         {
             var highlightedTexts = new string[] { "the" };
-            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(4);
             result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " first ", "item" });
             regex.Should().Be("((?:item)|(?:the))");
@@ -57,7 +57,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextParameterAndHighlightedTextsParameterWithMultipleElementsTest()
         {
             var highlightedTexts = new string[] { "first", "the" };
-            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(6);
             result.Should().BeEquivalentTo(new List<string> { "This is ", "the", " ", "first", " ", "item" });
             regex.Should().Be("((?:item)|(?:first)|(?:the))");
@@ -67,7 +67,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldUseUntilNextBoundaryTest()
         {
             var highlightedText = "it";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, false, true);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, false, true).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:it.*?\\b))");
@@ -77,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldBeCaseSensitiveTest()
         {
             var highlightedText = "It";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:It))");
@@ -88,7 +88,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //regex characters are properly escaped in GetFragments
             var highlightedText = ".";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false);
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:\\.))");
@@ -98,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
         public void DontMessWithDuplicatedHighlightPatternsInHighlightedTextsParameterTest()
         {
             var highlightedTexts = new string[] { "item", "item" };
-            var result = GetFragments(TEXT, null, highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, null, highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item)|(?:item))");
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
         public void DontMessWithDuplicatedHighlightPatternsInHighlightedTextParameterAndHighlightedTextsParameterTest()
         {
             var highlightedTexts = new string[] { "item" };
-            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex);
+            var result = GetFragments(TEXT, "item", highlightedTexts, out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item)|(?:item))");

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -6,9 +6,9 @@
 
 @foreach (var fragment in fragments)
 {
-    if (!string.IsNullOrWhiteSpace(HighlightedText)
+    if (!string.IsNullOrWhiteSpace(regex)
         && Regex.IsMatch(fragment,
-           Regex.Escape(HighlightedText), //escape until add a property to accept regex
+            regex,
             CaseSensitive
                 ? RegexOptions.None
                 : RegexOptions.IgnoreCase))
@@ -24,6 +24,7 @@
 @code
 {
     IEnumerable<string> fragments;
+    string regex;
 
     /// <summary>
     /// The whole text in which a fragment will be highlighted
@@ -38,6 +39,13 @@
     [Parameter] 
     [Category(CategoryTypes.Highlighter.Behavior)]
     public string HighlightedText { get; set; }
+
+    /// <summary>
+    /// The fragments of text to be highlighted
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public IEnumerable<string> HighlightedTexts { get; set; }
 
     /// <summary>
     /// Whether or not the highlighted text is case sensitive
@@ -61,6 +69,6 @@
 
     protected override void OnParametersSet()
     {
-        fragments = GetFragments(Text, HighlightedText, CaseSensitive, UntilNextBoundary);
+        fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out regex, CaseSensitive, UntilNextBoundary);
     }
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -4,11 +4,11 @@
 @using System.Text.RegularExpressions
 @using static MudBlazor.Components.Highlighter.Splitter
 
-@foreach (var fragment in fragments.Span)
+@foreach (var fragment in _fragments.Span)
 {
-    if (!string.IsNullOrWhiteSpace(regex)
+    if (!string.IsNullOrWhiteSpace(_regex)
         && Regex.IsMatch(fragment,
-            regex,
+            _regex,
             CaseSensitive
                 ? RegexOptions.None
                 : RegexOptions.IgnoreCase))
@@ -18,57 +18,5 @@
     else
     {
         @fragment
-    }
-}
-
-@code
-{
-    Memory<string> fragments;
-    string regex;
-
-    /// <summary>
-    /// The whole text in which a fragment will be highlighted
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.Highlighter.Behavior)]
-    public string Text { get; set; }
-
-    /// <summary>
-    /// The fragment of text to be highlighted
-    /// </summary>
-    [Parameter] 
-    [Category(CategoryTypes.Highlighter.Behavior)]
-    public string HighlightedText { get; set; }
-
-    /// <summary>
-    /// The fragments of text to be highlighted
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.Highlighter.Behavior)]
-    public IEnumerable<string> HighlightedTexts { get; set; }
-
-    /// <summary>
-    /// Whether or not the highlighted text is case sensitive
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.Highlighter.Behavior)]
-    public bool CaseSensitive { get; set; }
-
-    /// <summary>
-    /// If true, highlights the text until the next regex boundary
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.Highlighter.Behavior)]
-    public bool UntilNextBoundary { get; set; }
-
-    //TODO
-    //Accept regex highlightings
-    // [Parameter] public bool IsRegex { get; set; }
-
-
-
-    protected override void OnParametersSet()
-    {
-        fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out regex, CaseSensitive, UntilNextBoundary);
     }
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -4,7 +4,7 @@
 @using System.Text.RegularExpressions
 @using static MudBlazor.Components.Highlighter.Splitter
 
-@foreach (var fragment in fragments)
+@foreach (var fragment in fragments.Span)
 {
     if (!string.IsNullOrWhiteSpace(regex)
         && Regex.IsMatch(fragment,
@@ -23,7 +23,7 @@
 
 @code
 {
-    IEnumerable<string> fragments;
+    Memory<string> fragments;
     string regex;
 
     /// <summary>

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+using static MudBlazor.Components.Highlighter.Splitter;
+
+namespace MudBlazor;
+
+public partial class MudHighlighter : MudComponentBase
+{
+    private Memory<string> _fragments;
+    private string _regex;
+
+    /// <summary>
+    /// The whole text in which a fragment will be highlighted
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public string Text { get; set; }
+
+    /// <summary>
+    /// The fragment of text to be highlighted
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public string HighlightedText { get; set; }
+
+    /// <summary>
+    /// The fragments of text to be highlighted
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public IEnumerable<string> HighlightedTexts { get; set; }
+
+    /// <summary>
+    /// Whether or not the highlighted text is case sensitive
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public bool CaseSensitive { get; set; }
+
+    /// <summary>
+    /// If true, highlights the text until the next regex boundary
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public bool UntilNextBoundary { get; set; }
+
+    //TODO
+    //Accept regex highlightings
+    // [Parameter] public bool IsRegex { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
+    }
+}

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace MudBlazor.Components.Highlighter
@@ -14,40 +15,84 @@ namespace MudBlazor.Components.Highlighter
         /// </summary>
         /// <param name="text">The whole text</param>
         /// <param name="highlightedText">The text to be highlighted</param>
+        /// <param name="highlightedTexts">The texts to be highlighted</param>
+        /// <param name="regex">Regex expression that was used to split fragments.</param>
         /// <param name="caseSensitive">Whether it's case sensitive or not</param>
         /// <param name="untilNextBoundary">If true, splits until the next regex boundary</param>
         /// <returns></returns>
         public static IEnumerable<string> GetFragments(string text,
                                                        string highlightedText,
+                                                       IEnumerable<string> highlightedTexts,
+                                                       out string regex,
                                                        bool caseSensitive = false,
                                                        bool untilNextBoundary = false)
         {
-            if (string.IsNullOrWhiteSpace(text))
+            if (string.IsNullOrEmpty(text))
             {
+                regex = "";
                 return new List<string>();
             }
 
-            if (string.IsNullOrWhiteSpace(highlightedText))
+            StringBuilder builder = new();
+            //the first brace in the pattern is to keep the patten when splitting,
+            //the `(?:` in the pattern is to accept multiple highlightedTexts but not capture them.
+            builder.Append("((?:");
+
+            //this becomes true if `AppendPattern` was called at least once.
+            bool hasAtLeastOnePattern = false;
+            if (!string.IsNullOrEmpty(highlightedText))
             {
-                return new List<string> { text };
+                AppendPattern(highlightedText);
+            }
+
+            if (highlightedTexts is not null)
+            {
+                foreach (var substring in highlightedTexts)
+                {
+                    if (string.IsNullOrEmpty(substring))
+                        continue;
+
+                    //split pattern if we already added an string to search.
+                    if (hasAtLeastOnePattern)
+                    {
+                        builder.Append(")|(?:");
+                    }
+
+                    AppendPattern(substring);
+                }
+            }
+
+            if (hasAtLeastOnePattern)
+            {
+                //close the last pattern group and the capture group.
+                builder.Append("))");
             }
             else
             {
-                //escapes the text for regex             
-                highlightedText = Regex.Escape(highlightedText);
+                //all patterns were empty or null.
+                regex = "";
+                return new List<string>() { text };
+            }
+
+            regex = builder.ToString();
+            return Regex
+                    .Split(text,
+                           regex,
+                           caseSensitive
+                             ? RegexOptions.None
+                             : RegexOptions.IgnoreCase)
+                    .Where(s => !string.IsNullOrEmpty(s));
+
+            void AppendPattern(string value)
+            {
+                hasAtLeastOnePattern = true;
+                //escapes the text for regex
+                value = Regex.Escape(value);
+                builder.Append(value);
                 if (untilNextBoundary)
                 {
-                    highlightedText += NextBoundary;
+                    builder.Append(NextBoundary);
                 }
-
-                //using braces in the pattern keeps the pattern when splitting
-                return Regex
-                     .Split(text,
-                            $"({highlightedText})",
-                            caseSensitive
-                              ? RegexOptions.None
-                              : RegexOptions.IgnoreCase)
-                     .Where(s => !string.IsNullOrEmpty(s));
             }
         }
     }


### PR DESCRIPTION
## Description

Resolves #4621 and resolves #3129.

Currently `MudHighlighter` can only highlight a single fragment of text.
This PR adds support to highlight multiple fragments by adding an enumerable property, which comes in handy when implementing multiple-word search features on pages.

Additionally, in the second commit (so in case you don't want it, you can exclude it easily from the PR) I avoided some simple allocations in the `MudHighlighter` type.

## How Has This Been Tested?
I implemented additional unit cases in `HighlighterTests.cs` file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

API change:

```diff
public partial class MudHighlighter
{
+    /// <summary>
+    /// The fragments of text to be highlighted
+    /// </summary>
+    [Parameter] 
+    [Category(CategoryTypes.Highlighter.Behavior)]
+    public IEnumerable<string> HighlightedTexts { get; set; }
}
```

Before:
![Before](https://user-images.githubusercontent.com/25068949/186685169-e25d3afb-2690-43e0-acd1-049f5569d0c8.gif)

After:
![After](https://user-images.githubusercontent.com/25068949/186685188-03db03b8-cfea-4c25-8112-49041fffd9e8.gif)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

About the second point (code style) I tried to follow what Visual Studio suggested (which uses the configuration of this project), I hope have done that right.
