### PR TITLE
MudTabs: Fix JsInteropException when trimmed binary (#5976)

### DIFF
--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -1,7 +1,15 @@
-﻿namespace MudBlazor.Interop
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MudBlazor.Interop
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public class BoundingClientRect
     {
+        public BoundingClientRect()
+        {
+            //This must be here or we can't deserialize when trimmed
+        }
+
         public double Top { get; set; }
         public double Left { get; set; }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Added attribute to let the trimmer know to leave the public parameterless constructor alone along with adding one just to make sure it's always there for BoundingClientRect. Without this change the MudTabs component doesn't work when used in a trimmed project (default as of .NET 7), instead you're faced with a exception only seen in the console log along with the component not really working right (can't switch tabs)

Fixes #5976

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I've tested this by building MudBlazor and replacing the NuGet package with a copy of my own build and putting it on GitHub Pages where i first discovered the issue.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
