### PR TITLE
MudInput: Add Accessibility Titles to Nested Icons

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -110,6 +110,7 @@
                     Icon="@ClearIcon" 
                     Size="@Size.Small" 
                     OnClick="@ClearButtonClickHandlerAsync"
+                    Title="Clear" 
                     tabindex="-1"
                 />
 	}
@@ -136,10 +137,10 @@
 	{
 	    <div class="mud-input-numeric-spin">
             <MudButton Variant="Variant.Text" @onclick="OnIncrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
-                <MudIcon Icon="@NumericUpIcon" Size="@GetButtonSize()" />
+                <MudIcon Title="Increment" Icon="@NumericUpIcon" Size="@GetButtonSize()" />
             </MudButton>
             <MudButton Variant="Variant.Text" @onclick="OnDecrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
-                <MudIcon Icon="@NumericDownIcon" Size="@GetButtonSize()" />
+                <MudIcon Title="Decrement" Icon="@NumericDownIcon" Size="@GetButtonSize()" />
             </MudButton>
 	    </div>
 	}

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -109,8 +109,8 @@
                     Color="@Color.Default" 
                     Icon="@ClearIcon" 
                     Size="@Size.Small" 
-                    OnClick="@ClearButtonClickHandlerAsync"
-                    Title="Clear" 
+                    OnClick="@ClearButtonClickHandlerAsync" 
+                    aria-label="Clear"
                     tabindex="-1"
                 />
 	}
@@ -137,10 +137,10 @@
 	{
 	    <div class="mud-input-numeric-spin">
             <MudButton Variant="Variant.Text" @onclick="OnIncrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
-                <MudIcon Title="Increment" Icon="@NumericUpIcon" Size="@GetButtonSize()" />
+                <MudIcon aria-label="Increment" Icon="@NumericUpIcon" Size="@GetButtonSize()" />
             </MudButton>
             <MudButton Variant="Variant.Text" @onclick="OnDecrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1">
-                <MudIcon Title="Decrement" Icon="@NumericDownIcon" Size="@GetButtonSize()" />
+                <MudIcon aria-label="Decrement" Icon="@NumericDownIcon" Size="@GetButtonSize()" />
             </MudButton>
 	    </div>
 	}


### PR DESCRIPTION
## Description
Resolves #5530 

Add Title details to the three icons nested inside of the MudInput Component for accessibility concerns in software test tools.

While performing some 508 testing, I noticed that our AutoComplete component was failing on the Clear Icon. Looks like a MudInput is being used in the source code, so I added a title value to it and the two increment/decrement icons while I was at it. 

Please let me know if there are any issues or concerns.

## How Has This Been Tested?
Unit tests run. I believe this counts as a trivial change, but I'm not certain.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. (I believe this is a trivial change, so no tests actually added.)
