### PR TITLE
MudList<T>: New Experimental List Implementation

### DIFF
--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -34,6 +34,10 @@ namespace MudBlazor.Docs.Compiler
                 var assembly = typeof(MudText).Assembly;
                 foreach (var type in assembly.GetTypes().OrderBy(t => GetSaveTypename(t)))
                 {
+                    if (type.Namespace != null && type.Namespace.Contains("Experimental"))
+                    {
+                        continue;
+                    }
                     foreach (var property in type.GetPropertyInfosWithAttribute<ParameterAttribute>())
                     {
                         var doc = property.GetDocumentation() ?? "";

--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -50,10 +50,10 @@ namespace MudBlazor.Docs.Compiler
                     if (IsObsolete(type))
                         continue;
                     cb.AddLine("[Test]");
-                    cb.AddLine($"public void {SafeTypeName(type, removeT: true)}_API_Test()");
+                    cb.AddLine($"public void {(type.Namespace.Contains("Experimental") ? "Experimental_" : null)}{SafeTypeName(type, removeT: true)}_API_Test()");
                     cb.AddLine("{");
                     cb.IndentLevel++;
-                    cb.AddLine(@$"ctx.RenderComponent<DocsApi>(ComponentParameter.CreateParameter(""Type"", typeof({SafeTypeName(type)})));");
+                    cb.AddLine(@$"ctx.RenderComponent<DocsApi>(ComponentParameter.CreateParameter(""Type"", typeof({(type.Namespace.Contains("Experimental") ? "MudExperimental." : null)}{SafeTypeName(type)})));");
                     cb.IndentLevel--;
                     cb.AddLine("}");
                 }

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListColorExample.razor
@@ -1,0 +1,46 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList Clickable="true" MultiSelection="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue" Color="_color">
+                <MudExperimental.MudListSubheader T="string">
+                    Select Your Character:
+                </MudExperimental.MudListSubheader>
+                <MudExperimental.MudListItem Text="Neutral" Value="1" />
+                <MudExperimental.MudListItem T="int" Text="Good">
+                    <NestedList>
+                        <MudExperimental.MudListItem Text="Frodo Baggins" Value="2" />
+                        <MudExperimental.MudListItem Text="Harry Potter" Value="3" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+                <MudExperimental.MudListItem T="int" Text="Evil">
+                    <NestedList>
+                        <MudExperimental.MudListItem Text="Sauron" Value="5" />
+                        <MudExperimental.MudListItem Text="Voldemort" Value="6" />
+                        <MudExperimental.MudListItem Text="McKaragoz" Value="7" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+                <MudExperimental.MudListItem Disabled="true" Text="Im not hero" Value="7" />
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudRadioGroup T="Color" @bind-SelectedOption="_color" Class="d-flex flex-column">
+            <MudRadio Option="Color.Primary" Color="Color.Primary">Primary</MudRadio>
+            <MudRadio Option="Color.Secondary" Color="Color.Secondary">Secondary</MudRadio>
+            <MudRadio Option="Color.Tertiary" Color="Color.Tertiary">Tertiary</MudRadio>
+            <MudRadio Option="Color.Info" Color="Color.Info">Info</MudRadio>
+            <MudRadio Option="Color.Success" Color="Color.Success">Success</MudRadio>
+            <MudRadio Option="Color.Warning" Color="Color.Warning">Warning</MudRadio>
+        </MudRadioGroup>
+    </MudItem>
+</MudGrid>
+
+
+@code {
+    MudExperimental.MudListItem<int> selectedItem;
+    int selectedValue = 1;
+    Color _color = Color.Primary;
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListCustomizeMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListCustomizeMultiSelectionExample.razor
@@ -1,0 +1,47 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="320px">
+            <MudExperimental.MudList T="string" Clickable="true" MultiSelection="true" MultiSelectionAlign="_listAlign"
+                     MultiSelectionComponent="_listSelectionComponent" DisableSelectedItemStyle="_disableSelectedItemStyle">
+                <ChildContent>
+                    <MudExperimental.MudListItem Value="@("Wifi")" Text="Wifi" Icon="@Icons.Filled.Wifi" />
+                    <MudExperimental.MudListItem Value="@("Bluetooth")" Text="Bluetooth" Icon="@Icons.Filled.Bluetooth" />
+                    <MudDivider />
+                    <MudExperimental.MudListItem Value="@("Location")" Text="Location" Icon="@Icons.Filled.LocationOn" />
+                    <MudExperimental.MudListItem Value="@("High Security")" Text="High Security" Icon="@Icons.Filled.Security" />
+                </ChildContent>
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @ref="_checkboxAlign" T="bool" CheckedChanged="AlignChanged" Color="Color.Primary" Label="Align End" />
+        <MudCheckBox @bind-Checked="_disableSelectedItemStyle" Color="Color.Primary" Label="Disable Selected Item Style" />
+        <MudSelect T="MultiSelectionComponent" @bind-Value="_listSelectionComponent" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Variant="Variant.Outlined">
+            @foreach (MultiSelectionComponent comp in Enum.GetValues(typeof(MultiSelectionComponent)))
+            {
+                <MudSelectItem T="MultiSelectionComponent" Value="@comp">@comp</MudSelectItem>
+            }
+        </MudSelect>
+    </MudItem>
+</MudGrid>
+
+@code {
+    Align _listAlign = Align.Start;
+    MultiSelectionComponent _listSelectionComponent = MultiSelectionComponent.CheckBox;
+    MudCheckBox<bool> _checkboxAlign;
+    bool _disableSelectedItemStyle = false;
+    private void AlignChanged()
+    {
+        if (_checkboxAlign.Checked == false)
+        {
+            _listAlign = Align.Start;
+        }
+        else
+        {
+            _listAlign = Align.End;
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListInteractiveExample.razor
@@ -1,0 +1,52 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex flex-wrap justify-space-around gap-4">
+        <div>
+            <MudText Typo="Typo.h6" GutterBottom="true">Text only</MudText>
+            <MudPaper Width="220px">
+                <MudExperimental.MudList T="string" Dense="@Dense" DisableGutters="@Gutters" DisablePadding="@Padding">
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" SecondaryText="Secondary Text" />
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" SecondaryText="Secondary Text" />
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" SecondaryText="Secondary Text" />
+                </MudExperimental.MudList>
+            </MudPaper>
+        </div>
+
+        <div>
+            <MudText Typo="Typo.h6" GutterBottom="true">Icons with text</MudText>
+            <MudPaper Width="220px">
+                <MudExperimental.MudList T="string" Dense="@Dense" DisableGutters="@Gutters" DisablePadding="@Padding">
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" Icon="@Icons.Filled.Bookmark" SecondaryText="Secondary Text" />
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" Icon="@Icons.Filled.Bookmark" IconColor="Color.Primary" SecondaryText="Secondary Text" />
+                    <MudExperimental.MudListItem T="string" Text="Single List Item" Icon="@Icons.Filled.Bookmark" IconColor="Color.Secondary" SecondaryText="Secondary Text" />
+                </MudExperimental.MudList>
+            </MudPaper>
+        </div>
+
+        <div>
+            <MudText Typo="Typo.h6" GutterBottom="true">Avatar with text</MudText>
+            <MudPaper Width="220px">
+                <MudExperimental.MudList T="string" Dense="@Dense" DisableGutters="@Gutters" DisablePadding="@Padding">
+                    <MudExperimental.MudListItem T="string" Text="Photo 1" Avatar="@Icons.Filled.Image" SecondaryText="@DateTime.Today.AddYears(-1).ToShortDateString()" />
+                    <MudExperimental.MudListItem T="string" Text="Photo 2" Avatar="@Icons.Filled.Image" IconColor="Color.Dark" SecondaryText="@DateTime.Today.AddMonths(-1).ToShortDateString()" />
+                    <MudExperimental.MudListItem T="string" Text="Photo 3" Avatar="@Icons.Filled.Image" IconColor="Color.Error" SecondaryText="Today" />
+                </MudExperimental.MudList>
+            </MudPaper>
+        </div>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="@Dense" Label="Dense" Color="Color.Default" />
+        <MudCheckBox @bind-Checked="@Padding" Label="Disable Padding" Color="Color.Primary" />
+        <MudCheckBox @bind-Checked="@Gutters" Label="Disable Gutters" Color="Color.Secondary" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public bool Dense { get; set; }
+    public bool Padding { get; set; }
+    public bool Gutters { get; set; }
+
+    MudExperimental.MudListItem<string> selectedItem = new();
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListItemsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListItemsExample.razor
@@ -1,0 +1,53 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System.ComponentModel
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-start justify-space-around">
+        <MudPaper Width="300px">
+            <MudText Class="ma-4">Array List</MudText>
+            <MudExperimental.MudList ItemCollection="states" Clickable="true" MaxItems="_maxItems" />
+        </MudPaper>
+
+        <MudPaper Width="300px">
+            <MudText Class="ma-4">Enum List</MudText>
+            <MudExperimental.MudList T="Continent" ItemCollection="(ICollection<Continent>)Enum.GetValues(typeof(Continent))" Clickable="true" MaxItems="_maxItems" />
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudNumericField @bind-Value="_maxItems" Label="Max Items" Min="0" Max="16" HelperText="Between 0 - 16" HelperTextOnFocus="true" />
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    int _maxItems = 8;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    public enum Continent
+    {
+        Europe,
+        Asia,
+        America,
+        Africa,
+        Australia,
+        Antarctica
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListKeyboardNavigationExample.razor
@@ -1,0 +1,53 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList @ref="_list" T="int" Clickable="_clickable" MultiSelection="_multiSelection" @bind-SelectedValue="_value" SelectedValuesChanged="GetSelectedValues" OnKeyDown="OnKeyDown">
+                <MudExperimental.MudListItem T="int" Text="Sparkling Water (1)" Value="1" />
+                <MudExperimental.MudListItem T="int" Text="Still Water (2)" Value="2" />
+                <MudExperimental.MudListItem T="int" Text="Teas">
+                    <NestedList>
+                        <MudExperimental.MudListItem Text="Earl Grey (3)" Value="3" />
+                        <MudExperimental.MudListItem Text="Matcha (4)" Value="4" />
+                        <MudExperimental.MudListItem Text="Pu'er (5)" Value="5" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+                <MudExperimental.MudListItem T="int" Text="Coffees">
+                    <NestedList>
+                        <MudExperimental.MudListItem Text="Irish Coffee (6)" Value="6" />
+                        <MudExperimental.MudListItem Text="Double Espresso (7)" Value="7" />
+                        <MudExperimental.MudListItem Text="Cafe Latte (8)" Value="8" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="_clickable" Color="Color.Primary" Label="Clickable" />
+        <MudCheckBox @bind-Checked="_multiSelection" Color="Color.Primary" Label="MultiSelection" />
+        <MudDivider />
+        <MudText Class="ma-4">Last pressed key: @_key</MudText>
+    </MudItem>
+</MudGrid>
+
+@code {
+    bool _clickable = false;
+    bool _multiSelection = false;
+    int _value;
+    MudExperimental.MudList<int> _list;
+    string _values = "";
+    string _key = "";
+
+    private void GetSelectedValues()
+    {
+        _values = string.Join(", ", _list.SelectedValues);
+        StateHasChanged();
+    }
+
+    private void OnKeyDown(KeyboardEventArgs args)
+    {
+        _key = args.Key;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListMultiSelectionExample.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.Docs.Examples
+@inject ISnackbar Snackbar
+
+<MudPaper Width="300px">
+    <MudExperimental.MudList @ref="_list" T="int" Clickable="true" SelectedValuesChanged="GetSelectedValues" MultiSelection="true">
+        <MudExperimental.MudListSubheader T="string">
+            Your drink:
+            <MudChip Color="Color.Secondary">
+
+            </MudChip>
+        </MudExperimental.MudListSubheader>
+        <MudExperimental.MudListItem Text="Sparkling Water" Value="1" />
+        <MudExperimental.MudListItem Text="Still Water" Value="11" />
+        <MudExperimental.MudListItem T="int" Text="Teas">
+            <NestedList>
+                <MudExperimental.MudListItem Text="Earl Grey" Value="2" />
+                <MudExperimental.MudListItem Text="Matcha" Value="3" />
+                <MudExperimental.MudListItem Text="Pu'er" Value="4" />
+            </NestedList>
+        </MudExperimental.MudListItem>
+        <MudExperimental.MudListItem T="int" Text="Coffees">
+            <NestedList>
+                <MudExperimental.MudListItem Text="Irish Coffee" Value="5" />
+                <MudExperimental.MudListItem Text="Double Espresso" Value="6" />
+                <MudExperimental.MudListItem Text="Cafe Latte" Value="7" />
+            </NestedList>
+        </MudExperimental.MudListItem>
+    </MudExperimental.MudList>
+</MudPaper>
+
+<MudText>Selected Values: @_values</MudText>
+@code
+{
+    //MudListItem<int> selectedItem;
+    MudExperimental.MudList<int> _list;
+    string _values = "";
+    IEnumerable<int> selectedValue = new HashSet<int>();
+
+    private void GetSelectedValues()
+    {
+        Snackbar.Add("Method invoke");
+        _values = string.Join(", ", _list.SelectedValues);
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListNestedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListNestedExample.razor
@@ -1,0 +1,33 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList T="string" Clickable="true" SecondaryBackgroundForNestedItemHeader="_secondaryBackground" Dense="_listDense">
+                <MudExperimental.MudListSubheader T="string">Nested List Items</MudExperimental.MudListSubheader>
+
+                <MudExperimental.MudListItem T="string" Icon="@Icons.Filled.Send">Sent mail</MudExperimental.MudListItem>
+                <MudExperimental.MudListItem T="string" Icon="@Icons.Filled.Drafts">Drafts</MudExperimental.MudListItem>
+
+                <MudExperimental.MudListItem T="string" Icon="@Icons.Filled.Inbox" Text="Inbox" InitiallyExpanded="true">
+                    <NestedList>
+                        <MudExperimental.MudListItem Dense="_nestedDense" T="string" Icon="@Icons.Filled.StarRate">Starred</MudExperimental.MudListItem>
+                        <MudExperimental.MudListItem Dense="_nestedDense" T="string" Icon="@Icons.Filled.WatchLater">Snoozed</MudExperimental.MudListItem>
+                    </NestedList>
+                </MudExperimental.MudListItem>
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="_secondaryBackground" Color="Color.Primary" Label="Secondary Background For Nested Item Header" />
+        <MudCheckBox @bind-Checked="_listDense" Color="Color.Primary" TriState="true" Label="List Dense" />
+        <MudCheckBox @bind-Checked="_nestedDense" Color="Color.Primary" TriState="true" Label="Nested List Dense" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    bool _secondaryBackground;
+    bool _listDense;
+    bool? _nestedDense;
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListSimpleExample.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px">
+    <MudExperimental.MudList T="string">
+        <MudExperimental.MudListItem T="string" Text="Trash" />
+        <MudExperimental.MudListItem T="string" Text="Spam" />
+        <MudDivider />
+        <MudExperimental.MudListItem T="string" Text="Inbox" Icon="@Icons.Filled.Inbox" />
+        <MudExperimental.MudListItem T="string" Text="Sent" Icon="@Icons.Filled.Send" />
+        <MudDivider />
+        <MudExperimental.MudListItem T="string" Avatar="@Icons.Filled.Image" IconColor="Color.Primary">Photos</MudExperimental.MudListItem>
+        <MudExperimental.MudListItem T="string" Avatar="@Icons.Filled.Work" IconColor="Color.Secondary">Work</MudExperimental.MudListItem>
+    </MudExperimental.MudList>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListStickySubHeaderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListStickySubHeaderExample.razor
@@ -1,0 +1,50 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList T="string" Clickable="true" MultiSelection="true" Style="max-height:400px; overflow-y: auto;" DisablePadding="_disablePadding">
+                <MudExperimental.MudListSubheader T="string" Sticky="_sticky" SecondaryBackground="_secondaryBackground">England</MudExperimental.MudListSubheader>
+                @foreach (string club in _englishClubs)
+                {
+                    <MudExperimental.MudListItem Value="@club" Text="@club" />
+                }
+
+                <MudExperimental.MudListSubheader T="string" Sticky="_sticky" SecondaryBackground="_secondaryBackground">Spain</MudExperimental.MudListSubheader>
+                @foreach (string club in _spanishClubs)
+                {
+                    <MudExperimental.MudListItem Value="@club" Text="@club" />
+                }
+
+                <MudExperimental.MudListSubheader T="string" Sticky="_sticky" SecondaryBackground="_secondaryBackground">Germany</MudExperimental.MudListSubheader>
+                @foreach (string club in _germanClubs)
+                {
+                    <MudExperimental.MudListItem Value="@club" Text="@club" />
+                }
+
+                <MudExperimental.MudListSubheader T="string" Sticky="_sticky" SecondaryBackground="_secondaryBackground">Turkey</MudExperimental.MudListSubheader>
+                @foreach (string club in _turkishClubs)
+                {
+                    <MudExperimental.MudListItem Value="@club" Text="@club" />
+                }
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="_sticky" Color="Color.Primary" Label="Sticky SubHeader" />
+        <MudCheckBox @bind-Checked="_secondaryBackground" Color="Color.Primary" Label="Secondary Background" />
+        <MudCheckBox @bind-Checked="_disablePadding" Color="Color.Primary" Label="Disable Padding" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    bool _sticky = true;
+    bool _secondaryBackground = true;
+    bool _disablePadding = true;
+
+    string[] _englishClubs = { "Arsenal", "Manchester City", "Liverpool", "Manchester United", "Chelsea" };
+    string[] _germanClubs = { "Bayern Munich", "Borussia Dortmund", "Schalke 04", "Bayern Leverkusen", "Stuttgart" };
+    string[] _spanishClubs = { "Barcelona", "Read Madrid", "Atletico Madrid", "Getafe", "Levante", "Sevilla", "Valencia", "Villareal" };
+    string[] _turkishClubs = { "Fenerbahçe", "Galatasaray", "Beşiktaş", "Trabzonspor", "Alanyaspor", "Antalyaspor", "Ankaragücü" };
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVariantExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVariantExample.razor
@@ -39,7 +39,7 @@
         <MudButton OnClick="@(() => _selectedValue = 2)">Select 2</MudButton>
         <MudButton OnClick="@(() => _selectedValues = new HashSet<int?>() { 2, 4 })">Select 2 and 4</MudButton>
         <MudButton OnClick="@(() => _selectedItem = _thirdItem)">Select 3rd Item</MudButton>
-        <MudButton OnClick="@(() => _selectedItems = new HashSet<MudBlazor.Experimental.MudListItem<int?>>() { _thirdItem, _fifthItem })">Select 3rd and 5th Items</MudButton>
+        <MudButton OnClick="@(() => _selectedItems = new HashSet<MudExperimental.MudListItem<int?>>() { _thirdItem, _fifthItem })">Select 3rd and 5th Items</MudButton>
         <MudButton OnClick="@(() => _list.Clear())">Clear</MudButton>
         <MudText Class="mt-2">Results:</MudText>
         <MudText Class="ma-4">Selected Value: @_selectedValue</MudText>

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVariantExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVariantExample.razor
@@ -1,0 +1,64 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-start justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList @ref="_list" T="int?" Clickable="_clickable" MultiSelection="_multiSelection" SelectAll="_selectAll" @bind-SelectedValue="_selectedValue" @bind-SelectedItem="_selectedItem" @bind-SelectedValues="_selectedValues" @bind-SelectedItems="_selectedItems">
+                <MudExperimental.MudListItem T="int?" Text="Sparkling Water (1)" Value="1" />
+                <MudExperimental.MudListItem T="int?" Text="Still Water (2)" Value="2" />
+                <MudExperimental.MudListItem T="int?" Text="Teas" InitiallyExpanded="true">
+                    <NestedList>
+                        <MudExperimental.MudListItem @ref="_thirdItem" T="int?" Text="Earl Grey (3)" Value="3" />
+                        <MudExperimental.MudListItem T="int?" Text="Matcha (4)" Value="4" />
+                        <MudExperimental.MudListItem @ref="_fifthItem" T="int?" Text="Pu'er (5)" Value="5" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+                <MudExperimental.MudListItem T="int?" Text="Coffees">
+                    <NestedList>
+                        <MudExperimental.MudListItem T="int?" Text="Irish Coffee (6)" Value="6" />
+                        <MudExperimental.MudListItem T="int?" Text="Double Espresso (7)" Value="7" />
+                        <MudExperimental.MudListItem T="int?" Text="Cafe Latte (8)" Value="8" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="_clickable" Color="Color.Primary" Label="Clickable" />
+        <MudCheckBox @bind-Checked="_multiSelection" Color="Color.Primary" Label="MultiSelection" />
+        <MudCheckBox @bind-Checked="_selectAll" Color="Color.Primary" Label="Select All" />
+        <MudDivider />
+        <MudTextField @bind-Value="_selectedValue" Clearable="true" />
+        <MudSelect T="int?" @bind-SelectedValues="_selectedValues" MultiSelection="true" Variant="Variant.Filled" Label="Selected Values">
+            @foreach (var item in _list.GetItems())
+            {
+                <MudSelectItem Value="item.Value">@item.Text</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton OnClick="@(() => _selectedValue = 2)">Select 2</MudButton>
+        <MudButton OnClick="@(() => _selectedValues = new HashSet<int?>() { 2, 4 })">Select 2 and 4</MudButton>
+        <MudButton OnClick="@(() => _selectedItem = _thirdItem)">Select 3rd Item</MudButton>
+        <MudButton OnClick="@(() => _selectedItems = new HashSet<MudBlazor.Experimental.MudListItem<int?>>() { _thirdItem, _fifthItem })">Select 3rd and 5th Items</MudButton>
+        <MudButton OnClick="@(() => _list.Clear())">Clear</MudButton>
+        <MudText Class="mt-2">Results:</MudText>
+        <MudText Class="ma-4">Selected Value: @_selectedValue</MudText>
+        <MudText Class="ma-4">Selected Values: @string.Join(", ", _selectedValues ?? new List<int?>())</MudText>
+        <MudText Class="ma-4">Selected Item Text: @_selectedItem?.Text</MudText>
+        <MudText Class="ma-4">Selected Items Texts: @string.Join(", ", _selectedItems == null ? new List<string>() : _selectedItems.Select(x => x.Text))</MudText>
+    </MudItem>
+</MudGrid>
+
+@code {
+    bool _clickable = true;
+    bool _multiSelection = false;
+    bool _selectAll = false;
+
+    MudExperimental.MudList<int?> _list;
+    int? _selectedValue = 1;
+    IEnumerable<int?> _selectedValues = new List<int?>();
+    MudExperimental.MudListItem<int?> _selectedItem;
+    MudExperimental.MudListItem<int?> _thirdItem;
+    MudExperimental.MudListItem<int?> _fifthItem;
+    IEnumerable<MudExperimental.MudListItem<int?>> _selectedItems = new List<MudExperimental.MudListItem<int?>>();
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVirtualizationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/Examples/ExperimentalListVirtualizationExample.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex align-center justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList ItemCollection="numbers" Clickable="true" Virtualize="true" MaxItems="10" />
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" sm="4">
+        <MudRadioGroup @ref="_radioGroup" T="int" SelectedOptionChanged="OptionChanged">
+            <MudRadio Option="100" Color="Color.Primary">100 Items</MudRadio>
+            <MudRadio Option="1000" Color="Color.Primary">1000 Items</MudRadio>
+            <MudRadio Option="10000" Color="Color.Primary">10.000 Items</MudRadio>
+            <MudRadio Option="100000" Color="Color.Primary">100.000 Items</MudRadio>
+        </MudRadioGroup>
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    MudRadioGroup<int> _radioGroup;
+    private int[] numbers = new int[1000];
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        for (int i = 0; i < 1000; i++)
+        {
+            numbers[i] = i;
+        }
+    }
+
+    private void OptionChanged()
+    {
+        numbers = new int[_radioGroup.SelectedOption];
+        for (int i = 0; i < _radioGroup.SelectedOption; i++)
+        {
+            numbers[i] = i;
+        }
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Experimental/List/ExperimentalListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Experimental/List/ExperimentalListPage.razor
@@ -1,0 +1,146 @@
+﻿@page "/experimental/list"
+
+<DocsPage>
+    <DocsPageHeader Title="Lists">
+        <Description>Easily customizable and scrollable lists. Make them suit your needs with avatars, icons, or something like checkboxes.</Description>
+        </DocsPageHeader>
+    <DocsPageContent>
+
+        <DocsPageSection>
+            <SectionHeader Title="Simple List, Icon and Avatar">
+                <Description>You can create list items with icon or avatar easily.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="ExperimentalListSimpleExample">
+                <ExperimentalListSimpleExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Nested List">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListNestedExample">
+                <ExperimentalListNestedExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Visuals">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListInteractiveExample">
+                <ExperimentalListInteractiveExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="List Variants, Selection and Multi Selection">
+                <Description>
+                    Lists can be varianted with <CodeInline>Clickable</CodeInline> and <CodeInline>MultiSelection</CodeInline> parameters.<br />
+                    There are 4 variants:<br />
+                    <b>(1)</b> A simple list without any interactivibility<br />
+                    <b>(2)</b> Selectable list with <CodeInline>Clickable</CodeInline> parameter<br />
+                    <b>(3)</b> Multi selectable list with both <CodeInline>MultiSelection</CodeInline> and <CodeInline>Clickable</CodeInline> parameters<br />
+                    <b>(4)</b> Multi selectable, but not clickable list with only <CodeInline>MultiSelection</CodeInline> parameter. With this variant, selection can only be possible with clicking checkbox (or equivalent component), not the item itself.<br />
+                    <MudAlert Class="mt-2" Severity="Severity.Info" NoIcon="true">
+                        <b>Note:</b> If you want to change value or item programmatically, be sure to set proper parameter. If MultiSelection is false, you should change Value or SelectedItem, not SelectedValues or SelectedItems. And if MultiSelection is true, should change SelectedValues or SelectedItems. Otherwise you may encounter wrong results.
+                    </MudAlert>
+                    <MudAlert Class="mt-2" Severity="Severity.Info" NoIcon="true">
+                        <b>Note 2:</b> Setting value or item also arranges other parameters and fires all change events. So you don't need to change both of them, you should only change one parameter to prevent conflicts and have maximum performance.
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListVariantExample">
+                <ExperimentalListVariantExample />
+            </SectionContent>
+        </DocsPageSection>
+
+         <DocsPageSection>
+            <SectionHeader Title="Customize Multiselection">
+                <Description>
+                    With <CodeInline>MultiSelectionAlign</CodeInline> parameter, the selection component's placement can be selected.<br />
+                   With <CodeInline>MultiSelectionComponent</CodeInline> parameter, users can select the selection component: Checkbox or switch.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListCustomizeMultiSelectionExample">
+                <ExperimentalListCustomizeMultiSelectionExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Groups With Sticky SubHeaders">
+                <Description>
+                    List items can be grouped and SubHeaders can be used as sticky header.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListStickySubHeaderExample">
+                <ExperimentalListStickySubHeaderExample />
+            </SectionContent>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Populate With ItemCollection Parameter">
+                <Description>
+                    By default, users can statically or dynamically (with for and foreach loops) place MudListItems. As an alternative, if <CodeInline>ItemCollection</CodeInline> set, MudList will automatically render items for you.
+                    This alternative is useful when you don't need item template and you want to construct list faster.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListItemsExample">
+                <ExperimentalListItemsExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Virtualization">
+                <Description>
+                    MudList support virtualization, if populated with <CodeInline>Items</CodeInline> parameter.<br />
+                    Note that keyboard navigation doesn't properly work with virtualization.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListVirtualizationExample">
+                <ExperimentalListVirtualizationExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Color">
+                <Description>
+                    In selectable MudList, you can also set the selected item's color.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListColorExample">
+                <ExperimentalListColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Keyboard Navigation">
+                <Description>
+                    List supports keyboard navigation once you get focus with clicking or pressing <CodeInline>Tab</CodeInline>.
+                    <br />
+                    <MudText><CodeInline>ArrowUp</CodeInline> key to select/navigate previous item</MudText>
+                    <MudText><CodeInline>ArrowDown</CodeInline> key to select/navigate next item</MudText>
+                    <MudText><CodeInline>Home</CodeInline> key to select/navigate first item</MudText>
+                    <MudText><CodeInline>End</CodeInline> key to select/navigate last item</MudText>
+                    <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to select item</MudText>
+                    <MudText><CodeInline>Ctrl+A</CodeInline> key to toggle select all/clear all items (MultiSelect only)</MudText>
+                    <br />
+                    <br />
+                    <MudAlert Severity="Severity.Info" NoIcon="true">
+                        <b>Note 1:</b> Keyboard navigation only works if list is Clickable or MultiSelection
+                    </MudAlert>
+                    <MudAlert Class="mt-2" Severity="Severity.Info" NoIcon="true">
+                        <b>Note 2:</b> If you use keys to navigate a collapsed item it will be automatically expanded.
+                    </MudAlert>
+                    <MudAlert Class="mt-2" Severity="Severity.Info" NoIcon="true">
+                        <b>Note 3:</b> Printable character primarily search for the text. If text is null, then it search for value.
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" ShowCode="false" Code="ExperimentalListKeyboardNavigationExample">
+                <ExperimentalListKeyboardNavigationExample />
+            </SectionContent>
+        </DocsPageSection>
+
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -79,6 +79,7 @@ namespace MudBlazor.Docs.Services
             .AddItem("Timeline", typeof(MudTimeline), typeof(MudTimelineItem))
             .AddItem("Pagination", typeof(MudPagination))
             .AddItem("Stack", typeof(MudStack))
+            .AddItem("List", typeof(MudExperimental.MudList<T>), typeof(MudExperimental.MudListItem<T>), typeof(MudExperimental.MudListSubheader<T>))
 
             //GROUPS
 

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -10,6 +10,7 @@ namespace MudBlazor.Docs.Services
     {
         //Menu sections
         IEnumerable<MudComponent> Components { get; }
+        IEnumerable<MudComponent> ExperimentalComponents { get; }
         IEnumerable<MudComponent> Api { get; }
         MudComponent GetParent(Type type);
         MudComponent GetComponent(Type type);
@@ -79,7 +80,6 @@ namespace MudBlazor.Docs.Services
             .AddItem("Timeline", typeof(MudTimeline), typeof(MudTimelineItem))
             .AddItem("Pagination", typeof(MudPagination))
             .AddItem("Stack", typeof(MudStack))
-            .AddItem("List", typeof(MudExperimental.MudList<T>), typeof(MudExperimental.MudListItem<T>), typeof(MudExperimental.MudListSubheader<T>))
 
             //GROUPS
 
@@ -124,7 +124,12 @@ namespace MudBlazor.Docs.Services
             // this must be last!
             .GetComponentsSortedByName();
 
+        private readonly List<MudComponent> _experimentalComponents = new DocsComponents()
+            .AddItem("List", typeof(MudExperimental.MudList<T>), typeof(MudExperimental.MudListItem<T>), typeof(MudExperimental.MudListSubheader<T>))
+            .GetComponentsSortedByName();
+
         public IEnumerable<MudComponent> Components => _docsComponents;
+        public IEnumerable<MudComponent> ExperimentalComponents => _experimentalComponents;
 
         private Dictionary<Type, MudComponent> _parents = new();
         private Dictionary<Type, MudComponent> _componentLookup = new();
@@ -152,6 +157,29 @@ namespace MudBlazor.Docs.Services
         public MenuService()
         {
             foreach (var comp in Components)
+            {
+                if (comp.IsNavGroup)
+                {
+                    foreach (var groupComp in comp.GroupComponents)
+                    {
+                        _componentLookup.Add(groupComp.Type, groupComp);
+                        _parents.Add(groupComp.Type, comp);
+                    }
+                }
+                else
+                {
+                    _componentLookup.Add(comp.Type, comp);
+                    // top-level types refer to themself as parent ;)
+                    _parents.Add(comp.Type, comp);
+                    if (comp.ChildTypes != null)
+                    {
+                        foreach (var childType in comp.ChildTypes)
+                            _parents.Add(childType, comp);
+                    }
+                }
+            }
+
+            foreach (var comp in ExperimentalComponents)
             {
                 if (comp.IsNavGroup)
                 {

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -4,12 +4,12 @@
 
 <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Docs</b></MudText>
 <MudNavLink Href="docs/overview" Class="docs-single-link">Overview</MudNavLink>
-<MudNavGroup Title="Components" Expanded="@(_section == "components")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+<MudNavGroup Title="Components" Expanded="@(_section == "components")" ExpandIcon="@Icons.Filled.ExpandMore">
     @foreach (var item in MenuService.Components)
     {
         if (item.IsNavGroup)
         {
-            <MudNavGroup Title="@item.Name" Expanded="@(IsSubGroupExpanded(item))" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+            <MudNavGroup Title="@item.Name" Expanded="@(IsSubGroupExpanded(item))" ExpandIcon="@Icons.Filled.ExpandMore">
                 @foreach (var subItem in item.GroupComponents)
                 {
                     string href = $"components/{subItem.Link}";
@@ -24,25 +24,45 @@
         }
     }
 </MudNavGroup>
-<MudNavGroup Title="API" Expanded="@(_section == "api")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+<MudNavGroup Title="API" Expanded="@(_section == "api")" ExpandIcon="@Icons.Filled.ExpandMore">
     @foreach (var item in MenuService.Api.OrderBy(x => x.Name))
     {
         <MudNavLink Href="@ApiLink.GetApiLinkFor(item.Type)">@item.Name</MudNavLink>
     }
 </MudNavGroup>
-<MudNavGroup Title="Features" Expanded="@(_section == "features")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+<MudNavGroup Title="Experimental" Expanded="@(_section == "experimental")" ExpandIcon="@Icons.Filled.ExpandMore">
+    @foreach (var item in MenuService.Components)
+    {
+        if (item.IsNavGroup)
+        {
+            <MudNavGroup Title="@item.Name" Expanded="@(IsSubGroupExpanded(item))" ExpandIcon="@Icons.Filled.ExpandMore">
+                @foreach (var subItem in item.GroupComponents)
+                {
+                    string href = $"experimental/{subItem.Link}";
+                    <MudNavLink Href="@href">@subItem.Name</MudNavLink>
+                }
+            </MudNavGroup>
+        }
+        else
+        {
+            string href = $"experimental/{item.Link}";
+            <MudNavLink Href="@href">@item.Name</MudNavLink>
+        }
+    }
+</MudNavGroup>
+<MudNavGroup Title="Features" Expanded="@(_section == "features")" ExpandIcon="@Icons.Filled.ExpandMore">
     @foreach (var link in MenuService.Features)
     {
         <MudNavLink Href="@link.Href">@link.Title</MudNavLink>
     }
 </MudNavGroup>
-<MudNavGroup Title="Customization" Expanded="@(_section == "customization")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+<MudNavGroup Title="Customization" Expanded="@(_section == "customization")" ExpandIcon="@Icons.Filled.ExpandMore">
     @foreach (var link in MenuService.Customization)
     {
         <MudNavLink Href="@link.Href">@link.Title</MudNavLink>
     }
 </MudNavGroup>
-<MudNavGroup Title="CSS Utilities" Expanded="@(_section == "utilities")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+<MudNavGroup Title="CSS Utilities" Expanded="@(_section == "utilities")" ExpandIcon="@Icons.Filled.ExpandMore">
     @foreach (var title in MenuService.Utilities.GroupBy(x => x.Group).Select(x => x.Key))
     {
         <div class="docs-css-utility-header">

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -31,7 +31,7 @@
     }
 </MudNavGroup>
 <MudNavGroup Title="Experimental" Expanded="@(_section == "experimental")" ExpandIcon="@Icons.Filled.ExpandMore">
-    @foreach (var item in MenuService.Components)
+    @foreach (var item in MenuService.ExperimentalComponents)
     {
         if (item.IsNavGroup)
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalCountTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalCountTest.razor
@@ -1,0 +1,41 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPaper Width="300px">
+    <MudExperimental.MudList T="int?" Clickable="true" SelectedValueChanged="ValueChanged" SelectedValuesChanged="ValuesChanged" SelectedItemChanged="ItemChanged" SelectedItemsChanged="ItemsChanged">
+        <MudExperimental.MudListItem T="int?" Value="1" Text="Trash" />
+        <MudExperimental.MudListItem T="int?" Value="2" Text="Spam" />
+        <MudDivider />
+        <MudExperimental.MudListItem T="int?" Value="3" Text="Inbox" Icon="@Icons.Filled.Inbox" />
+        <MudExperimental.MudListItem T="int?" Value="4" Text="Sent" Icon="@Icons.Filled.Send" />
+        <MudDivider />
+        <MudExperimental.MudListItem T="int?" Value="5" Avatar="@Icons.Filled.Image" IconColor="Color.Primary">Photos</MudExperimental.MudListItem>
+        <MudExperimental.MudListItem T="int?" Value="6" Avatar="@Icons.Filled.Work" IconColor="Color.Secondary">Work</MudExperimental.MudListItem>
+    </MudExperimental.MudList>
+</MudPaper>
+
+@code {
+    public int ValueChangeCount { get; set; }
+    public int ValuesChangeCount { get; set; }
+    public int ItemChangeCount { get; set; }
+    public int ItemsChangeCount { get; set; }
+
+    private void ValueChanged()
+    {
+        ValueChangeCount++;
+    }
+
+    private void ValuesChanged()
+    {
+        ValuesChangeCount++;
+    }
+
+    private void ItemChanged()
+    {
+        ItemChangeCount++;
+    }
+
+    private void ItemsChanged()
+    {
+        ItemsChangeCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalEnhancedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalEnhancedTest.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPaper Width="300px">
+    <MudExperimental.MudList T="int" Clickable="true" MultiSelection="true" @bind-SelectedValue="selectedValue" @bind-SelectedItem="selectedItem">
+        <MudExperimental.MudListSubheader T="string">
+            Your drink:
+            <MudChip Color="Color.Secondary">
+                @(selectedItem?.Text ?? "You are dry") (@(selectedValue.ToString()))
+            </MudChip>
+        </MudExperimental.MudListSubheader>
+        <MudExperimental.MudListItem Text="Water 1" Value="1" />
+        <MudExperimental.MudListItem IsFunctional="true" Text="Exceptional Water" Value="2" />
+        <MudExperimental.MudListItem Text="Water 2" Value="3" />
+        <MudExperimental.MudListItem T="int" Text="Teas">
+            <NestedList>
+                <MudExperimental.MudListItem Text="Earl Grey" Value="4" />
+                <MudExperimental.MudListItem Text="Matcha" Value="5" />
+                <MudExperimental.MudListItem Text="Pu'er" Value="6" />
+            </NestedList>
+        </MudExperimental.MudListItem>
+        <MudExperimental.MudListItem T="int" Text="Coffees">
+            <NestedList>
+                <MudExperimental.MudListItem Text="Irish Coffee" Value="7" />
+                <MudExperimental.MudListItem Text="Double Espresso" Value="8" />
+                <MudExperimental.MudListItem Disabled="true" Text="Cafe Latte" Value="9" />
+            </NestedList>
+        </MudExperimental.MudListItem>
+    </MudExperimental.MudList>
+</MudPaper>
+
+@code
+{
+    MudExperimental.MudListItem<int> selectedItem;
+    int selectedValue;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionInitialValueTest.razor
@@ -7,7 +7,7 @@
             @(selectedItem?.Text ?? "You are dry")
         </MudChip>
     </MudExperimental.MudListSubheader>
-    <MudExperimental.MudListItem T="int?" Text="Sparkling  Water" Value="1"/>
+    <MudExperimental.MudListItem T="int?" Text="Sparkling Water" Value="1"/>
     <MudExperimental.MudListItem T="int?" Text="Teas">
         <NestedList>
             <MudExperimental.MudListItem T="int?" Text="Earl Grey" Value="2" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionInitialValueTest.razor
@@ -1,0 +1,40 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudExperimental.MudList @ref="_list" T="int?" Clickable="true" Color="Color" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue">
+    <MudExperimental.MudListSubheader T="int?">
+        Your drink:
+        <MudChip Color="Color.Secondary">
+            @(selectedItem?.Text ?? "You are dry")
+        </MudChip>
+    </MudExperimental.MudListSubheader>
+    <MudExperimental.MudListItem T="int?" Text="Sparkling  Water" Value="1"/>
+    <MudExperimental.MudListItem T="int?" Text="Teas">
+        <NestedList>
+            <MudExperimental.MudListItem T="int?" Text="Earl Grey" Value="2" />
+            <MudExperimental.MudListItem T="int?" Text="Matcha"  Value="3"/>
+            <MudExperimental.MudListItem T="int?" Text="Pu'er"  Value="4"/>
+        </NestedList>
+    </MudExperimental.MudListItem>
+    <MudExperimental.MudListItem T="int?" Text="Coffees">
+        <NestedList>
+            <MudExperimental.MudListItem T="int?" Text="Irish Coffee" Value="5" />
+            <MudExperimental.MudListItem T="int?" Text="Double Espresso" Value="6" />
+            <MudExperimental.MudListItem T="int?" Text="Cafe Latte"  Value="7"/>
+        </NestedList>
+    </MudExperimental.MudListItem>
+</MudExperimental.MudList>
+
+@code
+{
+    [Parameter] public Color Color { get; set; } = Color.Primary;
+    MudExperimental.MudList<int?> _list;
+    public static string __description__ = "Sparkling Water should be selected initially.";
+    MudExperimental.MudListItem<int?> selectedItem;
+    int? selectedValue = 1;
+
+    public void SetSelectedValue(int? value)
+    {
+        selectedValue = value;
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalSelectionTest.razor
@@ -1,0 +1,31 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudExperimental.MudList T="int" Clickable="true" @bind-SelectedItem="selectedItem">
+    <MudExperimental.MudListSubheader T="int">
+        Your drink:
+        <MudChip Color="Color.Secondary">
+            @(selectedItem?.Text ?? "You are dry")
+        </MudChip>
+    </MudExperimental.MudListSubheader>
+    <MudExperimental.MudListItem T="int" Text="Sparkling Water" Value="1" />
+    <MudExperimental.MudListItem T="int" Text="Teas">
+        <NestedList>
+            <MudExperimental.MudListItem Text="Earl Grey"  Value="2"/>
+            <MudExperimental.MudListItem Text="Matcha"  Value="3"/>
+            <MudExperimental.MudListItem Text="Pu'er"  Value="4"/>
+        </NestedList>
+    </MudExperimental.MudListItem>
+    <MudExperimental.MudListItem T="int" Text="Coffees">
+        <NestedList>
+            <MudExperimental.MudListItem Text="Irish Coffee"  Value="5"/>
+            <MudExperimental.MudListItem Text="Double Espresso"  Value="6"/>
+            <MudExperimental.MudListItem Text="Cafe Latte"  Value="7"/>
+        </NestedList>
+    </MudExperimental.MudListItem>
+</MudExperimental.MudList>
+
+@code
+{
+    public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+    MudExperimental.MudListItem<int> selectedItem;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalVariantTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListExperimentalVariantTest.razor
@@ -1,0 +1,58 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
+    <MudItem xs="12" sm="4">
+        <MudCheckBox @bind-Checked="_clickable" Color="Color.Primary" Label="Clickable" />
+        @*<MudCheckBox @bind-Checked="_multiSelection" Color="Color.Primary" Label="MultiSelection" />*@
+        <MudCheckBox @bind-Checked="_selectAll" Color="Color.Primary" Label="Select All" />
+        <MudDivider />
+        <MudTextField @bind-Value="_selectedValue" Clearable="true" />
+
+        <MudButton OnClick="@(() => _selectedValue = 2)">Select 2</MudButton>
+        <MudButton OnClick="@(() => _selectedValues = new HashSet<int?>() { 2, 4 })">Select 2 and 4</MudButton>
+        <MudButton OnClick="@(() => _selectedItem = _thirdItem)">Select 3rd Item</MudButton>
+        <MudButton OnClick="@(() => _selectedItems = new HashSet<MudExperimental.MudListItem<int?>>() { _thirdItem, _fifthItem })">Select 3rd and 5th Items</MudButton>
+        <MudButton OnClick="@(() => _list.Clear())">Clear</MudButton>
+        <MudText Class="mt-2">Results:</MudText>
+        <MudText Class="ma-4">Selected Value: @_selectedValue</MudText>
+        <MudText Class="ma-4">Selected Values: @string.Join(", ", _selectedValues ?? new List<int?>())</MudText>
+        <MudText Class="ma-4">Selected Item Text: @_selectedItem?.Text</MudText>
+        <MudText Class="ma-4">Selected Items Texts: @string.Join(", ", _selectedItems == null ? new List<string>() : _selectedItems.Select(x => x.Text))</MudText>
+    </MudItem>
+
+    <MudItem xs="12" sm="8" Class="d-flex align-start justify-center">
+        <MudPaper Width="300px">
+            <MudExperimental.MudList @ref="_list" T="int?" Clickable="_clickable" SelectAll="_selectAll" @bind-SelectedValue="_selectedValue" @bind-SelectedItem="_selectedItem" @bind-SelectedValues="_selectedValues" @bind-SelectedItems="_selectedItems">
+                <MudExperimental.MudListItem T="int?" Text="Sparkling Water (1)" Value="1" />
+                <MudExperimental.MudListItem T="int?" Text="Still Water (2)" Value="2" />
+                <MudExperimental.MudListItem T="int?" Text="Teas" InitiallyExpanded="true">
+                    <NestedList>
+                        <MudExperimental.MudListItem @ref="_thirdItem" T="int?" Text="Earl Grey (3)" Value="3" />
+                        <MudExperimental.MudListItem T="int?" Text="Matcha (4)" Value="4" />
+                        <MudExperimental.MudListItem @ref="_fifthItem" T="int?" Text="Pu'er (5)" Value="5" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+                <MudExperimental.MudListItem T="int?" Text="Coffees">
+                    <NestedList>
+                        <MudExperimental.MudListItem T="int?" Text="Irish Coffee (6)" Value="6" />
+                        <MudExperimental.MudListItem T="int?" Text="Double Espresso (7)" Value="7" />
+                        <MudExperimental.MudListItem T="int?" Text="Cafe Latte (8)" Value="8" />
+                    </NestedList>
+                </MudExperimental.MudListItem>
+            </MudExperimental.MudList>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@code {
+    bool _clickable = true;
+    bool _selectAll = false;
+
+    MudExperimental.MudList<int?> _list;
+    int? _selectedValue = 1;
+    IEnumerable<int?> _selectedValues = new List<int?>();
+    MudExperimental.MudListItem<int?> _selectedItem;
+    MudExperimental.MudListItem<int?> _thirdItem;
+    MudExperimental.MudListItem<int?> _fifthItem;
+    IEnumerable<MudExperimental.MudListItem<int?>> _selectedItems = new List<MudExperimental.MudListItem<int?>>();
+}

--- a/src/MudBlazor.UnitTests/Components/ListExperimentalTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListExperimentalTests.cs
@@ -1,0 +1,347 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable BL0005
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
+using MudBlazor.UnitTests.TestComponents;
+using MudExperimental;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ListExperimentalTests : BunitTest
+    {
+        [Test]
+        public async Task List_EventCountTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalCountTest>();
+            var list = comp.FindComponent<MudExperimental.MudList<int?>>().Instance;
+
+            comp.Instance.ValueChangeCount.Should().Be(0);
+            comp.Instance.ValuesChangeCount.Should().Be(0);
+            comp.Instance.ItemChangeCount.Should().Be(0);
+            comp.Instance.ItemsChangeCount.Should().Be(0);
+
+            await comp.InvokeAsync(() => list.SelectedValue = 1);
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(1));
+            comp.Instance.ValuesChangeCount.Should().Be(1);
+            comp.Instance.ItemChangeCount.Should().Be(1);
+            comp.Instance.ItemsChangeCount.Should().Be(1);
+            // Clicking the current item should not fire events
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-list-item")[0].Click());
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(1));
+            comp.Instance.ValuesChangeCount.Should().Be(1);
+            comp.Instance.ItemChangeCount.Should().Be(1);
+            comp.Instance.ItemsChangeCount.Should().Be(1);
+
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-list-item")[1].Click());
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(2));
+            comp.Instance.ValuesChangeCount.Should().Be(2);
+            comp.Instance.ItemChangeCount.Should().Be(2);
+            comp.Instance.ItemsChangeCount.Should().Be(2);
+
+            await comp.InvokeAsync(() => list.SelectedItem = list.GetItems()[3]);
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(3));
+            comp.Instance.ValuesChangeCount.Should().Be(3);
+            comp.Instance.ItemChangeCount.Should().Be(3);
+            comp.Instance.ItemsChangeCount.Should().Be(3);
+            // Setting same item shold not fire events
+            await comp.InvokeAsync(() => list.SelectedItem = list.GetItems()[3]);
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(3));
+            comp.Instance.ValuesChangeCount.Should().Be(3);
+            comp.Instance.ItemChangeCount.Should().Be(3);
+            comp.Instance.ItemsChangeCount.Should().Be(3);
+
+            await comp.InvokeAsync(() => list.MultiSelection = true);
+
+            await comp.InvokeAsync(() => list.SelectedValues = new HashSet<int?>() { 1, 6 });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(4));
+            comp.Instance.ValuesChangeCount.Should().Be(4);
+            comp.Instance.ItemChangeCount.Should().Be(4);
+            comp.Instance.ItemsChangeCount.Should().Be(4);
+            // SelectedValue takes last value on SelectedValues, so if changed values have same last item, value and item should not change
+            await comp.InvokeAsync(() => list.SelectedValues = new HashSet<int?>() { 2, 6 });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(4));
+            comp.Instance.ValuesChangeCount.Should().Be(5);
+            comp.Instance.ItemChangeCount.Should().Be(4);
+            comp.Instance.ItemsChangeCount.Should().Be(5);
+            // Last value changed, so expected to all events fire
+            await comp.InvokeAsync(() => list.SelectedValues = new HashSet<int?>() { 2, 5 });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(5));
+            comp.Instance.ValuesChangeCount.Should().Be(6);
+            comp.Instance.ItemChangeCount.Should().Be(5);
+            comp.Instance.ItemsChangeCount.Should().Be(6);
+            // Changing to same value should not fire any events
+            await comp.InvokeAsync(() => list.SelectedValues = new HashSet<int?>() { 2, 5 });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(5));
+            comp.Instance.ValuesChangeCount.Should().Be(6);
+            comp.Instance.ItemChangeCount.Should().Be(5);
+            comp.Instance.ItemsChangeCount.Should().Be(6);
+
+            await comp.InvokeAsync(() => list.SelectedItems = new HashSet<MudExperimental.MudListItem<int?>>() { list.GetItems()[0], list.GetItems()[3] });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(6));
+            comp.Instance.ValuesChangeCount.Should().Be(7);
+            comp.Instance.ItemChangeCount.Should().Be(6);
+            comp.Instance.ItemsChangeCount.Should().Be(7);
+            // Same for selected values, if last value doesn't change, value event should not fire
+            await comp.InvokeAsync(() => list.SelectedItems = new HashSet<MudExperimental.MudListItem<int?>>() { list.GetItems()[1], list.GetItems()[3] });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(6));
+            comp.Instance.ValuesChangeCount.Should().Be(8);
+            comp.Instance.ItemChangeCount.Should().Be(6);
+            comp.Instance.ItemsChangeCount.Should().Be(8);
+            // Changing to the same should not fire any events
+            await comp.InvokeAsync(() => list.SelectedItems = new HashSet<MudExperimental.MudListItem<int?>>() { list.GetItems()[1], list.GetItems()[3] });
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(6));
+            comp.Instance.ValuesChangeCount.Should().Be(8);
+            comp.Instance.ItemChangeCount.Should().Be(6);
+            comp.Instance.ItemsChangeCount.Should().Be(8);
+        }
+
+        /// <summary>
+        /// Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// 
+        /// In this test no item is selected to begin with
+        /// </summary>
+        [Test]
+        public async Task ListSelectionTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalSelectionTest>();
+            //Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudExperimental.MudList<int>>().Instance;
+            list.SelectedItem.Should().Be(null);
+            // we have seven choices, none is active
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups 
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0); //nested lists generate 1 selected item tag
+            // click water
+            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Sparkling Water"));
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Markup.Should().Contain("mud-selected-item");
+            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            comp.FindAll("div.mud-list-item")[4].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Pu'er"));
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[4].Markup.Should().Contain("mud-selected-item");
+            // click Cafe Latte
+            comp.FindAll("div.mud-list-item")[8].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Cafe Latte"));
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[8].Markup.Should().Contain("mud-selected-item");
+        }
+
+        [Test]
+        public async Task ListMultiSelectionTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalSelectionTest>();
+            //Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudExperimental.MudList<int>>().Instance;
+            list.SelectedItem.Should().Be(null);
+            // we have seven choices, none is active
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups 
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0); //nested lists generate 1 selected item tag
+            // click water
+            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Sparkling Water"));
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Markup.Should().Contain("mud-selected-item");
+            list.MultiSelection = true;
+            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            comp.FindAll("div.mud-list-item")[4].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Pu'er"));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(2));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Markup.Should().Contain("mud-selected-item"));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[4].Markup.Should().Contain("mud-selected-item"));
+            // click Cafe Latte
+            comp.FindAll("div.mud-list-item")[8].Click();
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Cafe Latte"));
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(3);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[4].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[8].Markup.Should().Contain("mud-selected-item");
+
+            comp.FindAll("div.mud-list-item")[4].Click();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(2);
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudExperimental.MudListItem<int>>()[8].Markup.Should().Contain("mud-selected-item");
+
+            await comp.InvokeAsync(() => list.Clear());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(0));
+        }
+
+        /// <summary>
+        /// Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// 
+        /// This test starts with a pre-selected item (by value)
+        /// </summary>
+        [Test]
+        public async Task ListWithPreSelectedValueTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalSelectionInitialValueTest>();
+            //Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudExperimental.MudList<int?>>().Instance;
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int?>>()[0].Markup.Should().Contain("mud-selected-item"));
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(1));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().Contain(1));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Sparkling Water"));
+            comp.WaitForAssertion(() => list.SelectedItems.First().Text.Should().Be("Sparkling Water"));
+            // we have seven choices, 1 is active because of the initial value of SelectedValue
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().Be(9)); // 7 choices, 2 groups
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
+            // set Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(4));
+            //await comp.InvokeAsync(() => list.HandleCentralValueCommander("SelectedValue"));
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(4));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Pu'er"));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int?>>()[4].Markup.Should().Contain("mud-selected-item"));
+            // set Cafe Latte via changing SelectedValue
+            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(7));
+            //await comp.InvokeAsync(() => list.HandleCentralValueCommander("SelectedValue"));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Cafe Latte"));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int?>>()[8].Markup.Should().Contain("mud-selected-item"));
+            // set water
+            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(1));
+            //await comp.InvokeAsync(() => list.HandleCentralValueCommander("SelectedValue"));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Sparkling Water"));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int?>>()[0].Markup.Should().Contain("mud-selected-item"));
+            // set nothing
+            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(null));
+            //await comp.InvokeAsync(() => list.HandleCentralValueCommander("SelectedValue"));
+            comp.WaitForAssertion(() => list.SelectedItem.Should().Be(null));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(0));
+        }
+
+        [Test]
+        public async Task List_ProgrammaticallyChangeValueAndItemTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalVariantTest>();
+            var list = comp.FindComponent<MudExperimental.MudList<int?>>().Instance;
+
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(1));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Sparkling Water (1)"));
+
+            comp.FindAll("button.mud-button-root")[1].Click();
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(2));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Still Water (2)"));
+
+            comp.FindAll("button.mud-button-root")[3].Click();
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(3));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Earl Grey (3)"));
+
+            // Changing multiselection should not affect value or item
+            await comp.InvokeAsync(() => list.MultiSelection = true);
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(3));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Earl Grey (3)"));
+
+            comp.FindAll("button.mud-button-root")[2].Click();
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainInOrder(new int?[] { 2, 4 }));
+            comp.WaitForAssertion(() => string.Join(", ", list.SelectedItems.Select(x => x.Text)).Should().Be("Still Water (2), Matcha (4)"));
+
+            comp.FindAll("button.mud-button-root")[4].Click();
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainInOrder(new int?[] { 3, 5 }));
+            comp.WaitForAssertion(() => string.Join(", ", list.SelectedItems.Select(x => x.Text)).Should().Be("Earl Grey (3), Pu'er (5)"));
+
+            // Changing multiselection now should select only one value
+            await comp.InvokeAsync(() => list.MultiSelection = false);
+            comp.WaitForAssertion(() => list.SelectedValue.Should().Be(3));
+            comp.WaitForAssertion(() => list.SelectedItem.Text.Should().Be("Earl Grey (3)"));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainSingle());
+            comp.WaitForAssertion(() => string.Join(", ", list.SelectedItems.Select(x => x.Text)).Should().Be("Earl Grey (3)"));
+        }
+
+        [Test]
+        public async Task List_KeyboardNavigationTest()
+        {
+            var comp = Context.RenderComponent<ListExperimentalEnhancedTest>();
+            //Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudExperimental.MudList<int>>().Instance;
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().BeNullOrEmpty());
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainSingle());
+            //Second item is functional, should skip.
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeFalse());
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[2].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainSingle());
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "NumpadEnter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[2].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().ContainInOrder(new int[] { 1, 3 }));
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown" }));
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown" }));
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[2].Instance.IsActive.Should().BeFalse());
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[5].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(3));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().Contain(5));
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[5].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(2));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().Contain(3));
+            //Last disabled item should not be active
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "End" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[9].Instance.IsActive.Should().BeTrue());
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Home" }));
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(1));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().NotContain(1));
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "a", CtrlKey = true }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(7));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().NotContain(2));
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "A", CtrlKey = true }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[0].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(0));
+
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-list-item")[5].Click());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(1));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().Contain(5));
+
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown" }));
+            await comp.InvokeAsync(() => list.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter" }));
+            comp.WaitForAssertion(() => comp.FindComponents<MudExperimental.MudListItem<int>>()[6].Instance.IsActive.Should().BeTrue());
+            comp.WaitForAssertion(() => list.SelectedValues.Should().HaveCount(2));
+            comp.WaitForAssertion(() => list.SelectedValues.Should().Contain(6));
+        }
+
+        [Test]
+        [TestCase(Color.Default)]
+        [TestCase(Color.Primary)]
+        [TestCase(Color.Secondary)]
+        [TestCase(Color.Tertiary)]
+        [TestCase(Color.Info)]
+        [TestCase(Color.Success)]
+        [TestCase(Color.Warning)]
+        [TestCase(Color.Error)]
+        [TestCase(Color.Dark)]
+        public void ListColorTest(Color color)
+        {
+            var comp = Context.RenderComponent<ListExperimentalSelectionInitialValueTest>(x => x.Add(c => c.Color, color));
+            var list = comp.FindComponent<MudExperimental.MudList<int?>>().Instance;
+            list.SelectedItem.Text.Should().Be("Sparkling Water");
+
+            var listItemClasses = comp.Find(".mud-selected-item");
+            listItemClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"mud-{color.ToDescriptionString()}-hover" });
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -53,6 +53,8 @@ namespace MudBlazor.UnitTests.Mocks
 
         public ValueTask ScrollToListItemAsync(string elementId) => ValueTask.CompletedTask;
 
