### PR TITLE
MudDataGrid: ServerData initialization fix

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -700,8 +700,8 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                GroupItems();
                 await InvokeServerLoadFunc();
+                GroupItems();
                 if (ServerData == null)
                     StateHasChanged();
                 _isFirstRendered = true;
@@ -1236,7 +1236,7 @@ namespace MudBlazor
             _groups = groupings.Select(x => new GroupDefinition<T>(x,
                 _groupExpansions.Contains(x.Key))).ToList();
 
-            if (_isFirstRendered)
+            if (_isFirstRendered || ServerData != null)
                 StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -700,9 +700,11 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                _isFirstRendered = true;
                 GroupItems();
                 await InvokeServerLoadFunc();
+                if (ServerData == null)
+                    StateHasChanged();
+                _isFirstRendered = true;
             }
             else
             {
@@ -1075,8 +1077,13 @@ namespace MudBlazor
         private async Task InvokeSortUpdates(Dictionary<string, SortDefinition<T>> activeSortDefinitions, HashSet<string> removedSortDefinitions)
         {
             SortChangedEvent?.Invoke(activeSortDefinitions, removedSortDefinitions);
-            await InvokeServerLoadFunc();
-            StateHasChanged();
+
+            if (_isFirstRendered)
+            {
+                await InvokeServerLoadFunc();
+                if (ServerData == null)
+                    StateHasChanged();
+            }
         }
 
         /// <summary>
@@ -1204,7 +1211,8 @@ namespace MudBlazor
             if (GroupedColumn == null)
             {
                 _groups = new List<GroupDefinition<T>>();
-                StateHasChanged();
+                if (_isFirstRendered)
+                    StateHasChanged();
                 return;
             }
 
@@ -1228,7 +1236,8 @@ namespace MudBlazor
             _groups = groupings.Select(x => new GroupDefinition<T>(x,
                 _groupExpansions.Contains(x.Key))).ToList();
 
-            StateHasChanged();
+            if (_isFirstRendered)
+                StateHasChanged();
         }
 
         internal void ChangedGrouping(Column<T> column)


### PR DESCRIPTION
## Description
Fixed initialization of MudDataGrid with ServerData to call StateHasChanged only when necessary on first load. Previously would call InvokeServerLoadFunc three times when you have a column with an InitialDirection set and SortMode == Single. This would also cause column headers to not render right away when using a wrapped Column component rather than the Column component directly.

The GroupItems and InvokeSortUpdates functions were what I was running into that were being called during initialization that were either calling or causing a call to InvokeServerLoadFunc before the component had finished initialization.

## How Has This Been Tested?
All unit tests passed. Manually tested DataGridServerData- tests by running the Viewer project and made sure only intended functionality was changed. Much manual testing was also done in another application.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
