### PR TITLE
MudTable: Ensure selection is updated when items are removed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest8.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+        <MudTd>
+            <MudButton OnClick="(() => DeleteItem(context))">Delete</MudButton>
+        </MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "SelectedItems should update when rows are removed and the header should remain checked.";
+
+    IList<int> items = new int[] { 0, 1, 2, 3, 4 }.ToList();
+    HashSet<int> selectedItems = new HashSet<int>();
+
+    private void DeleteItem(int i)
+    {
+        items.Remove(i);
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -709,8 +709,6 @@ namespace MudBlazor.UnitTests.Components
         public void TableMultiSelectionTest7()
         {
             var comp = Context.RenderComponent<TableMultiSelectionTest7>();
-            // print the generated html
-            //Console.WriteLine(comp.Markup);
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -748,6 +746,46 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+        }
+
+        /// <summary>
+        /// Removing rows should not uncheck the header checkbox, which should select all items (all checkboxes on, all items in SelectedItems)
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest8()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionTest8>();
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+
+            // click header checkbox and verify selection text
+            var inputs = comp.Find("input");
+            inputs.Change(true);
+            table.SelectedItems.Count.Should().Be(5);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3, 4 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(6);
+
+            // click delete button
+            var buttons = comp.FindAll("button");
+            buttons[2].Click(); //delete one of the elements
+
+            checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+
+            //verify table markup
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(5); // <-- one header, four rows
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(12); // three td per row for multi selection
+            var inputs2 = comp.FindAll("input").ToArray();
+            inputs2.Length.Should().Be(5); // one checkbox per row + one for the header
+
+            //verify selection
+            table.SelectedItems.Count.Should().Be(4);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 3, 4 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(5);
+
+            checkboxes[0].Checked.Should().BeTrue(); //manually verify header is checked after deleting item
         }
 
         /// <summary>
@@ -1024,7 +1062,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TableInlineEditTestApplyButtons>(
                 p => p.Add(x => x.ApplyButtonPosition, position));
-            
+
             var trs = comp.FindAll("tr");
 
             //header + 3 items + footer

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -432,6 +432,16 @@ namespace MudBlazor
                 _editingItem = item;
         }
 
+        public override bool ContainsItem(object item)
+        {
+            var t = item.As<T>();
+            if (t is null)
+                return false;
+            return FilteredItems?.Contains(t) ?? false;
+        }
+
+        public override void UpdateSelection() => SelectedItemsChanged.InvokeAsync(SelectedItems);
+
         public override TableContext TableContext
         {
             get

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -512,6 +512,9 @@ namespace MudBlazor
 
         internal abstract bool IsEditable { get; }
 
+        public abstract bool ContainsItem(object item);
+        public abstract void UpdateSelection();
+
         public Interfaces.IForm Validator { get; set; } = new TableRowValidator();
     }
 }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -111,6 +111,11 @@ namespace MudBlazor
                 return;
             if (Rows[t] == row)
                 Rows.Remove(t);
+            if (!Table.ContainsItem(item))
+            {
+                Selection.Remove(t);
+                Table.UpdateSelection();
+            }
         }
 
         #region --> Sorting


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR fixes a bug where removing items from the Items collection would not remove them from the SelectedItems hashset, leading to odd behavior. For example, if all items are selected and an item is removed, the header checkbox will uncheck, as the number of selected items becomes *greater* than the items.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
