### PR TITLE
MudToggleIconButton: Add ToggledVariant Parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonBasicExample.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudToggleIconButton Icon="@Icons.Filled.AlarmOff" ToggledIcon="@Icons.Filled.AlarmOn"
+        Color="@Color.Primary" ToggledColor="@Color.Primary" />
+
+<MudToggleIconButton Icon="@Icons.Filled.AlarmOn" ToggledIcon="@Icons.Filled.AlarmOn"
+        Variant="Variant.Filled" ToggledVariant="Variant.Filled" Color="Color.Dark" ToggledColor="Color.Success" />
+
+<MudToggleIconButton Icon="@Icons.Filled.AlarmOn" ToggledIcon="@Icons.Filled.AlarmOn"
+        Variant="Variant.Outlined" ToggledVariant="Variant.Filled" Color="Color.Success" ToggledColor="Color.Success" />
+
+<MudToggleIconButton Icon="@Icons.Filled.AlarmOn" ToggledIcon="@Icons.Filled.AlarmOn"
+        Size="Size.Medium" ToggledSize="Size.Large" Color="Color.Dark" ToggledColor="Color.Success" />
+

--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
@@ -9,7 +9,18 @@
 
     <DocsPageContent>
         <DocsPageSection>
-            <SectionHeader Title="Basic usage">
+            <SectionHeader Title="Basic Usage">
+                <Description>You can toggle Color, Variant, Size, Icon, Title or combination of these.</Description>
+                </SectionHeader>
+                <SectionContent Code="ToggleIconButtonBasicExample">
+                    <ToggleIconButtonBasicExample />
+                </SectionContent>
+            </DocsPageSection>
+        </DocsPageContent>
+
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="Two Way Bind">
                 <Description>Use two-way binding <CodeInline>@(@"@bind-Toggle=""...""")</CodeInline> to update a bound value in the parent component.</Description>
             </SectionHeader>
             <SectionContent Code="ToggleIconButtonTwoWayBindingExample">
@@ -20,7 +31,7 @@
 
     <DocsPageContent>
         <DocsPageSection>
-            <SectionHeader Title="Advanced usage">
+            <SectionHeader Title="Advanced Usage">
                 <Description>You may act on the toggled state by using the <CodeInline>Toggled</CodeInline> EventCallback.</Description>
             </SectionHeader>
             <SectionContent Code="ToggleIconButtonEventCallbackExample" ShowCode="false">

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor
@@ -9,7 +9,7 @@
                Size="(Toggled ? ToggledSize : Size)"
                Color="(Toggled ? ToggledColor : Color)"
                Title="@(Toggled && ToggledTitle != null ? ToggledTitle : Title)"
-               Variant="Variant"
+               Variant="@(Toggled ? ToggledVariant : Variant)"
                Disabled="Disabled"
                Edge="Edge"
                DisableRipple="DisableRipple"

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -101,6 +101,13 @@ namespace MudBlazor
         [Category(CategoryTypes.Button.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
 
+        /// <summary>
+        /// The toggled variant to use.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public Variant ToggledVariant { get; set; } = Variant.Text;
+
         public Task Toggle()
         {
             return SetToggledAsync(!Toggled);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
ToggleIconButton has only the variant parameter and doesn't allow us to change variant regard to toggled state.

ToggledVariant is a common use and have good looking when using properly.

Also added a new doc example to show all basic usages. In the video, the third ToggleIconButton uses ToggledVariant.

https://user-images.githubusercontent.com/78308169/208265824-e6e3e712-cfbf-44ba-bc08-b062870fa140.mp4


## How Has This Been Tested?
It's a pure visual thing, but a new doc example added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
