### PR TITLE
DataGrid: Add Culture property to DataGrid Column

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -249,8 +249,9 @@
         <DocsPageSection>
             <SectionHeader Title="CultureInfo">
                 <Description>
-                    Each <CodeInline>&lt;Column></CodeInline> can define his own culture (CultureInfo),
-                    to allow specify its format individually, both when displaying the data and when editing/filtering.
+                    DataGrid <CodeInline>Culture</CodeInline> (CultureInfo) property is used to display and editing/filter columns data.
+                    Each <CodeInline>&lt;Column></CodeInline> can define his own culture,
+                    to allow specify its format individually.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="DataGridColumnCultureExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -246,5 +246,16 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="CultureInfo">
+                <Description>
+                    Each <CodeInline>&lt;Column></CodeInline> can define his own culture (CultureInfo),
+                    to allow specify its format individually, both when displaying the data and when editing/filtering.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="DataGridColumnCultureExample" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridColumnCultureExample />
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnCultureExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnCultureExample.razor
@@ -1,0 +1,29 @@
+@using System.Globalization
+@namespace MudBlazor.Docs.Examples
+
+<MudDataGrid Items="@_items" Filterable="true">
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+        <Column T="Model"
+            Field="@nameof(Model.Amount)"
+            Title="Amount (es-ES culture)"
+            Culture="@(new CultureInfo("es-ES"))" />
+        <Column T="Model"
+            Field="@nameof(Model.Total)"
+            Title="Total (invariant culture)"
+            Culture="@CultureInfo.InvariantCulture" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, 2.3, 3.2), 
+        new Model("Alicia", 54, 4.5, 4.9), 
+        new Model("Ira", 27, 2.1, 2.5),
+        new Model("John", 32, 5.9, 6.1)
+    };
+
+    public record Model(string Name, int? Age, double? Amount, double? Total);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureEditableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureEditableTest.razor
@@ -1,0 +1,29 @@
+@namespace MudBlazor.UnitTests.TestComponents
+@using System.Globalization
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items"
+    Filterable="true"
+    ReadOnly="@false"
+    EditMode="@DataGridEditMode.Cell"
+    EditTrigger=@DataGridEditTrigger.OnRowClick
+    FilterMode="@DataGridFilterMode.ColumnFilterRow">
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+        <Column T="Model" Field="@nameof(Model.Amount)" Culture="@CultureInfo.InvariantCulture" />
+        <Column T="Model" Field="@nameof(Model.Total)" Culture="@(new CultureInfo("es-ES"))"/>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, 3.5, 5.2), 
+        new Model("Alicia", 54, 3.6, 4.8), 
+        new Model("Ira", 27, 3.9, 6.2),
+        new Model("John", 32, 4.2, 3.2)
+    };
+
+    public record Model(string Name, int? Age, double? Amount, double? Total);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureSimpleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureSimpleTest.razor
@@ -1,0 +1,24 @@
+@namespace MudBlazor.UnitTests.TestComponents
+@using System.Globalization
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items" Filterable="true">
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+        <Column T="Model" Field="@nameof(Model.Amount)" Culture="@CultureInfo.InvariantCulture" />
+        <Column T="Model" Field="@nameof(Model.Total)" Culture="@(new CultureInfo("es-ES"))"/>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, 3.5, 5.2), 
+        new Model("Alicia", 54, 3.6, 4.8), 
+        new Model("Ira", 27, 3.9, 6.2),
+        new Model("John", 32, 4.2, 3.2)
+    };
+
+    public record Model(string Name, int? Age, double? Amount, double? Total);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCulturesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCulturesTest.razor
@@ -1,0 +1,38 @@
+@namespace MudBlazor.UnitTests.TestComponents
+@using System.Globalization
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items"
+    Filterable="true"
+    ReadOnly="@false"
+    EditMode="@DataGridEditMode.Cell"
+    EditTrigger=@DataGridEditTrigger.OnRowClick
+    FilterMode="@DataGridFilterMode.ColumnFilterRow">
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+        <Column T="Model" Field="@nameof(Model.Amount)" Culture="@CultureInfo.InvariantCulture" />
+        <Column T="Model" Field="@nameof(Model.Total)" Culture="@(new CultureInfo("es-ES"))"/>
+        <Column T="Model" Field="@nameof(Model.Distance)" Culture="@_customCulture" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private CultureInfo _customCulture = new CultureInfo("es")
+    {
+        NumberFormat = new NumberFormatInfo
+        {
+            NumberDecimalSeparator = "#",
+        }
+    };
+
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, 3.5, 5.2, 2.1), 
+        new Model("Alicia", 54, 3.6, 4.8, 2.2), 
+        new Model("Ira", 27, 3.9, 6.2, 2.3),
+        new Model("John", 32, 4.2, 3.2, 2.4)
+    };
+
+    public record Model(string Name, int? Age, double? Amount, double? Total, double? Distance);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3729,5 +3729,19 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
             dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(2.2);
         }
