### PR TITLE
ScrollManager: Fix exceptions when no JS environment available

### DIFF
--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -12,17 +12,9 @@ namespace MudBlazor
     public static class TaskExtensions
     {
         /// <summary>
-        /// Task will be awaited and exceptions will be managed by the Blazor framework.
-        /// </summary>
-        public static async void AndForget(this Task task)
-        {
-            await task;
-        }
-
-        /// <summary>
         /// Task will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
         /// </summary>
-        public static async void AndForget(this Task task, TaskOption option)
+        public static async void AndForget(this Task task, TaskOption option = TaskOption.None)
         {
             try
             {
@@ -38,17 +30,27 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// ValueTask will be awaited and exceptions will be managed by the Blazor framework.
+        /// ValueTask will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
         /// </summary>
-        public static async void AndForget(this ValueTask task)
+        public static async void AndForget(this ValueTask task, TaskOption option = TaskOption.None)
         {
-            await task;
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                if (option != TaskOption.Safe)
+                    throw;
+
+                Console.WriteLine(ex);
+            }
         }
 
         /// <summary>
-        /// ValueTask will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// ValueTask(bool) will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
         /// </summary>
-        public static async void AndForget(this ValueTask task, TaskOption option)
+        public static async void AndForget(this ValueTask<bool> task, TaskOption option = TaskOption.None)
         {
             try
             {

--- a/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
@@ -10,6 +11,37 @@ namespace MudBlazor
 {
     public static class IIJSRuntimeExtentions
     {
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation.</returns>
+        public static async ValueTask InvokeVoidAsyncIgnoreErrors(this IJSRuntime jsRuntime, string identifier, params object[] args)
+        {
+            try
+            {
+                await jsRuntime.InvokeVoidAsync(identifier, args);
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+            }
+#endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+            }
+            catch (JSDisconnectedException)
+            {
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+
         /// <summary>
         /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
         /// </summary>
@@ -31,6 +63,11 @@ namespace MudBlazor
                 return false;
             }
 #endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
             catch (JSDisconnectedException)
             {
                 return false;
@@ -75,6 +112,11 @@ namespace MudBlazor
                 return (false, fallbackValue);
             }
 #endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return (false, fallbackValue);;
+            }
             catch (JSDisconnectedException)
             {
                 return (false, fallbackValue);

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -113,7 +113,7 @@ namespace MudBlazor
             _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);
 
         public ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.unlockScroll", selector, cssClass);
+            _jSRuntime.InvokeVoidAsyncIgnoreErrors("mudScrollManager.unlockScroll", selector, cssClass);
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes https://github.com/MudBlazor/MudBlazor/issues/4102

Catch JS exceptions when running `ScrollManager.UnlockScrollAsync` method
Situations when this may occur are pre-rendering BSS and disposing
If this works I would like to audit others situations like this and also remove the error handling which is repeated in many components

Note this PR is slightly off topic in that it refactors `AndForget`  (DRY)

When we were running on BSS in azure we used to pick up these exceptions in the server logs.
Since moving to WASM they have been forgotten.
They generally don't affect app functionality but might cause subsequent code in dispose to be missed or fill up hosting logs.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested using original issues [repo](https://github.com/jasongdove/MudBlazorRepro1) and adding a project reference instead of the nuget.
Exception is now caught and ignored 👍 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

@Mr-Technician @henon