### PR TITLE
MudTimePicker: Fix TimePicker validation in MudForm (#5883)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
@@ -1,5 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
+<MudPopoverProvider></MudPopoverProvider>
+
 <MudForm ValidationDelay="0">
     <MudTimePicker Required="true" @bind-Time="Time">
     </MudTimePicker>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -669,7 +669,73 @@ namespace MudBlazor.UnitTests.Components
             datepicker.ErrorText.Should().Be("Only full hours allowed");
         }
 
+        /// <summary>
+        /// TimePicker should be validated like every other form component when time is selected using picker
+        /// </summary>
+        [Test]
+        public async Task FormWithTimePickerTest_When_TimeSelectedViaPicker()
+        {
+            var comp = Context.RenderComponent<FormWithTimePickerTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dateComp = comp.FindComponent<MudTimePicker>();
+            var datepicker = comp.FindComponent<MudTimePicker>().Instance;
+            // check initial state: form should not be valid because datepicker is required
+            form.IsValid.Should().Be(false);
+            datepicker.Error.Should().BeFalse();
+            datepicker.ErrorText.Should().BeNullOrEmpty();
+            comp.Find("input").Click();
+            // select 09:30
+            comp.FindAll("div.mud-picker-stick-inner.mud-hour")[8].Click();
+            comp.FindAll("div.mud-minute")[30].Click();
+            // wait for picker to close
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            form.IsTouched.Should().Be(true);
+            form.IsValid.Should().Be(true);
+            form.Errors.Length.Should().Be(0);
+            datepicker.Error.Should().BeFalse();
+            datepicker.ErrorText.Should().BeNullOrEmpty();
+            // clear selection
+            comp.SetParam(x => x.Time, null);
+            form.IsValid.Should().Be(false);
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Required");
+            datepicker.Error.Should().BeTrue();
+            datepicker.ErrorText.Should().Be("Required");
+        }
 
+        /// <summary>
+        /// TimePicker should be validated like every other form component when time is selected using picker
+        /// </summary>
+        [Test]
+        public async Task Form_Should_ValidateTimePickerTest_When_TimeSelectedViaPicker()
+        {
+            var comp = Context.RenderComponent<FormWithTimePickerTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dateComp = comp.FindComponent<MudTimePicker>();
+            var datepicker = comp.FindComponent<MudTimePicker>().Instance;
+            dateComp.SetParam(x => x.Validation, new Func<TimeSpan?, string>(time => time != null && time.Value.Minutes == 0 ? null : "Only full hours allowed"));
+            comp.Find("input").Click();
+            // select 09:00
+            comp.FindAll("div.mud-picker-stick-inner.mud-hour")[8].Click();
+            comp.FindAll("div.mud-minute")[0].Click();
+            // wait for picker to close
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            form.IsTouched.Should().Be(true);
+            form.IsValid.Should().Be(true);
+            form.Errors.Length.Should().Be(0);
+            datepicker.Error.Should().BeFalse();
+            datepicker.ErrorText.Should().BeNullOrEmpty();
+            // set invalid date:
+            comp.Find("input").Click();
+            // select 17:05
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
+            comp.FindAll("div.mud-minute")[5].Click();
+            form.IsValid.Should().Be(false);
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Only full hours allowed");
+            datepicker.Error.Should().BeTrue();
+            datepicker.ErrorText.Should().Be("Only full hours allowed");
+        }
 
         /// <summary>
         /// Testing the functionality of the EditForm example from the docs.

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -154,6 +154,7 @@ namespace MudBlazor
         {
             if (_value != time)
             {
+                Touched = true;
                 TimeIntermediate = time;
                 _value = time;
                 if (updateValue)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes an issue where the `MudTimePicker` component would keep a `MudForm` invalid unless its value is changed via the text input.

The `MudTimePicker` component is now considered `Touched` if its value is changed via the picker itself.

Fixes: #5883

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Tested by repeating `Form` tests with `TimePicker` components, but this time by applying value changes using the **Picker**.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
