### PR TITLE
MudTable: Fixed table grouping item selection issue (#5759)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1631,8 +1631,8 @@ namespace MudBlazor.UnitTests.Components
             inputs = comp.FindAll("input").ToArray();
             inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
 
-            buttons[2].Click(); //collapse            
-            buttons[2].Click(); //expand            
+            buttons[0].Click(); //collapse            
+            buttons[0].Click(); //expand            
             //selected item should persist
             table.SelectedItems.Count.Should().Be(2);
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1589,8 +1589,8 @@ namespace MudBlazor.UnitTests.Components
 
             // expand and collapse groups:
             table.GroupBy.Indentation = false;
-            table.GroupBy.Expandable = true;            
-            table.GroupBy.InnerGroup.Expandable = true;            
+            table.GroupBy.Expandable = true;
+            table.GroupBy.InnerGroup.Expandable = true;
             comp.Render();
 
             var buttons = comp.FindAll("button").ToArray();

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1589,8 +1589,8 @@ namespace MudBlazor.UnitTests.Components
 
             // expand and collapse groups:
             table.GroupBy.Indentation = false;
-            table.GroupBy.Expandable = true;
-            table.GroupBy.InnerGroup.Expandable = true;
+            table.GroupBy.Expandable = true;            
+            table.GroupBy.InnerGroup.Expandable = true;            
             comp.Render();
 
             var buttons = comp.FindAll("button").ToArray();
@@ -1605,6 +1605,46 @@ namespace MudBlazor.UnitTests.Components
             buttons[0].Click();
             tr = comp.FindAll("tr").ToArray();
             tr.Length.Should().Be(36);
+
+
+            //verify the collapse and expand selection on UI and items
+
+            inputs[1].Change(false); // LMP1 
+
+            table.GroupBy.Indentation = true;
+            table.GroupBy.Expandable = true;
+            table.GroupBy.IsInitiallyExpanded = true;
+            table.GroupBy.InnerGroup.Indentation = true;
+            table.GroupBy.InnerGroup.Expandable = true;
+            table.GroupBy.InnerGroup.IsInitiallyExpanded  = true;
+                       
+
+            comp.Render();            
+            
+            table.SelectedItems.Count.Should().Be(0);
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(0);
+
+            inputs[1].Change(true); // LMP1            
+            table.SelectedItems.Count.Should().Be(2);
+
+            buttons = comp.FindAll("button").ToArray();
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
+
+            buttons[0].Click(); //collapse            
+            buttons[0].Click(); //expand            
+            //selected item should persist
+            table.SelectedItems.Count.Should().Be(2);
+
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
+
+            inputs[1].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(0);
+
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1589,8 +1589,8 @@ namespace MudBlazor.UnitTests.Components
 
             // expand and collapse groups:
             table.GroupBy.Indentation = false;
-            table.GroupBy.Expandable = true;
-            table.GroupBy.InnerGroup.Expandable = true;
+            table.GroupBy.Expandable = true;            
+            table.GroupBy.InnerGroup.Expandable = true;            
             comp.Render();
 
             var buttons = comp.FindAll("button").ToArray();
@@ -1605,6 +1605,46 @@ namespace MudBlazor.UnitTests.Components
             buttons[0].Click();
             tr = comp.FindAll("tr").ToArray();
             tr.Length.Should().Be(36);
+
+
+            //verify the collapse and expand selection on UI and items
+
+            inputs[1].Change(false); // LMP1 
+
+            table.GroupBy.Indentation = true;
+            table.GroupBy.Expandable = true;
+            table.GroupBy.IsInitiallyExpanded = true;
+            table.GroupBy.InnerGroup.Indentation = true;
+            table.GroupBy.InnerGroup.Expandable = true;
+            table.GroupBy.InnerGroup.IsInitiallyExpanded  = true;
+                       
+
+            comp.Render();            
+            
+            table.SelectedItems.Count.Should().Be(0);
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(0);
+
+            inputs[1].Change(true); // LMP1            
+            table.SelectedItems.Count.Should().Be(2);
+
+            buttons = comp.FindAll("button").ToArray();
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
+
+            buttons[2].Click(); //collapse            
+            buttons[2].Click(); //expand            
+            //selected item should persist
+            table.SelectedItems.Count.Should().Be(2);
+
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
+
+            inputs[1].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+
+            inputs = comp.FindAll("input").ToArray();
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(0);
+
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -201,7 +201,7 @@
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
              } 
              <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
-                        IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+           IsChecked="Context.Selection.Contains(item)" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                     {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -201,7 +201,7 @@
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
              } 
              <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" IsExpandable="isExpandable"
-           IsChecked="Context.Selection.Contains(item)" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                        IsChecked="Context.Selection.Contains(item)" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                     {

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -112,7 +112,7 @@ namespace MudBlazor
         {
             if (GroupDefinition.InnerGroup != null)
             {
-                _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);                
+                _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
             }
             if (IsCheckable && Items is not null && Table is not null && Table.SelectedItems.Count > 0)
                 _checked = Items.All(Table.SelectedItems.Contains);

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -112,8 +112,10 @@ namespace MudBlazor
         {
             if (GroupDefinition.InnerGroup != null)
             {
-                _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
+                _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);                
             }
+            if (IsCheckable && Items is not null && Table is not null && Table.SelectedItems.Count > 0)
+                _checked = Items.All(Table.SelectedItems.Contains);
         }
 
         public void Dispose()


### PR DESCRIPTION



## Description
Fixed the table grouping selection issue where the selection is not reflected if the expander is reopened because of the one-way binding.  
Resolves #5759 

## How Has This Been Tested?
Tested visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Before change:**

![image](https://user-images.githubusercontent.com/13073344/201954780-59a6c8f5-e935-45ff-ad4d-304b6322f2ee.png)


**After fix:** 

![image](https://user-images.githubusercontent.com/13073344/201954876-6915b483-8d6a-4f99-a5b0-f165f051c43b.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
