### PR TITLE
MudFileUpload: Maximum file count integrated as a parameter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudFileUpload T="IReadOnlyList<IBrowserFile>" MaximumFileCount="100" OnFilesChanged="OnInputFileChanged">
+    <ButtonTemplate>
+        <MudButton HtmlTag="label" for="@context">Upload</MudButton>
+    </ButtonTemplate>
+    <SelectedTemplate>
+        <div>
+            Select Template
+        </div>
+    </SelectedTemplate>
+</MudFileUpload>
+
+<div>
+    @(fileCount)
+</div>
+
+
+@code {
+
+    private int? fileCount = null;
+
+    private void OnInputFileChanged(InputFileChangeEventArgs e)
+    {
+        var files = e.GetMultipleFiles(100);
+        fileCount = files.Count;
+    }
+
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
@@ -11,7 +11,7 @@
     </SelectedTemplate>
 </MudFileUpload>
 
-<div>
+<div class="multipleFileUploadResult">
     @(fileCount)
 </div>
 

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -224,6 +225,41 @@ namespace MudBlazor.UnitTests.Components
             entries.Count.Should().Be(1);
             entries[0].Level.Should().Be(LogLevel.Warning);
             entries[0].Message.Should().Be(string.Format("T must be of type {0} or {1}", typeof(IReadOnlyList<IBrowserFile>), typeof(IBrowserFile)));
+        }
+
+        /// <summary>
+        /// Tests multiple file upload
+        /// </summary>
+        [Test]
+        public async Task FileUpload_MultipleFiles()
+        {
+            int nFiles = 20;
+            TestFile[] testFiles = new TestFile[nFiles];
+            for (int i = 0; i < 20; i++)
+                testFiles[i] = new TestFile() { Name = i.ToString() };
+
+            var testFilesArgs = new InputFileChangeEventArgs(testFiles);
+
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>();
+
+            var multiple = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
+            var multipleInput = multiple.FindComponent<InputFile>().Instance;
+            await comp.InvokeAsync(() => multipleInput.OnChange.InvokeAsync(testFilesArgs));
+
+            var outputs = comp.Find(".multipleFileUploadResult");
+            outputs.InnerHtml.Should().Be(nFiles.ToString());
+        }
+        record TestFile : IBrowserFile
+        {
+            public string Name { get; init; }
+            public DateTimeOffset LastModified { get; init; }
+            public long Size { get; init; }
+            public string ContentType { get; init; } = string.Empty;
+
+            public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -98,12 +98,18 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FileUpload.Appearance)]
         public string InputStyle { get; set; }
+        /// <summary>
+        /// Number of files accepted when multiple attribute is set
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FileUpload.Behavior)]
+        public int MaximumFileCount { get; set; } = 10;
 
         private async Task OnChange(InputFileChangeEventArgs args)
         {
             if (typeof(T) == typeof(IReadOnlyList<IBrowserFile>))
             {
-                _value = (T)args.GetMultipleFiles();
+                _value = (T)args.GetMultipleFiles(MaximumFileCount);
             }
             else if (typeof(T) == typeof(IBrowserFile))
             {

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -99,7 +99,7 @@ namespace MudBlazor
         [Category(CategoryTypes.FileUpload.Appearance)]
         public string InputStyle { get; set; }
         /// <summary>
-        /// Number of files accepted when multiple attribute is set
+        /// Maximum number of files that can be uploaded
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]


### PR DESCRIPTION
## Description
MudFileUpload only allows a maximum of 10 files to be uploaded simultaneously. This limitation is due to the Method `GetMultipleFiles` beeing not supplied with the optional parameter `maximumFileCount`.

## How Has This Been Tested?
New unit test `FileUploadMultipleFilesTest` in Viewer project.
This creates a new instance on the test page and shows the number of uploaded files successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
