### PR TITLE
Docs: Fix issue where one of the code copy commands copied incorrect text

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -33,6 +33,12 @@
   <PropertyGroup>
     <ProjectDocsCompiler>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"</ProjectDocsCompiler>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;RZ9992</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;RZ9992</NoWarn>
+  </PropertyGroup>
 
   <!--Execute the code generator-->
   <Target Name="CompileDocs" BeforeTargets="BeforeBuild">

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualScriptExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualScriptExample.razor
@@ -1,0 +1,3 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<script src="_content/MudBlazor/MudBlazor.min.js"></script>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -85,7 +85,7 @@
                     <SectionHeader Title="Add script reference">
                         <Description>In the same file but located in the end of it add the MudBlazor js file, it should be in the same location as the default blazor script.</Description>
                     </SectionHeader>
-                    <SectionContent Code="InstallScriptManual"/>
+                    <SectionContent Code="InstallationManualScriptExample"/>
                 </DocsPageSection>
 
                 <DocsPageSection>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves #4111. The code block in the docs did not have a corresponding component in the appropriate Examples folder. Added and updated the snippet name to be standard with other snippet names.

**NOTE:** In order to make this work, I had to suppress a compiler error in `MudBlazor.Docs` because script blocks in components are prohibited. I think this makes sense given that this is a docs project, but let me know if you have objections.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I don't see any manual unit tests for docs stuff, so no tests added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