+        public ValueTask ScrollToMiddleAsync(string parentId, string childId) => ValueTask.CompletedTask;
+
         public Task ScrollToTop(ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => Task.CompletedTask;
         
         public ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) => ValueTask.CompletedTask;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -212,7 +212,7 @@ namespace MudBlazor
             execute().AndForget();
         }
 
-        protected void BeginValidate()
+        protected internal void BeginValidate()
         {
             Func<Task> execute = async () =>
             {

--- a/src/MudBlazor/Enums/MultiSelectionComponent.cs
+++ b/src/MudBlazor/Enums/MultiSelectionComponent.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace MudBlazor
+{
+    public enum MultiSelectionComponent
+    {
+        [Description("none")]
+        None,
+        [Description("checkbox")]
+        CheckBox,
+        [Description("switch")]
+        Switch,
+    }
+}

--- a/src/MudBlazor/Experimental/Components/List/MudList.razor
+++ b/src/MudBlazor/Experimental/Components/List/MudList.razor
@@ -1,0 +1,33 @@
+﻿@namespace MudExperimental
+@typeparam T
+@inherits MudComponentBase
+@using MudBlazor
+
+<div @attributes="UserAttributes" id="@_elementId" class="@Classname" style="@Stylename" tabindex="-1" @onkeydown="HandleKeyDown" @onfocusout="HandleOnFocusOut">
+    <CascadingValue Value="@this" IsFixed="true">
+        @if (MultiSelection && SelectAll && ParentList == null)
+        {
+            <MudExperimental.MudListItem T="T" IsFunctional="true" Icon="@SelectAllCheckBoxIcon" IconColor="@Color" Text="@SelectAllText" OverrideMultiSelectionComponent="MultiSelectionComponent.None" OnClick="@(() => SelectAllItems(_allSelected))" OnClickHandlerPreventDefault="true" Dense="@Dense" Class="mb-2" />
+            <MudDivider />
+        }
+        @if (ItemCollection != null)
+        {
+            <MudVirtualize IsEnabled="@Virtualize" Items="ItemCollection" Context="item">
+@*                @if (MudSelect != null)
+                {
+                    <MudSelectItem Value="@item" Text="@(MudSelect.ToStringFunc == null ? item.ToString() : MudSelect.ToStringFunc(item))" />
+                }
+                else
+                {
+                    <MudListItem Value="@item" Text="@item.ToString()" />
+                }*@
+                @*Upper commented block will replace after Experimental Select*@
+                <MudExperimental.MudListItem Value="@item" Text="@item.ToString()" />
+            </MudVirtualize>
+        }
+        else
+        {
+            @ChildContent
+        }
+    </CascadingValue>
+</div>

--- a/src/MudBlazor/Experimental/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Experimental/Components/List/MudList.razor.cs
@@ -1,0 +1,1235 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using MudBlazor.Services;
+using MudBlazor.Utilities;
+
+namespace MudExperimental
+{
+    public partial class MudList<T> : MudComponentBase, IDisposable
+    {
+        #region Parameters, Fields, Injected Services
+
+        [Inject] IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
+        [Inject] IScrollManager ScrollManager { get; set; }
+
+        // Fields used in more than one place (or protected and internal ones) are shown here.
+        // Others are next to the relevant parameters. (Like _selectedValue)
+        private string _elementId = "list_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private List<MudListItem<T>> _items = new();
+        private List<MudList<T>> _childLists = new();
+        internal MudListItem<T> _lastActivatedItem;
+        internal bool? _allSelected = false;
+
+        protected string Classname =>
+        new CssBuilder("mud-list")
+           .AddClass("mud-list-padding", !DisablePadding)
+          .AddClass(Class)
+        .Build();
+
+        protected string Stylename =>
+        new StyleBuilder()
+            .AddStyle("max-height", $"{MaxItems * (Dense == false ? 48 : 36) + (DisablePadding == true ? 0 : 16)}px", MaxItems != null)
+            .AddStyle("overflow-y", "auto", MaxItems != null)
+            .AddStyle(Style)
+            .Build();
+
+        [CascadingParameter] protected MudSelect<T> MudSelect { get; set; }
+        [CascadingParameter] protected MudAutocomplete<T> MudAutocomplete { get; set; }
+        [CascadingParameter] protected MudList<T> ParentList { get; set; }
+
+        /// <summary>
+        /// The color of the selected List Item.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public Color Color { get; set; } = Color.Primary;
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Optional presentation template for items
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment<MudListItem<T>> ItemTemplate { get; set; }
+
+        /// <summary>
+        /// Optional presentation template for selected items
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment<MudListItem<T>> ItemSelectedTemplate { get; set; }
+
+        /// <summary>
+        /// Optional presentation template for disabled items
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment<MudListItem<T>> ItemDisabledTemplate { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public DefaultConverter<T> Converter { get; set; } = new DefaultConverter<T>();
+
+        private IEqualityComparer<T> _comparer;
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public IEqualityComparer<T> Comparer
+        {
+            get => _comparer;
+            set
+            {
+                if (_comparer == value)
+                    return;
+                _comparer = value;
+                // Apply comparer and refresh selected values
+                if (_selectedValues == null)
+                {
+                    return;
+                }
+                _selectedValues = new HashSet<T>(_selectedValues, _comparer);
+                SelectedValues = _selectedValues;
+            }
+        }
+
+        /// <summary>
+        /// Predefined enumerable items. If its not null, creates list items automatically.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public ICollection<T> ItemCollection { get; set; } = null;
+
+        /// <summary>
+        /// Allows virtualization. Only work if ItemCollection parameter is not null.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool Virtualize { get; set; }
+
+        /// <summary>
+        /// Set max items to show in list. Other items can be scrolled. Works if list items populated with ItemCollection parameter.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public int? MaxItems { get; set; } = null;
+
+        private bool _multiSelection = false;
+        /// <summary>
+        /// Allows multi selection and adds MultiSelectionComponent for each list item.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool MultiSelection
+        {
+            get => _multiSelection;
+
+            set
+            {
+                if (ParentList != null)
+                {
+                    _multiSelection = ParentList.MultiSelection;
+                    return;
+                }
+                if (_multiSelection == value)
+                {
+                    return;
+                }
+                _multiSelection = value;
+                if (_setParametersDone == false)
+                {
+                    return;
+                }
+                if (_multiSelection == false)
+                {
+                    if (!_centralCommanderIsProcessing)
+                    {
+                        HandleCentralValueCommander("MultiSelectionOff");
+                    }
+
+                    UpdateSelectedStyles();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The MultiSelectionComponent's placement. Accepts Align.Start and Align.End
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public Align MultiSelectionAlign { get; set; } = Align.Start;
+
+        /// <summary>
+        /// The component which shows as a MultiSelection check.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public MultiSelectionComponent MultiSelectionComponent { get; set; } = MultiSelectionComponent.CheckBox;
+
+        /// <summary>
+        /// Set true to make the list items clickable. This is also the precondition for list selection to work.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public bool Clickable { get; set; }
+
+        /// <summary>
+        /// If true the active (hilighted) item select on tab key. Designed for only single selection. Default is true.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public bool SelectValueOnTab { get; set; } = true;
+
+        /// <summary>
+        /// If true, vertical padding will be removed from the list.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisablePadding { get; set; }
+
+        /// <summary>
+        /// If true, selected items doesn't have a selected background color.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisableSelectedItemStyle { get; set; }
+
+        /// <summary>
+        /// If true, compact vertical padding will be applied to all list items.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool Dense { get; set; }
+
+        /// <summary>
+        /// If true, the left and right padding is removed on all list items.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisableGutters { get; set; }
+
+        /// <summary>
+        /// If true, will disable the list item if it has onclick.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// If set to true and the MultiSelection option is set to true, a "select all" checkbox is added at the top of the list of items.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public bool SelectAll { get; set; }
+
+        /// <summary>
+        /// Define the text of the Select All option.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string SelectAllText { get; set; } = "Select All";
+
+        /// <summary>
+        /// If true, change background color to secondary for all nested item headers.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool SecondaryBackgroundForNestedItemHeader { get; set; }
+
+        /// <summary>
+        /// Fired on the KeyDown event.
+        /// </summary>
+        [Parameter] public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
+
+        /// <summary>
+        /// Fired on the OnFocusOut event.
+        /// </summary>
+        [Parameter] public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
+
+        #endregion
+
+
+        #region Values & Items (Core: Be careful if you change something inside the region, it affects all logic and also Select and Autocomplete)
+
+        bool _centralCommanderIsProcessing = false;
+        bool _centralCommanderResultRendered = false;
+        // CentralCommander has a simple aim: Prevent racing conditions. It has two mechanism to do this:
+        // (1) When this method is running, it doesn't allow to run a second one. That guarantees to different value parameters can not call this method at the same time.
+        // (2) When this method runs once, prevents all value setters until OnAfterRender runs. That guarantees to have proper values.
+        protected void HandleCentralValueCommander(string changedValueType, bool updateStyles = true)
+        {
+            if (_setParametersDone == false)
+            {
+                return;
+            }
+            if (_centralCommanderIsProcessing == true)
+            {
+                return;
+            }
+            _centralCommanderIsProcessing = true;
+
+            if (changedValueType == nameof(SelectedValue))
+            {
+                if (MultiSelection == false)
+                {
+                    SelectedValues = new HashSet<T>(_comparer) { SelectedValue };
+                    UpdateSelectedItem();
+                }
+            }
+            else if (changedValueType == nameof(SelectedValues))
+            {
+                if (MultiSelection == true)
+                {
+                    SelectedValue = SelectedValues == null ? default(T) : SelectedValues.LastOrDefault();
+                    UpdateSelectedItem();
+                }
+            }
+            else if (changedValueType == nameof(SelectedItem))
+            {
+                if (MultiSelection == false)
+                {
+                    SelectedItems = new HashSet<MudListItem<T>>() { SelectedItem };
+                    UpdateSelectedValue();
+                }
+            }
+            else if (changedValueType == nameof(SelectedItems))
+            {
+                if (MultiSelection == true)
+                {
+                    SelectedItem = SelectedItems == null ? null : SelectedItems.LastOrDefault();
+                    UpdateSelectedValue();
+                }
+            }
+            else if (changedValueType == "MultiSelectionOff")
+            {
+                SelectedValue = SelectedValues.FirstOrDefault();
+                var items = CollectAllMudListItems(true);
+                SelectedValues = SelectedValue == null ? null : new HashSet<T>(_comparer) { SelectedValue };
+                UpdateSelectedItem();
+            }
+
+            _centralCommanderResultRendered = false;
+            _centralCommanderIsProcessing = false;
+            if (updateStyles)
+            {
+                UpdateSelectedStyles();
+            }
+        }
+
+        protected internal void UpdateSelectedItem()
+        {
+            var items = CollectAllMudListItems(true);
+
+            if (MultiSelection && (SelectedValues == null || SelectedValues.Count() == 0))
+            {
+                SelectedItem = null;
+                SelectedItems = null;
+                return;
+            }
+
+            SelectedItem = items.FirstOrDefault(x => SelectedValue == null ? x.Value == null : Comparer != null ? Comparer.Equals(x.Value, SelectedValue) : x.Value.Equals(SelectedValue));
+            SelectedItems = SelectedValues == null ? null : items.Where(x => SelectedValues.Contains(x.Value, _comparer));
+        }
+
+        protected internal void UpdateSelectedValue()
+        {
+            if (MultiSelection == false && SelectedItem == null)
+            {
+                SelectedValue = default(T);
+                SelectedValues = null;
+                return;
+            }
+
+            SelectedValue = SelectedItem == null ? default(T) : SelectedItem.Value;
+            SelectedValues = SelectedItems.Select(x => x.Value).ToHashSet(_comparer);
+        }
+
+        private T _selectedValue;
+        /// <summary>
+        /// The current selected value.
+        /// Note: Make the list Clickable or set MultiSelection true for item selection to work.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public T SelectedValue
+        {
+            get => _selectedValue;
+            set
+            {
+                if (Converter.Set(_selectedValue) != Converter.Set(default(T)) && _firstRendered == false)
+                {
+                    return;
+                }
+                if (_centralCommanderResultRendered == false && _firstRendered == true)
+                {
+                    return;
+                }
+                if (ParentList != null)
+                {
+                    return;
+                }
+                if ((_selectedValue != null && value != null && _selectedValue.Equals(value)) || (_selectedValue == null && value == null))
+                {
+                    return;
+                }
+
+                _selectedValue = value;
+                HandleCentralValueCommander(nameof(SelectedValue));
+                SelectedValueChanged.InvokeAsync(_selectedValue).AndForget();
+            }
+        }
+
+        private HashSet<T> _selectedValues;
+        /// <summary>
+        /// The current selected values. Holds single value (SelectedValue) if MultiSelection is false.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public IEnumerable<T> SelectedValues
+        {
+            get
+            {
+                return _selectedValues;
+            }
+
+            set
+            {
+                if (value == null && _firstRendered == false)
+                {
+                    return;
+                }
+                if (_centralCommanderResultRendered == false && _firstRendered == true)
+                {
+                    return;
+                }
+                if (ParentList != null)
+                {
+                    return;
+                }
+                //var set = value ?? new List<T>();
+                if (value == null && _selectedValues == null)
+                {
+                    return;
+                }
+
+                if (value != null && _selectedValues != null && _selectedValues.SetEquals(value))
+                {
+                    return;
+                }
+                // This return condition(s) can be discussed. It is also important when we add experimental select, because commenting one more return condition causes infinite loops.
+                //if (SelectedValues.Count() == set.Count() && _selectedValues != null && _selectedValues.All(x => set.Contains(x)))
+                //{
+                //    return;
+                //}
+
+                _selectedValues = value == null ? null : new HashSet<T>(value, _comparer);
+                if (_setParametersDone == false)
+                {
+                    return;
+                }
+                HandleCentralValueCommander(nameof(SelectedValues));
+                SelectedValuesChanged.InvokeAsync(SelectedValues == null ? null : new HashSet<T>(SelectedValues, _comparer)).AndForget();
+            }
+        }
+
+        private MudListItem<T> _selectedItem;
+        /// <summary>
+        /// The current selected list item.
+        /// Note: make the list Clickable or MultiSelection or both for item selection to work.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public MudListItem<T> SelectedItem
+        {
+            get => _selectedItem;
+            set
+            {
+                if (_centralCommanderResultRendered == false && _firstRendered == true)
+                {
+                    return;
+                }
+                if (_selectedItem == value)
+                    return;
+
+                _selectedItem = value;
+                if (_setParametersDone == false)
+                {
+                    return;
+                }
+                HandleCentralValueCommander(nameof(SelectedItem));
+                SelectedItemChanged.InvokeAsync(_selectedItem).AndForget();
+            }
+        }
+
+        private HashSet<MudListItem<T>> _selectedItems;
+        /// <summary>
+        /// The current selected listitems.
+        /// Note: make the list Clickable for item selection to work.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public IEnumerable<MudListItem<T>> SelectedItems
+        {
+            get => _selectedItems;
+            set
+            {
+                if (_centralCommanderResultRendered == false && _firstRendered == true)
+                {
+                    return;
+                }
+
+                if (value == null && _selectedItems == null)
+                {
+                    return;
+                }
+
+                if (value != null && _selectedItems != null && _selectedItems.SetEquals(value))
+                    return;
+
+                _selectedItems = value == null ? null : value.ToHashSet();
+                if (_setParametersDone == false)
+                {
+                    return;
+                }
+                HandleCentralValueCommander(nameof(SelectedItems));
+                SelectedItemsChanged.InvokeAsync(_selectedItems).AndForget();
+            }
+        }
+
+        /// <summary>
+        /// Called whenever the selection changed. Can also be called even MultiSelection is true.
+        /// </summary>
+        [Parameter] public EventCallback<T> SelectedValueChanged { get; set; }
+
+        /// <summary>
+        /// Called whenever selected values changes. Can also be called even MultiSelection is false.
+        /// </summary>
+        [Parameter] public EventCallback<IEnumerable<T>> SelectedValuesChanged { get; set; }
+
+        /// <summary>
+        /// Called whenever the selected item changed. Can also be called even MultiSelection is true.
+        /// </summary>
+        [Parameter] public EventCallback<MudListItem<T>> SelectedItemChanged { get; set; }
+
+        /// <summary>
+        /// Called whenever the selected items changed. Can also be called even MultiSelection is false.
+        /// </summary>
+        [Parameter] public EventCallback<IEnumerable<MudListItem<T>>> SelectedItemsChanged { get; set; }
+
+        /// <summary>
+        /// Get all MudListItems in the list.
+        /// </summary>
+        public List<MudListItem<T>> GetAllItems()
+        {
+            return CollectAllMudListItems();
+        }
+
+        /// <summary>
+        /// Get all items that holds value.
+        /// </summary>
+        public List<MudListItem<T>> GetItems()
+        {
+            return CollectAllMudListItems(true);
+        }
+
+        #endregion
+
+
+        #region Lifecycle Methods, Dispose & Register
+
+        bool _setParametersDone = false;
+        public override Task SetParametersAsync(ParameterView parameters)
+        {
+            if (_centralCommanderIsProcessing == true)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (MudSelect != null || MudAutocomplete != null)
+            {
+                return Task.CompletedTask;
+            }
+
+            base.SetParametersAsync(parameters).AndForget();
+
+            _setParametersDone = true;
+            return Task.CompletedTask;
+        }
+
+        protected override void OnInitialized()
+        {
+            if (ParentList != null)
+            {
+                ParentList.Register(this);
+            }
+        }
+
+        internal event Action ParametersChanged;
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            ParametersChanged?.Invoke();
+        }
+
+        private IKeyInterceptor _keyInterceptor;
+        private bool _firstRendered = false;
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                _firstRendered = false;
+                _keyInterceptor = KeyInterceptorFactory.Create();
+
+                await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+                {
+                    //EnableLogging = true,
+                    TargetClass = "mud-list-item",
+                    Keys = {
+                        new KeyOptions { Key=" ", PreventDown = "key+none" }, //prevent scrolling page, toggle open/close
+                        new KeyOptions { Key="ArrowUp", PreventDown = "key+none" }, // prevent scrolling page, instead hilight previous item
+                        new KeyOptions { Key="ArrowDown", PreventDown = "key+none" }, // prevent scrolling page, instead hilight next item
+                        new KeyOptions { Key="Home", PreventDown = "key+none" },
+                        new KeyOptions { Key="End", PreventDown = "key+none" },
+                        new KeyOptions { Key="Escape" },
+                        new KeyOptions { Key="Enter", PreventDown = "key+none" },
+                        new KeyOptions { Key="NumpadEnter", PreventDown = "key+none" },
+                        new KeyOptions { Key="a", PreventDown = "key+ctrl" }, // select all items instead of all page text
+                        new KeyOptions { Key="A", PreventDown = "key+ctrl" }, // select all items instead of all page text
+                        new KeyOptions { Key="/./", SubscribeDown = true, SubscribeUp = true }, // for our users
+                    },
+                });
+
+                if (MudSelect == null && MudAutocomplete == null)
+                {
+                    if (MultiSelection == false && SelectedValue != null)
+                    {
+                        HandleCentralValueCommander(nameof(SelectedValue));
+                    }
+                    else if (MultiSelection == true && SelectedValues != null)
+                    {
+                        HandleCentralValueCommander(nameof(SelectedValues));
+                    }
+                }
+
+                if (MudSelect != null || MudAutocomplete != null)
+                {
+                    if (MultiSelection)
+                    {
+                        UpdateSelectAllState();
+                        if (MudSelect != null)
+                        {
+                            SelectedValues = MudSelect.SelectedValues;
+                        }
+                        else if (MudAutocomplete != null)
+                        {
+                            // Uncomment on Autocomplete Phase. Currently autocomplete doesn't have "SelectedValues".
+                            //SelectedValues = MudAutocomplete.SelectedValues;
+                        }
+                        HandleCentralValueCommander(nameof(SelectedValues));
+                    }
+                    else
+                    {
+                        // These updated style method cause to fail some tests after adding select phase. Can be discuss later.
+                        //UpdateSelectedStyles();
+                        UpdateLastActivatedItem(SelectedValue);
+                    }
+                }
+                if (SelectedValues != null)
+                {
+                    UpdateLastActivatedItem(SelectedValues.LastOrDefault());
+                }
+                if (_lastActivatedItem != null && !(MultiSelection && _allSelected == true))
+                {
+                    await ScrollToMiddleAsync(_lastActivatedItem);
+                }
+                _firstRendered = true;
+            }
+            _centralCommanderResultRendered = true;
+        }
+
+        public void Dispose()
+        {
+            ParametersChanged = null;
+            ParentList?.Unregister(this);
+        }
+
+        protected internal void Register(MudListItem<T> item)
+        {
+            _items.Add(item);
+            if (SelectedValue != null && object.Equals(item.Value, SelectedValue))
+            {
+                item.SetSelected(true);
+                //TODO check if item is the selectable for a nested list, and deselect this.
+                //SelectedItem = item;
+                //SelectedItemChanged.InvokeAsync(item);
+            }
+        }
+
+        protected internal void Unregister(MudListItem<T> item)
+        {
+            _items.Remove(item);
+        }
+
+        protected internal void Register(MudList<T> child)
+        {
+            _childLists.Add(child);
+        }
+
+        protected internal void Unregister(MudList<T> child)
+        {
+            _childLists.Remove(child);
+        }
+
+        #endregion
+
+
+        #region Events (Key, Focus)
+
+        protected internal async Task HandleKeyDown(KeyboardEventArgs obj)
+        {
+            if (Disabled || (Clickable == false && MultiSelection == false))
+                return;
+            if (ParentList != null)
+            {
+                return;
+            }
+
+            var key = obj.Key.ToLowerInvariant();
+            if (key.Length == 1 && key != " " && !(obj.CtrlKey || obj.ShiftKey || obj.AltKey || obj.MetaKey))
+            {
+                await ActiveFirstItem(key);
+                return;
+            }
+            switch (obj.Key)
+            {
+                case "Tab":
+                    if (!MultiSelection && SelectValueOnTab)
+                    {
+                        SetSelectedValue(_lastActivatedItem);
+                    }
+                    break;
+                case "ArrowUp":
+                    await ActiveAdjacentItem(-1);
+                    break;
+                case "ArrowDown":
+                    await ActiveAdjacentItem(1);
+                    break;
+                case "Home":
+                    await ActiveFirstItem();
+                    break;
+                case "End":
+                    await ActiveLastItem();
+                    break;
+                case "Enter":
+                case "NumpadEnter":
+                    if (_lastActivatedItem == null)
+                    {
+                        return;
+                    }
+                    SetSelectedValue(_lastActivatedItem);
+                    break;
+                case "a":
+                case "A":
+                    if (obj.CtrlKey == true)
+                    {
+                        if (MultiSelection)
+                        {
+                            SelectAllItems(_allSelected);
+                        }
+                    }
+                    break;
+            }
+            await OnKeyDown.InvokeAsync(obj);
+        }
+
+        protected async Task HandleOnFocusOut()
+        {
+            DeactiveAllItems();
+            await OnFocusOut.InvokeAsync();
+        }
+
+        #endregion
+
+
+        #region Select
+
+        protected internal void SetSelectedValue(T value, bool force = false)
+        {
+            if ((!Clickable && !MultiSelection) && !force)
+                return;
+
+            //Make sure its the most parent one before continue method.
+            if (ParentList != null)
+            {
+                ParentList?.SetSelectedValue(value);
+                return;
+            }
+
+            if (!MultiSelection)
+            {
+                SelectedValue = value;
+            }
+            else
+            {
+                if (SelectedValues.Contains(value, _comparer))
+                {
+                    SelectedValues = SelectedValues?.Where(x => Comparer != null ? !Comparer.Equals(x, value) : !x.Equals(value)).ToHashSet(_comparer);
+                }
+                else
+                {
+                    SelectedValues = SelectedValues.Append(value).ToHashSet(_comparer);
+                }
+            }
+            UpdateLastActivatedItem(value);
+        }
+
+        protected internal void SetSelectedValue(MudListItem<T> item, bool force = false)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            if ((!Clickable && !MultiSelection) && !force)
+                return;
+
+            //Make sure its the most parent one before continue method
+            if (ParentList != null)
+            {
+                ParentList?.SetSelectedValue(item);
+                return;
+            }
+
+            if (MultiSelection == false)
+            {
+                SelectedValue = item.Value;
+            }
+            else
+            {
+                if (item.IsSelected)
+                {
+                    SelectedValues = SelectedValues?.Where(x => Comparer != null ? !Comparer.Equals(x, item.Value) : !x.Equals(item.Value));
+                }
+                else
+                {
+                    if (SelectedValues == null)
+                    {
+                        SelectedValues = new HashSet<T>(_comparer) { item.Value };
+                    }
+                    else
+                    {
+                        SelectedValues = SelectedValues.Append(item.Value).ToHashSet(_comparer);
+                    }
+                }
+            }
+
+            UpdateSelectAllState();
+            _lastActivatedItem = item;
+        }
+
+        protected internal void UpdateSelectedStyles(bool deselectFirst = true)
+        {
+            var items = CollectAllMudListItems(true);
+            if (deselectFirst)
+            {
+                DeselectAllItems(items);
+            }
+
+            if (IsSelectable() == false)
+            {
+                return;
+            }
+
+            if (MultiSelection == false)
+            {
+                items.FirstOrDefault(x => SelectedValue == null ? x.Value == null : SelectedValue.Equals(x == null ? null : x.Value))?.SetSelected(true);
+            }
+            else if (SelectedValues != null)
+            {
+                items.Where(x => SelectedValues.Contains(x.Value, Comparer == null ? null : Comparer)).ToList().ForEach(x => x.SetSelected(true));
+            }
+
+            StateHasChanged();
+        }
+
+        protected bool IsSelectable()
+        {
+            if (Clickable || MultiSelection)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        protected void DeselectAllItems(List<MudListItem<T>> items)
+        {
+            foreach (var listItem in items)
+                listItem?.SetSelected(false);
+        }
+
+        protected List<MudListItem<T>> CollectAllMudListItems(bool exceptNestedAndExceptional = false)
+        {
+            var items = new List<MudListItem<T>>();
+
+            if (ParentList != null)
+            {
+                items.AddRange(ParentList._items);
+                foreach (var list in ParentList._childLists)
+                    items.AddRange(list._items);
+            }
+            else
+            {
+                items.AddRange(_items);
+                foreach (var list in _childLists)
+                    items.AddRange(list._items);
+            }
+
+            if (exceptNestedAndExceptional == false)
+            {
+                return items;
+            }
+            else
+            {
+                return items.Where(x => x.NestedList == null && x.IsFunctional == false).ToList();
+            }
+        }
+
+        #endregion
+
+
+        #region SelectAll
+
+        protected internal void UpdateSelectAllState()
+        {
+            if (MultiSelection)
+            {
+                var oldState = _allSelected;
+                if (_selectedValues == null || !_selectedValues.Any())
+                {
+                    _allSelected = false;
+                }
+                else if (CollectAllMudListItems(true).Count() == _selectedValues.Count)
+                {
+                    _allSelected = true;
+                }
+                else
+                {
+                    _allSelected = null;
+                }
+            }
+        }
+
+        protected string SelectAllCheckBoxIcon
+        {
+            get
+            {
+                return _allSelected.HasValue ? _allSelected.Value ? CheckedIcon : UncheckedIcon : IndeterminateIcon;
+            }
+        }
+
+        /// <summary>
+        /// Custom checked icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string CheckedIcon { get; set; } = Icons.Filled.CheckBox;
+
+        /// <summary>
+        /// Custom unchecked icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string UncheckedIcon { get; set; } = Icons.Filled.CheckBoxOutlineBlank;
+
+        /// <summary>
+        /// Custom indeterminate icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string IndeterminateIcon { get; set; } = Icons.Filled.IndeterminateCheckBox;
+
+        protected void SelectAllItems(bool? deselect = false)
+        {
+            var items = CollectAllMudListItems(true);
+            if (deselect == true)
+            {
+                foreach (var item in items)
+                {
+                    if (item.IsSelected == true)
+                    {
+                        item.SetSelected(false);
+                    }
+                }
+                _allSelected = false;
+            }
+            else
+            {
+                foreach (var item in items)
+                {
+                    if (item.IsSelected == false)
+                    {
+                        item.SetSelected(true);
+                    }
+                }
+                _allSelected = true;
+            }
+
+            SelectedValues = items.Where(x => x.IsSelected == true).Select(y => y.Value).ToHashSet(_comparer);
+            if (MudSelect != null)
+            {
+                MudSelect.BeginValidate();
+            }
+        }
+
+        #endregion
+
+
+        #region Active (Hilight)
+
+        protected int GetActiveItemIndex()
+        {
+            var items = CollectAllMudListItems(true);
+            if (_lastActivatedItem == null)
+            {
+                var a = items.FindIndex(x => x.IsActive == true);
+                return a;
+            }
+            else
+            {
+                var a = items.FindIndex(x => _lastActivatedItem.Value == null ? x.Value == null : Comparer != null ? Comparer.Equals(_lastActivatedItem.Value, x.Value) : _lastActivatedItem.Value.Equals(x.Value));
+                return a;
+            }
+        }
+
+        protected T GetActiveItemValue()
+        {
+            var items = CollectAllMudListItems(true);
+            if (_lastActivatedItem == null)
+            {
+                return items.FirstOrDefault(x => x.IsActive == true).Value;
+            }
+            else
+            {
+                return _lastActivatedItem.Value;
+            }
+        }
+
+        protected internal void UpdateLastActivatedItem(T value)
+        {
+            var items = CollectAllMudListItems(true);
+            _lastActivatedItem = items.FirstOrDefault(x => value == null ? x.Value == null : Comparer != null ? Comparer.Equals(value, x.Value) : value.Equals(x.Value));
+        }
+
+        protected void DeactiveAllItems(List<MudListItem<T>> items = null)
+        {
+            if (items == null)
+            {
+                items = CollectAllMudListItems(true);
+            }
+
+            foreach (var item in items)
+            {
+                item.SetActive(false);
+            }
+        }
+
+#pragma warning disable BL0005
+        public async Task ActiveFirstItem(string startChar = null)
+        {
+            var items = CollectAllMudListItems(true);
+            if (items == null || items.Count == 0 || items[0].Disabled == true)
+            {
+                return;
+            }
+            DeactiveAllItems(items);
+
+            if (string.IsNullOrWhiteSpace(startChar))
+            {
+                items[0].SetActive(true);
+                _lastActivatedItem = items[0];
+                if (items[0].ParentListItem != null && items[0].ParentListItem.Expanded == false)
+                {
+                    items[0].ParentListItem.Expanded = true;
+                }
+                await ScrollToMiddleAsync(items[0]);
+                return;
+            }
+
+            // find first item that starts with the letter
+            var possibleItems = items.Where(x => (x.Text ?? Converter.Set(x.Value) ?? "").StartsWith(startChar, StringComparison.CurrentCultureIgnoreCase)).ToList();
+            if (possibleItems == null || !possibleItems.Any())
+            {
+                if (_lastActivatedItem == null)
+                {
+                    return;
+                }
+                _lastActivatedItem.SetActive(true);
+                if (_lastActivatedItem.ParentListItem != null && _lastActivatedItem.ParentListItem.Expanded == false)
+                {
+                    _lastActivatedItem.ParentListItem.Expanded = true;
+                }
+                await ScrollToMiddleAsync(_lastActivatedItem);
+                return;
+            }
+
+            var theItem = possibleItems.FirstOrDefault(x => x == _lastActivatedItem);
+            if (theItem == null)
+            {
+                possibleItems[0].SetActive(true);
+                _lastActivatedItem = possibleItems[0];
+                if (_lastActivatedItem.ParentListItem != null && _lastActivatedItem.ParentListItem.Expanded == false)
+                {
+                    _lastActivatedItem.ParentListItem.Expanded = true;
+                }
+                await ScrollToMiddleAsync(possibleItems[0]);
+                return;
+            }
+
+            if (theItem == possibleItems.LastOrDefault())
+            {
+                possibleItems[0].SetActive(true);
+                _lastActivatedItem = possibleItems[0];
+                if (_lastActivatedItem.ParentListItem != null && _lastActivatedItem.ParentListItem.Expanded == false)
+                {
+                    _lastActivatedItem.ParentListItem.Expanded = true;
+                }
+                await ScrollToMiddleAsync(possibleItems[0]);
+            }
+            else
+            {
+                var item = possibleItems[possibleItems.IndexOf(theItem) + 1];
+                item.SetActive(true);
+                _lastActivatedItem = item;
+                if (_lastActivatedItem.ParentListItem != null && _lastActivatedItem.ParentListItem.Expanded == false)
+                {
+                    _lastActivatedItem.ParentListItem.Expanded = true;
+                }
+                await ScrollToMiddleAsync(item);
+            }
+        }
+
+        public async Task ActiveAdjacentItem(int changeCount)
+        {
+            var items = CollectAllMudListItems(true);
+            if (items == null || items.Count == 0)
+            {
+                return;
+            }
+            int index = GetActiveItemIndex();
+            if (index + changeCount >= items.Count || 0 > index + changeCount)
+            {
+                return;
+            }
+            if (items[index + changeCount].Disabled == true)
+            {
+                // Recursive
+                await ActiveAdjacentItem(changeCount > 0 ? changeCount + 1 : changeCount - 1);
+                return;
+            }
+            DeactiveAllItems(items);
+            items[index + changeCount].SetActive(true);
+            _lastActivatedItem = items[index + changeCount];
+
+            if (items[index + changeCount].ParentListItem != null && items[index + changeCount].ParentListItem.Expanded == false)
+            {
+                items[index + changeCount].ParentListItem.Expanded = true;
+            }
+
+            await ScrollToMiddleAsync(items[index + changeCount]);
+        }
+
+        public async Task ActivePreviousItem()
+        {
+            var items = CollectAllMudListItems(true);
+            if (items == null || items.Count == 0)
+            {
+                return;
+            }
+            int index = GetActiveItemIndex();
+            if (0 > index - 1)
+            {
+                return;
+            }
+            DeactiveAllItems(items);
+            items[index - 1].SetActive(true);
+            _lastActivatedItem = items[index - 1];
+
+            if (items[index - 1].ParentListItem != null && items[index - 1].ParentListItem.Expanded == false)
+            {
+                items[index - 1].ParentListItem.Expanded = true;
+            }
+
+            await ScrollToMiddleAsync(items[index - 1]);
+        }
+
+        public async Task ActiveLastItem()
+        {
+            var items = CollectAllMudListItems(true);
+            if (items == null || items.Count == 0)
+            {
+                return;
+            }
+            var properLastIndex = items.Count - 1;
+            DeactiveAllItems(items);
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (items[properLastIndex - i].Disabled != true)
+                {
+                    properLastIndex -= i;
+                    break;
+                }
+            }
+            items[properLastIndex].SetActive(true);
+            _lastActivatedItem = items[properLastIndex];
+
+            if (items[properLastIndex].ParentListItem != null && items[properLastIndex].ParentListItem.Expanded == false)
+            {
+                items[properLastIndex].ParentListItem.Expanded = true;
+            }
+
+            await ScrollToMiddleAsync(items[properLastIndex]);
+        }
+#pragma warning restore BL0005
+
+        #endregion
+
+
+        #region Others (Clear, Scroll)
+
+        /// <summary>
+        /// Clears value(s) and item(s) and deactive all items.
+        /// </summary>
+        public void Clear()
+        {
+            var items = CollectAllMudListItems();
+            if (!MultiSelection)
+            {
+                SelectedValue = default(T);
+            }
+            else
+            {
+                SelectedValues = null;
+            }
+
+            DeselectAllItems(items);
+            DeactiveAllItems();
+            UpdateSelectAllState();
+        }
+
+        protected internal ValueTask ScrollToMiddleAsync(MudListItem<T> item)
+            => ScrollManager.ScrollToMiddleAsync(_elementId, item.ItemId);
+
+        #endregion
+    }
+}

--- a/src/MudBlazor/Experimental/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Experimental/Components/List/MudListItem.razor
@@ -1,0 +1,101 @@
+﻿@namespace MudExperimental
+@typeparam T
+@inherits MudComponentBase
+@using MudBlazor
+
+<div tabindex="0" @attributes="UserAttributes" id="@ItemId" class="@Classname" @onclick="@(((MudList?.Clickable == true || NestedList != null) && IsFunctional == false) ? OnClickHandler : OnlyOnClick)" @onclick:stopPropagation="true" style="@Style">
+
+    @if (MudList?.ItemDisabledTemplate != null && Disabled == true)
+    {
+        @MudList.ItemDisabledTemplate(this)
+    }
+    else if (MudList?.ItemSelectedTemplate != null && IsSelected == true)
+    {
+        @MudList.ItemSelectedTemplate(this)
+    }
+    else if (MudList?.ItemTemplate != null)
+    {
+        @MudList.ItemTemplate(this)
+    }
+    else
+    {
+        if (MudList != null && NestedList == null && MudList.MultiSelection == true && MudList.MultiSelectionAlign != Align.End && IsFunctional == false &&
+        (OverrideMultiSelectionComponent != MultiSelectionComponent.None || (MudList.MultiSelectionComponent == MultiSelectionComponent.None && (OverrideMultiSelectionComponent != null || OverrideMultiSelectionComponent != MultiSelectionComponent.None))))
+        {
+            <div class="@MultiSelectClassName">
+                @if (OverrideMultiSelectionComponent == null ? MudList?.MultiSelectionComponent == MultiSelectionComponent.CheckBox : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.CheckBox)
+                {
+                    <MudCheckBox Color="@MudList.Color" Disabled="@Disabled" @bind-Checked="_selected" @onclick="OnClickHandler" Dense="true" />
+                }
+                else if (OverrideMultiSelectionComponent == null ? MudList?.MultiSelectionComponent == MultiSelectionComponent.Switch : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.Switch)
+                {
+                    <MudSwitch Color="@MudList.Color" Disabled="@Disabled" @bind-Checked="_selected" @onclick="OnClickHandler" OnClickStopPropagation="true" />
+                }
+
+            </div>
+        }
+
+        if (!string.IsNullOrWhiteSpace(Avatar))
+        {
+            <div class="mud-list-item-avatar">
+                <MudAvatar Class="@AvatarClass">
+                    <MudIcon Icon="@Avatar" Color="@IconColor" Size="@IconSize" />
+                </MudAvatar>
+            </div>
+        }
+        else if (!string.IsNullOrWhiteSpace(Icon))
+        {
+            <div class="mud-list-item-icon">
+                <MudIcon Icon="@Icon" Color="@IconColor" Size="@IconSize" />
+            </div>
+        }
+        <div class="mud-list-item-text @(Inset? "mud-list-item-text-inset" : "")">
+            <MudText Typo="@_textTypo">
+                @if (ChildContent != null)
+                {
+                    @ChildContent
+                }
+                else
+                {
+                    @Text
+                    <MudText Style="font-weight:500; color: var(--mud-palette-text-secondary)" Typo="Typo.subtitle2">@SecondaryText</MudText>
+                }
+            </MudText>
+        </div>
+
+        if (MudList != null && NestedList == null && MudList.MultiSelection == true && MudList.MultiSelectionAlign == Align.End && IsFunctional == false &&
+        (OverrideMultiSelectionComponent != MultiSelectionComponent.None || (MudList.MultiSelectionComponent == MultiSelectionComponent.None && (OverrideMultiSelectionComponent != null || OverrideMultiSelectionComponent != MultiSelectionComponent.None))))
+        {
+            <div class="@MultiSelectClassName">
+                @if (OverrideMultiSelectionComponent == null ? MudList?.MultiSelectionComponent == MultiSelectionComponent.CheckBox : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.CheckBox)
+                {
+                    <MudCheckBox Color="@MudList.Color" Disabled="@Disabled" @bind-Checked="_selected" @onclick="OnClickHandler" Dense="true" />
+                }
+                else if (OverrideMultiSelectionComponent == null ? MudList?.MultiSelectionComponent == MultiSelectionComponent.Switch : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.Switch)
+                {
+                    <MudSwitch Color="@MudList.Color" Disabled="@Disabled" @bind-Checked="_selected" @onclick="OnClickHandler" OnClickStopPropagation="true" />
+                }
+            </div>
+        }
+
+        if (NestedList != null)
+        {
+            <MudIcon Icon="@($"{(_expanded ? ExpandLessIcon : ExpandMoreIcon)}")" Size="@IconSize" Color="@AdornmentColor" />
+        }
+    }
+
+
+</div>
+
+@if (NestedList != null)
+{
+    <CascadingValue Value="this" IsFixed="true">
+        <MudCollapse Expanded="@Expanded" ExpandedChanged="@ExpandedChanged">
+            <MudExperimental.MudList T="T" Clickable="MudList?.Clickable ?? false" Color="MudList?.Color ?? Color.Primary" MultiSelection="MudList?.MultiSelection ?? false" MultiSelectionComponent="MudList?.MultiSelectionComponent ?? MultiSelectionComponent.CheckBox" MultiSelectionAlign="MudList?.MultiSelectionAlign ?? Align.Start" DisablePadding="true" Class="mud-nested-list" Disabled="@Disabled" Dense="@((Dense ?? MudList?.Dense) ?? false)">
+                <ChildContent>
+                    @NestedList
+                </ChildContent>
+            </MudExperimental.MudList>
+        </MudCollapse>
+    </CascadingValue>
+}

--- a/src/MudBlazor/Experimental/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Experimental/Components/List/MudListItem.razor.cs
@@ -1,0 +1,406 @@
+﻿using System;
+using System.Windows.Input;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+using MudBlazor;
+
+namespace MudExperimental
+{
+    public partial class MudListItem<T> : MudComponentBase, IDisposable
+    {
+
+        #region Parameters, Fields, Injected Services
+
+        [Inject] protected NavigationManager UriHelper { get; set; }
+
+        [CascadingParameter] protected MudList<T> MudList { get; set; }
+        [CascadingParameter] protected internal MudListItem<T> ParentListItem { get; set; }
+
+        protected string Classname =>
+        new CssBuilder("mud-list-item")
+          .AddClass("mud-list-item-dense", Dense == true || MudList?.Dense == true)
+          .AddClass("mud-list-item-gutters", !DisableGutters && !(MudList?.DisableGutters == true))
+          .AddClass("mud-list-item-clickable", MudList?.Clickable)
+          .AddClass("mud-ripple", MudList?.Clickable == true && !DisableRipple && !Disabled)
+          .AddClass($"mud-selected-item mud-{MudList?.Color.ToDescriptionString()}-text mud-{MudList?.Color.ToDescriptionString()}-hover", _selected && !Disabled && NestedList == null && !MudList.DisableSelectedItemStyle)
+          .AddClass("mud-list-item-hilight", _active && !Disabled && NestedList == null && IsFunctional == false)
+          .AddClass("mud-list-item-disabled", Disabled)
+          .AddClass("mud-list-item-nested-background", MudList != null && MudList.SecondaryBackgroundForNestedItemHeader && NestedList != null)
+          .AddClass(Class)
+        .Build();
+
+        protected string MultiSelectClassName =>
+        new CssBuilder()
+            .AddClass("mud-list-item-multiselect")
+            .AddClass("mud-list-item-multiselect-checkbox", MudList?.MultiSelectionComponent == MultiSelectionComponent.CheckBox || OverrideMultiSelectionComponent == MultiSelectionComponent.CheckBox)
+            .Build();
+
+        protected internal string ItemId { get; } = "_" + Guid.NewGuid().ToString().Substring(0, 8);
+
+        /// <summary>
+        /// Functional items does not hold values. If a value set on Functional item, it ignores by the MudList. They can not count on Items list (they count on AllItems), cannot be subject of keyboard navigation and selection.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool IsFunctional { get; set; }
+
+        /// <summary>
+        /// The text to display
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// The secondary text to display
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string SecondaryText { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.List.Selecting)]
+        public T Value { get; set; }
+
+        /// <summary>
+        /// Avatar to use if set.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string Avatar { get; set; }
+
+        /// <summary>
+        /// Avatar CSS Class to apply if Avatar is set.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public string AvatarClass { get; set; }
+
+        /// <summary>
+        /// Link to a URL when clicked.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public string Href { get; set; }
+
+        /// <summary>
+        /// If true, force browser to redirect outside component router-space.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public bool ForceLoad { get; set; }
+
+        private bool _disabled;
+        /// <summary>
+        /// If true, will disable the list item if it has onclick.
+        /// The value can be overridden by the parent list.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool Disabled
+        {
+            get => _disabled || (MudList?.Disabled ?? false);
+            set => _disabled = value;
+        }
+
+        /// <summary>
+        /// If true, the left and right padding is removed.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisableGutters { get; set; }
+
+        /// <summary>
+        /// If true, disables ripple effect.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisableRipple { get; set; }
+
+        /// <summary>
+        /// Overrided component for multiselection. Keep it null to have default one that MudList has.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public MultiSelectionComponent? OverrideMultiSelectionComponent { get; set; } = null;
+
+        /// <summary>
+        /// Icon to use if set.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string Icon { get; set; }
+
+        /// <summary>
+        /// The color of the icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public Color IconColor { get; set; } = Color.Inherit;
+
+        /// <summary>
+        /// Sets the Icon Size.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public Size IconSize { get; set; } = Size.Medium;
+
+        /// <summary>
+        /// The color of the adornment if used. It supports the theme colors.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Expanding)]
+        public Color AdornmentColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// Custom expand less icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Expanding)]
+        public string ExpandLessIcon { get; set; } = Icons.Filled.ExpandLess;
+
+        /// <summary>
+        /// Custom expand more icon.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Expanding)]
+        public string ExpandMoreIcon { get; set; } = Icons.Filled.ExpandMore;
+
+        /// <summary>
+        /// If true, the List Subheader will be indented.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool Inset { get; set; }
+
+        private bool? _dense;
+        /// <summary>
+        /// If true, compact vertical padding will be used.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool? Dense
+        {
+            get => _dense;
+            set
+            {
+                if (_dense == value)
+                {
+                    return;
+                }
+                _dense = value;
+                OnListParametersChanged();
+            }
+        }
+
+        /// <summary>
+        /// Command parameter.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public object CommandParameter { get; set; }
+
+        /// <summary>
+        /// Command executed when the user clicks on an element.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public ICommand Command { get; set; }
+
+        /// <summary>
+        /// Prevent default behavior when click on MudSelectItem. Default behavior is selecting the item and style adjustments.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool OnClickHandlerPreventDefault { get; set; }
+
+        /// <summary>
+        /// Display content of this list item. If set, overrides Text.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Add child list items here to create a nested list.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public RenderFragment NestedList { get; set; }
+
+        /// <summary>
+        /// List click event.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+        /// <summary>
+        /// If true, expands the nested list on first display.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Expanding)]
+        public bool InitiallyExpanded { get; set; }
+
+        private bool _expanded;
+        /// <summary>
+        /// Expand or collapse nested list. Two-way bindable. Note: if you directly set this to
+        /// true or false (instead of using two-way binding) it will force the nested list's expansion state.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Expanding)]
+        public bool Expanded
+        {
+            get => _expanded;
+            set
+            {
+                if (_expanded == value)
+                    return;
+                _expanded = value;
+                _ = ExpandedChanged.InvokeAsync(value);
+            }
+        }
+
+        /// <summary>
+        /// Called when expanded state change.
+        /// </summary>
+        [Parameter]
+        public EventCallback<bool> ExpandedChanged { get; set; }
+
+        #endregion
+
+
+        #region Lifecycle Methods (& Dispose)
+
+        protected override void OnInitialized()
+        {
+            _expanded = InitiallyExpanded;
+            if (MudList != null)
+            {
+                MudList.Register(this);
+                OnListParametersChanged();
+                MudList.ParametersChanged += OnListParametersChanged;
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (MudList == null)
+                    return;
+                MudList.ParametersChanged -= OnListParametersChanged;
+                MudList.Unregister(this);
+            }
+            catch (Exception) { /*ignore*/ }
+        }
+
+        #endregion
+
+
+        #region Select & Active
+
+        private bool _selected;
+        private bool _active;
+
+        /// <summary>
+        /// Selected state of the option. Readonly. Use SetSelected for selecting.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => _selected;
+        }
+
+        internal bool IsActive
+        {
+            get => _active;
+        }
+
+        public void SetSelected(bool selected, bool forceRender = true)
+        {
+            if (Disabled)
+                return;
+            if (_selected == selected)
+                return;
+            _selected = selected;
+            if (forceRender)
+            {
+                StateHasChanged();
+            }
+        }
+
+        internal void SetActive(bool active, bool forceRender = true)
+        {
+            if (Disabled)
+                return;
+            if (_active == active)
+                return;
+            _active = active;
+            if (forceRender)
+            {
+                StateHasChanged();
+            }
+        }
+
+        #endregion
+
+
+        #region Other (ClickHandler etc.)
+
+        public void ForceRender()
+        {
+            StateHasChanged();
+        }
+
+        protected void OnClickHandler(MouseEventArgs ev)
+        {
+            if (Disabled)
+                return;
+
+            if (OnClickHandlerPreventDefault == true)
+            {
+                OnClick.InvokeAsync(ev).AndForget();
+                return;
+            }
+
+            if (NestedList != null)
+            {
+                Expanded = !Expanded;
+            }
+            else if (Href != null)
+            {
+                MudList?.SetSelectedValue(this);
+                OnClick.InvokeAsync(ev).AndForget();
+                UriHelper.NavigateTo(Href, ForceLoad);
+            }
+            else if (MudList?.Clickable == true || MudList?.MultiSelection == true)
+            {
+                MudList?.SetSelectedValue(this);
+                OnClick.InvokeAsync(ev).AndForget();
+            }
+        }
+
+        protected void OnlyOnClick(MouseEventArgs ev)
+        {
+            OnClick.InvokeAsync(ev).AndForget();
+        }
+
+        private Typo _textTypo;
+        protected void OnListParametersChanged()
+        {
+            if ((Dense ?? MudList?.Dense) ?? false)
+            {
+                _textTypo = Typo.body2;
+            }
+            else
+            {
+                _textTypo = Typo.body1;
+            }
+            StateHasChanged();
+        }
+
+        #endregion
+
+    }
+}

