### PR TITLE
MudTd/MudTh: Add ability to toggle visibility of columns

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableToggleColumnsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableToggleColumnsExample.razor
@@ -1,0 +1,45 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable Items="@Elements" Hover="true" SortLabel="Sort By">
+    <HeaderContent>
+        <MudTh Visible="_showNr">Nr</MudTh>
+        <MudTh Visible="_showSign">Sign</MudTh>
+        <MudTh Visible="_showName">Name</MudTh>
+        <MudTh Visible="_showPosition">Position</MudTh>
+        <MudTh Visible="_showMolasMass">Mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd Visible="_showNr" DataLabel="Nr">@context.Number</MudTd>
+        <MudTd Visible="_showSign" DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd Visible="_showName" DataLabel="Name">@context.Name</MudTd>
+        <MudTd Visible="_showPosition" DataLabel="Position">@context.Position</MudTd>
+        <MudTd Visible="_showMolasMass" DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
+    </PagerContent>
+</MudTable>
+
+<MudSwitch @bind-Checked="_showNr" Color="Color.Info">Nr</MudSwitch>
+<MudSwitch @bind-Checked="_showSign" Color="Color.Info">Sign</MudSwitch>
+<MudSwitch @bind-Checked="_showName" Color="Color.Info">Name</MudSwitch>
+<MudSwitch @bind-Checked="_showPosition" Color="Color.Info">Position</MudSwitch>
+<MudSwitch @bind-Checked="_showMolasMass" Color="Color.Info">Molar Mass</MudSwitch>
+
+@code {
+    private bool _showNr = true;
+    private bool _showSign = true;
+    private bool _showName = true;
+    private bool _showPosition = true;
+    private bool _showMolasMass = true;
+
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -76,6 +76,21 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Dynamically Toggling Columns">
+                <Description>
+                    By setting the <CodeInline>Visibile</CodeInline> property on the <CodeInline>&lt;MudTh></CodeInline> and <CodeInline>&lt;MudTd></CodeInline> of the desired column, you are able to
+                    dynamically toggle columns.
+                        <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                            <CodeInline>Visible</CodeInline> of <CodeInline>&lt;MudTh></CodeInline> and <CodeInline>&lt;MudTd></CodeInline> must be set simultaneously to ensure columns appear/dissappear correctly
+                        </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="TableToggleColumnsExample" ShowCode="false" Block="true" FullWidth="true">
+                <TableToggleColumnsExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Multi-Selection">
                 <Description>
                     To enable multiselection of rows using checkboxes, set <CodeInline>MultiSelection="true"</CodeInline>.<br />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableToggleColumnsTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableToggleColumnsTest1.razor
@@ -1,0 +1,21 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+
+<MudTable Items="@Examples" T="string">
+    <HeaderContent>
+        <MudTh Visible="Visible">#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd Visible="Visible">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public bool Visible;
+    private IEnumerable<string> Examples = new List<string>();
+
+    protected override void OnInitialized()
+    {
+        Examples = new List<string>() { "A","B","C" };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableToggleColumnsTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableToggleColumnsTest2.razor
@@ -1,0 +1,21 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+
+<MudTable Items="@Examples" T="string" Breakpoint="Breakpoint.Always">
+    <HeaderContent>
+        <MudTh Visible="Visible">#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd Visible="Visible">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public bool Visible;
+    private IEnumerable<string> Examples = new List<string>();
+
+    protected override void OnInitialized()
+    {
+        Examples = new List<string>() { "A","B","C" };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1967,5 +1967,35 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell")[1].TextContent.Should().Be("Value_0");
             comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(true);
         }
+        [Test]
+        public async Task TestTogglingColumnsSmallScreen()
+        {
+            var comp = Context.RenderComponent<TableToggleColumnsTest2>();
+            var tableCellsMarkup = comp.FindAll(".mud-table-cell").Select(x => x.ToMarkupElementOnly()).ToList();
+            tableCellsMarkup[0].Should().Be("<th scope=\"col\" class=\"mud-table-cell\" style=\"display:none;\">...</th>");
+            tableCellsMarkup.Skip(1).Take(3).All(x => x == "<td style=\"display:none;\" class=\"mud-table-cell\">...</td>").Should().Be(true);
+            tableCellsMarkup.Count.Should().Be(4);
+            comp.Instance.Visible = true;
+            comp.Render();
+            var updatedMarkup = comp.FindAll(".mud-table-cell").Select(x => x.ToMarkupElementOnly()).ToList();
+            updatedMarkup[0].Should().Be("<th scope=\"col\" class=\"mud-table-cell\" style=\"\">...</th>");
+            updatedMarkup.Skip(1).Take(3).All(x => x == "<td style=\"\" class=\"mud-table-cell\">...</td>").Should().Be(true);
+            updatedMarkup.Count.Should().Be(4);
+        }
+        [Test]
+        public async Task TestTogglingColumnsWideScreen()
+        {
+            var comp = Context.RenderComponent<TableToggleColumnsTest1>();
+            var tableCellsMarkup = comp.FindAll(".mud-table-cell").Select(x => x.ToMarkupElementOnly()).ToList();
+            tableCellsMarkup[0].Should().Be("<th scope=\"col\" class=\"mud-table-cell\" style=\"display:none;\">...</th>");
+            tableCellsMarkup.Skip(1).Take(3).All(x => x == "<td style=\"display:none;\" class=\"mud-table-cell\">...</td>").Should().Be(true);
+            tableCellsMarkup.Count.Should().Be(4);
+            comp.Instance.Visible = true;
+            comp.Render();
+            var updatedMarkup = comp.FindAll(".mud-table-cell").Select(x => x.ToMarkupElementOnly()).ToList();
+            updatedMarkup[0].Should().Be("<th scope=\"col\" class=\"mud-table-cell\" style=\"\">...</th>");
+            updatedMarkup.Skip(1).Take(3).All(x => x == "<td style=\"\" class=\"mud-table-cell\">...</td>").Should().Be(true);
+            updatedMarkup.Count.Should().Be(4);
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTd.razor
+++ b/src/MudBlazor/Components/Table/MudTd.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<td data-label="@DataLabel" style="@Style" class="@Classname" @attributes="@UserAttributes">
+<td data-label="@DataLabel" style="@TdStyle" class="@Classname" @attributes="@UserAttributes">
     @ChildContent
 </td>

--- a/src/MudBlazor/Components/Table/MudTd.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTd.razor.cs
@@ -20,5 +20,17 @@ namespace MudBlazor
         /// Hide cell when breakpoint is smaller than the defined value in table.
         /// </summary>
         [Parameter] public bool HideSmall { get; set; }
+
+        /// <summary>
+        /// Used to control whether this column data is visible.
+        /// Must be set on MudTh of same property to achieve
+        /// proper toggling of columns
+        /// </summary>
+        [Parameter] public bool Visible { get; set; } = true;
+        private string TdStyle => new StyleBuilder()
+            .AddStyle("display", "none", !Visible)
+            .AddStyle(Style)
+            .Build();
+
     }
 }

--- a/src/MudBlazor/Components/Table/MudTh.razor
+++ b/src/MudBlazor/Components/Table/MudTh.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-<th scope="col" class="@Classname" style="@Style" @attributes="@UserAttributes">
+<th scope="col" class="@Classname" style="@ThStyle" @attributes="@UserAttributes">
     @ChildContent
 </th>
 

--- a/src/MudBlazor/Components/Table/MudTh.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTh.razor.cs
@@ -1,7 +1,4 @@
-﻿
-
-using Microsoft.AspNetCore.Components;
-
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -12,6 +9,16 @@ namespace MudBlazor
             .AddClass(Class).Build();
 
         [Parameter] public RenderFragment ChildContent { get; set; }
+        /// <summary>
+        /// Used to control whether this header column is visible.
+        /// Must be set on MudTd of same property to achieve
+        /// proper toggling of columns
+        /// </summary>
+        [Parameter] public bool Visible { get; set; } = true;
+        private string ThStyle => new StyleBuilder()
+            .AddStyle("display", "none", !Visible)
+            .AddStyle(Style)
+            .Build();
     }
 }
 


### PR DESCRIPTION
## Description
Adds the ability to toggle Table columns by changing the `Visible` property of `MudTh` and `MudTd`

## How Has This Been Tested?
unit & visually
I created a new Unit test in `TableTests` that ensure table cells have a style of `display: none;` when Visible is set to false

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
[Video showing functionality in Docs](https://streamable.com/cc35ft)
![All properties](https://user-images.githubusercontent.com/84036995/213057502-f2e26f6b-44b6-4f50-a253-d5936671a63b.png)
![Some properties](https://user-images.githubusercontent.com/84036995/213057654-ab9651a8-31d9-4374-9bda-1ef193ec7ab0.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
