### PR TITLE
MudTabs: Fix JsInteropException when trimmed binary (#6050)

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/BoundingClientRectConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BoundingClientRectConverterTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) MudBlazor 2022
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
+using MudBlazor.Interop;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities
+{
+    [TestFixture]
+    public class BoundingClientRectConverterTests
+    {
+        public BoundingClientRectConverterTests()
+        {
+            _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+            _jsonSerializerOptions.Converters.Clear();
+            _jsonSerializerOptions.Converters.Add(new BoundingClientRectJsonConverter());
+        }
+
+        private readonly JsonSerializerOptions _jsonSerializerOptions;
+
+        [Test]
+        public void SingleDeserializeTest()
+        {
+            var json = "{\"x\":282,\"y\":108.5,\"width\":160,\"height\":48,\"top\":108.5,\"right\":442,\"bottom\":156.5,\"left\":282}";
+            var result = JsonSerializer.Deserialize<BoundingClientRect>(json, _jsonSerializerOptions)!;
+            result.Top.Should().Be(108.5);
+            result.Left.Should().Be(282);
+            result.Width.Should().Be(160);
+            result.Height.Should().Be(48);
+        }
+
+        [Test]
+        public void MultipleDeserializeTest()
+        {
+            var json = "[{\"x\":282,\"y\":108.5,\"width\":160,\"height\":48,\"top\":108.5,\"right\":442,\"bottom\":156.5,\"left\":282},{\"x\":442,\"y\":108.5,\"width\":160,\"height\":48,\"top\":108.5,\"right\":602,\"bottom\":156.5,\"left\":442}]";
+            var result = JsonSerializer.Deserialize<IEnumerable<BoundingClientRect>>(json, _jsonSerializerOptions)!.ToList();
+            result.Count.Should().Be(2);
+
+            result[0].Top.Should().Be(108.5);
+            result[0].Left.Should().Be(282);
+            result[0].Width.Should().Be(160);
+            result[0].Height.Should().Be(48);
+
+            result[1].Top.Should().Be(108.5);
+            result[1].Left.Should().Be(442);
+            result[1].Width.Should().Be(160);
+            result[1].Height.Should().Be(48);
+
+        }
+
+    }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes #6050

I implemented a CustomJson converter for BoundingClientRect to resolve a issue i encountered when using the latest build of MudBlazor, during investigation of the issue i found out that the issue only happened in trimmed binaries.

The converter only supports deserialization as i could not find any use case for it being needed for serialization.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

It's both been tested using my own Blazor application with a custom build of MudBlazor and using a Unit test to verify that it doesn't crash and gets the correct values as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
