### PR TITLE
MudTable: Fix issue where sub-tables in the last row of a table would not have borders

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -42,9 +42,9 @@
         }
     }
 
-    & .mud-table-body:last-child {
-        & .mud-table-row:last-child {
-            & .mud-table-cell {
+    > .mud-table-body:last-child {
+        > .mud-table-row:last-child {
+            > .mud-table-cell {
                 border-bottom: none;
             }
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes #5761.

Sub-tables in the last row of a table are missing their borders:
![image](https://user-images.githubusercontent.com/26885142/207770781-1d770434-52b5-487b-ba15-797a5962cbda.png)

After PR:
![image](https://user-images.githubusercontent.com/26885142/207770831-c62bab0b-4fbe-4eab-80c9-ab62d2cdea81.png)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
