### PR TITLE
MudTable: Fix 2nd level checkbox default indeterminate state

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
@@ -14,7 +14,7 @@
     }
 </style>
 
-<MudText>Selected items (@selectedItems?.Count): @(selectedItems == null ? "" : string.Join(", ", selectedItems.OrderBy(x => x.Sign).Select(x => x.Sign)))</MudText>
+<MudText>Total items: @Elements?.Count() - Selected items: @selectedItems?.Count</MudText>
 
 <MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
           Items="@Elements"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest.razor
@@ -1,0 +1,73 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSwitch @bind-Checked="_groupsDefinition.Indentation" Color="Color.Primary">Indentation</MudSwitch>
+<MudSwitch @bind-Checked="_groupsDefinition.Expandable" Color="Color.Primary">Expandable (Root Level)</MudSwitch>
+<MudSwitch @bind-Checked="_groupsDefinition.InnerGroup.Expandable" Color="Color.Primary">Expandable (Second Level)</MudSwitch>
+<MudSwitch @bind-Checked="_virtualize" Color="Color.Primary">Virtualize</MudSwitch>
+
+<MudText>Total items: @_cars?.Count() - Selected items: @selectedItems?.Count</MudText>
+
+<MudTable @ref="MudTable" Items="@_cars" Height="500px" FixedHeader="true" Hover Dense MultiSelection Virtualize="@_virtualize"
+          @bind-SelectedItems="selectedItems"
+          GroupBy="@_groupsDefinition"
+          GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
+          GroupFooterStyle="background-color:var(--mud-palette-background-grey)">
+    <HeaderContent>
+        <MudTh>Model:</MudTh>
+    </HeaderContent>
+    <GroupHeaderTemplate>
+        <MudTh Style="font-weight: 500;" colspan="5">@($"{context.GroupName}: {context.Key}")</MudTh>
+    </GroupHeaderTemplate>
+        <RowTemplate>
+            <MudTd DataLabel="Nr">@context.ToString()</MudTd>
+        </RowTemplate>
+    <GroupFooterTemplate>
+        <MudTh Style="font-weight: 500;text-align: right;">Count: @context.Items.Count()</MudTh>
+    </GroupFooterTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "All row-, group- and header/footer checkbox states must be false; nothing selected, no indeterminate state.";
+    public MudTable<TableGroupingTest.RacingCar> MudTable;
+    bool _virtualize;
+    IEnumerable<TableGroupingTest.RacingCar> _cars;
+    HashSet<TableGroupingTest.RacingCar> selectedItems = new();
+
+    protected override Task OnInitializedAsync()
+    {
+        _cars = new List<TableGroupingTest.RacingCar>()
+        {
+                new("919 Hybrid", "Porsche", "LMP1"),
+                new("911 RSR", "Porsche", "GTE"),
+                new("911 RS", "Porsche", "GT3"),
+                new("R18 e-tron quattor", "Audi", "LMP1"),
+                new("R8 LMS", "Audi", "GT3"),
+                new ("F488", "Ferrari", "GTE"),
+                new ("SF-1000", "Ferrari", "Formula 1"),
+                new ("MCL35M", "McLaren", "Formula 1"),
+                new ("720s", "McLaren", "GT3"),
+                new ("Vantage", "Aston Martin", "GTE"),
+                new ("AMR21", "Aston Martin", "Formula 1"),
+        };
+        return base.OnInitializedAsync();
+    }
+
+    private TableGroupDefinition<TableGroupingTest.RacingCar> _groupsDefinition = new()
+    {
+        GroupName = "Category",
+        Selector = rc => rc.Category,
+        Indentation = true,
+        Expandable = true,
+
+        InnerGroup = new TableGroupDefinition<TableGroupingTest.RacingCar>()
+        {
+            GroupName = "Brand",
+            Indentation = true,
+            Expandable = true,
+            Selector = rc => rc.Brand
+        }
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -503,16 +503,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void TableMultiSelection_Grouping2ndLevelCheckboxStateTest()
+        public void TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest()
         {
-            //var comp = Context.RenderComponent<TableMultiGroupingExample>();
-            //var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
-            //var table = comp.FindComponent<MudTable<int>>().Instance;
+            var comp = Context.RenderComponent<TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest>();
+            var mudTable = comp.Instance.MudTable;
 
-            //foreach (var row in rows) row.Click();
-            //table.SelectedItems.Count.Should().Be(0);
+            // All row checkbox states must be false.
+            mudTable.Context.Rows.Count(r => r.Value.IsChecked).Should().Be(0);
+
+            // All grouprow checkbox states must be false.
+            mudTable.Context.GroupRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(14);
+
+            // The headerrow checkbox state must be false.
+            mudTable.Context.HeaderRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(1);
+
+            // The footerrow checkbox state must be false.
+            mudTable.Context.FooterRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(0);
         }
-
 
         /// <summary>
         /// checking the header checkbox should select all items (all checkboxes on, all items in SelectedItems)

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -8,6 +8,7 @@ using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -504,12 +505,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelection_Grouping2ndLevelCheckboxStateTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
-            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
-            var table = comp.FindComponent<MudTable<int>>().Instance;
+            //var comp = Context.RenderComponent<TableMultiGroupingExample>();
+            //var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
+            //var table = comp.FindComponent<MudTable<int>>().Instance;
 
-            foreach (var row in rows) row.Click();
-            table.SelectedItems.Count.Should().Be(0);
+            //foreach (var row in rows) row.Click();
+            //table.SelectedItems.Count.Should().Be(0);
         }
 
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -501,6 +501,17 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(0);
         }
 