+
+        [Test]
+        public async Task DataGridCultureColumnOverridesTest()
+        {
+            var comp = Context.RenderComponent<DataGridCulturesTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCulturesTest.Model>>();
+
+            // amount with invariant culture (decimals separated by point)
+            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("3.5");
+            // total with 'es' culture (decimals separated by commas)
+            dataGrid.FindAll("td input")[3].GetAttribute("value").Trim().Should().Be("5,2");
+            // distance with custom culture (decimals separated by '#')
+            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("2#1");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Moq;
 using MudBlazor.UnitTests.TestComponents;
@@ -3643,6 +3644,90 @@ namespace MudBlazor.UnitTests.Components
             });
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()["Id"].Should().Be(Guid.Parse(comp.Instance.Guid2));
+        }
+
+        [Test]
+        public void DataGridCultureColumnSimpleTest()
+        {
+            var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
+
+            dataGrid.FindAll("td")[2].TextContent.Trim().Should().Be("3.5");
+            dataGrid.FindAll("td")[3].TextContent.Trim().Should().Be("5,2");
+        }
+
+        [Test]
+        public void DataGridCultureColumnEditableTest()
+        {
+            var comp = Context.RenderComponent<DataGridCultureEditableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
+
+            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("3.5");
+            dataGrid.FindAll("td input")[3].GetAttribute("value").Trim().Should().Be("5,2");
+        }
+
+        [Test]
+        public async Task DataGridCultureColumnFilterTest()
+        {
+            var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
+
+            // amount with invariant culture (decimals separated by point)
+            var amountHeader = dataGrid.FindAll("th .mud-menu button")[2];
+            amountHeader.Click();
+            var filterAmount = comp.FindAll(".mud-list-item-clickable")[1];
+            filterAmount.Click();
+
+            var filterField = comp.Find(".filters-panel .filter-field .mud-select-input");
+            filterField.TextContent.Trim().Should().Be("Amount");
+
+            var filterInput = comp.FindAll(".filters-panel input")[2];
+            filterInput.Input(new ChangeEventArgs() { Value = "2,2" });
+
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(22.0);
+
+            dataGrid.Instance.FilterDefinitions.Clear();
+            dataGrid.Render();
+
+            // total with es-ES culture (decimals separated by comma)
+            var totalHeader = dataGrid.FindAll("th .mud-menu button")[3];
+            totalHeader.Click();
+            var filterTotal = comp.FindAll(".mud-list-item-clickable")[1];
+            filterTotal.Click();
+
+            var filterTotalField = comp.Find(".filters-panel .filter-field .mud-select-input");
+            filterTotalField.TextContent.Trim().Should().Be("Total");
+
+            var filterTotalInput = comp.FindAll(".filters-panel input")[2];
+            filterTotalInput.Input(new ChangeEventArgs() { Value = "2,2" });
+
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(2.2);
+        }
+
+        [Test]
+        public async Task DataGridCultureColumnFilterHeaderTest()
+        {
+            var comp = Context.RenderComponent<DataGridCultureEditableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
+
+            // amount with invariant culture (decimals separated by point)
+            var filterAmount = dataGrid.FindAll("th.filter-header-cell input")[2];
+            filterAmount.Input(new ChangeEventArgs() { Value = "2,2" });
+
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(22.0);
+
+            dataGrid.Instance.FilterDefinitions.Clear();
+            dataGrid.Render();
+            
+            // total with es-ES culture (decimals separated by comma)
+            var filterTotal = dataGrid.FindAll("th.filter-header-cell input")[3];
+            filterTotal.Input(new ChangeEventArgs() { Value = "2,2" });
+
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(2.2);
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/Column.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.cs
@@ -113,12 +113,20 @@ namespace MudBlazor
 
         [Parameter] public RenderFragment<FilterContext<T>> FilterTemplate { get; set; }
 
+        private CultureInfo _culture;
         /// <summary>
         /// The culture used to represent this column and by the filtering input field.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Appearance)]
-        public CultureInfo Culture { get; set; }
+        public CultureInfo Culture
+        {
+            get => _culture ?? DataGrid?.Culture;
+            set
+            {
+                _culture = value;
+            }
+        }
         #endregion
 
         #region Cell Properties

--- a/src/MudBlazor/Components/DataGrid/Column.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.Json;
@@ -112,6 +113,12 @@ namespace MudBlazor
 
         [Parameter] public RenderFragment<FilterContext<T>> FilterTemplate { get; set; }
 
+        /// <summary>
+        /// The culture used to represent this column and by the filtering input field.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Appearance)]
+        public CultureInfo Culture { get; set; }
         #endregion
 
         #region Cell Properties

--- a/src/MudBlazor/Components/DataGrid/Filter.razor
+++ b/src/MudBlazor/Components/DataGrid/Filter.razor
@@ -32,7 +32,7 @@
         }
         else if (isNumber && !(_operator ?? "").EndsWith("empty"))
         {
-            <MudNumericField T="double?" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense" 
+            <MudNumericField T="double?" Culture="@FilterColumn?.Culture" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense" 
             Immediate="true" Class="filter-input" />
         }
         else if (isEnum)
