### PR TITLE
Remove unused code in ElementReferenceExtensions

### DIFF
--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿#nullable enable
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -13,17 +12,17 @@ namespace MudBlazor
     [ExcludeFromCodeCoverage]
     public static class ElementReferenceExtensions
     {
-        private static readonly PropertyInfo jsRuntimeProperty =
+        private static readonly PropertyInfo? jsRuntimeProperty =
             typeof(WebElementReferenceContext).GetProperty("JSRuntime", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        internal static IJSRuntime GetJSRuntime(this ElementReference elementReference)
+        internal static IJSRuntime? GetJSRuntime(this ElementReference elementReference)
         {
             if (elementReference.Context is not WebElementReferenceContext context)
             {
                 return null;
             }
 
-            return (IJSRuntime)jsRuntimeProperty.GetValue(context);
+            return (IJSRuntime?)jsRuntimeProperty?.GetValue(context);
         }
 
         public static ValueTask MudFocusFirstAsync(this ElementReference elementReference, int skip = 0, int min = 0) =>
@@ -52,81 +51,6 @@ namespace MudBlazor
 
         public static ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
-
-        /// <summary>
-        /// Gets the client rect of the element 
-        /// </summary>
-        public static ValueTask<BoundingClientRect> MudGetClientRectFromParentAsync(this ElementReference elementReference) =>
-           elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getClientRectFromParent", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
-
-        /// <summary>
-        /// Gets the client rect of the first child of the element.
-        /// Useful when you want to know the dimensions of a render fragment and for that you wrap it into a div
-        /// </summary>
-        public static ValueTask<BoundingClientRect> MudGetClientRectFromFirstChildAsync(this ElementReference elementReference) =>
-           elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getClientRectFromFirstChild", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
-
-        /// <summary>
-        /// Returns true if the element has an ancestor with style position == "fixed"
-        /// </summary>
-        /// <param name="elementReference"></param>
-        public static ValueTask<bool> MudHasFixedAncestorsAsync(this ElementReference elementReference) =>
-            elementReference.GetJSRuntime()?
-            .InvokeAsync<bool>("mudElementRef.hasFixedAncestors", elementReference) ?? ValueTask.FromResult(false);
-
-
-        public static ValueTask MudChangeCssVariableAsync(this ElementReference elementReference, string variableName, int value) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.changeCssVariable", elementReference, variableName, value) ?? ValueTask.CompletedTask;
-
-        public static ValueTask<int> MudAddEventListenerAsync<T>(this ElementReference elementReference, DotNetObjectReference<T> dotnet, string @event, string callback, bool stopPropagation = false) where T : class
-        {
-            var parameters = dotnet?.Value.GetType().GetMethods().First(m => m.Name == callback).GetParameters().Select(p => p.ParameterType);
-            if (parameters != null)
-            {
-                var parameterSpecs = new object[parameters.Count()];
-                for (var i = 0; i < parameters.Count(); ++i)
-                {
-                    parameterSpecs[i] = GetSerializationSpec(parameters.ElementAt(i));
-                }
-                return elementReference.GetJSRuntime()?.InvokeAsync<int>("mudElementRef.addEventListener", elementReference, dotnet, @event, callback, parameterSpecs, stopPropagation) ?? ValueTask.FromResult(0);
-            }
-            else
-            {
-                return new ValueTask<int>(0);
-            }
-        }
-
-        public static ValueTask MudRemoveEventListenerAsync(this ElementReference elementReference, string @event, int eventId) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.removeEventListener", elementReference, eventId) ?? ValueTask.CompletedTask;
-
-        private static object GetSerializationSpec(Type type)
-        {
-            var props = type.GetProperties();
-            var propsSpec = new Dictionary<string, object>();
-            foreach (var prop in props)
-            {
-                if (prop.PropertyType.IsPrimitive || prop.PropertyType == typeof(string))
-                {
-                    propsSpec.Add(prop.Name.ToJsString(), "*");
-                }
-                else if (prop.PropertyType.IsArray)
-                {
-                    propsSpec.Add(prop.Name.ToJsString(), GetSerializationSpec(prop.PropertyType.GetElementType()));
-                }
-                else if (prop.PropertyType.IsClass)
-                {
-                    propsSpec.Add(prop.Name.ToJsString(), GetSerializationSpec(prop.PropertyType));
-                }
-            }
-
-            return propsSpec;
-        }
-
-        public static ValueTask<int> AddDefaultPreventingHandler(this ElementReference elementReference, string eventName) =>
-            elementReference.GetJSRuntime()?.InvokeAsync<int>("mudElementRef.addDefaultPreventingHandler", elementReference, eventName) ?? new ValueTask<int>(0);
-
-        public static ValueTask RemoveDefaultPreventingHandler(this ElementReference elementReference, string eventName, int listenerId) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.removeDefaultPreventingHandler", elementReference, eventName, listenerId) ?? ValueTask.CompletedTask;
 
         public static ValueTask<int[]> AddDefaultPreventingHandlers(this ElementReference elementReference, string[] eventNames) =>
             elementReference.GetJSRuntime()?.InvokeAsync<int[]>("mudElementRef.addDefaultPreventingHandlers", elementReference, eventNames) ?? new ValueTask<int[]>(Array.Empty<int>());

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -85,29 +85,6 @@ class MudElementReference {
             element.select();
         }
     }
-    /**
-     * gets the client rect of the parent of the element
-     * @param {HTMLElement} element
-     */
-    getClientRectFromParent(element) {
-        if (!element) return;
-        let parent = element.parentElement;
-        if (!parent) return;
-        return this.getBoundingClientRect(parent);
-    }
-
-    /**
-     * Gets the client rect of the first child of the element
-     * @param {any} element
-     */
-
-    getClientRectFromFirstChild(element) {
-        if (!element) return;
-        let child = element.children && element.children[0];
-        if (!child) return;
-        return this.getBoundingClientRect(child);
-    }
-
 
     getBoundingClientRect(element) {
         if (!element) return;
@@ -122,43 +99,11 @@ class MudElementReference {
         return rect;
     }
 
-    /**
-     * Returns true if the element has any ancestor with style position==="fixed"
-     * @param {Element} element
-     */
-    hasFixedAncestors(element) {
-        for (; element && element !== document; element = element.parentNode) {
-            if (window.getComputedStyle(element).getPropertyValue("position") === "fixed")
-                return true;
-        }
-        return false;
-    }
-
     changeCss (element, css) {
         if (element)
         {
             element.className = css;
         }
-    }
-
-    changeCssVariable (element, name, newValue) {
-        if (element)
-        {
-            element.style.setProperty(name, newValue);
-        }
-    }
-
-    addEventListener (element, dotnet, event, callback, spec, stopPropagation) {
-        let listener = function (e) {
-            const args = Array.from(spec, x => serializeParameter(e, x));
-            dotnet.invokeMethodAsync(callback, ...args);
-            if (stopPropagation) {
-                e.stopPropagation();
-            }
-        };
-        element.addEventListener(event, listener);
-        this.eventListeners[++this.listenerId] = listener;
-        return this.listenerId;
     }
 
     removeEventListener (element, event, eventId) {


### PR DESCRIPTION
## Description
After this PRs #5563, #5562 the `MudAddEventListenerAsync` with `GetSerializationSpec` are not used anymore.
This methods are also not trim friendly.
I also found that following methods are not used at all in the framework:
- `MudGetClientRectFromParentAsync`
- `MudGetClientRectFromFirstChildAsync`
- `MudHasFixedAncestorsAsync`
- `MudChangeCssVariableAsync`
- `MudRemoveEventListenerAsync`
- `AddDefaultPreventingHandler`
- `RemoveDefaultPreventingHandler`

Yes, these are public methods that are available to everyone if necessary which makes it technically a breaking change, but the risk is low / minimal.
These methods were used for mud components in the past, if components are not using them anymore, there is no point keeping them. Don't think that UI framework should really provide such kind of js utility methods for others, since anyone is free to add their own js for their third party components if needed. 
I haven't found any third party open source components that would use them.
Removing some dead code and JS is always nice :)

Removed JS methods from `mudElementReference.js`:
- `mudElementRef.getClientRectFromParent`
- `mudElementRef.getClientRectFromFirstChild`
- `mudElementRef.hasFixedAncestors`
- `mudElementRef.changeCssVariable`
- `mudElementRef.addEventListener`
Despite of removing the `MudRemoveEventListenerAsync` the `mudElementRef.removeEventListener` is kept. because it seems that `mudElement.addDefaultPreventingHandlers` is using it, and this JS parts used by the `MudSwipeArea`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