+        [Test]
+        public void TableMultiSelection_Grouping2ndLevelCheckboxStateTest()
+        {
+            var comp = Context.RenderComponent<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
+            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+
+            foreach (var row in rows) row.Click();
+            table.SelectedItems.Count.Should().Be(0);
+        }
+
 
         /// <summary>
         /// checking the header checkbox should select all items (all checkboxes on, all items in SelectedItems)
@@ -1635,7 +1646,7 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(2);
 
             inputs = comp.FindAll("input").ToArray();
-            inputs.Where(x => x.IsChecked()).Count().Should().Be(3);
+            inputs.Where(x => x.IsChecked()).Count().Should().Be(5);
 
             inputs[1].Change(false);
             table.SelectedItems.Count.Should().Be(0);

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
-        private bool? _checked;
+        private bool? _checked = false;
         public bool? IsChecked
         {
             get => _checked;

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
-        private bool? _checked;
+        private bool? _checked = false;
         public bool? IsChecked
         {
             get => _checked;

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -462,7 +462,9 @@ namespace MudBlazor
                 Context.Selection.Add(item);
             else
                 Context.Selection.Remove(item);
-            SelectedItemsChanged.InvokeAsync(SelectedItems);
+
+            if (SelectedItemsChanged.HasDelegate)
+                SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
         internal override void OnHeaderCheckboxClicked(bool checkedState)
@@ -474,16 +476,17 @@ namespace MudBlazor
             }
             else
                 Context.Selection.Clear();
-            
-            Context.UpdateRowCheckBoxes(notify: false);
-            SelectedItemsChanged.InvokeAsync(SelectedItems);
+
+            Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+
+            if (SelectedItemsChanged.HasDelegate)
+                SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
                 await InvokeServerLoadFunc();
-
             TableContext.UpdateRowCheckBoxes();
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -576,8 +579,10 @@ namespace MudBlazor
                     Context.Selection.Remove(item);
             }
 
-            Context.UpdateRowCheckBoxes(notify: false);
-            SelectedItemsChanged.InvokeAsync(SelectedItems);
+            Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+
+            if (SelectedItemsChanged.HasDelegate)
+                SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -483,14 +483,6 @@ namespace MudBlazor
                 SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-                await InvokeServerLoadFunc();
-            TableContext.UpdateRowCheckBoxes(updateGroups: false);
-            await base.OnAfterRenderAsync(firstRender);
-        }
-
         /// <summary>
         /// Supply an async function which (re)loads filtered, paginated and sorted data from server.
         /// Table will await this func and update based on the returned TableData.
