### PR TITLE
Docs: Fix InvalidOperationException in "Record Type Support" docs example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRecordComparerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRecordComparerExample.razor
@@ -29,7 +29,7 @@
 
 <MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
 
-@code {
+    @code {
     private HashSet<Element> selectedItems1 = new HashSet<Element>();
 
     private List<Element> Elements = new List<Element>();
@@ -38,7 +38,8 @@
 
     private void OnSelectedItemsChanged(HashSet<Element> elements)
     {
-        elements.First().Name = "Changed";
+        if (elements.Any())
+            elements.First().Name = "Changed";
     }
 
     protected override async Task OnInitializedAsync()

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRecordComparerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRecordComparerExample.razor
@@ -27,9 +27,9 @@
     </FooterContent>
 </MudTable>
 
-<MudText Inline="true">Selected items: @(selectedItems1==null ? "" : string.Join(", ", selectedItems1.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
+<MudText Inline="true">Selected items: @(selectedItems1 == null ? "" : string.Join(", ", selectedItems1.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
 
-    @code {
+@code {
     private HashSet<Element> selectedItems1 = new HashSet<Element>();
 
     private List<Element> Elements = new List<Element>();


### PR DESCRIPTION
## Description
There is a `System.InvalidOperationException: 'Sequence contains no elements'`
thrown in the "Record Type Support" docs example, when clicking the header checkbox to select/deselect all items.

## How Has This Been Tested?
Visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] DOCS Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
