### PR TITLE
MudDataGrid: Fix CollapseAll not clearing internal variable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
@@ -1,0 +1,69 @@
+@namespace MudBlazor.UnitTests.TestComponents
+@using System.Collections.ObjectModel
+<MudDataGrid @ref="dataGrid"
+	Items="@Fruits"
+	Sortable="true"
+	Filterable="true"
+	Hideable="true"
+	Groupable="true"
+	GroupExpanded="false">
+	<ToolBarContent>
+		<MudText Typo="Typo.h6">Fruits</MudText>
+		<MudSpacer />
+	</ToolBarContent>
+	<Columns>
+		<Column T="TestObject" Field="Name" Title="Name" Filterable="false" Groupable="false" />
+		<Column T="TestObject" Field="Category" Title="Category" Grouping="true" GroupBy="@_groupBy">
+			<GroupTemplate>
+				<span style="font-weight:bold">Category: @context.Grouping.Key</span>
+			</GroupTemplate>
+		</Column>
+	</Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+	<MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+	<MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+	<MudButton OnClick="@RefreshList" Color="@Color.Primary">Refresh</MudButton>
+</div>
+
+@code {
+	MudDataGrid<TestObject> dataGrid;
+	public record TestObject(string Name, string Category);
+
+	IEnumerable<TestObject> Fruits { get; set; } =
+		new List<TestObject>()
+			{
+			new TestObject("1", "1"),
+			new TestObject("1-1", "1"),
+			new TestObject("1-2", "1"),
+
+			new TestObject("2", "2"),
+			new TestObject("2-1", "2"),
+			new TestObject("2-2", "2"),
+
+			new TestObject("3", "3"),
+			new TestObject("3-1", "3"),
+			new TestObject("3-2", "3")
+					};
+
+	Func<TestObject, object> _groupBy = x =>
+	{
+		return x.Category;
+	};
+
+	public void RefreshList()
+	{
+		Fruits = Fruits.Select(x => new TestObject(x.Name, x.Category)).ToList();
+	}
+
+	public void ExpandAllGroups()
+	{
+		dataGrid?.ExpandAllGroups();
+	}
+
+	public void CollapseAllGroups()
+	{
+		dataGrid?.CollapseAllGroups();
+	}
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4345,5 +4345,24 @@ namespace MudBlazor.UnitTests.Components
             // datagrid should be expanded with the new category
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(8);
         }
+
+        [Test]
+        public async Task DataGridGroupCollapseAllTest()
+        {
+            var comp = Context.RenderComponent<DataGridGroupCollapseAllTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupCollapseAllTest.TestObject>>();
+
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
+            comp.Instance.ExpandAllGroups();
+            comp.Render();
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(15);
+            comp.Instance.CollapseAllGroups();
+            comp.Render();
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
+            comp.Instance.RefreshList();
+            comp.Render();
+            // after all groups are expanded
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1284,10 +1284,10 @@ namespace MudBlazor
 
         public void CollapseAllGroups()
         {
+            _groupExpansions.Clear();
+
             foreach (var group in _groups)
-            {
                 group.IsExpanded = false;
-            }
         }
 
         #endregion


### PR DESCRIPTION
## Description
Simple bugfix for the datagrid. The CollapseAll method was not clearing an internal variable containing which group was "opened" or not. This cause an issue where refreshing the list of rows would expend all the rows with existing group keys.

## How Has This Been Tested?
Tested with unit tests and manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
