### PR TITLE
Picker: Improve test coverage and fix ColorPicker bug

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedPickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedPickerTest.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using MudBlazor.Utilities
+@using System.Text.RegularExpressions
+@using System.ComponentModel.DataAnnotations
+
+<MudForm @ref="form" FieldChanged="((v) => FormFieldChangedEventArgs = v)">
+    <MudDatePicker Editable />
+    <MudTimePicker Editable />
+    <MudColorPicker Editable />
+</MudForm>
+
+@code {
+    MudForm form;
+
+    public FormFieldChangedEventArgs FormFieldChangedEventArgs;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormFieldChangedTest.razor
@@ -4,8 +4,7 @@
 @using System.ComponentModel.DataAnnotations
 
 <MudForm @ref="form" FieldChanged="((v) => FormFieldChangedEventArgs = v)">
-    <MudTextField T="string" Label="Username" />
-    <MudTextField T="string" Label="Email" />
+    <MudTextField T="string"/>
     <MudNumericField T="int" />
     <div class="d-flex">
         <MudRadioGroup T="string" Required="true" RequiredError="Account type is required!">

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1342,5 +1342,19 @@ namespace MudBlazor.UnitTests.Components
             Assert.Throws<ElementNotFoundException>(() => comp.Find(".mud-picker-color-overlay"));
             _ = comp.Find(".mud-picker-color-grid");
         }
+
+        /// <summary>
+        /// Ensures both the text and value update when the text is changed
+        /// </summary>
+        [Test]
+        public void ColorPickerValueShouldUpdateOnTextTest()
+        {
+            var comp = Context.RenderComponent<MudColorPicker>(parameters => parameters
+            .Add(x => x.Editable, true));
+
+            comp.Find("input").Change("#180f6fff");
+            comp.Instance.Text.Should().Be("#180f6fff");
+            comp.Instance.Value.Should().Be(new MudColor("#180f6fff"));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -148,7 +148,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.ResetValidation());
             form.IsTouched.Should().Be(true);
         }
-        
+
         /// <summary>
         /// Changing the nested form fields value should set IsTouched 
         /// </summary>
@@ -827,8 +827,8 @@ namespace MudBlazor.UnitTests.Components
             textfields[7].Instance.ErrorText.Should().NotBeNullOrEmpty();
             numericFields[1].Instance.HasErrors.Should().BeTrue();
             numericFields[1].Instance.ErrorText.Should().NotBeNullOrEmpty();
-        } 
-        
+        }
+
         /// <summary>
         /// Testing the functionality of the MudForm example from the docs.
         /// Root MudForm is invalid and nested MudForm is valid
@@ -976,7 +976,7 @@ namespace MudBlazor.UnitTests.Components
             tf.Instance.Error.Should().Be(true);
             tf.Instance.ErrorText.Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
         }
-        
+
         /// <summary>
         /// Testing error handling of MudFormComponent.ValidateModelWithFullPathOfMember
         /// We have set no For expression, error should reflect that
@@ -1105,7 +1105,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.Reset());
             datePicker.Date.Should().BeNull();
             datePicker.Text.Should().BeNullOrEmpty();
-            
+
             // input a date
             datePickerComp.Find("input").Change(testDateString);
             datePicker.Date.Should().Be(testDate);
@@ -1138,7 +1138,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(false);
             numericFieldComp.Find("input").Input("1");
             form.IsValid.Should().Be(true);
-            
+
             await comp.InvokeAsync(() => form.Reset());
             form.IsValid.Should().Be(false); // required fields
         }
@@ -1165,12 +1165,12 @@ namespace MudBlazor.UnitTests.Components
             var textFields = comp.FindComponents<MudTextField<string>>();
             var numericFields = comp.FindComponents<MudNumericField<int>>();
             var defaultValidation = "v";
-            
+
             textFields[0].Instance.Validation.Should().Be(defaultValidation);
             textFields[1].Instance.Validation.Should().Be(defaultValidation);
             textFields[2].Instance.Validation.Should().Be(defaultValidation);
             textFields[3].Instance.Validation.Should().Be("a");
-            
+
             numericFields[0].Instance.Validation.Should().Be(defaultValidation);
             numericFields[1].Instance.Validation.Should().NotBe(defaultValidation);
             numericFields[2].Instance.Validation.Should().Be(defaultValidation);
@@ -1193,43 +1193,36 @@ namespace MudBlazor.UnitTests.Components
         /// When changing field values, the FieldChanged event should fire with the correct IFormComponent and new value
         /// </summary>
         [Test]
-        public async Task FieldChangedEventShouldTrigger()
+        public async Task FieldChangedEventShouldTriggerTest()
         {
             var comp = Context.RenderComponent<FormFieldChangedTest>();
             var formsComp = comp.FindComponents<MudForm>();
-            var textCompFields = comp.FindComponents<MudTextField<string>>();
-            var textField1 = textCompFields[0].Instance;
-            var textField2 = textCompFields[0].Instance;
-            var radioGroup = comp.FindComponent<MudRadioGroup<string>>().Instance;
+
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var numeric = comp.FindComponent<MudNumericField<int>>().Instance;
+            var radioGroup = comp.FindComponent<MudRadioGroup<string>>().Instance;
 
-            var eventArgs = comp.Instance.FormFieldChangedEventArgs; //the args from the field changed event
-
-            eventArgs.Should().BeNull();
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull();
 
             //in all below cases, the event args should switch to an instance of the field changed and contain the new value that was set
 
-            await comp.InvokeAsync(() => textField1.SetText("new value"));
+            await comp.InvokeAsync(() => textField.SetText("new value"));
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("new value");
-            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, textField1);
-
-            await comp.InvokeAsync(() => textField2.SetText("new value2"));
-            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("new value2");
-            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, textField2);
-
-            var inputs = comp.FindAll("input").ToArray();
-            // check initial state
-            radioGroup.SelectedOption.Should().Be(null);
-            // click radio 1
-            inputs[3].Click();
-            radioGroup.SelectedOption.Should().Be("1");
-            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("1");
-            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, radioGroup);
+            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, textField);
 
             numeric.Value.Should().Be(0);
             await comp.InvokeAsync(() => numeric.Increment());
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be(1);
             Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, numeric);