@@ -537,6 +529,14 @@ namespace MudBlazor
             base.OnAfterRender(firstRender);
             if (!firstRender)
                 Context?.PagerStateHasChanged?.Invoke();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+                await InvokeServerLoadFunc();
+            TableContext.UpdateRowCheckBoxes(updateGroups: false);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -487,7 +487,7 @@ namespace MudBlazor
         {
             if (firstRender)
                 await InvokeServerLoadFunc();
-            TableContext.UpdateRowCheckBoxes();
+            TableContext.UpdateRowCheckBoxes(updateGroups: false);
             await base.OnAfterRenderAsync(firstRender);
         }
 

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -477,7 +477,7 @@ namespace MudBlazor
             else
                 Context.Selection.Clear();
 
-            Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+            Context.UpdateRowCheckBoxes();
 
             if (SelectedItemsChanged.HasDelegate)
                 SelectedItemsChanged.InvokeAsync(SelectedItems);
@@ -579,7 +579,7 @@ namespace MudBlazor
                     Context.Selection.Remove(item);
             }
 
-            Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+            Context.UpdateRowCheckBoxes();
 
             if (SelectedItemsChanged.HasDelegate)
                 SelectedItemsChanged.InvokeAsync(SelectedItems);

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -43,6 +43,8 @@ else
 
 @if (IsExpanded)
 {
+    Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+
     @*CHILDREN:*@
     @if (_innerGroupItems != null && GroupDefinition != null)
     {

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -43,7 +43,7 @@ else
 
 @if (IsExpanded)
 {
-    Context.UpdateRowCheckBoxes(notify: false, updateRows: false);
+    Context?.UpdateRowCheckBoxes();
 
     @*CHILDREN:*@
     @if (_innerGroupItems != null && GroupDefinition != null)

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -80,7 +80,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
-        private bool? _checked;
+        private bool? _checked = false;
         public bool? IsChecked
         {
             get => _checked;

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -53,6 +53,9 @@ namespace MudBlazor
         /// <summary>
         /// Updates the state of all group- and/or header/footer checkboxs.
         /// </summary>
+        /// <remarks>
+        /// Setting checkbox state for Row items and refresh all, is triggered from MudTable OnAfterRenderAsync.
+        /// </remarks>
         public override void UpdateRowCheckBoxes(bool updateGroups = true, bool updateHeaderFooter = true)
         {
             if (!Table.MultiSelection)
@@ -61,14 +64,14 @@ namespace MudBlazor
             if (updateGroups)
             {
                 // Update group checkboxes
-                foreach (var row in GroupRows)
+                foreach (var groupRow in GroupRows)
                 {
-                    var rowGroupItems = row.Items.ToList();
+                    var rowGroupItems = groupRow.Items.ToList();
                     var itemsCount = Selection.Intersect(rowGroupItems).Count();
                     var selectAll = itemsCount == rowGroupItems.Count;
                     var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
                     var state = indeterminate && !selectAll ? (bool?)null : selectAll;
-                    row.SetChecked(state, notify: false);
+                    groupRow.SetChecked(state, notify: false);
                 }
             }
 
@@ -83,12 +86,12 @@ namespace MudBlazor
                     var state = indeterminate ? (bool?)null : isChecked;
 
                     // Update header checkbox
-                    foreach (var header in HeaderRows)
-                        header.SetChecked(state, notify: false);
+                    foreach (var headerRow in HeaderRows)
+                        headerRow.SetChecked(state, notify: false);
 
                     // Update footer checkbox
-                    foreach (var footer in FooterRows)
-                        footer.SetChecked(state, notify: false);
+                    foreach (var footerRow in FooterRows)
+                        footerRow.SetChecked(state, notify: false);
                 }
             }
         }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         public bool HasPager { get; set; }
         public abstract void Add(MudTr row, object item);
         public abstract void Remove(MudTr row, object item);
-        public abstract void UpdateRowCheckBoxes(bool notify = true);
+        public abstract void UpdateRowCheckBoxes(bool notify = true, bool updateRows = true);
         public List<MudTHeadRow> HeaderRows { get; set; } = new List<MudTHeadRow>();
         public List<MudTFootRow> FooterRows { get; set; } = new List<MudTFootRow>();
 
@@ -50,17 +50,25 @@ namespace MudBlazor
 
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new List<MudTableSortLabel<T>>();
 
-        public override void UpdateRowCheckBoxes(bool notify = true)
+        /// <summary>
+        /// Updates the checkboxe checked state of all row-, group-, header- and footer items.
+        /// </summary>
+        public override void UpdateRowCheckBoxes(bool notify = true, bool updateRows = true)
         {
             if (!Table.MultiSelection)
                 return;
-            // Update row checkboxes
-            foreach (var pair in Rows.ToArray())
+
+            if (updateRows)
             {
-                var row = pair.Value;
-                var item = pair.Key;
-                row.SetChecked(Selection.Contains(item), notify);
+                // Update row checkboxes
+                foreach (var pair in Rows.ToArray())
+                {
+                    var row = pair.Value;
+                    var item = pair.Key;
+                    row.SetChecked(Selection.Contains(item), notify);
+                }
             }
+
             // Update group checkboxes
             foreach (var row in GroupRows)
             {
@@ -68,21 +76,25 @@ namespace MudBlazor
                 var itemsCount = Selection.Intersect(rowGroupItems).Count();
                 var selectAll = itemsCount == rowGroupItems.Count;
                 var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
-                row.SetChecked(indeterminate && !selectAll ? null : selectAll, notify: false);
+                var state = indeterminate && !selectAll ? (bool?)null : selectAll;
+                row.SetChecked(state, notify: false);
             }
+
             if (HeaderRows.Count > 0 || FooterRows.Count > 0)
             {
                 var itemsCount = Table.GetFilteredItemsCount();
                 var selectAll = Selection.Count == itemsCount;
                 var indeterminate = !selectAll && Selection.Count > 0;
                 var isChecked = selectAll && itemsCount != 0;
+                var state = indeterminate ? (bool?)null : isChecked;
+
                 // Update header checkbox
                 foreach (var header in HeaderRows)
-                    header.SetChecked(indeterminate ? null : isChecked, notify: false);
+                    header.SetChecked(state, notify: false);
 
                 // Update footer checkbox
                 foreach (var footer in FooterRows)
-                    footer.SetChecked(indeterminate ? null : isChecked, notify: false);
+                    footer.SetChecked(state, notify: false);
             }
         }
 

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         public bool HasPager { get; set; }
         public abstract void Add(MudTr row, object item);
         public abstract void Remove(MudTr row, object item);
-        public abstract void UpdateRowCheckBoxes(bool notify = true, bool updateRows = true);
+        public abstract void UpdateRowCheckBoxes();
         public List<MudTHeadRow> HeaderRows { get; set; } = new List<MudTHeadRow>();
         public List<MudTFootRow> FooterRows { get; set; } = new List<MudTFootRow>();
 
@@ -51,23 +51,12 @@ namespace MudBlazor
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new List<MudTableSortLabel<T>>();
 
         /// <summary>
-        /// Updates the checkboxe checked state of all row-, group-, header- and footer items.
+        /// Updates the state of all group-, header- and footer checkboxs.
         /// </summary>
-        public override void UpdateRowCheckBoxes(bool notify = true, bool updateRows = true)
+        public override void UpdateRowCheckBoxes()
         {
             if (!Table.MultiSelection)
                 return;
-
-            if (updateRows)
-            {
-                // Update row checkboxes
-                foreach (var pair in Rows.ToArray())
-                {
-                    var row = pair.Value;
-                    var item = pair.Key;
-                    row.SetChecked(Selection.Contains(item), notify);
-                }
-            }
 
             // Update group checkboxes
             foreach (var row in GroupRows)

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         public bool HasPager { get; set; }
         public abstract void Add(MudTr row, object item);
         public abstract void Remove(MudTr row, object item);
-        public abstract void UpdateRowCheckBoxes();
+        public abstract void UpdateRowCheckBoxes(bool updateGroups = true, bool updateHeaderFooter = true);
         public List<MudTHeadRow> HeaderRows { get; set; } = new List<MudTHeadRow>();
         public List<MudTFootRow> FooterRows { get; set; } = new List<MudTFootRow>();
 
@@ -51,39 +51,45 @@ namespace MudBlazor
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new List<MudTableSortLabel<T>>();
 
         /// <summary>
-        /// Updates the state of all group-, header- and footer checkboxs.
+        /// Updates the state of all group- and/or header/footer checkboxs.
         /// </summary>
-        public override void UpdateRowCheckBoxes()
+        public override void UpdateRowCheckBoxes(bool updateGroups = true, bool updateHeaderFooter = true)
         {
             if (!Table.MultiSelection)
                 return;
 
-            // Update group checkboxes
-            foreach (var row in GroupRows)
+            if (updateGroups)
             {
-                var rowGroupItems = row.Items.ToList();
-                var itemsCount = Selection.Intersect(rowGroupItems).Count();
-                var selectAll = itemsCount == rowGroupItems.Count;
-                var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
-                var state = indeterminate && !selectAll ? (bool?)null : selectAll;
-                row.SetChecked(state, notify: false);
+                // Update group checkboxes
+                foreach (var row in GroupRows)
+                {
+                    var rowGroupItems = row.Items.ToList();
+                    var itemsCount = Selection.Intersect(rowGroupItems).Count();
+                    var selectAll = itemsCount == rowGroupItems.Count;
+                    var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
+                    var state = indeterminate && !selectAll ? (bool?)null : selectAll;
+                    row.SetChecked(state, notify: false);
+                }
             }
 
-            if (HeaderRows.Count > 0 || FooterRows.Count > 0)
+            if (updateHeaderFooter)
             {
-                var itemsCount = Table.GetFilteredItemsCount();
-                var selectAll = Selection.Count == itemsCount;
-                var indeterminate = !selectAll && Selection.Count > 0;
-                var isChecked = selectAll && itemsCount != 0;
-                var state = indeterminate ? (bool?)null : isChecked;
+                if (HeaderRows.Count > 0 || FooterRows.Count > 0)
+                {
+                    var itemsCount = Table.GetFilteredItemsCount();
+                    var selectAll = Selection.Count == itemsCount;
+                    var indeterminate = !selectAll && Selection.Count > 0;
+                    var isChecked = selectAll && itemsCount != 0;
+                    var state = indeterminate ? (bool?)null : isChecked;
 
-                // Update header checkbox
-                foreach (var header in HeaderRows)
-                    header.SetChecked(state, notify: false);
+                    // Update header checkbox
+                    foreach (var header in HeaderRows)
+                        header.SetChecked(state, notify: false);
 
-                // Update footer checkbox
-                foreach (var footer in FooterRows)
-                    footer.SetChecked(state, notify: false);
+                    // Update footer checkbox
+                    foreach (var footer in FooterRows)
+                        footer.SetChecked(state, notify: false);
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Fixes #6072

## How Has This Been Tested?
-Tested this with several company apps.
-Visually, manually, using the Doc examples regarding MultiSelect and Grouping.
-Also tested this with Virtualization mode.
-Unit tests; slight modification of existing unit tests to accommodate for the checkbox tri-state.
-Added visual unit test.

Bug:
![Animation](https://user-images.githubusercontent.com/10358198/210170432-e0e1f762-ad9c-4788-921a-c95aa10053b7.gif)

Expected:
![Animation](https://user-images.githubusercontent.com/10358198/210255127-da409455-051f-4c1b-bf90-a50666649375.gif)



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- The default value for `public bool? IsChecked` is now `false` instead of `null`.
This is the root cause and reason for this PR.
- Just like in my PR #5985,
I had to modify a unit test to accommodate for indeterminate state.
- Signature change for method `public abstract void UpdateRowCheckBoxes()`

I believe I was able to refine method `UpdateRowCheckBoxes()` to increase performance.


<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