@@ -92,7 +92,7 @@ else
         }
         else if (isNumber && !(_operator ?? "").EndsWith("empty"))
         {
-            <MudNumericField T="double?" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense" 
+            <MudNumericField T="double?" Culture="@FilterColumn?.Culture" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense" 
             Immediate="true" Class="filter-input" />
         }
         else if (isEnum)

--- a/src/MudBlazor/Components/DataGrid/Filter.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.razor.cs
@@ -87,6 +87,10 @@ namespace MudBlazor
             }
         }
 
+        private Column<T> FilterColumn =>
+            Column != null
+                ? Column
+                : DataGrid?.RenderedColumns?.FirstOrDefault(c => c.Field == Field);
         #endregion
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -18,7 +18,7 @@
                 }
                 else if (isNumber && !(_operator ?? "").EndsWith("empty"))
                 {
-                    <MudNumericField T="double?" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense" Immediate="true"></MudNumericField>
+                    <MudNumericField T="double?" Culture="@Column.Culture" Value="@_valueNumber" ValueChanged="@NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense" Immediate="true"></MudNumericField>
                 }
                 else if (isEnum)
                 {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -333,7 +333,7 @@
                     else if (column.isNumber)
                     {
                         <MudNumericField T="double?" Value="@cell.valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense" Style="margin-top:0"
-                            Required="true" Variant="@Variant.Text" />
+                            Required="true" Variant="@Variant.Text" Culture="@column.Culture" />
                     }
                 }
             }
@@ -342,6 +342,10 @@
                 if (column.CellTemplate != null)
                 {
                     @column.CellTemplate(cell.cellContext)
+                }
+                else if (column.Culture != null && column.isNumber)
+                {
+                    @cell.valueNumber?.ToString(column.Culture)
                 }
                 else
                 {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -395,6 +396,13 @@ namespace MudBlazor
         /// The Columns that make up the data grid. Add Column components to this RenderFragment.
         /// </summary>
         [Parameter] public RenderFragment Columns { get; set; }
+
+        /// <summary>
+        /// The culture used to represent numeric columns and his filtering input fields.
+        /// Each column can override this DataGrid Culture.
+        /// </summary>
+        [Parameter]
+        public CultureInfo Culture { get; set; }
 
         /// <summary>
         /// Row Child content of the component.


### PR DESCRIPTION
## Description
resolves #5138.

Adds a culture property to DataGrid.Column,
to allow specific formatting settings by each column.
This property is used for displaying/editing numbers in the datagrid body
and in the filtering inputs.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
