### PR TITLE
MudDataGrid: ExpandAllGroups (persist group expansions)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
@@ -1,0 +1,62 @@
+@namespace MudBlazor.UnitTests.TestComponents
+@using System.Collections.ObjectModel
+<MudDataGrid @ref="dataGrid"
+             Items="@Fruits"
+             Sortable="true"
+             Filterable="true"
+             Hideable="true"
+             Groupable="true"
+             GroupExpanded="false">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <Column T="Fruit" Field="Name" Title="Name" Filterable="false" Groupable="false" />
+        <Column T="Fruit" Field="Count" />
+        <Column T="Fruit" Field="Category" Title="Category" Grouping="true" GroupBy="@_groupBy">
+            <GroupTemplate>
+                <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+            </GroupTemplate>
+        </Column>
+    </Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+    <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+</div>
+
+@code {
+    MudDataGrid<Fruit> dataGrid;
+    public record Fruit(string Name, int Count, string Category);
+
+    ObservableCollection<Fruit> Fruits { get; set; } =
+        new ObservableCollection<Fruit>()
+        {
+            new Fruit("Apple", 2, "Pome"),
+            new Fruit("Pear", 4, "Pome"),
+            new Fruit("Orange", 4, "Citrus")
+        };
+    
+    Func<Fruit, object> _groupBy = x => 
+    {
+        return x.Category;
+    };
+
+    public void AddFruit()
+    {
+        Fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void ExpandAllGroups()
+    {
+        dataGrid?.ExpandAllGroups();
+    }
+
+    public void CollapseAllGroups()
+    {
+        dataGrid?.CollapseAllGroups();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4199,5 +4199,22 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(true);
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-asc").Should().Be(false);
         }
+
+        [Test]
+        public async Task DataGridGroupExpandedTest()
+        {
+            var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
+
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
+            comp.Instance.ExpandAllGroups();
+            dataGrid.Render();
+            // after all groups are expanded
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(7);
+            await comp.InvokeAsync(() =>
+                comp.Instance.AddFruit());
+            // datagrid should be expanded with the new category
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(8);
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1243,6 +1243,7 @@ namespace MudBlazor
             foreach (var group in _groups)
             {
                 group.IsExpanded = true;
+                _groupExpansions.Add(group.Grouping.Key);
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #5404.

When DataGrid.ExpandAllGroups is called, it does not persist current _groupExpansions,
so when items source changed, current group expansions are not preserved.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
