### PR TITLE
Snackbar: Enable RenderFragment in addition to string message

### DIFF
--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -1,11 +1,11 @@
-﻿using Blazored.LocalStorage;
-using Blazor.Analytics;
+﻿using Blazor.Analytics;
+using Blazored.LocalStorage;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Docs.Services;
 using MudBlazor.Docs.Services.Notifications;
 using MudBlazor.Docs.Services.UserPreferences;
-using MudBlazor.Services;
 using MudBlazor.Examples.Data;
+using MudBlazor.Services;
 
 namespace MudBlazor.Docs.Extensions
 {
@@ -16,13 +16,20 @@ namespace MudBlazor.Docs.Extensions
             services.AddMudServices(config =>
             {
                 config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomLeft;
-                config.SnackbarConfiguration.PreventDuplicates = false;
                 config.SnackbarConfiguration.NewestOnTop = false;
                 config.SnackbarConfiguration.ShowCloseIcon = true;
                 config.SnackbarConfiguration.VisibleStateDuration = 10000;
                 config.SnackbarConfiguration.HideTransitionDuration = 500;
                 config.SnackbarConfiguration.ShowTransitionDuration = 500;
                 config.SnackbarConfiguration.SnackbarVariant = Variant.Filled;
+
+                // we're currently planning on deprecating `PreventDuplicates`, at least to the end dev. however,
+                // we may end up wanting to instead set it as internal because the docs project relies on it
+                // to ensure that the Snackbar always allows duplicates. disabling the warning for now because
+                // the project is set to treat warnings as errors.
+#pragma warning disable 0618
+                config.SnackbarConfiguration.PreventDuplicates = false;
+#pragma warning restore 0618
             });
 
             services.AddScoped<GitHubApiClient>();

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarFromCustomComponentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarFromCustomComponentExample.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@inject ISnackbar SnackbarService
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnClick">Show a snackbar with a custom component</MudButton>
+
+@code {
+    private void OnClick()
+    {
+        SnackbarService.Add<MudChip>(new Dictionary<string, object>() {
+            { "Text", "This is a snackbar with a chip!" },
+            { "Color", Color.Primary }
+        });
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarFromRenderFragmentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarFromRenderFragmentExample.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@inject ISnackbar SnackbarService
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnClick">Show a RenderFragment snackbar</MudButton>
+
+@code {
+    private void OnClick()
+    {
+        SnackbarService.Add
+        (
+            @<div>
+                <h3>Hi from a RenderFragment</h3>
+                <ul>
+                    <li>Here's a regular item</li>
+                    <li>Here's a <strong>bold item</strong></li>
+                    <li>Here's an <em>italicized item</em></li>
+                </ul>
+            </div>
+        );
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarPreventDuplicatesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarPreventDuplicatesExample.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.Docs.Examples
+@inject ISnackbar SnackbarService
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnClick">Prevent duplicate Snackbars</MudButton>
+
+@code {
+    private void OnClick()
+    {
+        // We'll set all three of these snackbars to prevent duplicates and give them
+        // all the same key ("mudblazor")
+        var config = (SnackbarOptions options) =>
+        {
+            options.DuplicatesBehavior = SnackbarDuplicatesBehavior.Prevent;
+        };
+
+        // Then we try to show all three in quick succession, but only the first pops!
+        SnackbarService.Add("This is the only snackbar that will be shown", configure: config, key: "mudblazor");
+        SnackbarService.Add(@<span>This one has the same key</span>, configure: config, key: "mudblazor");
+        SnackbarService.Add<MudChip>(new Dictionary<string, object>() {
+            { "Text", "This one also has the same key" }
+        }, configure: config, key: "mudblazor");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
@@ -1,6 +1,5 @@
 ﻿@page "/components/snackbar"
 
-
 @inject MudBlazor.ISnackbar Snackbar
 
 <DocsPage>
@@ -31,6 +30,31 @@
             </SectionHeader>
             <SectionContent Code="SnackbarHtmlInMessageExample" ShowCode="false">
                 <SnackbarHtmlInMessageExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="RenderFragment messages">
+                <Description>
+                    In addition to setting the Snackbar message with a string, you can also use <CodeInline>RenderFragment</CodeInline>s to 
+                    create Snackbars with more complex content.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="SnackbarFromRenderFragmentExample" ShowCode="false">
+                <SnackbarFromRenderFragmentExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Custom component messages">
+                <Description>
+                    You can also create messages containing a custom component. This example renders a message based on MudBlazor's
+                    <CodeInline>MudChip</CodeInline>, but you can use any component to define the content. Pass parameters to the component 
+                    using the <CodeInline>componentParameters</CodeInline> argument.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="SnackbarFromCustomComponentExample" ShowCode="false">
+                <SnackbarFromCustomComponentExample />
             </SectionContent>
         </DocsPageSection>
 
@@ -155,5 +179,17 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Preventing duplication">
+                <Description>
+                    <CodeInline>SnackbarService</CodeInline> can prevent more than one snackbar with identical message content from appearing. It does
+                    this by default when you call <CodeInline>.Add</CodeInline> with a <CodeInline>string</CodeInline>. If you want to prevent duplication of
+                    a Snackbar created with a <CodeInline>RenderFragment</CodeInline> or a custom component, pass a key to <CodeInline>.Add</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="SnackbarPreventDuplicatesExample" ShowCode="false">
+                <SnackbarPreventDuplicatesExample />
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomComponent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomComponent.razor
@@ -1,0 +1,4 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<h3>Hello, Snackbar!</h3>
+<MudChip Color="Color.Primary">This is a message with a chip!</MudChip>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomComponentMessageTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomComponentMessageTest.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@inject ISnackbar SnackbarService
+
+<MudButton OnClick="@OnClick">Show the snackbar!</MudButton>
+
+@code {
+    public static string __description__ = "Click the button to fire a Snackbar built with a custom component.";
+
+    private void OnClick()
+    {
+        SnackbarService.Add<SnackbarCustomComponent>();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarRenderFragmentMessageTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarRenderFragmentMessageTest.razor
@@ -1,0 +1,22 @@
+﻿@using Microsoft.AspNetCore.Components.Rendering
+
+@namespace MudBlazor.UnitTests.TestComponents
+@inject ISnackbar SnackbarService
+
+<MudButton OnClick="@OnClick">Show the snackbar!</MudButton>
+
+@code {
+    public static string __description__ = "Click the button to fire a Snackbar built with a RenderFragment.";
+
+    private void OnClick()
+    {
+        SnackbarService.Add
+        (
+            @<ul>
+                <li>Here's a regular item</li>
+                <li>Here's a <strong>bold item</strong></li>
+                <li>Here's an <em>italicized item</em></li>
+            </ul>    
+        );
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -1,9 +1,13 @@
 ﻿
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -11,135 +15,240 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class SnackbarTests : BunitTest
     {
+        private IRenderedComponent<MudSnackbarProvider> _provider;
+        private ISnackbar _service;
+
+        [SetUp]
+        public void SnackbarSetUp()
+        {
+            _service = Context.Services.GetService<ISnackbar>();
+            _provider = Context.RenderComponent<MudSnackbarProvider>();
+            _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
+        }
+
+        [TearDown]
+        public void SnackbarTearDown()
+        {
+            foreach (var closeButton in _provider.FindAll("button"))
+            {
+                closeButton?.Click();
+            }
+
+            _provider.WaitForAssertion(() => _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+        }
+
+
         [Test]
         public async Task SimpleTest()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            service.Should().NotBe(null);
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Boom, big reveal. Im a pickle!"));
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
-            comp.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
+            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
         }
 
         [Test]
-        public async Task HtmlInMessages()
+        public async Task SimpleTestWithRenderFragment()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            service.Should().NotBe(null);
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Hello <span>World</span>"));
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
-            comp.Find("div.mud-snackbar-content-message>span").Should().NotBeNull();
+            var testText = "Boom, big reveal. Im a pickle!";
+            var renderFragment = new RenderFragment(builder =>
+            {
+                builder.AddContent(0, testText);
+            });
+
+            await _provider.InvokeAsync(() => _service.Add(renderFragment));
+            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be(testText);
         }
 
         [Test]
-        public async Task DisposeTest()
+        public async Task SimpleTestWithHtmlInMessageString()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            service.Should().NotBe(null);
+            await _provider.InvokeAsync(() => _service.Add("Hello <span>World</span>"));
+            var messageText = HttpUtility.HtmlDecode(_provider.Find("div.mud-snackbar-content-message").InnerHtml.Trim());
+            messageText.Should().Be("Hello <span>World</span>");
+        }
 
+        [Test]
+        public async Task TestWithHierarchicalRenderFragment()
+        {
+            var testText = "Boom, big reveal. Im a pickle!";
+            var renderFragment = new RenderFragment(builder =>
+            {
+                builder.OpenElement(0, "ul");
+                builder.OpenElement(1, "li");
+                builder.AddContent(2, testText);
+                builder.CloseElement();
+                builder.CloseElement();
+            });
             // shoot out a snackbar
-            Snackbar snackbar = null;
-            await comp.InvokeAsync(() => snackbar = service?.Add("Boom, big reveal. Im a pickle!"));
-            //Console.WriteLine(comp.Markup);
+            await _provider.InvokeAsync(() => _service.Add(renderFragment));
+            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find("div.mud-snackbar-content-message").InnerHtml.Should().Be($"<ul><li>{testText}</li></ul>");
+        }
 
-            snackbar?.Dispose();
+        [Test]
+        public void TestWithRenderFragmentLiteral()
+        {
+            var testComponent = Context.RenderComponent<SnackbarRenderFragmentMessageTest>();
 
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
-            comp.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+            testComponent.Find("button").Click();
+            _provider.WaitForAssertion(() =>
+                _provider.Find("div.mud-snackbar-content-message").Should().NotBe(null)
+            );
+            _provider.Find("div.mud-snackbar-content-message").TrimmedText().Replace(" ", "").Should().Be("Here'saregularitem\nHere'sabolditem\nHere'sanitalicizeditem");
+        }
+
+        [Test]
+        public void TestWithCustomComponent()
+        {
+            var testComponent = Context.RenderComponent<SnackbarCustomComponentMessageTest>();
+
+            testComponent.Find("button").Click();
+            _provider.WaitForAssertion(() =>
+                _provider.Find("div.mud-snackbar-content-message").Should().NotBe(null)
+            );
+            _provider.Find("div.mud-snackbar-content-message .mud-chip").Should().NotBe(null);
+        }
+
+        [Test]
+        public void TestStringMessageShouldAutofillKey()
+        {
+            var bar = _service.Add("Oh no!");
+            Assert.AreEqual("Oh no!", bar.Message.Key);
+        }
+
+        [Test]
+        public void TestKeyPreventsDuplication()
+        {
+            var key = "This is the key";
+
+            _service.Add("A string message", key: key);
+            _service.Add(new RenderFragment(builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "A renderfragment message");
+                builder.CloseElement();
+
+            }), Severity.Normal, key: key);
+            _service.Add<SnackbarCustomComponent>(null, key: key);
+
+            Assert.AreEqual(1, _service.ShownSnackbars.Count());
+        }
+
+        [Test]
+        public void TestPerBarPreventDuplicatesWorks()
+        {
+            var key = "This is the key";
+            var config = (SnackbarOptions opts) =>
+            {
+                opts.DuplicatesBehavior = SnackbarDuplicatesBehavior.Prevent;
+            };
+            _service.Configuration.PreventDuplicates = false;
+
+            _service.Add("Message 1", configure: config, key: key);
+            _service.Add("Message 2", configure: config, key: key);
+
+            Assert.AreEqual(1, _service.ShownSnackbars.Count());
+        }
+
+        [Test]
+        public void TestPerBarAllowDuplicatesWorks()
+        {
+            var key = "This is the key";
+            var config = (SnackbarOptions opts) =>
+            {
+                opts.DuplicatesBehavior = SnackbarDuplicatesBehavior.Allow;
+            };
+            _service.Configuration.PreventDuplicates = true;
+
+            _service.Add("Message 1", configure: config, key: key);
+            _service.Add("Message 2", configure: config, key: key);
+
+            Assert.AreEqual(2, _service.ShownSnackbars.Count());
+        }
+
+        [Test]
+        public void PerBarGlobalDefaultFallsThroughToGlobalTrue()
+        {
+            var key = "This is the key";
+            var config = (SnackbarOptions opts) =>
+            {
+                opts.DuplicatesBehavior = SnackbarDuplicatesBehavior.GlobalDefault;
+            };
+            _service.Configuration.PreventDuplicates = true;
+
+            _service.Add("Message 1", configure: config, key: key);
+            _service.Add("Message 2", configure: config, key: key);
+
+            Assert.AreEqual(1, _service.ShownSnackbars.Count());
+        }
+
+        [Test]
+        public void PerBarGlobalDefaultFallsThroughToGlobalFalse()
+        {
+            var key = "This is the key";
+            var config = (SnackbarOptions opts) =>
+            {
+                opts.DuplicatesBehavior = SnackbarDuplicatesBehavior.GlobalDefault;
+            };
+            _service.Configuration.PreventDuplicates = false;
+
+            _service.Add("Message 1", configure: config, key: key);
+            _service.Add("Message 2", configure: config, key: key);
+
+            Assert.AreEqual(2, _service.ShownSnackbars.Count());
         }
 
         [Test]
         public async Task IconTest()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Boom, big reveal. Im a pickle!"));
-            //Console.WriteLine(comp.Markup);
-            // Test that the snackbar has an icon.
-            comp.Find("#mud-snackbar-container .mud-snackbar .mud-snackbar-icon").InnerHtml.Trim().Should().NotBeEmpty();
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
+            _provider.Find("#mud-snackbar-container .mud-snackbar .mud-snackbar-icon").InnerHtml.Trim().Should().NotBeEmpty();
         }
 
         [Test]
         public async Task HideIconTest()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.HideIcon = true; }));
-            //Console.WriteLine(comp.Markup);
-            // Test that the snackbar does NOT have an icon.
-            var hasIcon = comp.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.ClassName.Contains("mud-snackbar-icon");
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.HideIcon = true; }));
+            var hasIcon = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.ClassName.Contains("mud-snackbar-icon");
             Assert.IsFalse(hasIcon);
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
         }
 
         [Test]
         public async Task CustomIconTest()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.IconColor = Color.Tertiary; config.IconSize = Size.Large; }));
