### PR TITLE
ScrollManager: Add ScrollIntoView

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -47,6 +47,8 @@ namespace MudBlazor.UnitTests.Mocks
 
         public ValueTask ScrollToAsync(string id, int left, int top, ScrollBehavior scrollBehavior) => ValueTask.CompletedTask;
 
+        public ValueTask ScrollIntoViewAsync(string selector, ScrollBehavior behavior) => ValueTask.CompletedTask;
+
         public Task ScrollToFragment(string id, ScrollBehavior behavior) => Task.CompletedTask;
 
         public ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior) => ValueTask.CompletedTask;

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
         Task ScrollToTop(ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
 
         ValueTask ScrollToAsync(string id, int left, int top, ScrollBehavior scrollBehavior);
+        ValueTask ScrollIntoViewAsync(string selector, ScrollBehavior behavior);
         ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior);
         ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
         ValueTask ScrollToYearAsync(string elementId);
@@ -68,6 +69,15 @@ namespace MudBlazor
         [Obsolete]
         public async Task ScrollTo(int left, int top, ScrollBehavior behavior) =>
             await ScrollToAsync(Selector, left, top, behavior);
+
+        /// <summary>
+        /// Scrolls the first instance of the selector into view
+        /// </summary>
+        /// <param name="selector"></param>
+        /// <param name="behavior"></param>
+        /// <returns></returns>
+        public ValueTask ScrollIntoViewAsync(string selector, ScrollBehavior behavior) =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollIntoView", selector, behavior.ToDescriptionString());
 
         /// <summary>
         /// Scrolls to the top of the element

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -47,7 +47,7 @@ namespace MudBlazor
         /// <param name="id">The id of the selector that is going to be scrolled to</param>
         /// <param name="behavior">smooth or auto</param>
         /// <returns></returns>
-        [Obsolete("Please use ScrollIntoView instead")]
+        [Obsolete("Please use ScrollIntoViewAsync instead")]
         public ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior) => ScrollIntoViewAsync(id, behavior);
 
         [Obsolete]

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -39,7 +39,6 @@ namespace MudBlazor
         public ScrollManager(IJSRuntime jSRuntime)
         {
             _jSRuntime = jSRuntime;
-
         }
 
         /// <summary>
@@ -48,8 +47,8 @@ namespace MudBlazor
         /// <param name="id">The id of the selector that is going to be scrolled to</param>
         /// <param name="behavior">smooth or auto</param>
         /// <returns></returns>
-        public ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior) =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToFragment", id, behavior.ToDescriptionString());
+        [Obsolete("Please use ScrollIntoView instead")]
+        public ValueTask ScrollToFragmentAsync(string id, ScrollBehavior behavior) => ScrollIntoViewAsync(id, behavior);
 
         [Obsolete]
         public async Task ScrollToFragment(string id, ScrollBehavior behavior) =>

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -2,16 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-class MudScrollManager {
-    //scrolls to an Id. Useful for navigation to fragments
-    scrollToFragment(elementId, behavior) {
-        let element = document.getElementById(elementId);
-
-        if (element) {
-            element.scrollIntoView({ behavior, block: 'center', inline: 'start' });
-        }
-    }
-
+class MudScrollManager { 
     //scrolls to year in MudDatePicker
     scrollToYear(elementId, offset) {
         let element = document.getElementById(elementId);

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -39,6 +39,13 @@ class MudScrollManager {
         element.scrollTo({ left, top, behavior });
     }
 
+    //scrolls the provided selector into view
+    scrollIntoView(selector, behavior) {
+        let element = document.querySelector(selector) || document.documentElement;
+        if (element)
+            element.scrollIntoView({ behavior, block: 'center', inline: 'start' });
+    }
+
     scrollToBottom(selector, behavior) {
         let element = document.querySelector(selector);
         if (element)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR adds a `ScrollIntoView` method, which was previously missing from the `ScrollManager`. The closest existing equivalent is `scrollToFragment`, but this function accepts an elementId rather than a CSS selector. This implementation takes the first instance of the CSS selector and scrolls it into view, if it exsists.

If desired, this functionality could be used to implement a scroll to error feature on the MudForm.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

None. I do not see any tests for the other scroll manager methods either. Should these be excluded from coverage?

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
