### PR TITLE
MudDrawer: Remove event listeners

### DIFF
--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<aside @ref="_drawerRef" @attributes="UserAttributes" class="@Classname" style="@Stylename">
+<aside @onmouseenter="OnMouseEnter" @onmouseleave="OnMouseLeave" @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <div @ref="_contentRef" class="mud-drawer-content">
         <CascadingValue Value="this" IsFixed="true">
             @ChildContent

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
 using MudBlazor.Services;
@@ -13,14 +12,11 @@ namespace MudBlazor
     public partial class MudDrawer : MudComponentBase, IDisposable, INavigationEventReceiver
     {
         private double _height;
-        private ElementReference _contentRef, _drawerRef;
+        private ElementReference _contentRef;
         private DrawerClipMode _clipMode;
         private bool? _isOpenWhenLarge = null;
-        private int _mouseEnterListenerId, _mouseLeaveListenerId;
         private bool _open, _rtl, _isRendered, _initial = true, _keepInitialState, _fixed = true;
         private Breakpoint _breakpoint = Breakpoint.Md, _screenBreakpoint = Breakpoint.None;
-        private DotNetObjectReference<MudDrawer> _dotNetRef;
-
         private Guid _breakpointListenerSubscriptionId;
 
         private bool OverlayVisible => _open && !DisableOverlay &&
@@ -262,7 +258,6 @@ namespace MudBlazor
             {
                 DrawerContainer?.Add(this);
             }
-            _dotNetRef = DotNetObjectReference.Create(this);
             base.OnInitialized();
         }
 
@@ -288,9 +283,6 @@ namespace MudBlazor
                 {
                     StateHasChanged();
                 }
-
-                _mouseEnterListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseenter", nameof(OnMouseEnter), true);
-                _mouseLeaveListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseleave", nameof(OnMouseLeave), true);
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -310,15 +302,6 @@ namespace MudBlazor
                 if (disposing)
                 {
                     DrawerContainer?.Remove(this);
-
-                    if (_mouseEnterListenerId != 0)
-                        _ = _drawerRef.MudRemoveEventListenerAsync("mouseenter", _mouseEnterListenerId);
-                    if (_mouseLeaveListenerId != 0)
-                        _ = _drawerRef.MudRemoveEventListenerAsync("mouseleave", _mouseLeaveListenerId);
-
-                    var toDispose = _dotNetRef;
-                    _dotNetRef = null;
-                    toDispose?.Dispose();
 
                     if (_breakpointListenerSubscriptionId != default)
                     {
@@ -411,7 +394,7 @@ namespace MudBlazor
 
 
         private bool closeOnMouseLeave = false;
-        [JSInvokable]
+
         public async void OnMouseEnter()
         {
             if (Variant == DrawerVariant.Mini && !Open && OpenMiniOnHover)
@@ -421,7 +404,6 @@ namespace MudBlazor
             }
         }
 
-        [JSInvokable]
         public async void OnMouseLeave()
         {
             if (Variant == DrawerVariant.Mini && Open && closeOnMouseLeave)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
I was looking at trimming I saw that MudDrawer was using. JSInterop for mouse events when better solutions exists.
This can be removed without loss of functionality and reduces complexity.
This simplifies MudDrawer
Also as a side affect
Fixes https://github.com/MudBlazor/MudBlazor/issues/4608

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Run test suite
Visual between dev.mudblazor.com and my local docs.
Set breakpoint on Event to check code is executing

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

@henon this also raises the question of the future of 
https://github.com/MudBlazor/MudBlazor/blob/4c58658ccef766bd58333cce4fbd9e40e23db8c3/src/MudBlazor/Extensions/ElementReferenceExtensions.cs#L81
Which is now only used in `MudCollapse`.
The reflection used to pass parameters to event registration doesn't seem to be trim friendly and I think we or users can use other methods with reduced complexity

https://learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?view=aspnetcore-6.0

