### PR TITLE
MudCollapse: Supress render due to native event

### DIFF
--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
         }
 
         internal double _height;
+        private bool _shouldRender = true;
         private bool _expanded, _isRendered, _updateHeight;
         private ElementReference _wrapper;
         internal CollapseState _state = CollapseState.Exited;
@@ -115,6 +116,19 @@ namespace MudBlazor
             }
         }
 
+        protected override bool ShouldRender()
+        {
+            if (_shouldRender)
+            {
+                return true;
+            }
+            else
+            {
+                _shouldRender = true;
+                return false;
+            }
+        }
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
@@ -133,6 +147,7 @@ namespace MudBlazor
 
         public void AnimationEnd()
         {
+            _shouldRender = false;
             if (_state == CollapseState.Entering)
             {
                 _state = CollapseState.Entered;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
https://github.com/MudBlazor/MudBlazor/pull/5563 introduced a render bug.
Using native events instead of JS has the side effect of adding a render cycle when the event occurs.
In the case of NavMenu in the docs this had a cascading effect and caused MudNavGroup to rerender multiple times

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
All the tests passed on the original PR and this one.
The bug was picked up visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
