### PR TITLE
MudTable: Allow row-click without selecting checkbox when in multi-select mode

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -3,51 +3,53 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudSwitch @bind-Checked="@_setCheckboxOnRowClick">SetCheckboxOnRowClick: @_setCheckboxOnRowClick</MudSwitch>
-<MudText Inline="true">Clicked: @_rowClicks</MudText>
-<MudText >Selected items: @(selectedItems1 == null ? "" : string.Join(", ", selectedItems1.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
+<MudSwitch @bind-Checked="@_selectOnRowClick">SelectOnRowClick: @_selectOnRowClick</MudSwitch>
+<MudText Inline="true">Clicks: @_clickCount</MudText>
+<MudText Inline="true">Item: @_clickText</MudText>
+<MudText>Selected items: @(selectedItems1 == null ? "" : string.Join(", ", selectedItems1.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
 
-<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover"
-          @ref="_table" T="Element" SetCheckboxOnRowClick="@_setCheckboxOnRowClick" OnRowClick="@OnRowClick">
-    <HeaderContent>
-        <MudTh>Nr</MudTh>
-        <MudTh>Sign</MudTh>
-        <MudTh>Name</MudTh>
-        <MudTh>Position</MudTh>
-        <MudTh>Molar mass</MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Nr">@context.Number</MudTd>
-        <MudTd DataLabel="Sign">@context.Sign</MudTd>
-        <MudTd DataLabel="Name">@context.Name</MudTd>
-        <MudTd DataLabel="Position">@context.Position</MudTd>
-        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
-    </RowTemplate>
-    <PagerContent>
-        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
-    </PagerContent>
-    <FooterContent>
-        <MudTd colspan="5">Select All</MudTd>
-    </FooterContent>
+
+   <MudTable @ref="_table" T="Element" Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="true"
+             OnRowClick="@OnRowClick" @bind-SelectOnRowClick="@_selectOnRowClick">
+   <HeaderContent>
+      <MudTh>Nr</MudTh>
+      <MudTh>Sign</MudTh>
+      <MudTh>Name</MudTh>
+      <MudTh>Position</MudTh>
+      <MudTh>Molar mass</MudTh>
+   </HeaderContent>
+   <RowTemplate>
+      <MudTd DataLabel="Nr">@context.Number</MudTd>
+      <MudTd DataLabel="Sign">@context.Sign</MudTd>
+      <MudTd DataLabel="Name">@context.Name</MudTd>
+      <MudTd DataLabel="Position">@context.Position</MudTd>
+      <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+   </RowTemplate>
+   <PagerContent>
+      <MudTablePager PageSizeOptions="new int[]{50, 100}" />
+   </PagerContent>
+   <FooterContent>
+      <MudTd colspan="5">Select All</MudTd>
+   </FooterContent>
 </MudTable>
 
-   @code {
-   private bool hover = true;
-   private HashSet<Element> selectedItems1 = new HashSet<Element>();
 
+@code {
+   private HashSet<Element> selectedItems1 = new HashSet<Element>();
    private IEnumerable<Element> Elements = new List<Element>();
-   private bool _setCheckboxOnRowClick = true;
+   private bool _selectOnRowClick = true;
    private MudTable<Element> _table;
-   private int _rowClicks;
+   private int _clickCount;
+   private string _clickText = "No row clicked";
 
    protected override async Task OnInitializedAsync()
    {
       Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
    }
 
-   Task OnRowClick()
+   void OnRowClick(TableRowClickEventArgs<Element> args)
    {
-      ++_rowClicks;
-      return Task.CompletedTask;
+      ++_clickCount;
+      _clickText = args.Item.Sign;
    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -9,47 +9,47 @@
 <MudText>Selected items: @(selectedItems1 == null ? "" : string.Join(", ", selectedItems1.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
 
 
-   <MudTable @ref="_table" T="Element" Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="true"
-             OnRowClick="@OnRowClick" @bind-SelectOnRowClick="@_selectOnRowClick">
-   <HeaderContent>
-      <MudTh>Nr</MudTh>
-      <MudTh>Sign</MudTh>
-      <MudTh>Name</MudTh>
-      <MudTh>Position</MudTh>
-      <MudTh>Molar mass</MudTh>
-   </HeaderContent>
-   <RowTemplate>
-      <MudTd DataLabel="Nr">@context.Number</MudTd>
-      <MudTd DataLabel="Sign">@context.Sign</MudTd>
-      <MudTd DataLabel="Name">@context.Name</MudTd>
-      <MudTd DataLabel="Position">@context.Position</MudTd>
-      <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
-   </RowTemplate>
-   <PagerContent>
-      <MudTablePager PageSizeOptions="new int[]{50, 100}" />
-   </PagerContent>
-   <FooterContent>
-      <MudTd colspan="5">Select All</MudTd>
-   </FooterContent>
+<MudTable @ref="_table" T="Element" Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="true"
+          OnRowClick="@OnRowClick" @bind-SelectOnRowClick="@_selectOnRowClick">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
+    </PagerContent>
+    <FooterContent>
+        <MudTd colspan="5">Select All</MudTd>
+    </FooterContent>
 </MudTable>
 
 
 @code {
-   private HashSet<Element> selectedItems1 = new HashSet<Element>();
-   private IEnumerable<Element> Elements = new List<Element>();
-   private bool _selectOnRowClick = true;
-   private MudTable<Element> _table;
-   private int _clickCount;
-   private string _clickText = "No row clicked";
+    private HashSet<Element> selectedItems1 = new HashSet<Element>();
+    private IEnumerable<Element> Elements = new List<Element>();
+    private bool _selectOnRowClick = true;
+    private MudTable<Element> _table;
+    private int _clickCount;
+    private string _clickText = "No row clicked";
 
-   protected override async Task OnInitializedAsync()
-   {
-      Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-   }
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
 
-   void OnRowClick(TableRowClickEventArgs<Element> args)
-   {
-      ++_clickCount;
-      _clickText = args.Item.Sign;
-   }
+    void OnRowClick(TableRowClickEventArgs<Element> args)
+    {
+        ++_clickCount;
+        _clickText = args.Item.Sign;
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -3,7 +3,12 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover">
+<MudSwitch @bind-Checked="@_setCheckboxOnRowClick">SetCheckboxOnRowClick: @_setCheckboxOnRowClick</MudSwitch>
+<MudText Inline="true">Clicked: @_rowClicks</MudText>
+<MudText >Selected items: @(selectedItems1 == null ? "" : string.Join(", ", selectedItems1.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
+
+<MudTable Items="@Elements" MultiSelection="true" @bind-SelectedItems="selectedItems1" Hover="@hover"
+          @ref="_table" T="Element" SetCheckboxOnRowClick="@_setCheckboxOnRowClick" OnRowClick="@OnRowClick">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -26,16 +31,23 @@
     </FooterContent>
 </MudTable>
 
-<MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
+   @code {
+   private bool hover = true;
+   private HashSet<Element> selectedItems1 = new HashSet<Element>();
 
-@code {
-    private bool hover = true;
-    private HashSet<Element> selectedItems1 = new HashSet<Element>();
+   private IEnumerable<Element> Elements = new List<Element>();
+   private bool _setCheckboxOnRowClick = true;
+   private MudTable<Element> _table;
+   private int _rowClicks;
 
-    private IEnumerable<Element> Elements = new List<Element>();
+   protected override async Task OnInitializedAsync()
+   {
+      Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+   }
 
-    protected override async Task OnInitializedAsync()
-    {
-        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-    } 
+   Task OnRowClick()
+   {
+      ++_rowClicks;
+      return Task.CompletedTask;
+   }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -75,8 +75,8 @@
         <DocsPageSection>
             <SectionHeader Title="Multi-Selection">
                 <Description>
-                    Set <CodeInline>MultiSelection="true"</CodeInline> to enable selecting multiple rows by a row- or checkbox-click.<br />
-                    To prevent toggling the checkbox state on row-click, set <CodeInline>SetCheckboxOnRowClick="false"</CodeInline>.
+                    To enable multiselection of rows using checkboxes, set <CodeInline>MultiSelection="true"</CodeInline>.<br />
+                    To disable toggling the checkbox state on row-click, set <CodeInline>SelectOnRowClick="false"</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableMultiSelectExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -75,7 +75,8 @@
         <DocsPageSection>
             <SectionHeader Title="Multi-Selection">
                 <Description>
-                    Setting <CodeInline>MultiSelection="true"</CodeInline> will enable selection check boxes for selecting multiple lines.
+                    Set <CodeInline>MultiSelection="true"</CodeInline> to enable selecting multiple rows by a row- or checkbox-click.<br />
+                    To prevent toggling the checkbox state on row-click, set <CodeInline>SetCheckboxOnRowClick="false"</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableMultiSelectExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -203,7 +203,7 @@
             <SectionHeader Title="Grouping (Basic)">
                 <Description>
                     Displays items in a grouped way, with Header and Footer by every group, allowing summaries on both.<br />
-                    NOTE: Grouping and Virtualization should not work together.
+                    NOTE: Grouping and Virtualization should not be used together.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableBasicGroupingExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_CheckboxClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_CheckboxClickTest.razor
@@ -8,7 +8,7 @@
 </MudTable>
 
 @code {
-    public static string __description__ = "A row click should not set the checkbox.";
+    public static string __description__ = "A checkbox- or row-click should toggle the checkbox state.";
 
     int[] items = new int[]{0,1,2};
     HashSet<int> selectedItems=new HashSet<int>();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
@@ -3,21 +3,21 @@
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable T="int" Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" SelectOnRowClick="false" OnRowClick="@OnRowClick">
     <RowTemplate>
-        <MudTd >@context</MudTd>
+        <MudTd>@context</MudTd>
     </RowTemplate>
 </MudTable>
 <MudText>Clicked: @_count</MudText>
 
 @code {
-   public static string __description__ = "A row-click should not toggle the checkbox.";
+    public static string __description__ = "A row-click should not toggle the checkbox.";
 
-   int[] items = new int[]{0,1,2};
-   HashSet<int> selectedItems=new HashSet<int>();
+    int[] items = new int[] { 0, 1, 2 };
+    HashSet<int> selectedItems = new HashSet<int>();
 
-   int _count = 0;
-   Task OnRowClick()
-   {
-      ++_count;
-      return Task.CompletedTask;
-   }
+    int _count = 0;
+    Task OnRowClick()
+    {
+        ++_count;
+        return Task.CompletedTask;
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
-<MudTable T="int" Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" SetCheckboxOnRowClick="false" OnRowClick="@OnRowClick">
+<MudTable T="int" Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" SelectOnRowClick="false" OnRowClick="@OnRowClick">
     <RowTemplate>
         <MudTd >@context</MudTd>
     </RowTemplate>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_IgnoreCheckbox_RowClickTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable T="int" Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" SetCheckboxOnRowClick="false" OnRowClick="@OnRowClick">
+    <RowTemplate>
+        <MudTd >@context</MudTd>
+    </RowTemplate>
+</MudTable>
+<MudText>Clicked: @_count</MudText>
+
+@code {
+   public static string __description__ = "A row-click should not toggle the checkbox.";
+
+   int[] items = new int[]{0,1,2};
+   HashSet<int> selectedItems=new HashSet<int>();
+
+   int _count = 0;
+   Task OnRowClick()
+   {
+      ++_count;
+      return Task.CompletedTask;
+   }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_RowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_RowClickTest.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "A row click should not set the checkbox.";
+
+    int[] items = new int[]{0,1,2};
+    HashSet<int> selectedItems=new HashSet<int>();
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -453,27 +453,27 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public void TableMultiSelection_RowClickTest()
-        {
-            var comp = Context.RenderComponent<TableMultiSelection_RowClickTest>();
-            var table = comp.FindComponent<MudTable<int>>().Instance;
-            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
-
-            foreach (var row in rows) row.Click();
-            table.SelectedItems.Count.Should().Be(0);
-        }
-
-        [Test]
         public void TableMultiSelection_CheckboxClickTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelection_RowClickTest>();
-            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var comp = Context.RenderComponent<TableMultiSelection_CheckboxClickTest>();
             var checkboxes = comp.FindComponent<MudTable<int>>().FindAll("input").ToArray();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
 
             foreach (var cbx in checkboxes) cbx.Change(true);
             table.SelectedItems.Count.Should().Be(3);
 
             foreach (var cbx in checkboxes) cbx.Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+        }
+
+        [Test]
+        public void TableMultiSelection_IgnoreCheckbox_RowClickTest()
+        {
+            var comp = Context.RenderComponent<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
+            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+
+            foreach (var row in rows) row.Click();
             table.SelectedItems.Count.Should().Be(0);
         }
 
@@ -505,7 +505,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
             // row click
             tr[1].Click();
-            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -451,6 +451,33 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(0);
         }
 
+
+        [Test]
+        public void TableMultiSelection_RowClickTest()
+        {
+            var comp = Context.RenderComponent<TableMultiSelection_RowClickTest>();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
+
+            foreach (var row in rows) row.Click();
+            table.SelectedItems.Count.Should().Be(0);
+        }
+
+        [Test]
+        public void TableMultiSelection_CheckboxClickTest()
+        {
+            var comp = Context.RenderComponent<TableMultiSelection_RowClickTest>();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var checkboxes = comp.FindComponent<MudTable<int>>().FindAll("input").ToArray();
+
+            foreach (var cbx in checkboxes) cbx.Change(true);
+            table.SelectedItems.Count.Should().Be(3);
+
+            foreach (var cbx in checkboxes) cbx.Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+        }
+
+
         /// <summary>
         /// the selected items (check-box click or row click) should be in SelectedItems
         /// </summary>
@@ -478,7 +505,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
             // row click
             tr[1].Click();
-            comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }");
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -171,7 +171,7 @@ namespace MudBlazor
         public Func<T, bool> Filter { get; set; } = null;
 
         /// <summary>
-        /// Button click event.
+        /// Row click event.
         /// </summary>
         [Parameter] public EventCallback<TableRowClickEventArgs<T>> OnRowClick { get; set; }
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -193,6 +193,13 @@ namespace MudBlazor
         public bool MultiSelection { get; set; }
 
         /// <summary>
+        /// When <c>true</c>, a row-click also toggles the checkbox state.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Rows)]
+        public bool SetCheckboxOnRowClick { get; set; } = true;
+
+        /// <summary>
         /// Optional. Add any kind of toolbar to this render fragment.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -197,7 +197,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Rows)]
-        public bool SetCheckboxOnRowClick { get; set; } = true;
+        public bool SelectOnRowClick { get; set; } = true;
 
         /// <summary>
         /// Optional. Add any kind of toolbar to this render fragment.

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -59,11 +59,6 @@ namespace MudBlazor
         {
             Context?.Table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
-
-            if (Context?.Table.MultiSelection == true && !(Context?.Table.IsEditable == true))
-            {
-                IsChecked = !IsChecked;
-            }
             Context?.Table.FireRowClickEvent(args, this, Item);
         }
 

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -57,9 +57,13 @@ namespace MudBlazor
 
         public void OnRowClicked(MouseEventArgs args)
         {
-            Context?.Table.SetSelectedItem(Item);
+            var table = Context?.Table;
+            if (table is null) return;
+
+            table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
-            Context?.Table.FireRowClickEvent(args, this, Item);
+            if (table.MultiSelection && table.SetCheckboxOnRowClick && !table.IsEditable) IsChecked = !IsChecked;
+            table.FireRowClickEvent(args, this, Item);
         }
 
         private void StartEditingItem() => StartEditingItem(buttonClicked: true);

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -58,11 +58,12 @@ namespace MudBlazor
         public void OnRowClicked(MouseEventArgs args)
         {
             var table = Context?.Table;
-            if (table is null) return;
-
+            if (table is null)
+                return;
             table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
-            if (table.MultiSelection && table.SelectOnRowClick && !table.IsEditable) IsChecked = !IsChecked;
+            if (table.MultiSelection && table.SelectOnRowClick && !table.IsEditable)
+                IsChecked = !IsChecked;
             table.FireRowClickEvent(args, this, Item);
         }
 

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -62,7 +62,7 @@ namespace MudBlazor
 
             table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
-            if (table.MultiSelection && table.SetCheckboxOnRowClick && !table.IsEditable) IsChecked = !IsChecked;
+            if (table.MultiSelection && table.SelectOnRowClick && !table.IsEditable) IsChecked = !IsChecked;
             table.FireRowClickEvent(args, this, Item);
         }
 


### PR DESCRIPTION
## Description
-Fixes #5545
-Minor Table docs improvement

Note: I marked this as a breaking feature because I had to modify
the `TableMultiSelectionTest1` unit test to accommodate this PR.

## How Has This Been Tested?
unit | visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