+
+            var inputs = comp.FindAll("input").ToArray();
+            // check initial state
+            radioGroup.SelectedOption.Should().Be(null);
+            // click radio 1
+            inputs[2].Click();
+            radioGroup.SelectedOption.Should().Be("1");
+            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("1");
+            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, radioGroup);
 
             var fileContent = InputFileContent.CreateFromText("", "upload.txt");
 
@@ -1239,6 +1232,36 @@ namespace MudBlazor.UnitTests.Components
 
             (comp.Instance.FormFieldChangedEventArgs.NewValue is IBrowserFile).Should().BeTrue();
             Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, mudFile);
+        }
+
+        /// <summary>
+        /// When changing field values, the FieldChanged event should fire with the correct IFormComponent and new value
+        /// </summary>
+        [Test]
+        public async Task FieldChangedEventShouldTriggerPickerTest()
+        {
+            var comp = Context.RenderComponent<FormFieldChangedPickerTest>();
+            var formsComp = comp.FindComponents<MudForm>();
+
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            var timePicker = comp.FindComponent<MudTimePicker>();
+            var colorPicker = comp.FindComponent<MudColorPicker>();
+
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull();
+
+            //in all below cases, the event args should switch to an instance of the field changed and contain the new value that was set
+
+            await comp.InvokeAsync(() => datePicker.Find("input").Change("04/03/2022"));
+            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be(new DateTime(2022, 04, 03));
+            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, datePicker.Instance);
+
+            await comp.InvokeAsync(() => timePicker.Find("input").Change("00:45"));
+            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be(new TimeSpan(00, 45, 00));
+            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, timePicker.Instance);
+
+            await comp.InvokeAsync(() => colorPicker.Find("input").Change("#180f6fff"));
+            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be(new MudColor("#180f6fff"));
+            Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, colorPicker.Instance);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -184,12 +184,14 @@ namespace MudBlazor
 
                     SetTextAsync(GetColorTextValue(), true).AndForget();
                     ValueChanged.InvokeAsync(value).AndForget();
+                    FieldChanged(value);
                 }
 
                 if (rgbChanged == false && UpdateBindingIfOnlyHSLChanged && hslChanged == true)
                 {
                     SetTextAsync(GetColorTextValue(), true).AndForget();
                     ValueChanged.InvokeAsync(value).AndForget();
+                    FieldChanged(value);
                 }
             }
         }
@@ -499,6 +501,12 @@ namespace MudBlazor
             }
 
             Value = color;
+        }
+
+        protected override Task StringValueChanged(string value)
+        {
+            Value = new MudColor(value);
+            return Task.CompletedTask;
         }
 
         private bool _attachedMouseEvent = false;

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -182,14 +182,14 @@ namespace MudBlazor
                         UpdateColorSelectorBasedOnRgb();
                     }
 
-                    SetTextAsync(GetColorTextValue(), true).AndForget();
+                    SetTextAsync(GetColorTextValue(), false).AndForget();
                     ValueChanged.InvokeAsync(value).AndForget();
                     FieldChanged(value);
                 }
 
                 if (rgbChanged == false && UpdateBindingIfOnlyHSLChanged && hslChanged == true)
                 {
-                    SetTextAsync(GetColorTextValue(), true).AndForget();
+                    SetTextAsync(GetColorTextValue(), false).AndForget();
                     ValueChanged.InvokeAsync(value).AndForget();
                     FieldChanged(value);
                 }
@@ -505,7 +505,7 @@ namespace MudBlazor
 
         protected override Task StringValueChanged(string value)
         {
-            Value = new MudColor(value);
+            SetInputString(value);
             return Task.CompletedTask;
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -47,6 +47,7 @@ namespace MudBlazor
                 }
                 await DateChanged.InvokeAsync(_value);
                 BeginValidate();
+                FieldChanged(_value);
             }
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -334,7 +334,6 @@ namespace MudBlazor
                 if (callback)
                     await StringValueChanged(_text);
                 await TextChanged.InvokeAsync(_text);
-                FieldChanged(_text);
             }
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -161,6 +161,7 @@ namespace MudBlazor
                 UpdateTimeSetFromTime();
                 await TimeChanged.InvokeAsync(_value);
                 BeginValidate();
+                FieldChanged(_value);
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This PR grew out of its original scope. It started as a refactoring of the FieldChanged event triggering, which is more appropriately placed in each picker component than in the Picker base class. This fixes a DatePicker bug in #4801 where the FormFieldChanged event would not fire when selecting a date.

However, I realized that the ColorPicker does not override `StringValueChanged`, which results in this bug:

https://try.mudblazor.com/snippet/GuGcblYVBfPxlilE

Try pasting a value like `#180f6fff`. It will only update the string value. If you use the color picker popup, both the string and MudColor values are updated. 

This was fixed by implementing `StringValueChanged` like so, but it breaks a unit test:

```csharp
protected override Task StringValueChanged(string value)
        {
            Value = new MudColor(value);
            return Task.CompletedTask;
        }
```

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
