### PR TITLE
Tests: Autocomplete loading finishes too quickly to test progress

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
@@ -29,7 +29,7 @@
     private async Task<IEnumerable<string>> Search1(string value)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(50);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -851,6 +851,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicator()
         {
+            // TODO: use a TaskCompletionSource that allows control over the search task
+            // for reliable testing.  Applies to other tests like this one.
+            // Currently we increase the load time to 50mms to catch the progress UI
+
             // Arrange
             var comp = Context.RenderComponent<AutocompleteTest1>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes #5839
Autocomplete progress indicator tests were flaky due to loading data too quickly.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tests on my machine and @henon machine were failing consistently.
Increased the load time in the test component.
Tests now pass.
Simple really :-)
@henon can you confirm this locally pls.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've fixed relevant tests.
