### PR TITLE
MudColorPicker: Fix MaxLength on HEX TextField for transparent colors

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -157,7 +157,7 @@ namespace MudBlazor.UnitTests.Components
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Color Picker");
         }
-        
+
         [Test]
         public async Task Default()
         {
@@ -321,7 +321,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase("#8qb829ff")]
-        public void SetColorInput_InvailidNoChange(string colorHexString)
+        public void SetColorInput_InvalidNoChange(string colorHexString)
         {
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX));
             //Console.WriteLine(comp.Markup);
@@ -469,7 +469,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Click_ModeBtton()
+        public void Click_ModeButton()
         {
             var comp = Context.RenderComponent<SimpleColorPickerTest>();
             //Console.WriteLine(comp.Markup);
@@ -573,7 +573,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Toogle_Toolbar()
+        public void Toggle_Toolbar()
         {
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.DisableToolbar, false));
             //Console.WriteLine(comp.Markup);
@@ -712,7 +712,6 @@ namespace MudBlazor.UnitTests.Components
             _ = comp.Find(_alphaInputCssSelector);
             comp.Instance.ColorValue.Should().Be(expectedColor);
             comp.Instance.TextValue.Should().Be(expectedColor.ToString(MudColorOutputFormats.HexA));
-
         }
 
         [Test]
@@ -739,6 +738,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Should().ContainSingle();
             inputs.Should().AllBeAssignableTo<IHtmlInputElement>();
             ((IHtmlInputElement)inputs[0]).Value.Should().Be("#0cdc7c");
+            ((IHtmlInputElement)inputs[0]).MaxLength.Should().Be(7);
 
             comp.Instance.TextValue.Should().Be("#0cdc7c");
 
@@ -748,6 +748,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Should().ContainSingle();
             inputs.Should().AllBeAssignableTo<IHtmlInputElement>();
             ((IHtmlInputElement)inputs[0]).Value.Should().Be("#0cdc7c78");
+            ((IHtmlInputElement)inputs[0]).MaxLength.Should().Be(9);
 
             comp.Instance.TextValue.Should().Be("#0cdc7c78");
         }
@@ -1289,12 +1290,12 @@ namespace MudBlazor.UnitTests.Components
             {
                 p.Add(x => x.Variant, PickerVariant.Inline);
             });
-            
+
             await comp.Instance.OpenPicker();
 
             //Console.WriteLine(comp.Markup);
 
-            var providerNode =  comp.Find(".mud-popover-provider");
+            var providerNode = comp.Find(".mud-popover-provider");
             providerNode.Children.Should().ContainSingle();
 
             var popoverNode = providerNode.Children[0];

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -112,7 +112,7 @@
                                             <MudNumericField Value="@_color.L" T="double"  ValueChanged="SetL" Class="mud-picker-color-inputfield" HelperText="L"Step="0.01"  Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
                                             break;
                                         case ColorPickerMode.HEX:
-                                            <MudTextField Value="@GetColorTextValue()" ValueChanged="SetInputString" T="string" Class="mud-picker-color-inputfield" Variant="Variant.Outlined" MaxLength="@_hexColorInputMaxLength" HelperText="HEX" />
+                                            <MudTextField Value="@GetColorTextValue()" ValueChanged="SetInputString" T="string" Class="mud-picker-color-inputfield" Variant="Variant.Outlined" MaxLength="@GetHexColorInputMaxLength()" HelperText="HEX" />
                                             break;
                                         default:
                                             break;

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -112,7 +112,7 @@
                                             <MudNumericField Value="@_color.L" T="double"  ValueChanged="SetL" Class="mud-picker-color-inputfield" HelperText="L"Step="0.01"  Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
                                             break;
                                         case ColorPickerMode.HEX:
-                                            <MudTextField Value="@GetColorTextValue()" ValueChanged="SetInputString" T="string" Class="mud-picker-color-inputfield" Variant="Variant.Outlined" HelperText="HEX" />
+                                            <MudTextField Value="@GetColorTextValue()" ValueChanged="SetInputString" T="string" Class="mud-picker-color-inputfield" Variant="Variant.Outlined" MaxLength="@_hexColorInputMaxLength" HelperText="HEX" />
                                             break;
                                         default:
                                             break;

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -81,7 +81,7 @@ namespace MudBlazor
                     {
                         Value = Value.SetAlpha(1.0);
                     }
