### PR TITLE
Docs: Add page tab to dialog focus trap example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -36,18 +36,18 @@
                 </Description>
             </SectionHeader>
             <SectionSubGroups>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Global Settings">
                         <Description>In the file where you added <CodeInline>&lt;MudDialogProvider/&gt;</CodeInline>, we can pass down different options as parameters. See <MudLink Href="/getting-started/installation">installation page</MudLink> for more information regarding this.</Description>
                     </SectionHeader>
-                    <SectionContent Code="DialogConfigurationExample"/>
+                    <SectionContent Code="DialogConfigurationExample" />
                 </DocsPageSection>
 
                 <DocsPageSection>
                     <SectionHeader Title="Per Dialog">
                         <Description>
-                            Below we pass along the DialogOptions class when we open the dialog, this can be done per dialog or you can predefine a bunch of them that you use for specific cases in your system.<br/>
+                            Below we pass along the DialogOptions class when we open the dialog, this can be done per dialog or you can predefine a bunch of them that you use for specific cases in your system.<br />
                         </Description>
                     </SectionHeader>
                     <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogOptionsExample"), new CodeFile("Dialog.razor", "DialogOptionsExample_Dialog")})">
@@ -65,7 +65,7 @@
                         <DialogSetOptionsExample />
                     </SectionContent>
                 </DocsPageSection>
-                
+
             </SectionSubGroups>
         </DocsPageSection>
 
@@ -136,16 +136,14 @@
             </SectionContent>
         </DocsPageSection>
 
-          <DocsPageSection>
+        <DocsPageSection>
             <SectionHeader Title="Focus Trap">
                 <Description>
                     Dialog uses the FocusTrap-Component to keep the keyboard-focus within. By default, the first element is focused With <CodeInline>DefaultFocus</CodeInline> you can change the behaviour to, for example, focus the last element.
                 </Description>
             </SectionHeader>
-            <SectionContent Outlined="true" Code="DialogFocusExample">
-                <MudContainer>
-                    <DialogFocusExample />
-                </MudContainer>
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogFocusExample"), new CodeFile("Dialog.razor","DialogFocusExample_Dialog")})">
+                <DialogFocusExample />
             </SectionContent>
         </DocsPageSection>
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
- Added the DialogFocusExample_Dialog, so users have it easier to see how to use the property.
- Centered the Open Dialog button, to keep all buttons the same
- Formatted the DialogPage, to keep code formating uniform

## How Has This Been Tested?
Visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