--- a/src/MudBlazor/Experimental/Components/List/MudListSubheader.razor
+++ b/src/MudBlazor/Experimental/Components/List/MudListSubheader.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudExperimental
+@typeparam T
+@inherits MudComponentBase
+@using MudBlazor
+
+<div @attributes="UserAttributes" class="@Classname" style="@Style">
+    @ChildContent
+</div>

--- a/src/MudBlazor/Experimental/Components/List/MudListSubheader.razor.cs
+++ b/src/MudBlazor/Experimental/Components/List/MudListSubheader.razor.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using MudBlazor.Utilities;
+
+namespace MudExperimental
+{
+    public partial class MudListSubheader<T> : MudComponentBase
+    {
+        protected string Classname =>
+        new CssBuilder("mud-list-subheader")
+            .AddClass("mud-list-subheader-gutters", !DisableGutters)
+            .AddClass("mud-list-subheader-inset", Inset)
+            .AddClass("mud-list-subheader-secondary-background", SecondaryBackground)
+            .AddClass("mud-list-subheader-sticky", Sticky)
+            .AddClass("mud-list-subheader-sticky-dense", Sticky && (MudList != null && MudList.DisablePadding))
+            .AddClass(Class)
+        .Build();
+
+        [CascadingParameter] protected MudList<T> MudList { get; set; }
+
+        /// <summary>
+        /// The child render fragment.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Disables the left and right spaces.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool DisableGutters { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool Inset { get; set; }
+
+        /// <summary>
+        /// If true, subheader behaves sticky and remains on top until other subheader comes to top.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool Sticky { get; set; }
+
+        /// <summary>
+        /// If true, subheader has darken background.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public bool SecondaryBackground { get; set; }
+    }
+}

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
         ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
         ValueTask ScrollToYearAsync(string elementId);
         ValueTask ScrollToListItemAsync(string elementId);