-            //Console.WriteLine(comp.Markup);
-            var svgClassNames = comp.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.IconColor = Color.Tertiary; config.IconSize = Size.Large; }));
+
+            var svgClassNames = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
             svgClassNames.Should().Contain("mud-icon-size-large");
             svgClassNames.Should().Contain("mud-tertiary-text");
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
         }
 
         [Test]
         public async Task CustomIconDefaultValuesTest()
         {
-            var comp = Context.RenderComponent<MudSnackbarProvider>();
-            //Console.WriteLine(comp.Markup);
-            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
-            var service = Context.Services.GetService<ISnackbar>() as SnackbarService;
-            // shoot out a snackbar
-            await comp.InvokeAsync(() => service?.Add("Boom, big reveal. Im a pickle!", Severity.Success));
-            //Console.WriteLine(comp.Markup);
-            var svgClassNames = comp.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success));
+
+            var svgClassNames = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
             svgClassNames.Should().Contain("mud-icon-size-medium");
 
             // Ensure no color classes are present, like "mud-primary-text", "mud-error-text", etc.
             var classNames = svgClassNames.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             foreach (var className in classNames)
                 Regex.IsMatch(className, "^mud-[a-z]+-text$", RegexOptions.IgnoreCase).Should().BeFalse();
+        }
 
