### PR TITLE
Docs: MudRadioGroup: vertical align

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
@@ -1,29 +1,17 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudGrid>
-    <MudItem xs="12" md="2" Class="d-block">
+    <MudItem xs="12" md="1">
         <MudRadioGroup @bind-SelectedOption="@Placement">
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.Top)">Top</MudRadio>
-            </MudItem>
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.Bottom)">Bottom</MudRadio>
-            </MudItem>
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.Start)">Start</MudRadio>
-            </MudItem>
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.End)">End</MudRadio>
-            </MudItem>
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.Left)">Left</MudRadio>
-            </MudItem>
-            <MudItem xs="12" md="2">
-                <MudRadio Color="Color.Primary" Option="@(Placement.Right)">Right</MudRadio>
-            </MudItem>
+            <MudRadio Color="Color.Primary" Option="@(Placement.Top)">Top</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Placement.Bottom)">Bottom</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Placement.Start)">Start</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Placement.End)">End</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Placement.Left)">Left</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Placement.Right)">Right</MudRadio>
         </MudRadioGroup>
     </MudItem>
-    <MudItem xs="12" md="8" Class="d-flex justify-center align-center my-auto">
+    <MudItem xs="12" md="9" Class="d-flex justify-center align-center my-auto">
         <MudRadioGroup T="string">
             <MudRadio T="string" Placement="@Placement" Color="Color.Secondary">Content Placement</MudRadio>
         </MudRadioGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
@@ -1,14 +1,26 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudGrid>
-    <MudItem xs="12" md="2">
+    <MudItem xs="12" md="2" Class="d-block">
         <MudRadioGroup @bind-SelectedOption="@Placement">
-            <MudRadio Color="Color.Primary" Option="@(Placement.Top)">Top</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Bottom)">Bottom</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Start)">Start</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.End)">End</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Left)">Left</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Right)">Right</MudRadio>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.Top)">Top</MudRadio>
+            </MudItem>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.Bottom)">Bottom</MudRadio>
+            </MudItem>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.Start)">Start</MudRadio>
+            </MudItem>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.End)">End</MudRadio>
+            </MudItem>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.Left)">Left</MudRadio>
+            </MudItem>
+            <MudItem xs="12" md="2">
+                <MudRadio Color="Color.Primary" Option="@(Placement.Right)">Right</MudRadio>
+            </MudItem>
         </MudRadioGroup>
     </MudItem>
     <MudItem xs="12" md="8" Class="d-flex justify-center align-center my-auto">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
In [this radio group](https://mudblazor.com/components/radio#content-placement), the buttons Start and End where aligned horizontally, while the other buttons where vertical aligned.

![afbeelding](https://user-images.githubusercontent.com/34547552/198530553-034a1158-4c6a-41fc-8bf3-018c2090c6a8.png)

I used the solution provided in closed issue #1540

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
