### PR TITLE
Tests: Fix TimePicker validation test

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -711,30 +711,32 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
-            var dateComp = comp.FindComponent<MudTimePicker>();
-            var datepicker = comp.FindComponent<MudTimePicker>().Instance;
-            dateComp.SetParam(x => x.Validation, new Func<TimeSpan?, string>(time => time != null && time.Value.Minutes == 0 ? null : "Only full hours allowed"));
-            comp.Find("input").Click();
+            var timePickerComp = comp.FindComponent<MudTimePicker>();
+            var timePicker = comp.FindComponent<MudTimePicker>().Instance;
+            timePickerComp.SetParam(x => x.Validation, new Func<TimeSpan?, string>(time => time != null && time.Value.Minutes == 0 ? null : "Only full hours allowed"));
+            await comp.InvokeAsync(() => comp.Find("input").Click());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             // select 09:00
-            comp.FindAll("div.mud-picker-stick-inner.mud-hour")[8].Click();
-            comp.FindAll("div.mud-minute")[0].Click();
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-inner.mud-hour")[8].Click());
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[0].Click());
             // wait for picker to close
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             form.IsTouched.Should().Be(true);
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
-            datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.Error.Should().BeFalse();
+            timePicker.ErrorText.Should().BeNullOrEmpty();
             // set invalid date:
-            comp.Find("input").Click();
+            await comp.InvokeAsync(() => comp.Find("input").Click());;
             // select 17:05
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
-            comp.FindAll("div.mud-minute")[5].Click();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click());
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[5].Click());
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Only full hours allowed");
-            datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().Be("Only full hours allowed");
+            timePicker.Error.Should().BeTrue();
+            timePicker.ErrorText.Should().Be("Only full hours allowed");
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #5919
Flaky test requiring InvokeAsync to preserve render context (I think)
Refactored incorrect variable naming (copied from other test)
Should pick this up at PR level.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Using existing test
Stress testing 100 times

```
       [Test]
        public async Task  StressTest()
        {
            for ( int i = 0; i < 100; i++ )
            {
                await Form_Should_ValidateTimePickerTest_When_TimeSelectedViaPicker();
                Console.WriteLine(i);
            }
        }
```
Failed every time usually after 80-90 tests
After changes every batch of 100 succeeds

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've fixed relevant tests.
