### PR TITLE
MudTabs: Fix incorrect ActivePanelIndex

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -49,7 +49,8 @@
         if (_stateHasChanged)
         {
             _stateHasChanged = false;
-            StateHasChanged();        }
+            StateHasChanged();
+        }
     }
 
     public void AddTab(Guid id)

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -1,18 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDynamicTabs @ref="@DynamicTabs"
-                Elevation="4" PanelClass="px-4 py-6"
-                Rounded="true" ApplyEffectsToContainer="true"
-                AddTab="AddTabCallback"
-                CloseTab="@((panel) => CloseTabCallback(panel))" @bind-ActivePanelIndex="UserIndex"
-                AddIconToolTip="Click here to add a new tab"
-                CloseIconToolTip="Close this tab. All data will be lost">
+<MudDynamicTabs @ref="@DynamicTabs" @bind-ActivePanelIndex="@UserIndex"
+                AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
+                AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
+                PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
     @foreach (var item in UserTabs)
     {
-        <MudTabPanel Text="@item.Name" Tag="@item.Id">@item.Content</MudTabPanel>
+        <MudTabPanel ID="@item.Id" Text="@item.Label">@item.Content</MudTabPanel>
     }
 </MudDynamicTabs>
-<MudButton Color="Color.Primary" OnClick="Restore" Size="Size.Small" Class="ml-2 mt-1 mb-n2">Restore</MudButton>
+<MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
 <MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
 <MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
 
@@ -20,55 +17,58 @@
 
     public class TabView
     {
-        public String Name { get; set; }
-        public String Content { get; set; }
+        public string Label { get; set; }
+        public string Content { get; set; }
         public Guid Id { get; set; }
     }
 
     public MudDynamicTabs DynamicTabs;
     public List<TabView> UserTabs = new();
-    public int UserIndex = 0;
-    private bool _updateIndex = false;
+    public int UserIndex;
+    bool _stateHasChanged;
 
-    private void Restore()
+    void RestoreUserTabs()
     {
         UserTabs.Clear();
-        UserTabs.Add(new TabView { Content = "First tab content", Name = "Tab A", Id = Guid.NewGuid() });
-        UserTabs.Add(new TabView { Content = "Second tab content", Name = "Tab B", Id = Guid.NewGuid() });
-        UserTabs.Add(new TabView { Content = "Third tab content", Name = "Tab C", Id = Guid.NewGuid() });
-        _updateIndex = true;
+        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content"});
+        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab B", Content = "Tab B content"});
+        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content"});
+        UserIndex = 1; // Start on 2nd tab: "Tab B"
+        _stateHasChanged = true;
     }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Restore();
