### PR TITLE
Fix ResizeBasedService trim warning

### DIFF
--- a/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
@@ -4,21 +4,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MudBlazor.Services
 {
     public class SubscriptionInfo<TAction,TOption>
     {
-        private Dictionary<Guid, Action<TAction>> _subscriptions;
+        private readonly Dictionary<Guid, Action<TAction>> _subscriptions;
         public TOption Option { get; init; }
 
         public SubscriptionInfo(TOption options)
         {
-            _subscriptions = new();
-
             Option = options;
             _subscriptions = new();
         }


### PR DESCRIPTION
## Description
@henon @mikes-gh 
Fixes trim warning 
```
'TValue' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in 'Microsoft.JSInterop.DotNetObjectReference<TValue>'. The generic parameter 'TSelf' of 'MudBlazor.Services.ResizeBasedService<TSelf, TInfo, TAction, TaskOption>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```
Did a small refactoring:
1. renamed TaskOption -> TTaskOption because it was hiding enum that also has TaskOption name
2. removed unnecessary $
3. `==` replaced with `is` as it's more recommended
4. `_subscriptions` can be readonly, also for some reason it was initialized twice in the constructor

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