-            // close by click on the snackbar
-            comp.Find("button").Click();
-            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+        [Test]
+        public async Task DisposeTest()
+        {
+            // shoot out a snackbar
+            Snackbar snackbar = null;
+            await _provider.InvokeAsync(() => snackbar = _service.Add("Boom, big reveal. Im a pickle!"));
+
+            snackbar?.Dispose();
+
+            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
         }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/InternalComponents/SnackbarMessageRenderFragment.razor
+++ b/src/MudBlazor/Components/Snackbar/InternalComponents/SnackbarMessageRenderFragment.razor
@@ -1,0 +1,9 @@
+﻿@namespace MudBlazor.Components.Snackbar.InternalComponents
+
+@Message
+
+@code {
+
+    [Parameter]
+    public RenderFragment Message { get; set; }
+}

--- a/src/MudBlazor/Components/Snackbar/InternalComponents/SnackbarMessageText.razor
+++ b/src/MudBlazor/Components/Snackbar/InternalComponents/SnackbarMessageText.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.Components.Snackbar.InternalComponents
+
+@Message
+
+@code {
+    [Parameter]
+    public MarkupString Message { get; set; }
+}

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -16,7 +16,10 @@
     }
 
     <div class="mud-snackbar-content-message">
-        @((MarkupString)Message)
+        @if (Message?.ComponentType != null)
+        {
+            <DynamicComponent Type="Message.ComponentType" Parameters="Message.ComponentParameters" />
+        }
     </div>
 
     @if (ShowCloseIcon || ShowActionButton)
