### PR TITLE
MudDataGrid: Added the case sensitivity when filtering string columns

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -123,6 +123,8 @@
                     <CodeInline>DataGridFilterMode.Simple</CodeInline> is the default where all filters are managed in one popover in the data grid. It allows you to
                     set multiple filters at one time for multiple different columns. In <CodeInline>DataGridFilterMode.ColumnFilterMenu</CodeInline> mode, there is a dedicated popover for 
                     each column. Lastly, <CodeInline>DataGridFilterMode.ColumnFilterRow</CodeInline> allows you to inline the filtering behavior directly into the data grid.
+                    <br><br>
+                    Is it possibile to define the case sensitivity when filtering string values by setting the parameter <CodeInline>FilterCaseSensitivity</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="DataGridFilteringExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid T="Element" Items="@Elements" Filterable="true" FilterMode="@_filterMode">
+<MudDataGrid T="Element" Items="@Elements" Filterable="true" FilterMode="@_filterMode" FilterCaseSensitivity="@_caseSensitivity">
     <Columns>
         <Column T="Element" Field="Number" Title="Nr" Filterable="false" />
         <Column T="Element" Field="Sign" />
@@ -25,10 +25,18 @@
     </MudRadioGroup>
 </div>
 
+<div class="d-flex flex-wrap mt-4">
+    <MudRadioGroup T="DataGridFilterCaseSensitivity" @bind-SelectedOption="@_caseSensitivity">
+        <MudRadio Dense="true" Option="@DataGridFilterCaseSensitivity.Default" Color="Color.Primary">Default Case Sensitivity</MudRadio>
+        <MudRadio Dense="true" Option="@DataGridFilterCaseSensitivity.CaseInsensitive" Color="Color.Tertiary">Case Insensitive</MudRadio>
+    </MudRadioGroup>
+</div>
+
 
 @code {
     IEnumerable<Element> Elements = new List<Element>();
     DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
+    DataGridFilterCaseSensitivity _caseSensitivity = DataGridFilterCaseSensitivity.Default;
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4,20 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using Moq;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using Microsoft.JSInterop.Infrastructure;
-using MudBlazor.Interop;
-using System.Text.Json;
-using System.Linq.Expressions;
-using PrimitiveCalculator;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -450,26 +445,61 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Contains
 
+            //default Case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new("Does not contain", 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
 
-            // null value
+            //case insensitive
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
-                Value = null
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new("Does not contain", 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+
+            // null value default case sensitivity
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Contains,
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new("Does not contain", 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new(null, 45)));
+
+            // null value default case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Contains,
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Does not contain", 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
@@ -479,15 +509,34 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.NotContains
 
+            // default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Does not contain", 45)));
+            Assert.IsFalse(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+
+            // case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotContains,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new("Does not contain", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
             Assert.IsFalse(func.Invoke(new("Joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
 
@@ -497,7 +546,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Does not contain", 45)));
@@ -508,46 +558,102 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Equal
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
 
-            // null value
+            //case insensitive
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
-                Value = null
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
+
+            // null value default case sensitivity
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Equal,
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
             Assert.IsTrue(func.Invoke(new(null, 45)));
 
+            // null value case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Equal,
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
+            Assert.IsTrue(func.Invoke(new(null, 45)));
+
             #endregion
 
             #region FilterOperator.String.NotEqual
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
             Assert.IsFalse(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotEqual,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+            Assert.IsFalse(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -555,7 +661,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -566,17 +673,36 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.StartsWith
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.StartsWith,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -584,7 +710,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Not Joe", 45)));
@@ -595,17 +722,36 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.EndsWith
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new("Joe Not", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.EndsWith,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new("Joe Not", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -613,7 +759,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -629,7 +776,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Empty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new("Joe Not", 45)));
@@ -643,7 +791,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -660,7 +809,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -674,7 +824,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -690,7 +841,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = null,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new("Joe Not", 45)));
@@ -706,17 +858,37 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Contains
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
-            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45} }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Contains,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
 
             // null value
@@ -726,7 +898,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
@@ -736,18 +909,37 @@ namespace MudBlazor.UnitTests.Components
             #endregion
 
             #region FilterOperator.String.NotContains
-
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotContains,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
 
             // null value
@@ -757,7 +949,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Does not contain" }, { "Age", 45 } }));
@@ -768,18 +961,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Equal
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Equal,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
 
             // null value
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
@@ -788,7 +1001,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -799,18 +1013,39 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.NotEqual
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
+
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotEqual,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
 
             // null value
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
@@ -819,7 +1054,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -830,18 +1066,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.StartsWith
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.StartsWith,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
 
             // null value
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
@@ -850,7 +1106,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Not Joe" }, { "Age", 45 } }));
@@ -860,19 +1117,38 @@ namespace MudBlazor.UnitTests.Components
             #endregion
 
             #region FilterOperator.String.EndsWith
-
+            //default case sensitivity
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<IDictionary<string, object>>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.EndsWith,
+                Value = "Joe",
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            func = filterDefinition.GenerateFilterFunction();
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
+            Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", null }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe" }, { "Age", 45 } }));
+            Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "joe" }, { "Age", 45 } }));
 
             // null value
             filterDefinition = new FilterDefinition<IDictionary<string, object>>
