### PR TITLE
MudCollapse: Remove event listeners

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -28,7 +28,6 @@ namespace MudBlazor.UnitTests.Components
 
             //MaxHeight acceptes minus value?
             _ = comp.Instance._state = CollapseState.Entering;
-            await comp.InvokeAsync(() => comp.Instance._disposeCount = 1);
 #pragma warning disable BL0005
             await comp.InvokeAsync(() => comp.Instance.MaxHeight = -1);
             await comp.InvokeAsync(() => comp.Instance.AnimationEnd());

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 @using System.Globalization;
 
-<div @ref="_container" @attributes="UserAttributes" class="@Classname" style="@Stylename">
+<div @onanimationend="AnimationEnd" @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <div @ref="_wrapper" class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent

--- a/src/MudBlazor/Interop/EventHandlers.cs
+++ b/src/MudBlazor/Interop/EventHandlers.cs
@@ -3,20 +3,18 @@ using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {
+    // used in MudCollapse
+    [EventHandler("onanimationend", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 #if !NET7_0_OR_GREATER
-    /// <summary>
-    /// see https://github.com/dotnet/aspnetcore/issues/13104
-    /// </summary>
-    /// 
-
-    //due to these event handlers are not implemented in Blazor, we can't pass MouseEventArgs,
-    //because that produces an error of casting, not being possible to convert EventArgs into MouseEventArgs.
-    //Change this when they are implemented natively in Blazor
-    [EventHandler("onmouseenter", typeof(EventArgs), true, true)]
-    [EventHandler("onmouseleave", typeof(EventArgs), true, true)]
+    // see https://github.com/dotnet/aspnetcore/issues/13104
+    // due to these event handlers are not implemented in Blazor before net7, we can't pass MouseEventArgs,
+    // because that produces an error of casting, not being possible to convert EventArgs into MouseEventArgs.
+    [EventHandler("onmouseenter", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+    [EventHandler("onmouseleave", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+#endif
     public static class EventHandlers
     {
 
     }
-#endif
+
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
I was looking at trimming I saw that MudCollapse was using. JSInterop for animation events when better solutions exists.
This can be removed without loss of functionality and reduces complexity.
This simplifies MudCollapse


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Run test suite
Visual between dev.mudblazor.com and my local docs.
Set breakpoint on Event to check code is executing
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

@henon This is the last use of AddEventListener ElementReferenceExtension.
I realise its public API but I would suggest we don't want our users using JSInterop unecessarily when other better soluitions exist
I therefore propose we remove this functionality since it is no longer used in the library.