@@ -32,8 +35,6 @@
             {
                 <MudIconButton Icon="@CloseIcon" Size="Size.Small" Class="ms-2" OnClick="CloseIconClicked" />
             }
-
         </div>
     }
-
 </div>

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Components.Snackbar;
 using static System.String;
 
 namespace MudBlazor
@@ -18,32 +19,36 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
 
-        protected RenderFragment Css;
+        // appearance
+        private string Action => Snackbar?.State.Options.Action;
+        private Color ActionColor => Snackbar?.State.Options.ActionColor ?? Color.Default;
+        private Variant ActionVariant => Snackbar?.State.Options.ActionVariant ?? Snackbar?.State.Options.SnackbarVariant ?? Variant.Text;
+        private string AnimationStyle => Snackbar?.State.AnimationStyle + Style;
+        private string SnackbarClass => Snackbar?.State.SnackbarClass;
+        private RenderFragment Css;
+        private bool ShowActionButton => Snackbar?.State.ShowActionButton == true;
+        private bool ShowCloseIcon => Snackbar?.State.ShowCloseIcon == true;
 
-        protected string AnimationStyle => Snackbar?.State.AnimationStyle + Style;
-        protected string SnackbarClass => Snackbar?.State.SnackbarClass;
+        // icon
+        private bool HideIcon => Snackbar?.State.HideIcon == true;
+        private string Icon => Snackbar?.State.Icon;
+        private Color IconColor => Snackbar?.State.Options.IconColor ?? Color.Inherit;
+        private Size IconSize => Snackbar?.State.Options.IconSize ?? Size.Medium;
 