@@ -881,7 +1157,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -898,7 +1175,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.Empty,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsFalse(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -913,7 +1191,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -931,7 +1210,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -946,7 +1226,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
                 Value = null,
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -963,7 +1244,8 @@ namespace MudBlazor.UnitTests.Components
                 Field = "Name",
                 Operator = null,
                 Value = "Joe",
-                FieldType = typeof(string)
+                FieldType = typeof(string),
+                DataGrid = new MudDataGrid<IDictionary<string, object>>()
             };
             func = filterDefinition.GenerateFilterFunction();
             Assert.IsTrue(func.Invoke(new Dictionary<string, object> { { "Name", "Joe Not" }, { "Age", 45 } }));
@@ -2119,17 +2401,37 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Contains
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
-            var func =expression.Compile();
+            var func = expression.Compile();
             Assert.IsFalse(func.Invoke(new("Does not contain", 45)));
             Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func.Invoke(new("joe", 45)));
+            Assert.IsFalse(func.Invoke(new(null, 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Contains,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func = expression.Compile();
+            Assert.IsFalse(func.Invoke(new("Does not contain", 45)));
+            Assert.IsTrue(func.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func.Invoke(new("joe", 45)));
             Assert.IsFalse(func.Invoke(new(null, 45)));
 
             // null value
@@ -2138,7 +2440,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Contains,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func2 = expression.Compile();
@@ -2150,17 +2453,37 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.NotContains
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func3 = expression.Compile();
             Assert.IsTrue(func3.Invoke(new("Does not contain", 45)));
             Assert.IsFalse(func3.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func3.Invoke(new("joe", 45)));
+            Assert.IsFalse(func3.Invoke(new(null, 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotContains,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func3 = expression.Compile();
+            Assert.IsTrue(func3.Invoke(new("Does not contain", 45)));
+            Assert.IsFalse(func3.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func3.Invoke(new("joe", 45)));
             Assert.IsFalse(func3.Invoke(new(null, 45)));
 
             // null value
@@ -2169,7 +2492,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotContains,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func4 = expression.Compile();
@@ -2181,18 +2505,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.Equal
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func5 = expression.Compile();
             Assert.IsFalse(func5.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func5.Invoke(new(null, 45)));
             Assert.IsTrue(func5.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func5.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.Equal,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func5 = expression.Compile();
+            Assert.IsFalse(func5.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func5.Invoke(new(null, 45)));
+            Assert.IsTrue(func5.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func5.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -2200,7 +2544,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Equal,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func6 = expression.Compile();
@@ -2212,18 +2557,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.NotEqual
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func7 = expression.Compile();
             Assert.IsTrue(func7.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func7.Invoke(new(null, 45)));
             Assert.IsFalse(func7.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func7.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.NotEqual,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func7 = expression.Compile();
+            Assert.IsTrue(func7.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func7.Invoke(new(null, 45)));
+            Assert.IsFalse(func7.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func7.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -2231,7 +2596,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEqual,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func8 = expression.Compile();
@@ -2243,18 +2609,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.StartsWith
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func9 = expression.Compile();
             Assert.IsFalse(func9.Invoke(new("Not Joe", 45)));
             Assert.IsFalse(func9.Invoke(new(null, 45)));
             Assert.IsTrue(func9.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func9.Invoke(new("joe", 45)));
+
+            //default case sensitivity
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.StartsWith,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func9 = expression.Compile();
+            Assert.IsFalse(func9.Invoke(new("Not Joe", 45)));
+            Assert.IsFalse(func9.Invoke(new(null, 45)));
+            Assert.IsTrue(func9.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func9.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -2262,7 +2648,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.StartsWith,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func10 = expression.Compile();
@@ -2274,18 +2661,38 @@ namespace MudBlazor.UnitTests.Components
 
             #region FilterOperator.String.EndsWith
 
+            //default case sensitivity
             filterDefinition = new FilterDefinition<TestModel1>
             {
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func11 = expression.Compile();
             Assert.IsFalse(func11.Invoke(new("Joe Not", 45)));
             Assert.IsFalse(func11.Invoke(new(null, 45)));
             Assert.IsTrue(func11.Invoke(new("Joe", 45)));
+            Assert.IsFalse(func11.Invoke(new("joe", 45)));
+
+            //case insensitive
+            filterDefinition = new FilterDefinition<TestModel1>
+            {
+                Id = Guid.NewGuid(),
+                Field = "Name",
+                Operator = FilterOperator.String.EndsWith,
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
+            };
+            filterDefinition.DataGrid.FilterCaseSensitivity = DataGridFilterCaseSensitivity.CaseInsensitive;
+            expression = filterDefinition.GenerateFilterExpression();
+            func11 = expression.Compile();
+            Assert.IsFalse(func11.Invoke(new("Joe Not", 45)));
+            Assert.IsFalse(func11.Invoke(new(null, 45)));
+            Assert.IsTrue(func11.Invoke(new("Joe", 45)));
+            Assert.IsTrue(func11.Invoke(new("joe", 45)));
 
             // null value
             filterDefinition = new FilterDefinition<TestModel1>
@@ -2293,7 +2700,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.EndsWith,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func12 = expression.Compile();
@@ -2310,7 +2718,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.Empty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func13 = expression.Compile();
@@ -2343,7 +2752,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func15 = expression.Compile();
@@ -2358,7 +2768,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = FilterOperator.String.NotEmpty,
-                Value = null
+                Value = null,
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func16 = expression.Compile();
@@ -2375,7 +2786,8 @@ namespace MudBlazor.UnitTests.Components
                 Id = Guid.NewGuid(),
                 Field = "Name",
                 Operator = null,
-                Value = "Joe"
+                Value = "Joe",
+                DataGrid = new MudDataGrid<TestModel1>()
             };
             expression = filterDefinition.GenerateFilterExpression();
             var func17 = expression.Compile();
@@ -3031,7 +3443,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dataGrid.Instance.FilterDefinitions.Add(filterDefinition4));
             await comp.InvokeAsync(() => dataGrid.Instance.FilterDefinitions.Add(filterDefinition5));
             await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
-            
+
             // check the number of filters displayed in the filters panel
             dataGrid.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(5);
 
@@ -3333,7 +3745,7 @@ namespace MudBlazor.UnitTests.Components
             var popover = dataGrid.FindComponent<MudPopover>();
             popover.Instance.Open.Should().BeFalse("Should start as closed");
 
-           
+
 
             var columnsButton = dataGrid.Find("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
             columnsButton.Click();
@@ -3495,7 +3907,7 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("td.footer-cell")[1].TrimmedText().Should().Be("Average age is 56");
             dataGrid.FindAll("tfoot td.footer-cell")[1].TrimmedText().Should().Be("Average age is 43");
         }
-        
+
         [Test]
         public async Task DataGridSequenceContainsNoElementsTest()
         {
@@ -3529,10 +3941,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridFilterGuid<Guid>>();
             var grid = comp.Instance.MudGridRef;
-            
+
             grid.Items.Count().Should().Be(2);
             grid.FilteredItems.Count().Should().Be(2);
-            
+
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid>.WeatherForecast>()
             {
                 Field = "Id",
@@ -3541,7 +3953,7 @@ namespace MudBlazor.UnitTests.Components
                 FieldType = typeof(Guid),
             });
             grid.FilteredItems.Count().Should().Be(0);
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid>.WeatherForecast>()
             {
@@ -3552,7 +3964,7 @@ namespace MudBlazor.UnitTests.Components
             });
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()?.Id.Should().Be(comp.Instance.Guid1);
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid>.WeatherForecast>()
             {
@@ -3570,10 +3982,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridFilterGuid<Nullable<Guid>>>();
             var grid = comp.Instance.MudGridRef;
-            
+
             grid.Items.Count().Should().Be(2);
             grid.FilteredItems.Count().Should().Be(2);
-            
+
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
             {
                 Field = "Id",
@@ -3582,7 +3994,7 @@ namespace MudBlazor.UnitTests.Components
                 FieldType = typeof(Nullable<Guid>),
             });
             grid.FilteredItems.Count().Should().Be(0);
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
             {
@@ -3593,7 +4005,7 @@ namespace MudBlazor.UnitTests.Components
             });
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()?.Id.Should().Be(comp.Instance.Guid1);
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
             {
@@ -3611,10 +4023,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridFilterDictionaryGuid>();
             var grid = comp.Instance.MudGridRef;
-            
+
             grid.Items.Count().Should().Be(2);
             grid.FilteredItems.Count().Should().Be(2);
-            
+
             grid.FilterDefinitions.Add(new FilterDefinition<IDictionary<string, object>>()
             {
                 Field = "Id",
@@ -3623,7 +4035,7 @@ namespace MudBlazor.UnitTests.Components
                 FieldType = typeof(Nullable<Guid>),
             });
             grid.FilteredItems.Count().Should().Be(0);
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<IDictionary<string, object>>()
             {
@@ -3634,7 +4046,7 @@ namespace MudBlazor.UnitTests.Components
             });
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()["Id"].Should().Be(Guid.Parse(comp.Instance.Guid1));
-            
+
             grid.FilterDefinitions.Clear();
             grid.FilterDefinitions.Add(new FilterDefinition<IDictionary<string, object>>()
             {
@@ -3722,7 +4134,7 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.FilterDefinitions.Clear();
             dataGrid.Render();
-            
+
             // total with es-ES culture (decimals separated by comma)
             var filterTotal = dataGrid.FindAll("th.filter-header-cell input")[3];
             filterTotal.Input(new ChangeEventArgs() { Value = "2,2" });

--- a/src/MudBlazor/Components/DataGrid/DataGridFilterCaseSensitivity.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridFilterCaseSensitivity.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+public enum DataGridFilterCaseSensitivity
+{
+    Default,
+
+    CaseInsensitive
+}

--- a/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
@@ -241,7 +241,7 @@ namespace MudBlazor
                 // filtered value is not a valid GUID
                 _ when valueGuid == null && Value != null =>
                     Expression.Constant(false),
-                
+
                 _ => Expression.Constant(true, typeof(bool))
             };
         }
@@ -323,29 +323,53 @@ namespace MudBlazor
 
             return Operator switch
             {
-                FilterOperator.String.Contains when Value != null =>
+                FilterOperator.String.Contains when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
                     Expression.AndAlso(isnotnull,
                         Expression.Call(field, dataType.GetMethod("Contains", new[] { dataType }), Expression.Constant(valueString))),
 
-                FilterOperator.String.NotContains when Value != null =>
+                FilterOperator.String.Contains when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Call(field, dataType.GetMethod("Contains", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) })),
+
+                FilterOperator.String.NotContains when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
                     Expression.AndAlso(isnotnull,
                         Expression.Not(Expression.Call(field, dataType.GetMethod("Contains", new[] { dataType }), Expression.Constant(valueString)))),
 
-                FilterOperator.String.Equal when Value != null =>
+                FilterOperator.String.NotContains when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Not(Expression.Call(field, dataType.GetMethod("Contains", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) }))),
+
+                FilterOperator.String.Equal when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
                     Expression.AndAlso(isnotnull,
                         Expression.Equal(field, Expression.Constant(valueString))),
 
-                FilterOperator.String.NotEqual when Value != null =>
+                FilterOperator.String.Equal when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
                     Expression.AndAlso(isnotnull,
-                    Expression.Not(Expression.Equal(field, Expression.Constant(valueString)))),
+                        Expression.Call(field, dataType.GetMethod("Equals", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) })),
 
-                FilterOperator.String.StartsWith when Value != null =>
+                FilterOperator.String.NotEqual when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Not(Expression.Equal(field, Expression.Constant(valueString)))),
+
+                FilterOperator.String.NotEqual when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Not(Expression.Call(field, dataType.GetMethod("Equals", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) }))),
+
+                FilterOperator.String.StartsWith when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
                     Expression.AndAlso(isnotnull,
                         Expression.Call(field, dataType.GetMethod("StartsWith", new[] { dataType }), Expression.Constant(valueString))),
 
