### PR TITLE
MudDialog: Added Draggable as a DialogOption.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
@@ -8,7 +8,7 @@
 <MudButton OnClick="@((e) => OpenDialog(disableBackdropClick))" Color="Color.Tertiary">Disable backdrop dialog</MudButton>
 <MudButton OnClick="@((e) => OpenDialog(fullScreen))" Color="Color.Info">Full Screen Dialog</MudButton>
 <MudButton OnClick="@((e) => OpenDialog(topCenter))" Color="Color.Success">Top Center Dialog</MudButton>
-
+<MudButton OnClick="@((e) => OpenDialog(draggable))" Color="Color.Warning">Draggable Dialog</MudButton>
 
 @code {
     DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true };
@@ -17,6 +17,7 @@
     DialogOptions disableBackdropClick = new DialogOptions() { DisableBackdropClick = true };
     DialogOptions fullScreen = new DialogOptions() { FullScreen = true, CloseButton = true };
     DialogOptions topCenter = new DialogOptions() { Position = DialogPosition.TopCenter };
+    DialogOptions draggable = new DialogOptions() { Draggable = true };
 
     private void OpenDialog(DialogOptions options)
     {

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -6,10 +6,14 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Css.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Moq;
+using MudBlazor.Interop;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Dialog;
 using NUnit.Framework;
@@ -825,6 +829,48 @@ namespace MudBlazor.UnitTests.Components
         {
             Func<IDialogReference> createMock = Moq.Mock.Of<IDialogReference>;
             createMock.Should().NotThrow();
+        }
+
+        [Test]
+        public async Task DialogDraggableOption()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetService<IDialogService>();
+            IDialogReference dialogReference = null;
+            //draggable dialog
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { Draggable = true }));
+            dialogReference.Should().NotBe(null);
+
+            comp.Find("div.mud-dialog .mud-dialog-title").GetAttribute("class").Should().Be("mud-dialog-title cursor-move");
+        }
+
+        [Test]
+        public async Task DraggableDialogDragged()
+        {
+            Mock<IJSRuntime> _jsruntimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            Context.Services.AddSingleton(typeof(IJSRuntime), _jsruntimeMock.Object);
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", It.IsAny<object[]>()
+                                )).ReturnsAsync(new BoundingClientRect()).Verifiable();
+
+
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetService<IDialogService>();
+            IDialogReference dialogReference = null;
+
+            //draggable dialog
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>(string.Empty, new DialogOptions() { Draggable = true }));
+            dialogReference.Should().NotBe(null);
+
+            var dialogTitle = comp.Find("div.mud-dialog .mud-dialog-title");
+
+            comp.Find("div.mud-dialog").GetAttribute("style").Should().NotContain("position:absolute");
+
+            await dialogTitle.MouseDownAsync(new MouseEventArgs() { ClientX = 13, ClientY = 37 });
+            await dialogTitle.MouseMoveAsync(new MouseEventArgs() { ClientX = 13, ClientY = 37 });
+
+            comp.Find("div.mud-dialog").GetAttribute("style").Should().Contain("position:absolute");
         }
     }
 

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using AngleSharp.Css.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
         public bool? CloseOnEscapeKey { get; set; }
         public bool? NoHeader { get; set; }
         public bool? CloseButton { get; set; }
+        public bool? Draggable { get; set; }
         public bool? FullScreen { get; set; }
         public bool? FullWidth { get; set; }
     }

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position" @onmousemove="Drag" @onmouseup="StopDragging">
+<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position" @onmousemove:preventDefault @onmousemove="Drag" @onmouseup="StopDragging">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClick" Class="mud-overlay-dialog" DarkBackground="true" />
     <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@InternalStyle">
         @if (!NoHeader)
         {
-            <div class="@InternalClass" @onmousedown="StartDragging" @ref="_dialogTitle">
+            <div class="@InternalClass" @onmousedown:preventDefault @onmousedown="StartDragging" @ref="_dialogTitle">
                 @if (TitleContent == null)
                 {
                     <MudText Typo="Typo.h6">@Title</MudText>

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position">
+<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position" @onmousemove="Drag" @onmouseup="StopDragging">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClick" Class="mud-overlay-dialog" DarkBackground="true" />
-    <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style">
+    <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@InternalStyle">
         @if (!NoHeader)
         {
-            <div class="mud-dialog-title">
+            <div class="@InternalClass" @onmousedown="StartDragging" @ref="_dialogTitle">
                 @if (TitleContent == null)
                 {
                     <MudText Typo="Typo.h6">@Title</MudText>


### PR DESCRIPTION
Added the parameter `Draggable` to the `DialogOptions` class. This parameter alters the behavior of the `MudDialogInstance` component. 

## Description
By adding the `Draggable` parameter to the `DialogOptions` class the user has the ability to create a draggable dialog. GIF of the resulting behavior:

![Muddialog draggable](https://user-images.githubusercontent.com/36229816/210363455-98b2f2e3-0039-4936-9fae-84094508706b.gif)

This has also been added to the documentation on the MudDialog page under the "Per Dialog" section.

The implementation contains no JsInterop except the method for getting the  BoundingClientRect (`MudGetBoundingClientRectAsync`) besides that it is purely written in C#.

## How Has This Been Tested?
- The `MudBlazor.Docs.Server` project has successfully compiled 
- All the tests in `MudBlazor.UnitTests` have passed.
- Two new tests have been added in the `DialogTests.cs` class to cover the code added for the draggable behavior:
  - DialogDraggableOption
  - DraggableDialogDragged

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
