### PR TITLE
MudText: Replace h6 with span for subtitle typos (#6059)

### DIFF
--- a/src/MudBlazor/Components/Typography/MudText.razor
+++ b/src/MudBlazor/Components/Typography/MudText.razor
@@ -23,10 +23,10 @@
         <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
         break;
     case Typo.subtitle1:
-        <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
+        <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
     case Typo.subtitle2:
-        <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
+        <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
     case Typo.body1:
         <p @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</p>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Instead of initializing the text with `<h6>` tag for `Typo.subtitle1` and `Typo.subtitle2`, initializes it with the more generic inline container: `<span>` tag.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Resolves #6059 
When using `Typo.subtitle2` on `MudText`, the text is not centered vertically, causing it to look strange with all other vertically centered text.
After further investigation with inspect element, it turns out that the text is being initialized using the tag `<h6>`, causing this inconsistency.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
The text "The University of Somewhere" with `Typo.subtitle2` using `<h6>`:
![image](https://user-images.githubusercontent.com/42851426/210015497-f3f87053-effe-4658-94a2-c2dbb67e4673.png)

The text "The University of Somewhere" with `Typo.subtitle2` using `<span>`:
![image](https://user-images.githubusercontent.com/42851426/210015547-57599eec-5d1d-46d3-8bfb-bd3fbedc5650.png)

Direct comparison. `<h6>` on the left, `<span>` on the right.
![image](https://user-images.githubusercontent.com/42851426/210015830-e6e2d4b8-b1ab-4656-9ad1-0b6b99e02dc6.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
