### PR TITLE
MudDataGrid: fixed the resizer handle visibility

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnResizerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnResizerTest.razor
@@ -1,0 +1,33 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items" Filterable="true" ColumnResizeMode="@(_resizeColumn ? ResizeMode.Column : ResizeMode.Container)">
+    <ColGroup>
+        <col />
+        <col />
+        <col />
+    </ColGroup>
+    <Columns>
+        <Column T="Model" Field="@nameof(Model.Name)" />
+        <Column T="Model" Field="@nameof(Model.Age)" />
+        <Column T="Model" Field="@nameof(Model.Status)" />
+    </Columns>
+</MudDataGrid>
+<div class="d-flex flex-wrap mt-4">
+    <div class="d-flex justify-start align-center">
+        <p class="mud-typography mud-typography-body1 mud-inherit-text mr-2">ResizeMode.Container</p>
+        <MudSwitch @bind-Checked="@_resizeColumn">ResizeMode.Column</MudSwitch>
+    </div>
+</div>
+
+@code {
+    private bool _resizeColumn;
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, Severity.Normal), 
+        new Model("Alicia", 54, Severity.Info), 
+        new Model("Ira", 27, Severity.Success),
+        new Model("John", 32, Severity.Warning)
+    };
+
+    public record Model (string Name, int Age, Severity Status);
+}

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -279,11 +279,12 @@ namespace MudBlazor
             {
                 _resizerHeight = gridHeight;
                 _width = targetWidth;
-                if (finishResize)
-                {
-                    _isResizing = false;
-                }
+                await InvokeAsync(StateHasChanged);
+            }
 
+            if (finishResize)
+            {
+                _isResizing = false;
                 await InvokeAsync(StateHasChanged);
             }
 


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes a visual glitch where the resize handle stays visible when the resizing target width is 0 and we leave the datagrid while keeping mouse button down. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Test done visually. Validated that behaviour while over the datagrid is the same. Then validated that the mouseup event will always hide the resizer handle.

https://user-images.githubusercontent.com/29356866/204039120-49713178-6029-495f-82c7-8ba18c951428.mp4

## Types of changes

Simply moved the resizing finished flag outside of the check if the target width is greater than 0. If the finish bool is passed, it should end the resizer display regardless of the target width. Also set the resizer height to 0 so it dissapear immediately instead of waiting for mouse to stop moving.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

Please validate if additionnal tests are required
