### PR TITLE
MudDataGrid: Add onmousedown callback parameter on DataGrid row

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventCallbacksTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventCallbacksTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDataGrid T="Item" Items="@_items" EditMode="@DataGridEditMode.Cell" RowClick="@OnRowClick" 
+<MudDataGrid T="Item" Items="@_items" EditMode="@DataGridEditMode.Cell" RowClick="@OnRowClick" RowMouseDown="@OnRowMouseDown"
     SelectedItemChanged="@OnSelectedItemChanged" CommittedItemChanges="@OnCommittedItemChanges" 
     ReadOnly="false">
     <Columns>
@@ -17,6 +17,7 @@
     };
 
     public bool RowClicked { get; set; }
+    public bool RowMouseDowned { get; set; }
     public bool SelectedItemChanged { get; set; }
     public bool CommittedItemChanges { get; set; }
 
@@ -24,6 +25,11 @@
     {
         RowClicked = true;
         Console.WriteLine("RowClicked fired.");
+    }
+
+    private void OnRowMouseDown(DataGridRowClickEventArgs<Item> args)
+    {
+        RowMouseDowned = true;
     }
 
     private void OnSelectedItemChanged(Item item)

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -344,6 +344,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Include callbacks in test coverage.
             dataGrid.Instance.RowClick.HasDelegate.Should().Be(true);
+            dataGrid.Instance.RowMouseDown.HasDelegate.Should().Be(true);
             dataGrid.Instance.SelectedItemChanged.HasDelegate.Should().Be(true);
             dataGrid.Instance.CommittedItemChanges.HasDelegate.Should().Be(true);
 
@@ -357,11 +358,14 @@ namespace MudBlazor.UnitTests.Components
 
             // Make sure that the callbacks have not been fired yet.
             comp.Instance.RowClicked.Should().Be(false);
+            comp.Instance.RowMouseDowned.Should().Be(false);
             comp.Instance.SelectedItemChanged.Should().Be(false);
             comp.Instance.CommittedItemChanges.Should().Be(false);
 
-            // Fire RowClick, SelectedItemChanged, SelectedItemsChanged, and StartedEditingItem callbacks.
+            // Fire RowClick, RowMouseDown, SelectedItemChanged, SelectedItemsChanged, and StartedEditingItem callbacks.
             dataGrid.FindAll(".mud-table-body tr")[0].Click();
+            // Fire RowMouseDown
+            dataGrid.FindAll(".mud-table-body tr")[0].MouseDown();
 
             //Console.WriteLine(dataGrid.Markup);
             // Edit an item.
@@ -369,6 +373,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Make sure that the callbacks have been fired.
             comp.Instance.RowClicked.Should().Be(true);
+            comp.Instance.RowMouseDowned.Should().Be(true);
             comp.Instance.SelectedItemChanged.Should().Be(true);
             comp.Instance.CommittedItemChanges.Should().Be(true);
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -146,7 +146,7 @@
                                             @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var tmpRowIndex = rowIndex; }
-                                            <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="item" @onclick="@((args) => OnRowClickedAsync(args, item, tmpRowIndex))">  
+                                            <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="item" @onclick="@((args) => OnRowClickedAsync(args, item, tmpRowIndex))" @onmousedown="@((args) => OnRowMouseDownAsync(args, item, tmpRowIndex))">  
                                                 <CascadingValue Value="@Validator" IsFixed="true">
                                                 @foreach (var column in RenderedColumns)
                                                 {
@@ -181,7 +181,7 @@
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }
-                                    <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="item" @onclick="@((args) => OnRowClickedAsync(args, item, tmpRowIndex))">  
+                                    <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="item" @onclick="@((args) => OnRowClickedAsync(args, item, tmpRowIndex))" @onmousedown="@((args) => OnRowMouseDownAsync(args, item, tmpRowIndex))">
                                         <CascadingValue Value="@Validator" IsFixed="true">
                                         @foreach (var column in RenderedColumns)
                                         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -155,6 +155,11 @@ namespace MudBlazor
         [Parameter] public EventCallback<DataGridRowClickEventArgs<T>> RowClick { get; set; }
 
         /// <summary>
+        /// Callback is called whenever mouse down on a row.
+        /// </summary>
+        [Parameter] public EventCallback<DataGridRowClickEventArgs<T>> RowMouseDown { get; set; }
+
+        /// <summary>
         /// Callback is called when an item has begun to be edited. Returns the item being edited.
         /// </summary>
         [Parameter] public EventCallback<T> StartedEditingItem { get; set; }
@@ -925,6 +930,18 @@ namespace MudBlazor
 
             if (EditMode != DataGridEditMode.Cell && EditTrigger == DataGridEditTrigger.OnRowClick)
                 await SetEditingItemAsync(item);
+
+            await SetSelectedItemAsync(item);
+        }
+
+        internal async Task OnRowMouseDownAsync(MouseEventArgs args, T item, int rowIndex)
+        {
+            await RowMouseDown.InvokeAsync(new DataGridRowClickEventArgs<T>
+            {
+                MouseEventArgs = args,
+                Item = item,
+                RowIndex = rowIndex,
+            });
 
             await SetSelectedItemAsync(item);
         }


### PR DESCRIPTION
## Description
Add onmousedown callback parameter on DataGrid row to be able to handle the middle and right click.
With only the onclick callback parameter I can't subscribe to the right click event.

## How Has This Been Tested?
I've tested it on my own project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
