### PR TITLE
Make Blazor Error UI message more legible

### DIFF
--- a/src/MudBlazor/Styles/core/_blazor.scss
+++ b/src/MudBlazor/Styles/core/_blazor.scss
@@ -1,16 +1,23 @@
 ﻿#blazor-error-ui {
-    background: lightyellow;
+    background-color: var(--mud-palette-error);
+    color: var(--mud-palette-error-text);
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     display: none;
     left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    padding: 0.6rem 1.75rem 0.7rem 1.25rem;
     position: fixed;
     width: 100%;
     z-index: 9999;
 }
 
+#blazor-error-ui .reload {
+    color: inherit;
+    text-decoration: underline;
+}
+
 #blazor-error-ui .dismiss {
+    color: inherit;
     cursor: pointer;
     position: absolute;
     right: 0.75rem;


### PR DESCRIPTION
Amends stylesheet of blazor ui error message to:
- make error text contrasting with bg
- use the same mudblazor error variables for bg/fg 


## Description
Closes #5948

## How Has This Been Tested?
visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![image](https://user-images.githubusercontent.com/57046415/207987868-34859a39-9bd8-47f9-b643-77d3964f13c7.png)
After:
![image](https://user-images.githubusercontent.com/57046415/207987088-e7f66bb9-5cf1-4408-a51c-7bb6d709933f.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
