### PR TITLE
MudDataGrid: Validate object before closing dialog and committing item.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormEditTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormEditTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.ComponentModel.DataAnnotations
 
 <MudDialogProvider />
 
@@ -20,6 +21,7 @@
 
     public class Model
     {
+        [Required]
         public string Name { get; set; }
         public int Age { get; set; }
         public string GetOnly => "snakex64";

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -347,6 +347,13 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("tbody tr")[1].Click();
 
             //edit data
+            //Test for empty required field.
+            comp.FindAll("div input")[0].Change("");
+            comp.Find(".mud-dialog-actions .mud-button-filled-primary").Click();
+            //Name should not be updated due to validation.
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("Johanna");
+
+            //Set to valid values.
             comp.FindAll("div input")[0].Change("Galadriel");
             comp.FindAll("div input")[1].Change(1);
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Prevent DataGrid dialog from saving and closing if data model annotations are not valid.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Updated DataGridDialogEditTest. All tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
