### PR TITLE
MudForm: Add LabelAttribute to replace DisplayAttribute

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/LabelAttributeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/LabelAttributeExample.razor
@@ -19,11 +19,11 @@
 
     public class DisplayNameLabelClass
     {
-        [Display(Name = "Date DisplayName")]
+        [Label("Date LabelAttribute")]
         public DateTime? Date { get; set; }
-        [Display(Name = "Boolean DisplayName")]
+        [Label("Boolean LabelAttribute")]
         public bool Boolean { get; set; }
-        [Display(Name = "String DisplayName")]
+        [Label("String LabelAttribute")]
         public string String { get; set; }
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
@@ -76,11 +76,11 @@
         <DocsPageSection>
             <SectionHeader Title="Automatically set Labels">
                 <Description>
-                    A form field <CodeInline>Label</CodeInline> can be set automatically by adding a <CodeInline>[Display]</CodeInline> attribute to the relevant property on the model class. The <CodeInline>For</CodeInline> property must also be set. An automatic label can be overriden by setting the <CodeInline>Label</CodeInline> property manually on the component.
+                    A form field <CodeInline>Label</CodeInline> can be set automatically by adding a <CodeInline>[Label]</CodeInline> attribute to the relevant property on the model class. The <CodeInline>For</CodeInline> property must also be set. An automatic label can be overriden by setting the <CodeInline>Label</CodeInline> property manually on the component.
                 </Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" ShowCode="false" Code="DisplayNameLabelExample">
-                <DisplayNameLabelExample />
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="LabelAttributeExample">
+                <LabelAttributeExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -349,7 +349,7 @@ namespace MudBlazor.UnitTests.Components
             var value = new DisplayNameLabelClass();
 
             var comp = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean));
-            comp.Instance.Label.Should().Be("Boolean DisplayName"); //label should be set by the attribute
+            comp.Instance.Label.Should().Be("Boolean LabelAttribute"); //label should be set by the attribute
 
             var comp2 = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain

--- a/src/MudBlazor.UnitTests/Components/PickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PickerTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
             var value = new DisplayNameLabelClass();
 
             var comp = Context.RenderComponent<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date));
-            comp.Instance.Label.Should().Be("Date DisplayName"); //label should be set by the attribute
+            comp.Instance.Label.Should().Be("Date LabelAttribute"); //label should be set by the attribute
 
             var comp2 = Context.RenderComponent<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -98,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
             var value = new DisplayNameLabelClass();
 
             var comp = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean));
-            comp.Instance.Label.Should().Be("Boolean DisplayName"); //label should be set by the attribute
+            comp.Instance.Label.Should().Be("Boolean LabelAttribute"); //label should be set by the attribute
 
             var comp2 = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -822,7 +822,7 @@ namespace MudBlazor.UnitTests.Components
             var value = new DisplayNameLabelClass();
 
             var comp = Context.RenderComponent<MudTextField<string>>(x => x.Add(f => f.For, () => value.String));
-            comp.Instance.Label.Should().Be("String DisplayName"); //label should be set by the attribute
+            comp.Instance.Label.Should().Be("String LabelAttribute"); //label should be set by the attribute
 
             var comp2 = Context.RenderComponent<MudTextField<string>>(x => x.Add(f => f.For, () => value.String).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain

--- a/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.UnitTests.Extensions
     {
         private class TestClass
         {
-            [Display(Name = "Display Attribute")]
+            [Label("Label Attribute")]
             public string Field1 { get; set; }
 
             public TestClass1 TestClass1 { get; set; }
@@ -60,23 +60,23 @@ namespace MudBlazor.UnitTests.Extensions
         }
 
         [Test]
-        public void GetDisplayNameStringTest1()
+        public void GetLabelStringTest1()
         {
             var model = new TestClass();
 
             Expression<Func<string>> expression = () => model.Field1;
 
-            expression.GetDisplayNameString().Should().Be("Display Attribute");
+            expression.GetLabelString().Should().Be("Label Attribute");
         }
 
         [Test]
-        public void GetDisplayNameStringTest2()
+        public void GetLabelStringTest2()
         {
             var model = new TestClass1();
 
             Expression<Func<string>> expression = () => model.Field1;
 
-            expression.GetDisplayNameString().Should().Be("");
+            expression.GetLabelString().Should().Be("");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/DisplayNameLabelClass.cs
+++ b/src/MudBlazor.UnitTests/Utilities/DisplayNameLabelClass.cs
@@ -13,11 +13,11 @@ namespace MudBlazor.UnitTests.Utilities
 {
     public class DisplayNameLabelClass
     {
-        [Display(Name ="Date DisplayName")]
+        [Label("Date LabelAttribute")]
         public DateTime? Date { get; set; }
-        [Display(Name = "Boolean DisplayName")]
+        [Label("Boolean LabelAttribute")]
         public bool Boolean { get; set; }
-        [Display(Name = "String DisplayName")]
+        [Label("String LabelAttribute")]
         public string String { get; set; }
     }
 }

--- a/src/MudBlazor/Attributes/LabelAttribute.cs
+++ b/src/MudBlazor/Attributes/LabelAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public class LabelAttribute : Attribute
+    {
+        public LabelAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -419,11 +419,11 @@ namespace MudBlazor
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
-            if (typeof(T) != typeof(string))
+            if (typeof(T) != typeof(string)) 
                 await UpdateTextPropertyAsync(false);
 
             if (Label == null && For != null)
-                Label = For.GetDisplayNameString();
+                Label = For.GetLabelString();
         }
 
         public virtual void ForceRender(bool forceTextUpdate)

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -214,7 +214,7 @@ namespace MudBlazor
             base.OnInitialized();
 
             if (Label == null && For != null)
-                Label = For.GetDisplayNameString();
+                Label = For.GetLabelString();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -435,7 +435,7 @@ namespace MudBlazor
             }
 
             if (Label == null && For != null)
-                Label = For.GetDisplayNameString();
+                Label = For.GetLabelString();
         }
 
         private async Task EnsureKeyInterceptor()

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -128,7 +128,7 @@ namespace MudBlazor
             base.OnInitialized();
 
             if (Label == null && For != null)
-                Label = For.GetDisplayNameString();
+                Label = For.GetLabelString();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -35,11 +35,11 @@ namespace MudBlazor
         /// <summary>
         /// Returns the display name attribute of the provided field property as a string. If this attribute is missing, the member name will be returned.
         /// </summary>
-        public static string GetDisplayNameString<T>(this Expression<Func<T>> expression)
+        public static string GetLabelString<T>(this Expression<Func<T>> expression)
         {
             var memberExpression = (MemberExpression)expression.Body;
             var propertyInfo = memberExpression.Expression?.Type.GetProperty(memberExpression.Member.Name);
-            return propertyInfo?.GetCustomAttributes(typeof(DisplayAttribute), true).Cast<DisplayAttribute>().FirstOrDefault()?.Name ?? string.Empty;
+            return propertyInfo?.GetCustomAttributes(typeof(LabelAttribute), true).Cast<LabelAttribute>().FirstOrDefault()?.Name ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

As pointed out in the discussion on #5225, using the `[Display]` attribute to generate form inputs automatically may have side effects and controlling this setting globally is infeasible at this time. The solution is a custom `[Label]` attribute that will not interfere with other uses of `[Display]`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tests updated

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