-                FilterOperator.String.EndsWith when Value != null =>
+                FilterOperator.String.StartsWith when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Call(field, dataType.GetMethod("StartsWith", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) })),
+
+                FilterOperator.String.EndsWith when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default =>
                     Expression.AndAlso(isnotnull,
                         Expression.Call(field, dataType.GetMethod("EndsWith", new[] { dataType }), Expression.Constant(valueString))),
+
+                FilterOperator.String.EndsWith when Value != null && DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.CaseInsensitive =>
+                    Expression.AndAlso(isnotnull,
+                        Expression.Call(field, dataType.GetMethod("EndsWith", new[] { dataType, typeof(StringComparison) }), new[] { Expression.Constant(valueString), Expression.Constant(StringComparison.OrdinalIgnoreCase) })),
 
                 FilterOperator.String.Empty =>
                     Expression.OrElse(isnull,
@@ -365,20 +389,22 @@ namespace MudBlazor
         {
             var valueString = Value?.ToString();
 
+            var caseSensitivity = DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
             return Operator switch
             {
                 FilterOperator.String.Contains when Value != null => x =>
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return v != null && v.Contains(valueString);
+                    return v != null && v.Contains(valueString, caseSensitivity);
                 }
                 ,
                 FilterOperator.String.NotContains when Value != null => x =>
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return v != null && !v.Contains(valueString);
+                    return v != null && !v.Contains(valueString, caseSensitivity);
                 }
                 ,
 
@@ -386,7 +412,7 @@ namespace MudBlazor
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return object.Equals(v, Value);
+                    return v != null && v.Equals(valueString, caseSensitivity);
                 }
                 ,
 
