### PR TITLE
Snackbar: Fix accidental API break by PR #5310

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -114,7 +114,16 @@ namespace MudBlazor.UnitTests.Components
         public void TestStringMessageShouldAutofillKey()
         {
             var bar = _service.Add("Oh no!");
-            Assert.AreEqual("Oh no!", bar.Message.Key);
+            Assert.AreEqual("Oh no!", bar.Message);
+            Assert.AreEqual("Oh no!", bar.SnackbarMessage.Key);
+        }
+
+        [Test]
+        public void TestStringMessageWithDifferentKey()
+        {
+            var bar = _service.Add("Oh no!", key:"zzz");
+            Assert.AreEqual("Oh no!", bar.Message);
+            Assert.AreEqual("zzz", bar.SnackbarMessage.Key);
         }
 
         [Test]

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         // behavior
         private void ActionClicked() => Snackbar?.Clicked(false);
         private void CloseIconClicked() => Snackbar?.Clicked(true);
-        private SnackbarMessage Message => Snackbar?.Message;
+        private SnackbarMessage Message => Snackbar?.SnackbarMessage;
 
         private void SnackbarClicked()
         {

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using MudBlazor.Components.Snackbar;
+using MudBlazor.Components.Snackbar.InternalComponents;
 
 namespace MudBlazor
 {
@@ -11,14 +12,15 @@ namespace MudBlazor
     {
         private Timer Timer { get; set; }
         internal SnackBarMessageState State { get; }
-        internal SnackbarMessage Message { get; }
+        public string Message => SnackbarMessage.Text as string;
+        internal SnackbarMessage SnackbarMessage { get; }
         public event Action<Snackbar> OnClose;
         public event Action OnUpdate;
         public Severity Severity => State.Options.Severity;
 
         internal Snackbar(SnackbarMessage message, SnackbarOptions options)
         {
-            Message = message;
+            SnackbarMessage = message;
             State = new SnackBarMessageState(options);
             Timer = new Timer(TimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
         }

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
     {
         private Timer Timer { get; set; }
         internal SnackBarMessageState State { get; }
-        public string Message => SnackbarMessage.Text as string;
+        public string Message => SnackbarMessage.Text;
         internal SnackbarMessage SnackbarMessage { get; }
         public event Action<Snackbar> OnClose;
         public event Action OnUpdate;

--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -19,5 +19,17 @@ namespace MudBlazor.Components.Snackbar
             ComponentParameters = componentParameters;
             Key = key;
         }
+
+        public string Text
+        {
+            get
+            {
+                if (ComponentParameters == null)
+                    return null;
+                if (!ComponentParameters.TryGetValue("Text", out var msg))
+                    return null;
+                return msg as string;
+            }
+        } 
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -20,16 +20,6 @@ namespace MudBlazor.Components.Snackbar
             Key = key;
         }
 
-        public string Text
-        {
-            get
-            {
-                if (ComponentParameters == null)
-                    return null;
-                if (!ComponentParameters.TryGetValue("Text", out var msg))
-                    return null;
-                return msg as string;
-            }
-        } 
+        public string Text { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -131,11 +131,11 @@ namespace MudBlazor
             if (message.IsEmpty()) return null;
             message = message.Trimmed();
 
-            var componentParams = new Dictionary<string, object>() { { "Message", new MarkupString(message) }, { "Text", message } };
+            var componentParams = new Dictionary<string, object>() { { "Message", new MarkupString(message) } };
 
             return Add
             (
-                new SnackbarMessage(typeof(SnackbarMessageText), componentParams, string.IsNullOrEmpty(key) ? message : key),
+                new SnackbarMessage(typeof(SnackbarMessageText), componentParams, string.IsNullOrEmpty(key) ? message : key) { Text = message },
                 severity,
                 configure
             );

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -131,7 +131,7 @@ namespace MudBlazor
             if (message.IsEmpty()) return null;
             message = message.Trimmed();
 
-            var componentParams = new Dictionary<string, object>() { { "Message", new MarkupString(message) } };
+            var componentParams = new Dictionary<string, object>() { { "Message", new MarkupString(message) }, { "Text", message } };
 
             return Add
             (
@@ -191,7 +191,7 @@ namespace MudBlazor
 
         private bool SnackbarAlreadyPresent(Snackbar newSnackbar)
         {
-            return !string.IsNullOrEmpty(newSnackbar.Message.Key) && SnackBarList.Any(snackbar => newSnackbar.Message.Key == snackbar.Message.Key);
+            return !string.IsNullOrEmpty(newSnackbar.SnackbarMessage.Key) && SnackBarList.Any(snackbar => newSnackbar.SnackbarMessage.Key == snackbar.SnackbarMessage.Key);
         }
 
         private void ConfigurationUpdated()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This fixes the accidental break of PR #5310
Up to Version 6.0.17 the Property Message in the class Snackbar was public. Since 6.0.18 it is internal. 

To remedy this, the internal property which is now of a different internal type has been renamed to `internal SnackbarMessage SnackbarMessage {get;}` and the old `public string Message {get; }` is back. 

fixes #5696

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
