### PR TITLE
MudDataGrid: Fix HierarchyColumn behavior

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -29,7 +29,7 @@
         <DocsPageSection>
             <SectionHeader Title="Advanced Data Grid">
                 <Description>
-                    In a more advanced scenario, the data grid offers sorting, filtering, pagination, selection and hierarchy detail. There are two ways to filter the data 
+                    In a more advanced scenario, the data grid offers sorting, filtering, pagination and selection. There are two ways to filter the data 
                     fed into the data grid. A <CodeInline>QuickFilter</CodeInline> function allows filtering the items in the grid globally. Data can also be filtered by specifying 
                     column filters, enabling a more robust filtration.
                     <br><br>
@@ -148,6 +148,19 @@
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="DataGridAdvancedFilteringExample" ShowCode="false" Block="true" FullWidth="true">
                 <DataGridAdvancedFilteringExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Row Detail View">
+                <Description>
+                    The The <CodeInline>&lt;MudDataGrid></CodeInline> allows you to create hierarchical layouts. To do that the <CodeInline>HierarchyColumn</CodeInline> has to be added in the <CodeInline>Columns</CodeInline> definitions. 
+                    <br><br>
+                    You can customize the icon to toggle the RowDetail and also disable the toggle button.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="DataGridDetailRowExample" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridDetailRowExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
@@ -12,7 +12,6 @@
             AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <Columns>
-        <HierarchyColumn T="Element" />
         <SelectColumn T="Element" />
         <Column T="Element" Field="Number" Title="Nr" Sortable="false" Filterable="false" />
         <Column T="Element" Field="Sign" />
@@ -21,19 +20,6 @@
         <Column T="Element" Field="Molar" Title="Molar mass" />
         <Column T="Element" Field="Group" Title="Category" />
     </Columns>
-    <ChildRowContent>
-        <MudCard>
-            <MudCardHeader>
-                <CardHeaderContent>
-                    <MudText Typo="Typo.h6">@context.Item.Name</MudText>
-                </CardHeaderContent>
-            </MudCardHeader>
-            <MudCardContent>
-                <MudText>This element is number @context.Item.Number</MudText>
-                <MudText>This element has a molar mass of @context.Item.Molar</MudText>
-            </MudCardContent>
-        </MudCard>
-    </ChildRowContent>
     <PagerContent>
         <MudDataGridPager T="Element" />
     </PagerContent>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -1,0 +1,40 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudDataGrid Items="@Elements">
