### PR TITLE
MudDialog: Fix Unselectable Content Text

### DIFF
--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
@@ -19,7 +19,9 @@
          tabindex="-1">
     </div>
 
-    @ChildContent
+    <div tabindex="-1">
+        @ChildContent
+    </div>
 
     <div @ref="_lastBumper"
          class="fixed pointer-events-none"
@@ -27,7 +29,7 @@
          @onfocus="OnBumperFocusAsync">
     </div>
 
-    <div sclass="fixed pointer-events-none"
+    <div class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"
          @onfocus="OnBottomFocusAsync">
     </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4477, Fixes #4700 (duplicate).

Dialog content text can not be selectable due to FocusTrap's tabindexed div (only works when we delete the tabindex attribute). So we also wrap the FocusTrap's ChildContent with a tabindexed div.

There is also a misspell `sclass` in FocusTrap, we also fixed it.

Result:
![Ekran Görüntüsü (318)](https://user-images.githubusercontent.com/78308169/192135420-d1dc6c7d-5152-4a48-b0e1-70be65c90273.png)


## How Has This Been Tested?
Its a pure visual thing.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
