### PR TITLE
MudTreeView: Enhance Public Select Method

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
@@ -1,0 +1,71 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px" Elevation="0">
+    <MudTreeView @ref="_treeView" Items="TreeItems" @bind-SelectedValue="SelectedValue" Hover="true">
+        <ItemTemplate>
+            <MudMenu Class="mud-width-full" ActivationEvent="MouseEvent.RightClick" @oncontextmenu:stopPropagation PositionAtCursor="true">
+                <ActivatorContent>
+                    <MudTreeViewItem Value="@context" Items="@context.TreeItems" Icon="@context.Icon" LoadingIconColor="Color.Info" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+                </ActivatorContent>
+                <ChildContent>
+                    <MudMenuItem OnClick="@(() => _treeView.Select(context))">Select</MudMenuItem>
+                    <MudMenuItem OnClick="@(() => _treeView.Select(context, false))">Deselect</MudMenuItem>
+                </ChildContent>
+            </MudMenu>
+        </ItemTemplate>
+    </MudTreeView>
+</MudPaper>
+
+<MudText Style="width: 100%" Typo="@Typo.subtitle1">Selected item: @SelectedValue?.Title</MudText>
+
+<MudButton OnClick="@(() => _treeView.Select(TreeItems.First()))">Select First Item</MudButton>
+<MudButton OnClick="@(() => _treeView.Select(TreeItems.FirstOrDefault(x => x.Title == "Trash")))">Select Second Item</MudButton>
+<MudButton OnClick="@(() => _treeView.Select(_treeView.GetAllItems().FirstOrDefault(x => x.Value.Title == "Social")))">Select Second Item</MudButton>
+
+@code {
+    MudTreeView<TreeItemData> _treeView;
+    TreeItemData SelectedValue { get; set; }
+
+    private HashSet<TreeItemData> TreeItems { get; set; } = new HashSet<TreeItemData>();
+
+    public class TreeItemData
+    {
+        public string Title { get; set; }
+
+        public string Icon { get; set; }
+
+        public int? Number { get; set; }
+
+        public HashSet<TreeItemData> TreeItems { get; set; }
+
+        public TreeItemData(string title, string icon, int? number = null)
+        {
+            Title = title;
+            Icon = icon;
+            Number = number;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        TreeItems.Add(new TreeItemData("All Mail", Icons.Filled.Email));
+        TreeItems.Add(new TreeItemData("Trash", Icons.Filled.Delete));
+        TreeItems.Add(new TreeItemData("Categories", Icons.Filled.Label)
+            {
+                TreeItems = new HashSet<TreeItemData>()
+            {
+                new TreeItemData("Social", Icons.Filled.Group, 90),
+                new TreeItemData("Updates", Icons.Filled.Info, 2294),
+                new TreeItemData("Forums", Icons.Filled.QuestionAnswer, 3566),
+                new TreeItemData("Promotions", Icons.Filled.LocalOffer, 733) 
+                {
+                    TreeItems = new HashSet<TreeItemData>()
+                    {
+                        new TreeItemData("Rare", Icons.Filled.LocalOffer, 20)
+                    }
+                }
+            }
+            });
+        TreeItems.Add(new TreeItemData("History", Icons.Filled.Label));
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
@@ -1,26 +1,36 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudPaper Width="300px" Elevation="0">
-    <MudTreeView @ref="_treeView" Items="TreeItems" @bind-SelectedValue="SelectedValue" Hover="true">
-        <ItemTemplate>
-            <MudMenu Class="mud-width-full" ActivationEvent="MouseEvent.RightClick" @oncontextmenu:stopPropagation PositionAtCursor="true">
-                <ActivatorContent>
-                    <MudTreeViewItem Value="@context" Items="@context.TreeItems" Icon="@context.Icon" LoadingIconColor="Color.Info" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
-                </ActivatorContent>
-                <ChildContent>
-                    <MudMenuItem OnClick="@(() => _treeView.Select(context))">Select</MudMenuItem>
-                    <MudMenuItem OnClick="@(() => _treeView.Select(context, false))">Deselect</MudMenuItem>
-                </ChildContent>
-            </MudMenu>
-        </ItemTemplate>
-    </MudTreeView>
-</MudPaper>
+<MudGrid>
+    <MudItem xs="12" sm="8" Class="d-flex- justify-center">
+        <MudPaper Width="300px" Elevation="0">
+            <MudTreeView @ref="_treeView" Items="TreeItems" @bind-SelectedValue="SelectedValue" Hover="true">
+                <ItemTemplate>
+                    <MudMenu Class="mud-width-full" ActivationEvent="MouseEvent.RightClick" @oncontextmenu:stopPropagation PositionAtCursor="true">
+                        <ActivatorContent>
+                            <MudTreeViewItem Value="@context" Items="@context.TreeItems" Icon="@context.Icon" LoadingIconColor="Color.Info" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+                        </ActivatorContent>
+                        <ChildContent>
+                            <MudMenuItem OnClick="@(() => _treeView.Select(context))">Select</MudMenuItem>
+                            <MudMenuItem OnClick="@(() => _treeView.Select(context, false))">Deselect</MudMenuItem>
+                        </ChildContent>
+                    </MudMenu>
+                </ItemTemplate>
+            </MudTreeView>
+        </MudPaper>
+    </MudItem>
 
-<MudText Style="width: 100%" Typo="@Typo.subtitle1">Selected item: @SelectedValue?.Title</MudText>
+    <MudItem xs="12" sm="4">
+        <MudStack Style="mud-width-full">
+            <MudText Typo="@Typo.subtitle1">Selected item: @SelectedValue?.Title</MudText>
+            <MudButton OnClick="@(() => _treeView.Select(TreeItems.First()))">Select First Item</MudButton>
+            <MudButton OnClick="@(() => _treeView.Select(TreeItems.FirstOrDefault(x => x.Title == "Trash")))">Select Second Item</MudButton>
+            <MudButton OnClick="@(() => _treeView.Select(_treeView.GetAllItems().FirstOrDefault(x => x.Value.Title == "Social")))">Select 'Social' Item</MudButton>
+        </MudStack>
+    </MudItem>
+</MudGrid>
 
-<MudButton OnClick="@(() => _treeView.Select(TreeItems.First()))">Select First Item</MudButton>
-<MudButton OnClick="@(() => _treeView.Select(TreeItems.FirstOrDefault(x => x.Title == "Trash")))">Select Second Item</MudButton>
-<MudButton OnClick="@(() => _treeView.Select(_treeView.GetAllItems().FirstOrDefault(x => x.Value.Title == "Social")))">Select Second Item</MudButton>
+
+
 
 @code {
     MudTreeView<TreeItemData> _treeView;

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewProgrammaticallySelectedExample.razor
@@ -29,9 +29,6 @@
     </MudItem>
 </MudGrid>
 
-
-
-
 @code {
     MudTreeView<TreeItemData> _treeView;
     TreeItemData SelectedValue { get; set; }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -71,6 +71,19 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Programmatically Select">
+                <Description>
+                    Use MudTreeView's <CodeInline>Select</CodeInline> method to select item or value programmatically.
+                    <br />
+                    This example shows the programmatically select situations like with button click or right click on treeview item.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="TreeViewProgrammaticallySelectedExample" ShowCode="false">
+                <TreeViewProgrammaticallySelectedExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Selected Color">
                 <Description>The color of the selected item can be changed with <CodeInline>Color</CodeInline> property.</Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest4.razor
@@ -27,4 +27,9 @@
         await _treeView.Select(_item2, false);
     }
 
+    public async Task SelectFirstWithValue()
+    {
+        await _treeView.Select("content", true);
+    }
+
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -182,6 +182,9 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => comp.Instance.DeselectSecond());
             comp.WaitForAssertion(() => comp.Instance.selectedValue.Should().Be(null));
+
+            await comp.InvokeAsync(() => comp.Instance.SelectFirstWithValue());
+            comp.WaitForAssertion(() => comp.Instance.selectedValue.Should().Be("content"));
         }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -242,9 +242,38 @@ namespace MudBlazor
             return SelectedValuesChanged.InvokeAsync(new HashSet<T>(_selectedValues.Select(i => i.Value)));
         }
 
+        public List<MudTreeViewItem<T>> GetAllItems()
+        {
+            List<MudTreeViewItem<T>> result = new();
+            foreach (var item in _childItems)
+            {
+                CollectItem(item, result);
+            }
+            return result;
+        }
+
+        private void CollectItem(MudTreeViewItem<T> item, List<MudTreeViewItem<T>> resultList)
+        {
+            resultList.Add(item);
+            foreach (var child in item.GetChildItems())
+            {
+                CollectItem(child, resultList);
+            }
+        }
+
         public async Task Select(MudTreeViewItem<T> item, bool isSelected = true)
         {
             await UpdateSelected(item, isSelected);
+        }
+
+        public async Task Select(T value, bool isSelected = true)
+        {
+            MudTreeViewItem<T> toBeSelectedItem = GetAllItems().FirstOrDefault(x =>  x.Value.Equals(value));
+            if (toBeSelectedItem == null)
+            {
+                return;
+            }
+            await UpdateSelected(toBeSelectedItem, isSelected);
         }
 
         internal void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -391,6 +391,11 @@ namespace MudBlazor
 
         private void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
 
+        internal List<MudTreeViewItem<T>> GetChildItems()
+        {
+            return _childItems;
+        }
+
         internal IEnumerable<MudTreeViewItem<T>> GetSelectedItems()
         {
             if (_isChecked)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
As we discussed with @henon and @mikes-gh at #5856, treeview didn't have good options for programmatically changes.

But the PR at 5856 also didn't bring the exact requirement. If we want to select dynamic data like loaded from server, we need to a method that select with value, not with the TreeViewItem. So this PR added this option as method overload.

## Where do we need this

In current situation, there is no way to select dynamic treeview item with right click on it. Now its possible. I also add a doc example that showed on this video


https://user-images.githubusercontent.com/78308169/206676816-f757f13b-6ca0-4fc4-a73c-62b12773f820.mp4



## How Has This Been Tested?
Current programmatic change test enhanced.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