+    <Columns>
+        <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" />
+        <Column T="Element" Field="Number" Title="Nr" />
+        <Column T="Element" Field="Sign" />
+        <Column T="Element" Field="Name" />
+        <Column T="Element" Field="Position" />
+        <Column T="Element" Field="Molar" Title="Molar mass" />
+    </Columns>
+    <ChildRowContent>
+        <MudCard>
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h6">@context.Item.Name</MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                <MudText>This element is number @context.Item.Number</MudText>
+                <MudText>This element has a molar mass of @context.Item.Molar</MudText>
+            </MudCardContent>
+        </MudCard>
+    </ChildRowContent>
+    <PagerContent>
+        <MudDataGridPager T="Element" />
+    </PagerContent>
+</MudDataGrid>
+
+@code { 
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -2,12 +2,15 @@
 
 <MudDataGrid Items="@_items" Filterable="true">
     <Columns>
+        <HierarchyColumn T="Model" ButtonDisabledFunc="@(x => x.Name == "Alicia")"/>
         <Column T="Model" Field="@nameof(Model.Name)" />
         <Column T="Model" Field="@nameof(Model.Age)" />
         <Column T="Model" Field="@nameof(Model.Status)" />
     </Columns>
     <ChildRowContent>
-        @($"uid = {context.Item.Name}|{context.Item.Age}|{context.Item.Status}|{Guid.NewGuid()}")
+        <tr>
+            <td colspan="3">@($"uid = {context.Item.Name}|{context.Item.Age}|{context.Item.Status}|{Guid.NewGuid()}")</td>
+        </tr>
     </ChildRowContent>
 </MudDataGrid>
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3633,10 +3633,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridChildRowContentOpenTest()
+        public async Task DataGridRowDetailOpenTest()
         {
-            var comp = Context.RenderComponent<DataGridChildRowContentTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridChildRowContentTest.Model>>();
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance
             .ToggleHierarchyVisibilityAsync(dataGrid.Instance.Items.First()));
@@ -3645,12 +3645,47 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridChildRowContentClosedTest()
+        public async Task DataGridRowDetailClosedTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            dataGrid.FindAll("td").SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Sam|56|Normal|")).Should().BeNull();
+        }
+
+        [Test]
+        public async Task DataGridRowDetailButtonDisabledTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            dataGrid.FindAll("button")[10].OuterHtml.Contains("disabled")
+                .Should().BeTrue();
+        }
+
+        [Test]
+        public async Task DataGridRowDetailButtonDisabledClickTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            await comp.InvokeAsync(() =>
+            {
+                var buttons = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon");
+                buttons[10].Click();
+
+                dataGrid.FindAll("td")
+                .SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Alicia|54|Info|")).Should().BeNull();
+            });
+        }
+
+        [Test]
+        public async Task DataGridChildRowContentTest()
         {
             var comp = Context.RenderComponent<DataGridChildRowContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridChildRowContentTest.Model>>();
 
-            dataGrid.FindAll("td").SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Sam|56|Normal|")).Should().BeNull();
+            dataGrid.FindAll("td").SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Sam|56|Normal|")).Should().NotBeNull();
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -9,7 +9,8 @@
             <MudIconButton
             Icon="@(context.openHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
             OnClick="context.Actions.ToggleHierarchyVisibilityForItem"
-            Size="@IconSize"/>
+            Size="@IconSize"
+            Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>
         </label>
     </CellTemplate>
 </Column>
@@ -18,4 +19,5 @@
     [Parameter] public string ClosedIcon { get; set; } = Icons.Material.Filled.ChevronRight;
     [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ExpandMore;
     [Parameter] public Size IconSize { get; set; } = Size.Medium;
+    [Parameter] public Func<T, bool> ButtonDisabledFunc { get; set; } = x => false;
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -157,7 +157,7 @@
                                                 }                                     
                                                 </CascadingValue>
                                             </tr>                                   
-                                            @if (_openHierarchies.Contains(item) && ChildRowContent != null)
+                                            @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !hasHierarchyColumn))
                                             {
                                                 <tr class="mud-table-row">
                                                     <td class="mud-table-cell" colspan="1000">
@@ -192,7 +192,7 @@
                                         }                                       
                                         </CascadingValue>
                                     </tr>                                   
-                                    @if (_openHierarchies.Contains(item) && ChildRowContent != null)
+                                    @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !hasHierarchyColumn))
                                     {
                                         <tr class="mud-table-row">
                                             <td class="mud-table-cell" colspan="1000">

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -688,6 +688,14 @@ namespace MudBlazor
             }
         }
 
+        private bool hasHierarchyColumn
+        {
+            get
+            {
+                return RenderedColumns.Any(x => x.Tag?.ToString() == "hierarchy-column");
+            }
+        }
+
         #endregion
 
         [UnconditionalSuppressMessage("Trimming", "IL2046: 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Suppressing because we annotating the whole component with RequiresUnreferencedCodeAttribute for information that generic type must be preserved.")]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Resolves #5500 and also the problem brought up in #5273 

I have brought back the old `ChildRowContent` behavior as it was until 6.0.16. 

![image](https://user-images.githubusercontent.com/12575417/196434244-7c98a110-d0af-46f4-b376-2c9517c2f683.png)

**The only change from that behavior is that, by default, the `ChildRowContent` will span for all the datagrid width.**

I have also added the possibility to disable the toggle button in the `HierarchyColumn`.

![image](https://user-images.githubusercontent.com/12575417/196435009-85ef6f97-caad-42e1-84c5-467733c562a0.png)

It is a func so it works indipendently for each row.

I have also added a new section in the DataGrid Examples since now we have some functionalities in the `HierarchyColumn`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tested and visually tested.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Change of a feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
