### PR TITLE
Build: Fix static assets need 2 builds to publish

### DIFF
--- a/.github/workflows/deploy-nuget.yml
+++ b/.github/workflows/deploy-nuget.yml
@@ -1,27 +1,24 @@
-name: Pack and Publish Nuget Package
+name: deploy-nuget
 
 on:
   workflow_dispatch:
     inputs:
         nuget-version:
-          description: 'Nuget version v[0-9]+.[0-9]+.[0-9]+*'
+          description: 'Tag to publish v[0-9]+.[0-9]+.[0-9]+*'
           required: true
           default: '' 
           type: string
+  push:
+    tags: 
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 env:
   VERSION: 1.0.0
-
-defaults:
-  run:
-    working-directory: ./src/MudBlazor
-    
+  
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Set version variable from input
+    - name: Set tag from input
       if: ${{ github.event.inputs.nuget-version != '' }}
       env:
         TAG: ${{ github.event.inputs.nuget-version }}
@@ -31,6 +28,10 @@ jobs:
       env:
         TAG: ${{ github.ref_name }}
       run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: 'refs/tags/v${{ env.VERSION }}'
     - name: Setup dotnet version
       uses: actions/setup-dotnet@v3
       with:
@@ -39,6 +40,13 @@ jobs:
           7.0.x
     - name: Pack nuget package
       run: dotnet pack -c Release --output nupkgs /p:PackageVersion=$VERSION
+      working-directory: ./src/MudBlazor
+    #- name: Upload Artifact (for testing before publish)
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: nuget
+    #    path: ./src/MudBlazor/nupkgs/*.nupkg
+    #    retention-days: 1
     - name: Publish nuget package
-      if: (github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')) || startsWith(${{ github.event.inputs.nuget-version }}, 'v')
       run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+      working-directory: ./src/MudBlazor

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -2,14 +2,6 @@
 <!--Use: dotnet msbuild -preprocess:<fileName>.xml to evaluate this project-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
-  <!--Hook for the generated static content-->
-  <PropertyGroup>
-    <ResolveStaticWebAssetsInputsDependsOn>
-      IncludeGeneratedStaticFiles;
-      $(ResolveStaticWebAssetsInputsDependsOn)
-    </ResolveStaticWebAssetsInputsDependsOn>
-  </PropertyGroup>
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
@@ -112,13 +104,14 @@
   </Target>
 
   <!--Output of Excubo webcompiler-->
-  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="WebCompiler">
-    <Error Condition="!Exists('wwwroot/MudBlazorDocs.min.css')" Text="Missing MudBlazorDocs.min.css in wwwroot" />
+  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="WebCompiler" BeforeTargets="BeforeBuild">
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazorDocs.min.css')" Text="Missing MudBlazorDocs.min.css in wwwroot" />
     <!--If we ever bundle js  for the docs site uncomment the below check-->
     <!--<Error Condition="!Exists('wwwroot/MudBlazorDocs.min.js')" Text="Missing MudBlazorDocs.min.js in wwwroot" />-->
     <ItemGroup>
-      <Content Include="wwwroot/MudBlazorDocs.min.css" Condition="!Exists('wwwroot/MudBlazorDocs.min.css')" />
-      <Content Include="wwwroot/MudBlazorDocs.min.js" Condition="!Exists('wwwroot/MudBlazorDocs.min.js')" />
+      <!--Include without duplication-->
+      <_NewCompiledDocsCssFiles Include="wwwroot\MudBlazorDocs.min.css" Exclude="@(Content)" />
+      <Content Include="@(_NewCompiledDocsCssFiles)" />
     </ItemGroup>
   </Target>
 
@@ -126,9 +119,6 @@
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
     <Content Remove="excubowebcompiler.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="wwwroot\images\landingpage" />
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <ResolveStaticWebAssetsInputsDependsOn>
-      IncludeGeneratedStaticFiles;
-      $(ResolveStaticWebAssetsInputsDependsOn)
-    </ResolveStaticWebAssetsInputsDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -90,12 +83,15 @@
     <Exec Command="dotnet webcompiler ./TScripts/combined/MudBlazor.js -c excubowebcompiler.json" StandardOutputImportance="high" StandardErrorImportance="high" />
   </Target>
 
-  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="WebCompiler">
-    <Error Condition="!Exists('wwwroot/MudBlazor.min.css')" Text="Missing MudBlazor.min.css in wwwroot" />
-    <Error Condition="!Exists('wwwroot/MudBlazor.min.js')" Text="Missing MudBlazor.min.js in wwwroot" />
+  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="WebCompiler" BeforeTargets="BeforeBuild">
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.css')" Text="Missing MudBlazor.min.css in wwwroot" />
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.js')" Text="Missing MudBlazor.min.js in wwwroot" />
     <ItemGroup>
-      <Content Include="wwwroot/MudBlazor.min.css" Condition="!Exists('wwwroot/MudBlazor.min.css')" />
-      <Content Include="wwwroot/MudBlazor.min.js" Condition="!Exists('wwwroot/MudBlazor.min.js')" />
+      <!--Include without duplication-->
+      <_NewCompiledCssFiles Include="wwwroot\MudBlazor.min.css" Exclude="@(Content)" />
+      <_NewCompiledJsFiles Include="wwwroot\MudBlazor.min.js" Exclude="@(Content)" />
+      <Content Include="@(_NewCompiledCssFiles)" />
+      <Content Include="@(_NewCompiledJsFiles)" />
     </ItemGroup>
   </Target>
 
@@ -103,11 +99,9 @@
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
     <Content Remove="excubowebcompiler.json" />
-    <Content Remove="**/*/DoNotRemove.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="TScripts\combined\" />
-    <Folder Include="wwwroot\" />
+    <Content Remove="wwwroot/DoNotRemove.txt" />
+    <!--macOS hidden file (causes problems with dotnet pack)-->
+    <Content Remove="**/*/.DS_Store" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #5801 which was reverted.
See that PR for bug report and more details.

MSBuild normally allows for forward slash in paths.
However because 

`<_NewCompiledCssFiles Include="wwwroot\MudBlazor.min.css" Exclude="@(Content)" />`

must be doing some sort of string comparison it seems to fail in this case.

MSBuild requires `\` in order that the exclude will work to prevent content duplication in staticwebassets.
Have done the checks and linux and mac still build and pack fine with backslash so we use it since it fixes windows.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Building locally.
Building in this PR.
dotnet pack and check nuget contents.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
