### PR TITLE
Snackbar: Allow messages to be defined as RenderFragment

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -30,6 +31,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task SimpleTestWithRenderFragment()
+        {
+            var comp = Context.RenderComponent<MudSnackbarProvider>();
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
+            service.Should().NotBe(null);
+
+            var testText = "Boom, big reveal. Im a pickle!";
+            var renderFragment = new RenderFragment(builder =>
+            {
+                builder.AddContent(1, testText);
+            });
+
+            // shoot out a snackbar
+            await comp.InvokeAsync(() => service?.Add(renderFragment));
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            comp.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be(testText);
+            // close by click on the snackbar
+            comp.Find("button").Click();
+            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+        }
+
+        [Test]
         public async Task HtmlInMessages()
         {
             var comp = Context.RenderComponent<MudSnackbarProvider>();
@@ -41,6 +65,32 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => service?.Add("Hello <span>World</span>"));
             comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             comp.Find("div.mud-snackbar-content-message>span").Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task TestWithHierarchicalRenderFragment()
+        {
+            var comp = Context.RenderComponent<MudSnackbarProvider>();
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
+            service.Should().NotBe(null);
+
+            var testText = "Boom, big reveal. Im a pickle!";
+            var renderFragment = new RenderFragment(builder =>
+            {
+                builder.OpenElement(0, "ul");
+                builder.OpenElement(1, "li");
+                builder.AddContent(2, testText);
+                builder.CloseElement();
+                builder.CloseElement();
+            });
+            // shoot out a snackbar
+            await comp.InvokeAsync(() => service?.Add(renderFragment));
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            comp.Find("div.mud-snackbar-content-message").InnerHtml.Should().Be($"<ul><li>{testText}</li></ul>");
+            // close by click on the snackbar
+            comp.Find("button").Click();
+            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
             var testText = "Boom, big reveal. Im a pickle!";
             var renderFragment = new RenderFragment(builder =>
             {
-                builder.AddContent(1, testText);
+                builder.AddContent(0, testText);
             });
 
             // shoot out a snackbar

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -16,7 +16,14 @@
     }
 
     <div class="mud-snackbar-content-message">
-        @((MarkupString)Message)
+        @if (Message?.MarkupString != null)
+        {
+            @((MarkupString)Message.MarkupString)
+        }
+        else if (Message?.RenderFragment != null)
+        {
+            @Message.RenderFragment
+        }
     </div>
 
     @if (ShowCloseIcon || ShowActionButton)

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -16,11 +16,7 @@
     }
 
     <div class="mud-snackbar-content-message">
-        @if (Message?.MarkupString != null)
-        {
-            @((MarkupString)Message.MarkupString)
-        }
-        else if (Message?.RenderFragment != null)
+        @if (Message?.RenderFragment != null)
         {
             @Message.RenderFragment
         }

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Components.Snackbar;
 using static System.String;
 
 namespace MudBlazor
@@ -23,7 +24,7 @@ namespace MudBlazor
         protected string AnimationStyle => Snackbar?.State.AnimationStyle + Style;
         protected string SnackbarClass => Snackbar?.State.SnackbarClass;
 