+        ValueTask ScrollToMiddleAsync(string parentId, string childId);
         ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
         ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
         ValueTask ScrollToBottomAsync(string elementId, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
@@ -99,6 +100,9 @@ namespace MudBlazor
 
         public ValueTask ScrollToListItemAsync(string elementId) =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId);
+
+        public ValueTask ScrollToMiddleAsync(string parentId, string childId) =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToMiddle", parentId, childId);
 
         public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);

--- a/src/MudBlazor/Styles/components/_list.scss
+++ b/src/MudBlazor/Styles/components/_list.scss
@@ -1,4 +1,6 @@
-﻿.mud-list {
+﻿@import '../abstracts/variables';
+
+.mud-list {
     margin: 0;
     padding: 0;
     position: relative;
@@ -21,6 +23,7 @@
     padding-bottom: 8px;
     justify-content: flex-start;
     text-decoration: none;
+    outline: none;
 
     &.mud-list-item-dense {
         padding-top: 4px;
@@ -55,10 +58,6 @@
     &:hover {
         background-color: var(--mud-palette-action-default-hover);
     }
-
-    &:focus:not(.mud-selected-item) {
-        background-color: var(--mud-palette-action-default-hover);
-    }
 }
 
 .mud-list-item-gutters {
@@ -72,6 +71,8 @@
     min-width: 0;
     margin-top: 4px;
     margin-bottom: 4px;
+    padding-inline-start: 8px;
+    padding-inline-end: 8px;
 }
 
 
@@ -84,10 +85,21 @@
 .mud-list-item-icon {
     color: var(--mud-palette-action-default);
     display: inline-flex;
-    min-width: 56px;
+    /*min-width: 56px;*/
     flex-shrink: 0;
+    padding-inline-start: 8px;
+    padding-inline-end: 8px;
+    margin-inline-start: -4px;
+    margin-inline-end: 4px;
 }
 
+.mud-list-item-multiselect {
+    max-height: 32px;
+
+    &.mud-list-item-multiselect-checkbox {
+        padding-inline-end: 16px;
+    }
+}
 
 .mud-list-subheader {
     color: var(--mud-palette-action-default);
@@ -95,8 +107,12 @@
     box-sizing: border-box;
     list-style: none;
     font-weight: 500;
-    padding-top: 8px;
-    padding-bottom: 20px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+}
+
+.mud-list-subheader-secondary-background {
+    background-color: var(--mud-palette-background-grey);
 }
 
 .mud-list-subheader-gutters {
@@ -111,12 +127,22 @@
 }
 
 .mud-list-subheader-sticky {
-    top: 0;
+    top: -8px;
     z-index: 1;
     position: sticky;
-    background-color: inherit;
+
+    &.mud-list-subheader-sticky-dense {
+        top: 0;
+    }
 }
 
+.mud-list-item-hilight {
+    background-color: var(--mud-palette-background-grey);
+}
+
+.mud-list-item-nested-background {
+    background-color: var(--mud-palette-background-grey);
+}
 
 .mud-list-item-avatar {
     min-width: 56px;

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -33,6 +33,13 @@ class MudScrollManager {
         }
     }
 
+    scrollToView(elementId) {
+        let element = document.getElementById(elementId);
+        if (element) {
+            element.scrollIntoView({ behavior: "auto", block: "nearest", inline: "nearest" });
+        }
+    }
+
     //scrolls to the selected element. Default is documentElement (i.e., html element)
     scrollTo(selector, left, top, behavior) {
         let element = document.querySelector(selector) || document.documentElement;
@@ -62,6 +69,14 @@ class MudScrollManager {
     unlockScroll(selector, lockclass) {
         let element = document.querySelector(selector) || document.body;
         element.classList.remove(lockclass);
+    }
+
+    scrollToMiddle(parentId, childId) {
+
+        let parent = document.getElementById(parentId);
+        let child = document.getElementById(childId);
+
+        parent.scrollTop = (child.offsetTop - parent.offsetHeight) + (parent.offsetHeight / 2) + (child.offsetHeight / 2);
     }
 };
 window.mudScrollManager = new MudScrollManager();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Big List and Select PR #5150 has been decided to seperate multiple phases. The big PR describes what it has, so we didn't write it here again.

MudList, MudSelect and MudAutocomplete will remain the same. Instead of we will add the new components with a new namespace `MudExperimental`. So both of the old and remaked components can be usable and testable by developers during the phases.

Please note that these experimental components are not planned to be changed drastically unless unexpected bugs are encountered during the phases. It totally depends on the success rate.

## Roadmap
**Phase 1: Experimental List. (Current Phase)
Creating `MudExperimental.MudList`**

Phase 2: Old List Arrangement
Bug fixes which are proper for old design for old MudList.

Phase 3: Experimental Select
Creating `MudExperimantal.MudSelect`

Phase 4: Old Select Arrangement
Bug fixes which are proper for old design for old MudSelect.

Phase 5: Experimental Autocomplete
Creating `MudExperimantal.MudAutocomplete`

Phase 6: Old Autocomplete Arrangement
Bug fixes which are proper for old design for old MudAutocomplete.

Phase 7: Overall Evaluation and Final Decision Phase.

## Phase Summary
Will be added as a comment in this PR.