### PR TITLE
MudTable: Preserve checked state when virtualized and MultiSelection="true"

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionVirtualizedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionVirtualizedTest.razor
@@ -1,0 +1,50 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable MultiSelection="true"
+          Items="Items" Height="350px"
+          Breakpoint="Breakpoint.Sm"
+          Virtualize>
+    <HeaderContent>
+        <MudTh>Column1</MudTh>
+        <MudTh>Column2</MudTh>
+        <MudTh>Column3</MudTh>
+        <MudTh>Column4</MudTh>
+        <MudTh>Column5</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Column1">@context.Column1</MudTd>
+        <MudTd DataLabel="Column2">@context.Column2</MudTd>
+        <MudTd DataLabel="Column3">@context.Column3</MudTd>
+        <MudTd DataLabel="Column4">@context.Column4</MudTd>
+        <MudTd DataLabel="Column5">@context.Column5</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public class TestItem
+    {
+        public string Column1 { get; set; }
+        public string Column2 { get; set; }
+        public string Column3 { get; set; }
+        public string Column4 { get; set; }
+        public string Column5 { get; set; }
+    }
+
+    public List<TestItem> Items;
+
+    protected override void OnInitialized()
+    {
+        Items = new List<TestItem>();
+        for (int i = 0; i < 2000; i++)
+        {
+            Items.Add(new TestItem
+            {
+                Column1 = $"Value_{i}",
+                Column2 = $"Value_{i}",
+                Column3 = $"Value_{i}",
+                Column4 = $"Value_{i}",
+                Column5 = $"Value_{i}",
+            });
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1687,5 +1687,36 @@ namespace MudBlazor.UnitTests.Components
             context.Selection.Comparer.Should().Be(comp.Instance.Comparer); //check comparer is set in HashSet and Dictionary
             context.Rows.Comparer.Should().Be(comp.Instance.Comparer);
         }
+
+        /// <summary>
+        /// Using a virtualized table with multiselection must preserve checked items
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TestVirtualizedTableWithMultiSelection()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionVirtualizedTest>();
+            var table = comp.FindComponent<MudTable<TableMultiSelectionVirtualizedTest.TestItem>>();
+            var virtualized = comp.FindComponent<Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TableMultiSelectionVirtualizedTest.TestItem>>();
+            // find first checkbox item and check it
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(false);
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell")[1].TextContent.Should().Be("Value_0");
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].Change(true);
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(true);
+
+            // scroll down
+            virtualized.SetParam(
+                v => v.Items,
+                table.Instance.Items.ToList().GetRange(1000, 100));
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell")[1].TextContent.Should().Be("Value_1000");
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(false);
+
+            // scroll up
+            virtualized.SetParam(
+                v => v.Items,
+                table.Instance.Items.ToList().GetRange(0, 100));
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell")[1].TextContent.Should().Be("Value_0");
+            comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(true);
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -84,7 +84,8 @@
                             <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
-                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" 
+                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable"
+                                      IsChecked="@(Context.Selection.Contains(item))"
                                       IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                                    @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #5190
Really simple fix that makes MudTr preserve checked state when virtualized.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