-        protected string Message => Snackbar?.Message;
+        // behavior
+        private void ActionClicked() => Snackbar?.Clicked(false);
+        private void CloseIconClicked() => Snackbar?.Clicked(true);
+        private SnackbarMessage Message => Snackbar?.Message;
 
-        protected string Action => Snackbar?.State.Options.Action;
-        protected Color ActionColor => Snackbar?.State.Options.ActionColor ?? Color.Default;
-        protected Variant ActionVariant => Snackbar?.State.Options.ActionVariant ?? Snackbar?.State.Options.SnackbarVariant ?? Variant.Text;
-
-        protected bool ShowActionButton => Snackbar?.State.ShowActionButton == true;
-        protected bool ShowCloseIcon => Snackbar?.State.ShowCloseIcon == true;
-
-        protected bool HideIcon => Snackbar?.State.HideIcon == true;
-        protected string Icon => Snackbar?.State.Icon;
-        protected Color IconColor => Snackbar?.State.Options.IconColor ?? Color.Inherit;
-        protected Size IconSize => Snackbar?.State.Options.IconSize ?? Size.Medium;
-
-        protected void ActionClicked() => Snackbar?.Clicked(false);
-        protected void CloseIconClicked() => Snackbar?.Clicked(true);
-
-        protected void SnackbarClicked()
+        private void SnackbarClicked()
         {
             if (!ShowActionButton)
                 Snackbar?.Clicked(false);
+        }
+
+        private void SnackbarUpdated()
+        {
+            InvokeAsync(StateHasChanged);
         }
 
         protected override void OnInitialized()
@@ -65,11 +70,6 @@ namespace MudBlazor
                     }
                 };
             }