-        protected string Message => Snackbar?.Message;
+        protected SnackbarMessage Message => Snackbar?.Message;
 
         protected string Action => Snackbar?.State.Options.Action;
         protected Color ActionColor => Snackbar?.State.Options.ActionColor ?? Color.Default;

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using MudBlazor.Components.Snackbar;
 
 namespace MudBlazor
 {
@@ -10,12 +11,12 @@ namespace MudBlazor
     {
         private Timer Timer { get; set; }
         internal SnackBarMessageState State { get; }
-        public string Message { get; }
+        public SnackbarMessage Message { get; }
         public event Action<Snackbar> OnClose;
         public event Action OnUpdate;
         public Severity Severity => State.Options.Severity;
 
-        internal Snackbar(string message, SnackbarOptions options)
+        internal Snackbar(SnackbarMessage message, SnackbarOptions options)
         {
             Message = message;
             State = new SnackBarMessageState(options);

--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -10,13 +10,7 @@ namespace MudBlazor.Components.Snackbar
     public class SnackbarMessage
     {
         internal Guid SnackbarMessageId { get; private set; } = Guid.NewGuid();
-        public string MarkupString { get; }
         public RenderFragment RenderFragment { get; }
-
-        internal SnackbarMessage(string markupString)
-        {
-            MarkupString = markupString;
-        }
 
         internal SnackbarMessage(RenderFragment renderFragment)
         {

--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.Components.Snackbar
+{
+    public class SnackbarMessage
+    {
+        internal Guid SnackbarMessageId { get; private set; } = Guid.NewGuid();
+        public string MarkupString { get; }
+        public RenderFragment RenderFragment { get; }
+
+        internal SnackbarMessage(string markupString)
+        {
+            MarkupString = markupString;
+        }
+
+        internal SnackbarMessage(RenderFragment renderFragment)
+        {
+            RenderFragment = renderFragment;
+        }
+    }
+}

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -134,9 +134,6 @@ namespace MudBlazor
         private bool SnackbarAlreadyPresent(Snackbar newSnackbar)
         {
             return SnackBarList.Any(snackbar => newSnackbar.Message.SnackbarMessageId == snackbar.Message.SnackbarMessageId);
-            //    newSnackbar.Message.Equals(snackbar.Message) &&
-            //    newSnackbar.Severity.Equals(snackbar.Severity)
-            //);
         }
 
         private void ConfigurationUpdated()

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using MudBlazor.Components.Snackbar;
 
 namespace MudBlazor
 {
@@ -55,12 +56,8 @@ namespace MudBlazor
             return Add(message, severity, configure);
         }
 
-        public Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
+        private Snackbar Add(SnackbarMessage message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
         {
-            if (message.IsEmpty()) return null;
-
-            message = message.Trimmed();
-
             var options = new SnackbarOptions(severity, Configuration);
             configure?.Invoke(options);
 
@@ -81,6 +78,22 @@ namespace MudBlazor
             OnSnackbarsUpdated?.Invoke();
 
             return snackbar;
+        }
+
+        public Snackbar Add(RenderFragment message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
+        {
+            if (message == null) return null;
+
+            return Add(new SnackbarMessage(message), severity, configure);
+        }
+
+        public Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
+        {
+            if (message.IsEmpty()) return null;
+
+            message = message.Trimmed();
+
+            return Add(new SnackbarMessage(message), severity, configure);
         }
 
         public void Clear()
@@ -120,10 +133,10 @@ namespace MudBlazor
 
         private bool SnackbarAlreadyPresent(Snackbar newSnackbar)
         {
-            return SnackBarList.Any(snackbar =>
-                newSnackbar.Message.Equals(snackbar.Message) &&
-                newSnackbar.Severity.Equals(snackbar.Severity)
-            );
+            return SnackBarList.Any(snackbar => newSnackbar.Message.SnackbarMessageId == snackbar.Message.SnackbarMessageId);
+            //    newSnackbar.Message.Equals(snackbar.Message) &&
+            //    newSnackbar.Severity.Equals(snackbar.Severity)
+            //);
         }
 
         private void ConfigurationUpdated()

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Routing;
 using MudBlazor.Components.Snackbar;
 
@@ -92,8 +93,13 @@ namespace MudBlazor
             if (message.IsEmpty()) return null;
 
             message = message.Trimmed();
+            RenderFragment renderFragmentMessage = (RenderTreeBuilder builder) =>
+            {
+                builder.AddMarkupContent(0, message);
+            };
 
-            return Add(new SnackbarMessage(message), severity, configure);
+
+            return Add(renderFragmentMessage, severity, configure);
         }
 
         public void Clear()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Partially addresses #974.

This PR allows end devs to specify the content of a Snackbar message as a `RenderFragment` (in addition to the existing functionality which lets them specify the content as `string` which may contain HTML). 

**NOTE:** Does not completely resolve the request, as the request asks us to allow the complete specification of the Snackbar in Razor. This seems like a bigger change, and I'm still getting my head around MudBlazor's internals. However, hopefully this PR will support a future one which completely fulfills that need, and in the meantime, I think it'd allow devs to specify a RenderFragment in Razor (like [this](https://www.syncfusion.com/faq/blazor/templated-components/how-do-you-define-a-render-fragment-using-a-razor-template-in-blazor)) and then pass them to `Snackbar.Add`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Unit tests added to `MudBlazor.UnitTests/Components/SnackbarTests.cs`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
