### PR TITLE
MudMessageBox: Class and Style attributes are not respected

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/MessageBox/SimpleMessageBox.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/MessageBox/SimpleMessageBox.razor
@@ -1,0 +1,21 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudButton Variant="Variant.Filled" OnClick="OpenMessageBox">Default</MudButton>
+
+<MudMessageBox @ref="mbox" Title="Warning" CancelText="Cancel" Class="messagebox" Style="z-index: 3000;">
+    <MessageContent>
+        Deleting can <b><i>not</i></b> be undone!
+    </MessageContent>
+    <YesButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteForever">Delete!</MudButton>
+    </YesButton>
+</MudMessageBox>
+
+@code {
+    MudMessageBox mbox { get; set; }
+
+    public async Task OpenMessageBox()
+    {
+        var _ = await mbox.Show();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Threading.Tasks;
+using AngleSharp.Css.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
@@ -100,6 +101,17 @@ namespace MudBlazor.UnitTests.Components
 
             comp.FindAll("button").Should().BeEmpty();
             yesNoCancel.Result.Should().Be(null);
+        }
+
+        [Test]
+        public async Task MessageBox_CustomClass()
+        {
+            var dialogs = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.RenderComponent<SimpleMessageBox>();
+            await comp.InvokeAsync(() => comp.Find("button").Click());
+
+            dialogs.Find(".mud-dialog").ClassList.Should().Contain("messagebox");
+            dialogs.Find(".mud-dialog").GetStyle().GetZIndex().Should().Be("3000");
         }
 
     }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<MudDialog @attributes="UserAttributes">
+<MudDialog Class="@Class" Style="@Style" @attributes="UserAttributes">
     <TitleContent>
         @if (TitleContent == null)
         {
@@ -12,7 +12,7 @@
         }
     </TitleContent>
     <DialogContent>
-        @if(MessageContent!=null)
+        @if (MessageContent != null)
         {
             @MessageContent
         }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -162,6 +162,8 @@ namespace MudBlazor
                 [nameof(NoButton)] = NoButton,
                 [nameof(YesText)] = YesText,
                 [nameof(YesButton)] = YesButton,
+                [nameof(Class)] = Class,
+                [nameof(Style)] = Style,
             };
             _reference = DialogService.Show<MudMessageBox>(parameters: parameters, options: options, title: Title);
             var result = await _reference.Result;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #5394.

When MudMessageBox is renderer through DialogService.Show (invoked in MudMessageBox.Show), 'Class' and 'Style' attributes are not propagated to DialogParameters.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