-        }
-
-        private void SnackbarUpdated()
-        {
-            InvokeAsync(StateHasChanged);
         }
 
         public void Dispose()

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using MudBlazor.Components.Snackbar;
 
 namespace MudBlazor
 {
@@ -10,12 +11,12 @@ namespace MudBlazor
     {
         private Timer Timer { get; set; }
         internal SnackBarMessageState State { get; }
-        public string Message { get; }
+        internal SnackbarMessage Message { get; }
         public event Action<Snackbar> OnClose;
         public event Action OnUpdate;
         public Severity Severity => State.Options.Severity;
 
-        internal Snackbar(string message, SnackbarOptions options)
+        internal Snackbar(SnackbarMessage message, SnackbarOptions options)
         {
             Message = message;
             State = new SnackBarMessageState(options);

--- a/src/MudBlazor/Components/Snackbar/SnackbarDuplicatesBehavior.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarDuplicatesBehavior.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor
+{
+    public enum SnackbarDuplicatesBehavior
+    {
+        Allow,
+        Prevent,
+        GlobalDefault,
+    }
+}

--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace MudBlazor.Components.Snackbar
+{
+    internal class SnackbarMessage
+    {
+        internal Type ComponentType { get; }
+        internal Dictionary<string, object> ComponentParameters { get; }
+        internal string Key { get; }
+
+        internal SnackbarMessage(Type componentType, Dictionary<string, object> componentParameters = null, string key = "")
+        {
+            ComponentType = componentType;
+            ComponentParameters = componentParameters;
+            Key = key;
+        }
+    }
+}

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Components.Snackbar;
 using MudBlazor.Extensions;
 
 namespace MudBlazor
@@ -29,6 +30,8 @@ namespace MudBlazor
         public string Icon { get; set; }
         public Color IconColor { get; set; } = Color.Inherit;
         public Size IconSize { get; set; } = Size.Medium;
+
+        public SnackbarDuplicatesBehavior DuplicatesBehavior { get; set; } = SnackbarDuplicatesBehavior.GlobalDefault;
 
         /// <summary>
         /// Custom normal icon.

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using MudBlazor.Components.Snackbar;
+using MudBlazor.Components.Snackbar.InternalComponents;
 
 namespace MudBlazor
 {
@@ -49,18 +52,8 @@ namespace MudBlazor
             }
         }
 
-        [Obsolete("Use Add instead.", true)]
-        public Snackbar AddNew(Severity severity, string message, Action<SnackbarOptions> configure)
+        private Snackbar Add(SnackbarMessage message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
         {
-            return Add(message, severity, configure);
-        }
-
-        public Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null)
-        {
-            if (message.IsEmpty()) return null;
-
-            message = message.Trimmed();
-
             var options = new SnackbarOptions(severity, Configuration);
             configure?.Invoke(options);
 
@@ -69,7 +62,7 @@ namespace MudBlazor
             SnackBarLock.EnterWriteLock();
             try
             {
-                if (Configuration.PreventDuplicates && SnackbarAlreadyPresent(snackbar)) return null;
+                if (ResolvePreventDuplicates(options) && SnackbarAlreadyPresent(snackbar)) return null;
                 snackbar.OnClose += Remove;
                 SnackBarList.Add(snackbar);
             }
@@ -81,6 +74,78 @@ namespace MudBlazor
             OnSnackbarsUpdated?.Invoke();
 
             return snackbar;
+        }
+
+        /// <summary>
+        /// Displays a snackbar containing a custom component specified by T.
+        /// </summary>
+        /// <typeparam name="T">The type of the custom component that specifies the content of the snackbar.</typeparam>
+        /// <param name="componentParameters">Any additional parameters needed by the custom component to display the message.</param>
+        /// <param name="severity">The severity of the snackbar. Dictates the color and default icon of the notification.</param>
+        /// <param name="configure">Additional configuration for the snackbar.</param>
+        /// <param name="key">If a key is provided, this message will not be shown while any other message with the same key is being shown.</param>
+        /// <returns>The snackbar created by the parameters.</returns>
+        public Snackbar Add<T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent
+        {
+            var type = typeof(T);
+            var message = new SnackbarMessage(type, componentParameters, key);
+
+            return Add(message, severity, configure);
+        }
+
+        /// <summary>
+        /// Displays a snackbar containing the RenderFragment.
+        /// </summary>
+        /// <param name="message">The RenderFragment which specifies the content of the snackbar.</param>
+        /// <param name="severity">The severity of the snackbar. Dictates the color and default icon of the notification.</param>
+        /// <param name="configure">Additional configuration for the snackbar.</param>
+        /// <param name="key">If a key is provided, this message will not be shown while any other message with the same key is being shown.</param>
+        /// <returns>The snackbar created by the parameters.</returns>
+        public Snackbar Add(RenderFragment message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "")
+        {
+            if (message == null) return null;
+
+            var componentParams = new Dictionary<string, object>()
+            {
+                { "Message", message as object }
+            };
+
+            return Add
+            (
+                new SnackbarMessage(typeof(SnackbarMessageRenderFragment), componentParams, key),
+                severity,
+                configure
+            );
+        }
+
+        /// <summary>
+        /// Displays a snackbar containing the text.
+        /// </summary>
+        /// <param name="message">The string which specifies the content of the snackbar.</param>
+        /// <param name="severity">The severity of the snackbar. Dictates the color and default icon of the notification.</param>
+        /// <param name="configure">Additional configuration for the snackbar.</param>
+        /// <param name="key">If no key is passed, defaults to the content of the message. This message will not be shown while any other message with the same key is being shown.</param>
+        /// <returns>The snackbar created by the parameters.</returns>
+        public Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "")
+        {
+            if (message.IsEmpty()) return null;
+            message = message.Trimmed();
+
+            var componentParams = new Dictionary<string, object>() { { "Message", new MarkupString(message) } };
+
+            return Add
+            (
+                new SnackbarMessage(typeof(SnackbarMessageText), componentParams, string.IsNullOrEmpty(key) ? message : key),
+                severity,
+                configure
+            );
+        }
+
+        [Obsolete("Use Add instead.", true)]
+        [ExcludeFromCodeCoverage]
+        public Snackbar AddNew(Severity severity, string message, Action<SnackbarOptions> configure)
+        {
+            return Add(message, severity, configure);
         }
 
         public void Clear()
@@ -118,12 +183,15 @@ namespace MudBlazor
             OnSnackbarsUpdated?.Invoke();
         }
 
