### PR TITLE
MudDivider: Fix fullwidth behavior in flex containers 

### DIFF
--- a/src/MudBlazor/Components/Divider/MudDivider.razor
+++ b/src/MudBlazor/Components/Divider/MudDivider.razor
@@ -13,7 +13,7 @@
       .AddClass($"mud-divider-flexitem", FlexItem)
       .AddClass($"mud-divider-light", Light)
       .AddClass($"mud-divider-vertical", Vertical)
-      .AddClass($"mud-divider-{DividerType.ToDescriptionString()}", when: () => DividerType != DividerType.FullWidth)
+      .AddClass($"mud-divider-{DividerType.ToDescriptionString()}", DividerType != DividerType.FullWidth || (DividerType == DividerType.FullWidth && Vertical == false))
       .AddClass(Class)
     .Build();
 

--- a/src/MudBlazor/Styles/components/_divider.scss
+++ b/src/MudBlazor/Styles/components/_divider.scss
@@ -37,3 +37,8 @@
     height: auto;
     align-self: stretch;
 }
+
+.mud-divider-fullwidth {
+    flex-grow: 1;
+    width: 100%;
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #5458.

MudDivider has a DividerType parameter and DividerType.FullWidth default value. However we don't apply any classes if it is fullwidth. This causes some problems on flex containers like #5458 has an example. So we may add new CSS class to be sure it takes fullwidth always.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
