### PR TITLE
MudCheckBox: Add label styling props (Typo, Style, Class)

### DIFF
--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -12,11 +12,11 @@
             </span>
             @if (!String.IsNullOrEmpty(Label))
             {
-                <MudText Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText Color="HasErrors ? Color.Error : Color.Inherit" Typo="@LabelTypo" Class="@LabelClass" Style="@LabelStyle">@Label</MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText Color="HasErrors ? Color.Error : Color.Inherit" Typo="@LabelTypo" Class="@LabelClass" Style="@LabelStyle">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -123,6 +123,27 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool TriState { get; set; }
 
+        /// <summary>
+        /// The class of the label.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string LabelClass { get; set; }
+
+        /// <summary>
+        /// The style of the label.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string LabelStyle { get; set; }
+
+        /// <summary>
+        /// The typography of the label.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public Typo LabelTypo { get; set; } = Typo.body1;
+
         private string GetIcon()
         {
             if (BoolValue == true)
@@ -245,7 +266,7 @@ namespace MudBlazor
 
             if (disposing == true)
             {
-                if(_keyInterceptor != null)
+                if (_keyInterceptor != null)
                 {
                     _keyInterceptor.KeyDown -= HandleKeyDown;
                     _keyInterceptor.Dispose();


### PR DESCRIPTION
It's not an easy task to change font size or style of a MudCheckBox.
I often encountered the need to make the text smaller.

This pull request solves the problem by adding 3 new properties:
- LabelTypo: to set the typo of the label
- LabelStyle: to set the style of the label
- LabelClass: to set the class of the label