### PR TITLE
Build: Separate EnumSwitch code to avoid BL0007

### DIFF
--- a/src/MudBlazor.Docs/Components/EnumSwitch.razor
+++ b/src/MudBlazor.Docs/Components/EnumSwitch.razor
@@ -8,23 +8,3 @@
         }
     </MudButtonGroup>
 </div>
-
-@code {
-    private T _value;
-
-    [Parameter]
-    public T Value
-    {
-        get => _value;
-        set
-        {
-            if (_value.Equals(value)) return;
-            _value = value;
-            ValueChanged.InvokeAsync(value);
-        }
-    }
-
-    [Parameter] public EventCallback<T> ValueChanged { get; set; }
-
-    private Type Type => typeof(T);
-}

--- a/src/MudBlazor.Docs/Components/EnumSwitch.razor.cs
+++ b/src/MudBlazor.Docs/Components/EnumSwitch.razor.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.Docs.Components;
+
+public partial class EnumSwitch<T>
+{
+    private T _value;
+
+    [Parameter]
+    public T Value
+    {
+        get => _value;
+        set
+        {
+            if (_value.Equals(value)) return;
+            _value = value;
+            ValueChanged.InvokeAsync(value);
+        }
+    }
+
+    [Parameter] public EventCallback<T> ValueChanged { get; set; }
+
+    private Type Type => typeof(T);
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
In net7
BL0007: Component parameters should be auto property
is now surfaced due to new analysers.
We ignore it in editorconfig for now as its a whole body of work to fix in the short term.
edit: Its actually because we only ignore it in *.cs I see no harm in this PR though

It appears that ignoring BL0007 in editorconfig only works for code behind.
There is only one situation that this affects in the Docs so we just move the code for EnumSwitch to code behind.
This will allow us to turn on warnings as errors once we fix trimming

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Run the API docs and check the enum switch still works

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