+        private bool ResolvePreventDuplicates(SnackbarOptions options)
+        {
+            return options.DuplicatesBehavior == SnackbarDuplicatesBehavior.Prevent
+                    || (options.DuplicatesBehavior == SnackbarDuplicatesBehavior.GlobalDefault && Configuration.PreventDuplicates);
+        }
+
         private bool SnackbarAlreadyPresent(Snackbar newSnackbar)
         {
-            return SnackBarList.Any(snackbar =>
-                newSnackbar.Message.Equals(snackbar.Message) &&
-                newSnackbar.Severity.Equals(snackbar.Severity)
-            );
+            return !string.IsNullOrEmpty(newSnackbar.Message.Key) && SnackBarList.Any(snackbar => newSnackbar.Message.Key == snackbar.Message.Key);
         }
 
         private void ConfigurationUpdated()

--- a/src/MudBlazor/Interfaces/ISnackbar.cs
+++ b/src/MudBlazor/Interfaces/ISnackbar.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {
@@ -14,7 +15,9 @@ namespace MudBlazor
 
         event Action OnSnackbarsUpdated;
 
-        Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null);
+        Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "");
+        Snackbar Add(RenderFragment message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "");
+        Snackbar Add<T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent;
 
         [Obsolete("Use Add instead.", true)]
         Snackbar AddNew(Severity severity, string message, Action<SnackbarOptions> configure);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Addresses #974.

This PR allows end devs to specify the content of a Snackbar message as a `RenderFragment` (in addition to the existing functionality which lets them specify the content as `string` which may contain HTML). 

**NOTES**
1. Does not completely resolve #974, as it asks us to allow the complete specification of the Snackbar in Razor. The current architecture makes this challenging and may merit a larger discussion. However, this PR may support a future one which completely fulfills that need, and in the meantime, it allows end devs to define the message via RenderFragment (as seen in the new `SnackbarRenderFragmentMessageTest.razor`) (See below)
2. This may also prompt a discussion about duplicate Snackbar prevention. Previously, duplicate Snackbars were defined as bars with equal message and severity. It's difficult (impossible?) to obtain HTML from a RenderFragment. I threw a Guid in there, but because creation of the `SnackbarMessage` is entirely internal, it doesn't do much. I suggest instead allowing the end dev to pass a `key` into `.Add` if they want to ensure that there are no duplicates fired.

```csharp
@using Microsoft.AspNetCore.Components.Rendering

@namespace MudBlazor.UnitTests.TestComponents
@inject ISnackbar SnackbarService

<MudButton OnClick="@OnClick">Show the snackbar!</MudButton>

@code {
    public static string __description__ = "Click the button to fire a Snackbar built with a RenderFragment."; 

    private RenderFragment GetRenderFragment() =>
        @<ul>
            <li>Here's a regular item</li>
            <li>Here's a <strong>bold item</strong></li>
            <li>Here's an <em>italicized item</em></li>
        </ul>;

    private void OnClick()
    {
        SnackbarService.Add(GetRenderFragment(), Severity.Normal);
    }
}
```

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Unit tests added to `MudBlazor.UnitTests/Components/SnackbarTests.cs`. Visual unit test added to the `Snackbar` directory of `MudBlazor.UnitTests.Viewer`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.