### PR TITLE
MudAlert: Fix CloseIcon color in Filled Variant (#5436)

### DIFF
--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -58,7 +58,7 @@
         font-weight: 500;
         background-color: var(--mud-palette-dark);
 
-        & .mud-button-root {
+        & .mud-alert-close .mud-button-root {
             color: currentColor;
         }
     }

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -57,6 +57,10 @@
         color: var(--mud-palette-dark-text);
         font-weight: 500;
         background-color: var(--mud-palette-dark);
+
+        & .mud-button-root {
+            color: currentColor;
+        }
     }
 
     @each $color in $mud-palette-colors {
@@ -64,6 +68,10 @@
             color: var(--mud-palette-#{$color}-text);
             font-weight: 500;
             background-color: var(--mud-palette-#{$color});
+
+            & .mud-button-root {
+                color: currentColor;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
fixes visual bug #5436

## How Has This Been Tested?
Visually, it's just a minor CSS update.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![image](https://user-images.githubusercontent.com/49674671/194562448-c2904abb-be0d-4e8b-8d34-f637eb6ee601.png)

![image](https://user-images.githubusercontent.com/49674671/194562252-a972cb6b-a616-4f4e-8e56-2ccbd8b5c494.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
