### PR TITLE
MudTable: Toggle multigrouping checkbox ocassionaly flickers

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1611,7 +1611,7 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(2);
 
             inputs = comp.FindAll("input").ToArray();
-            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(3);
 
             inputs[1].Change(false);
             table.SelectedItems.Count.Should().Be(0);

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -114,8 +114,6 @@ namespace MudBlazor
             {
                 _innerGroupItems = Table?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
             }
-            if (IsCheckable && Items is not null && Table is not null && Table.SelectedItems.Count > 0)
-                _checked = Items.All(Table.SelectedItems.Contains);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Description
Following up on my PR #5985, this PR removes the flickering that now occurs
when the Groupheader checkbox is toggled rapidly.

Curently: Header checkboxes in "Group: Noble Gas"
![Animation](https://user-images.githubusercontent.com/10358198/208250429-2868f0e0-1371-4577-b23a-274151e746d3.gif)

Fixed:
![AnimationFixed](https://user-images.githubusercontent.com/10358198/208250437-e33294c3-af95-453a-9e6e-13b4cf6497a0.gif)

The flickering is due to code that was added in PR #5760,
https://github.com/Gopichandar/MudBlazor/blob/11692a6909efda90471e538d400ddaa744a5f108/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs#L117
```csharp
    if (IsCheckable && Items is not null && Table is not null && Table.SelectedItems.Count > 0)
        _checked = Items.All(Table.SelectedItems.Contains);
```

My previous PR fixed the overal checkbox state making these two lines obsolete.
This PR removes those two lines, which removes the flickering.


## How Has This Been Tested?
unit | visually

Note: As in my previous PR, I had to change a unit test to accomodate for the checkbox tristate:
![image](https://user-images.githubusercontent.com/10358198/208251137-3073ddcf-a818-4c33-b75a-b0a27b6b6c79.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Since I changed a unit test, I marked it breaking.

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