@@ -394,7 +420,7 @@ namespace MudBlazor
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return !object.Equals(v, Value);
+                    return !valueString.Equals(v, caseSensitivity);
                 }
                 ,
 
@@ -402,7 +428,7 @@ namespace MudBlazor
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return v != null && v.StartsWith(valueString);
+                    return v != null && v.StartsWith(valueString, caseSensitivity);
                 }
                 ,
 
@@ -410,7 +436,7 @@ namespace MudBlazor
                 {
                     string v = GetStringFromObject(((IDictionary<string, object>)x)[Field]);
 
-                    return v != null && v.EndsWith(valueString);
+                    return v != null && v.EndsWith(valueString, caseSensitivity);
                 }
                 ,
 
@@ -550,7 +576,7 @@ namespace MudBlazor
 
         private Func<T, bool> GenerateFilterForGuidTypeInIDictionary()
         {
-            Guid? valueGuid = Value == null ? null : ParseGuid((string) Value);
+            Guid? valueGuid = Value == null ? null : ParseGuid((string)Value);
             return Operator switch
             {
                 FilterOperator.Guid.Equal when Value != null => x =>
@@ -565,7 +591,8 @@ namespace MudBlazor
                     var v = GetGuidFromObject(((IDictionary<string, object>)x)[Field]);
 
                     return v != valueGuid;
-                },
+                }
+                ,
 
                 _ => x => true
             };

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -260,6 +260,8 @@ namespace MudBlazor
 
         [Parameter] public DataGridFilterMode FilterMode { get; set; }
 
+        [Parameter] public DataGridFilterCaseSensitivity FilterCaseSensitivity { get; set; }
+
         [Parameter] public RenderFragment<List<FilterDefinition<T>>> FilterTemplate { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This pull request add the possibility to define the case sensitivity when filtering string values. I have added the parameter FilterCaseSensitivity to the MudDataGrid to do so. The default behavior is not changed.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
It is been tested updating existing unit tests and visually.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

![image](https://user-images.githubusercontent.com/12575417/191526545-1a3545e6-8436-4d6f-970f-67d70aa090cc.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