-                    }
+
                     Text = GetColorTextValue();
                 }
             }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -3,19 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using System.Collections.Generic;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
-using static MudBlazor.Colors;
 
 namespace MudBlazor
 {
     public partial class MudColorPicker : MudPicker<MudColor>, IAsyncDisposable
     {
+        private const int _disabledAlphaHexColorInputMaxLength = 7;
+        private const int _enabledAlphaHexColorInputMaxLength = 9;
+
         public MudColorPicker() : base(new DefaultConverter<MudColor>())
         {
             AdornmentIcon = Icons.Material.Outlined.Palette;
@@ -63,6 +65,7 @@ namespace MudBlazor
         [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
 
         private bool _disableAlpha = false;
+        private int _hexColorInputMaxLength = _enabledAlphaHexColorInputMaxLength;
 
         /// <summary>
         /// If true, Alpha options will not be displayed and color output will be RGB, HSL or HEX and not RGBA, HSLA or HEXA.
@@ -81,6 +84,11 @@ namespace MudBlazor
                     if (value == true)
                     {
                         Value = Value.SetAlpha(1.0);
+                        _hexColorInputMaxLength = _disabledAlphaHexColorInputMaxLength;
+                    }
+                    else
+                    {
+                        _hexColorInputMaxLength = _enabledAlphaHexColorInputMaxLength;
                     }
 
                     Text = GetColorTextValue();
@@ -297,7 +305,8 @@ namespace MudBlazor
                 _ => ColorPickerMode.RGB,
             };
 
-        public async Task ChangeView(ColorPickerView value) {
+        public async Task ChangeView(ColorPickerView value)
+        {
 
             var oldValue = _activeColorPickerView;
 
@@ -313,7 +322,7 @@ namespace MudBlazor
             {
                 _attachedMouseEvent = true;
             }
-        } 
+        }
 
         private void UpdateBaseColorSlider(int value)
         {
@@ -558,7 +567,7 @@ namespace MudBlazor
         {
             if (DisableDragEffect == true) { return; }
 
-            if(_throttledEventManager == null)
+            if (_throttledEventManager == null)
             {
                 _throttledEventManager = ThrottledEventManagerFactory.Create();
             }
@@ -581,7 +590,7 @@ namespace MudBlazor
 
         public async ValueTask DisposeAsync()
         {
-           if(_throttledEventManager == null) { return; }
+            if (_throttledEventManager == null) { return; }
 
             await _throttledEventManager.DisposeAsync();
         }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -84,13 +84,9 @@ namespace MudBlazor
                     if (value == true)
                     {
                         Value = Value.SetAlpha(1.0);
-                        _hexColorInputMaxLength = _disabledAlphaHexColorInputMaxLength;
-                    }
-                    else
-                    {
-                        _hexColorInputMaxLength = _enabledAlphaHexColorInputMaxLength;
                     }
 
+                    _hexColorInputMaxLength = GetHexColorInputMaxLength();
                     Text = GetColorTextValue();
                 }
             }
@@ -531,6 +527,7 @@ namespace MudBlazor
 
         private string GetSelectorLocation() => $"translate({Math.Round(_selectorX, 2).ToString(CultureInfo.InvariantCulture)}px, {Math.Round(_selectorY, 2).ToString(CultureInfo.InvariantCulture)}px);";
         private string GetColorTextValue() => (DisableAlpha == true || _activeColorPickerView is ColorPickerView.Palette or ColorPickerView.GridCompact) ? _color.ToString(MudColorOutputFormats.Hex) : _color.ToString(MudColorOutputFormats.HexA);
+        private int GetHexColorInputMaxLength() => DisableAlpha == true ? _disabledAlphaHexColorInputMaxLength : _enabledAlphaHexColorInputMaxLength;
 
         private EventCallback<MouseEventArgs> GetEventCallback() => EventCallback.Factory.Create<MouseEventArgs>(this, () => Close());
         private bool IsAnyControlVisible() => !(DisablePreview && DisableSliders && DisableInputs);

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -15,9 +15,6 @@ namespace MudBlazor
 {
     public partial class MudColorPicker : MudPicker<MudColor>, IAsyncDisposable
     {
-        private const int _disabledAlphaHexColorInputMaxLength = 7;
-        private const int _enabledAlphaHexColorInputMaxLength = 9;
-
         public MudColorPicker() : base(new DefaultConverter<MudColor>())
         {
             AdornmentIcon = Icons.Material.Outlined.Palette;
@@ -65,7 +62,6 @@ namespace MudBlazor
         [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
 
         private bool _disableAlpha = false;
-        private int _hexColorInputMaxLength = _enabledAlphaHexColorInputMaxLength;
 
         /// <summary>
         /// If true, Alpha options will not be displayed and color output will be RGB, HSL or HEX and not RGBA, HSLA or HEXA.
@@ -85,8 +81,7 @@ namespace MudBlazor
                     {
                         Value = Value.SetAlpha(1.0);
                     }
-
-                    _hexColorInputMaxLength = GetHexColorInputMaxLength();
+                    }
                     Text = GetColorTextValue();
                 }
             }
@@ -527,7 +522,7 @@ namespace MudBlazor
 
         private string GetSelectorLocation() => $"translate({Math.Round(_selectorX, 2).ToString(CultureInfo.InvariantCulture)}px, {Math.Round(_selectorY, 2).ToString(CultureInfo.InvariantCulture)}px);";
         private string GetColorTextValue() => (DisableAlpha == true || _activeColorPickerView is ColorPickerView.Palette or ColorPickerView.GridCompact) ? _color.ToString(MudColorOutputFormats.Hex) : _color.ToString(MudColorOutputFormats.HexA);
-        private int GetHexColorInputMaxLength() => DisableAlpha == true ? _disabledAlphaHexColorInputMaxLength : _enabledAlphaHexColorInputMaxLength;
+        private int GetHexColorInputMaxLength() => DisableAlpha ? 7 : 9;
 
         private EventCallback<MouseEventArgs> GetEventCallback() => EventCallback.Factory.Create<MouseEventArgs>(this, () => Close());
         private bool IsAnyControlVisible() => !(DisablePreview && DisableSliders && DisableInputs);


### PR DESCRIPTION
## Description
The ColorPicker component with ColorPickerMode.HEX displays a MudTextField to enter the HEX color as a string value.
When setting ColorPicker.DisableAlpha to true, one would expect that the ColorPickers HEX MudTextField would only accept six digit HEX color values, which is not the case. The issue is that a user could enter an 8 digit HEX value even when ColorPicker.DisableAlpha has been set to true which leads to a confusing state of the control...

Example with ColorPicker.ColorPickerMode=ColorPickerMode.HEX and ColorPicker.DisableAlpha=true:
- If user enters '#0000ff00' 8 digit HEX value, ColorPicker.Value will be set to '#0000ff00'
- The ColorPicker HEX MudTextField displays a 6 digit HEX value (which does not represent the correct color value)
- The ColorPicker color preview displays the blue color as completely transparent which is confusing to the user
- And by setting ColorPicker.DisableAlpha to true the user cannot change the Alpha value of the stored 8 digit HEX value

![image](https://user-images.githubusercontent.com/39911245/198057197-dcc8ae8e-83d9-40ff-91d1-7dad051c131e.png)

## How Has This Been Tested?
Verifying HEX MudTextField MaxLength has been added to ColorPickerTests.Toggle_Alpha_HexInputMode test case:
It has already been verified that the correct HEX string value will be displayed when switching DisableAlpha from false to true. Additionally we test that correct MaxLength value is set on HEX MudTextField when switching between DisableAlpha true and false.

## Types of changes
Added setting ColorPicker HEX MudTextField.MaxLength when ColorPicker.DisableAlpha is being set.
New, the ColorPicker HEX MudTextField has a default MaxLength of 9 and when ColorPicker.DisableAlpha is true a MaxLength of 7.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
