### PR TITLE
Snackbar: Fix break due to trimming of SnackbarMessageType

### DIFF
--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor.Components.Snackbar
 {
@@ -13,6 +14,8 @@ namespace MudBlazor.Components.Snackbar
         internal Dictionary<string, object> ComponentParameters { get; }
         internal string Key { get; }
 
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(InternalComponents.SnackbarMessageRenderFragment))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(InternalComponents.SnackbarMessageText))]
         internal SnackbarMessage(Type componentType, Dictionary<string, object> componentParameters = null, string key = "")
         {
             ComponentType = componentType;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes https://github.com/MudBlazor/MudBlazor/issues/5695
Due to new dynamic behaviour of the SnackBarMessage where it now uses potentially 1 of 2 components at runtime I have added trimming annotations to support this senario

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Publish to
https://mudblazor-test.azurewebsites.net/components/snackbar#api

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