-    }
-
-    private void AddTabCallback()
-    {
-        UserTabs.Add(new TabView { Name = "Dynamic Content", Content = "A new tab", Id = Guid.NewGuid() });
-        //the tab becomes available after it is rendered. Hence, we can't set the index here
-        _updateIndex = true;
-    }
-
-    private void CloseTabCallback(MudTabPanel panel)
-    {
-        var tabView = UserTabs.FirstOrDefault(x => x.Id == (Guid)panel.Tag);
-        if (tabView != null)
-        {
-            UserTabs.Remove(tabView);
-            _updateIndex = true;
-        }
+        RestoreUserTabs();
     }
 
     protected override void OnAfterRender(bool firstRender)
     {
-        if (_updateIndex == true)
+        base.OnAfterRender(firstRender);
+        if (_stateHasChanged)
         {
-            UserIndex = UserTabs.Count - 1;
-            _updateIndex = false;
-            StateHasChanged();
+            _stateHasChanged = false;
+            StateHasChanged();        }
+    }
+
+    public void AddTab(Guid id)
+    {
+        UserTabs.Add(new TabView {Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}"});
+        UserIndex = UserTabs.Count - 1; // Automatically switch to the new tab.
+        _stateHasChanged = true;
+    }
+
+    public void RemoveTab(Guid id)
+    {
+        var tabView = UserTabs.SingleOrDefault((t) => Equals(t.Id, id));
+        if (tabView is not null)
+        {
+            UserTabs.Remove(tabView);
+            _stateHasChanged = true;
         }
     }
+
+    void AddTabCallback() => AddTab(Guid.NewGuid());
+    void CloseTabCallback(MudTabPanel panel) => RemoveTab((Guid)panel.ID);
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1039,38 +1039,36 @@ namespace MudBlazor.UnitTests.Components
             var userTabs = comp.Instance.UserTabs;
             var mudTabs = comp.Instance.DynamicTabs;
 
+            // Initial
             userTabs.Count.Should().Be(3);
             mudTabs.Panels.Count.Should().Be(3);
 
             // Remove
-            userTabs.Remove(userTabs.Last());
+            comp.Instance.RemoveTab(userTabs.Last().Id);
             userTabs.Count.Should().Be(2);
-            // MudTabs needs render.
-            mudTabs.Panels.Count.Should().Be(3);
-            comp.Render();
+            comp.Render(); // Render to refresh MudTabs
             mudTabs.Panels.Count.Should().Be(2);
 
             // Add
-            userTabs.Add(userTabs.First());
+            comp.Instance.AddTab(Guid.NewGuid());
             userTabs.Count.Should().Be(3);
-            // MudTabs needs render.
-            comp.Render();
+            comp.Render(); // Render to refresh MudTabs
             mudTabs.Panels.Count.Should().Be(3);
 
-            // Remove all, no ArgumentOutOfRangeException may be thrown.
-            userTabs.Remove(userTabs.Last());
-            userTabs.Remove(userTabs.Last());
-            userTabs.Remove(userTabs.Last());
+            // Remove all, no ArgumentOutOfRangeException should be thrown.
+            comp.Instance.RemoveTab(userTabs.Last().Id);
+            comp.Instance.RemoveTab(userTabs.Last().Id);
+            comp.Instance.RemoveTab(userTabs.Last().Id);
             userTabs.Count.Should().Be(0);
-            // MudTabs needs render.
-            comp.Render();
+            comp.Render(); // Render to refresh MudTabs.
             mudTabs.Panels.Count.Should().Be(0);
 
-            // TODO 2023-01-01: Disabled; Will be addressed in a future PR
-            // No panels means no active panel index.
-            // Note that in the docs example -1 is returned instead of 0.
-            //comp.Instance.UserIndex.Should().Be(0);
-            //mudTabs.ActivePanelIndex.Should().Be(0);
+            // No active panel.
+            mudTabs.ActivePanel.Should().BeNull();
+
+            // No active panel means no active panel index.
+            comp.Instance.UserIndex.Should().Be(-1);
+            mudTabs.ActivePanelIndex.Should().Be(-1);
         }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -316,7 +316,7 @@ namespace MudBlazor
                 var items = _panels.Select(x => x.PanelRef).ToList();
                 items.Add(_tabsContentSize);
 
-                if (_panels.Count > 0)
+                if (_activePanelIndex != -1 && _panels.Count > 0)
                     ActivePanel = _panels[_activePanelIndex];
 
                 await _resizeObserver.Observe(items);
@@ -349,9 +349,6 @@ namespace MudBlazor
             if (_panels.Count == 1)
                 ActivePanel = tabPanel;
             StateHasChanged();
-
-            if (_panels.Count == 1 && _activePanelIndex == -1)
-                ActivePanelIndex = 0;
         }
 
         internal async Task SetPanelRef(ElementReference reference)

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -370,7 +370,14 @@ namespace MudBlazor
 
             // We're at the right-most tab.
             if (_activePanelIndex == index && index == _panels.Count - 1)
-                ActivePanelIndex = _panels.Count == 1 ? -1 : index > 0 ? index - 1 : 0;
+            {
+                if (_panels.Count == 1)
+                    ActivePanelIndex = -1;
+                else if (index > 0)
+                    ActivePanelIndex = index - 1;
+                else
+                    ActivePanelIndex = 0;
+            }
 
             // Active tab is not necessarily the tab being closed.
             else if (_activePanelIndex > index)


### PR DESCRIPTION
## Description
Following up on PR #6070, this PR fixes the return value for the MudTab `ActivePanelIndex` property.
In the docs example it correctly returns `-1`, but in the unit tests it returns `0`.

## How Has This Been Tested?
unit | visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

-Fixed Docs example code.

The current situation:
-On startup, Tab C should be the active tab and not Tab A, the `ActivePanelIndex` is out of sync;
-On startup, clicking on Tab C does not work;

![Animation](https://user-images.githubusercontent.com/10358198/210757398-b5d299fa-c019-424c-a996-a4c00718d6e5.gif)

-PR fixes:
-On startup, Tab B is correctly set as the active tab;
-There's a slight behavioral change in that the tab panel click-event is now always raised, even when `ev` is null:
https://github.com/MudBlazor/MudBlazor/blob/73ea3e9c4459e605b226d65f33732ac5cca3c622/src/MudBlazor/Components/Tabs/MudTabs.razor.cs#L415-L416
![Animation](https://user-images.githubusercontent.com/10358198/210759382-ff1d4147-cdbc-4fd7-b698-c1bc5d2723c4.gif)


## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
