### PR TITLE
MudTable: Add null check on server data items in FilteredItems

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest6.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    #pragma warning disable CS1998 // async without await
+    public static string __description__ = "The table should not crash when the TableData Items are null.";
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<int>> ServerReload(TableState state)
+    {
+        return new TableData<int>();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1022,6 +1022,15 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The table should not crash if its ServerData Items are null
+        /// </summary>
+        [Test]
+        public async Task TableServerSideDataNull()
+        {
+            var comp = Context.RenderComponent<TableServerSideDataTest6>();
+        }
+
+        /// <summary>
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -358,7 +358,7 @@ namespace MudBlazor
                     return _preEditSort;
                 if (ServerData != null)
                 {
-                    _preEditSort = _server_data.Items.ToList();
+                    _preEditSort = _server_data.Items?.ToList();
                     return _preEditSort;
                 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes an issue where adjusting the page size would cause a null exception due to the server data items being null at that point.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

All existing tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
