### PR TITLE
MudSnackbar: Fix overflowing, long message (#3945)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarLongMessageTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarLongMessageTest.razor
@@ -1,0 +1,48 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@inject ISnackbar SnackbarService
+
+<MudButton OnClick="@ShowDefault">Show default snackbar</MudButton>
+<MudButton OnClick="@ShowCustom">Show custom snackbar</MudButton>
+<MudButton OnClick="@ShowPrevious">Show previous snackbar</MudButton>
+
+@code {
+    public static string __description__ = "Show snackbar that has custom content message class applied";
+
+    private string messageText = "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch is a village in Anglesey, Wales, United Kingdom.";
+    private string actionText = "Learn Pronunciation";
+
+    protected override void OnInitialized()
+    {
+        SnackbarService.Configuration.PositionClass = Defaults.Classes.Position.BottomRight;
+        SnackbarService.Configuration.PreventDuplicates = false;
+        SnackbarService.Configuration.ShowCloseIcon = true;
+        SnackbarService.Configuration.RequireInteraction = true;
+    }
+
+
+    private void ShowDefault()
+    {
+        SnackbarService.Add(messageText, Severity.Info, options =>
+        {
+            options.Action = actionText;
+        });
+    }
+
+    private void ShowCustom()
+    {
+        SnackbarService.Add(messageText, Severity.Info, options =>
+        {
+            options.Action = actionText;
+            options.SnackbarContentMessageClass = "mud-typography-nowrap";
+        });
+    }
+
+    private void ShowPrevious()
+    {
+        SnackbarService.Add(messageText, Severity.Info, options =>
+        {
+            options.Action = actionText;
+            options.SnackbarContentMessageClass = " ";
+        });
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -259,5 +259,28 @@ namespace MudBlazor.UnitTests.Components
             _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
         }
+
+        [Test]
+        public async Task SnackbarContentMessageClassIsDefaultTest()
+        {
+            var defaultClassName = "mud-snackbar-content-message";
+
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
+
+            _provider.Find($"div.{defaultClassName}").Should().NotBe(null);
+        }
+
+        [Test]
+        public async Task SnackbarContentMessageClassIsCustomTest()
+        {
+            var defaultClassName = "mud-snackbar-content-message";
+            var customClassName = "mud-typography-nowrap";
+
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.SnackbarContentMessageClass = customClassName; }));
+
+            Assert.Throws(typeof(ElementNotFoundException), ()=>_provider.Find($"div.{defaultClassName}"));
+            _provider.Find($"div.{customClassName}").Should().NotBe(null);
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -15,7 +15,7 @@
         </div>
     }
 
-    <div class="mud-snackbar-content-message">
+    <div class="@SnackbarContentMessageClass">
         @if (Message?.ComponentType != null)
         {
             <DynamicComponent Type="Message.ComponentType" Parameters="Message.ComponentParameters" />

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor.cs
@@ -25,6 +25,7 @@ namespace MudBlazor
         private Variant ActionVariant => Snackbar?.State.Options.ActionVariant ?? Snackbar?.State.Options.SnackbarVariant ?? Variant.Text;
         private string AnimationStyle => Snackbar?.State.AnimationStyle + Style;
         private string SnackbarClass => Snackbar?.State.SnackbarClass;
+        private string SnackbarContentMessageClass => Snackbar?.State?.SnackbarContentMessageClass;
         private RenderFragment Css;
         private bool ShowActionButton => Snackbar?.State.ShowActionButton == true;
         private bool ShowCloseIcon => Snackbar?.State.ShowCloseIcon == true;

--- a/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
@@ -78,6 +78,17 @@ namespace MudBlazor
             }
         }
 
+        public string SnackbarContentMessageClass
+        {
+            get
+            {
+                var result = IsNullOrEmpty(Options.SnackbarContentMessageClass) ?
+                    $"mud-snackbar-content-message" :
+                    Options.SnackbarContentMessageClass;
+                return result;
+            }
+        }
+
         public string TransitionClass
         {
             get

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -23,6 +23,11 @@ namespace MudBlazor
 
         public string SnackbarTypeClass { get; set; }
 
+        /// <summary>
+        /// Overwrites mud-snackbar-content-message class applied by default
+        /// </summary>
+        public string SnackbarContentMessageClass { get; set; }
+
         public bool CloseAfterNavigation { get; set; }
 
         public bool HideIcon { get; set; }

--- a/src/MudBlazor/Styles/components/_snackbar.scss
+++ b/src/MudBlazor/Styles/components/_snackbar.scss
@@ -15,8 +15,8 @@
     border-radius: var(--mud-default-borderradius);
     box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12);
 
-    &.force-cursor{
-        cursor:pointer;
+    &.force-cursor {
+        cursor: pointer;
     }
 
     &.mud-snackbar-blurred {
@@ -29,6 +29,7 @@
 
     .mud-snackbar-content-message {
         padding: 8px 0;
+        word-break: break-word;
     }
 
     .mud-snackbar-content-action {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
1. Fixes #3945 by adding `word-break: break-word;` to `mud-snackbar-content-message` class.

2. Adds new API property `SnackbarContentMessageClass`, for example:
````
SnackbarService.Add(messageText, Severity.Info, options =>
{
    options.SnackbarContentMessageClass = "mud-typography-nowrap";
});
````

Should anyone prefer a different class they can now do so.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Units + visually + existing examples in Docs looks the same
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![image](https://user-images.githubusercontent.com/57046415/205470559-6ea7ee2a-a701-44cb-8aae-7958ba2f8068.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
