### PR TITLE
TreeView: Add Public Select Method and Disable Text Selection When ExpandOnDoubleClick is true

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest4.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView @ref="_treeView" T="string" @bind-SelectedValue="selectedValue">
+    <MudTreeViewItem @ref="_item1" Value='"content"' />
+    <MudTreeViewItem @ref="_item2" Value='"src"' />
+</MudTreeView>
+
+@code {
+    MudTreeView<string> _treeView;
+    MudTreeViewItem<string> _item1;
+    MudTreeViewItem<string> _item2;
+
+    public string selectedValue;
+
+    public async Task SelectFirst()
+    {
+        await _treeView.Select(_item1);
+    }
+
+    public async Task SelectSecond()
+    {
+        await _treeView.Select(_item2);
+    }
+
+    public async Task DeselectSecond()
+    {
+        await _treeView.Select(_item2, false);
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -174,5 +174,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-treeview-item-content").DoubleClick();
             selectedItem.Should().Be("content");
         }
+
+        [Test]
+        public async Task TreeViewItem_ProgrammaticallySelect()
+        {
+            var comp = Context.RenderComponent<TreeViewTest4>();
+            var treeView = comp.FindComponent<MudTreeView<string>>();
+
+            await comp.InvokeAsync(() => comp.Instance.SelectFirst());
+            comp.WaitForAssertion(() => comp.Instance.selectedValue.Should().Be("content"));
+
+            await comp.InvokeAsync(() => comp.Instance.SelectSecond());
+            comp.WaitForAssertion(() => comp.Instance.selectedValue.Should().Be("src"));
+
+            await comp.InvokeAsync(() => comp.Instance.DeselectSecond());
+            comp.WaitForAssertion(() => comp.Instance.selectedValue.Should().Be(null));
+        }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -242,7 +242,7 @@ namespace MudBlazor
             return SelectedValuesChanged.InvokeAsync(new HashSet<T>(_selectedValues.Select(i => i.Value)));
         }
 
-        public async Task SelectItem(MudTreeViewItem<T> item, bool isSelected = true)
+        public async Task Select(MudTreeViewItem<T> item, bool isSelected = true)
         {
             await UpdateSelected(item, isSelected);
         }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -242,6 +242,11 @@ namespace MudBlazor
             return SelectedValuesChanged.InvokeAsync(new HashSet<T>(_selectedValues.Select(i => i.Value)));
         }
 
+        public async Task SelectItem(MudTreeViewItem<T> item, bool isSelected = true)
+        {
+            await UpdateSelected(item, isSelected);
+        }
+
         internal void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
 
         protected string Classname =>
         new CssBuilder("mud-treeview-item")
+            .AddClass("mud-treeview-select-none", MudTreeRoot?.ExpandOnDoubleClick == true)
           .AddClass(Class)
         .Build();
 

--- a/src/MudBlazor/Styles/components/_treeview.scss
+++ b/src/MudBlazor/Styles/components/_treeview.scss
@@ -119,6 +119,10 @@
     }
 }
 
+.mud-treeview-select-none {
+    user-select: none;
+}
+
 @keyframes rotation {
     from {
         transform: rotate(0deg);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
The issue described into #5853.

This PR does not make big changes or breaking changes about the issue. Only add a public method that now developers can safely and properly control the selected styles.

This video shows that changing `@bind-SelectedValue` only changes the value, not the style. And the new SelectItem method (Buttons have "Update" text) changes both value and style.

https://user-images.githubusercontent.com/78308169/204097504-eaed9c9d-66c7-4f03-9e44-f3b82b3f5263.mp4


And as the second change, disabled the text select with CSS when double click is true, because when we didn't disable text selection, the text selects with double click on each expand.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
