### PR TITLE
MudDateRangePicker: Add ClearAsync close state test (#5340)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerCloseOnClearTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerCloseOnClearTest.razor
@@ -1,14 +1,18 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
-<MudPopoverProvider></MudPopoverProvider>
+<MudPopoverProvider/>
 
 <MudDateRangePicker id="picker" @ref="_picker" Label="With action buttons" @bind-DateRange="DateRange">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear(@CloseOnClear))">Clear</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync(CloseOnClear))">Clear</MudButton>
     </PickerActions>
 </MudDateRangePicker>
 
 @code {
-    MudDateRangePicker _picker;
-    [Parameter] public DateRange DateRange { get; set; }
-    [Parameter] public bool CloseOnClear { get; set; }
+    private MudDateRangePicker _picker;
+
+    [Parameter]
+    public DateRange DateRange { get; set; }
+
+    [Parameter]
+    public bool CloseOnClear { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerCloseOnClearTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerCloseOnClearTest.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDateRangePicker id="picker" @ref="_picker" Label="With action buttons" @bind-DateRange="DateRange">
+    <PickerActions>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear(@CloseOnClear))">Clear</MudButton>
+    </PickerActions>
+</MudDateRangePicker>
+
+@code {
+    MudDateRangePicker _picker;
+    [Parameter] public DateRange DateRange { get; set; }
+    [Parameter] public bool CloseOnClear { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -838,5 +838,41 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().Contain("2024 April 22");
             comp.Markup.Should().Contain("2024 April 23");
         }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CheckCloseOnClearDateRangePicker(bool closeOnClear)
+        {
+            // Define a date range for comparison
+            var initialDateRange = new DateRange(
+                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 01),
+                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
+
+            // Get access to the date range picker of the instance
+            var comp = Context.RenderComponent<DateRangePickerCloseOnClearTest>(
+                Parameter(nameof(DateRangePickerCloseOnClearTest.DateRange), initialDateRange),
+                Parameter(nameof(DateRangePickerCloseOnClearTest.CloseOnClear), closeOnClear));
+
+            // Open the date range picker
+            comp.Find("input").Click();
+
+            // Clicking day buttons to select a date range
+            comp
+                .FindAll("button.mud-button").First(x => x.TrimmedText().Equals("Clear")).Click();
+
+            // Check that the date range was cleared
+            comp.Instance.DateRange.Should().NotBe(initialDateRange);
+            if (closeOnClear)
+            {
+                // Check that the component is closed
+                comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            }
+            else
+            {
+                // Check that the component is open
+                comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes #5340
This pull requests fixes the existing issue noted in #5340 by passing on the optional parameter within the DateRangePicker's Clear method along to the base MudPicker's Clear() method.

## How Has This Been Tested?
Tested via existing and additional unit tests, including a new test component.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
