### PR TITLE
Popover : Check popoverContentNode null before use

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -142,11 +142,11 @@ window.mudpopoverHelper = {
         if (popoverNode && popoverNode.parentNode) {
             const id = popoverNode.id.substr(8);
             const popoverContentNode = document.getElementById('popovercontent-' + id);
-            
+
             if (!popoverContentNode) {
                 return;
             }
-            
+
             if (popoverContentNode.classList.contains('mud-popover-open') == false) {
                 return;
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -142,11 +142,12 @@ window.mudpopoverHelper = {
         if (popoverNode && popoverNode.parentNode) {
             const id = popoverNode.id.substr(8);
             const popoverContentNode = document.getElementById('popovercontent-' + id);
-            if (popoverContentNode.classList.contains('mud-popover-open') == false) {
+            
+            if (!popoverContentNode) {
                 return;
             }
-
-            if (!popoverContentNode) {
+            
+            if (popoverContentNode.classList.contains('mud-popover-open') == false) {
                 return;
             }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes the issue encountered in #5849 (popoverContentNode is null on Firefox)

The relevant js method attempts to access `popoverContentNode.classList` before a null check is performed on the `popoverContentNode` object. The null check exists but it happens after this point. I have therefore moved the null check to the correct point.

## How Has This Been Tested?
This is already tested in `ToolTipTests.cs : RenderContent(bool usingFocusout)`; the bug was a silent JS error which would not be caught by any C# unit testing, because the final result is still the same (`popoverContentNode.Children.Should().BeEmpty();`)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.