### PR TITLE
MudDateRangePicker: Fix DateRangePicker validation in MudForm (#6194)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDateRangePickerTest.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudForm ValidationDelay="0">
+    <MudDateRangePicker Required="true" @bind-DateRange="DateRange">
+    </MudDateRangePicker>
+</MudForm>
+
+@code {
+    public static string __description__ = "Form should validate date range picker's date range.";
+
+    [Parameter]
+    public DateRange? DateRange { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -616,6 +617,73 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// DateRangePicker should be validated like every other form component when the dateRange
+        /// is changed via inputs
+        /// </summary>
+        [Test]
+        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs()
+        {
+            var comp = Context.RenderComponent<FormWithDateRangePickerTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dateRangeComp = comp.FindComponent<MudDateRangePicker>();
+            var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
+            var firstDateTime = new DateTime(2023, 01, 20);
+            var secondDateTime = new DateTime(2023, 02, 20);
+            // check initial state: form should not be valid because dateRangePicker is required
+            form.IsValid.Should().Be(false);
+            dateRangePicker.Error.Should().BeFalse();
+            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            // input a date
+            await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[0].Change(firstDateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern)));
+            await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[1].Change(secondDateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern)));
+            form.IsValid.Should().Be(true);
+            form.Errors.Length.Should().Be(0);
+            dateRangePicker.Error.Should().BeFalse();
+            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            // clear selection
+            comp.SetParam(x => x.DateRange, null);
+            form.IsValid.Should().Be(false);
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Required");
+            dateRangePicker.Error.Should().BeTrue();
+            dateRangePicker.ErrorText.Should().Be("Required");
+        }
+        
+        /// <summary>
+        /// DateRangePicker should be validated like every other form component when the dateRange is selected using
+        /// the picker
+        /// </summary>
+        [Test]
+        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaPicker()
+        {
+            var comp = Context.RenderComponent<FormWithDateRangePickerTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
+            // check initial state: form should not be valid because dateRangePicker is required
+            form.IsValid.Should().Be(false);
+            dateRangePicker.Error.Should().BeFalse();
+            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            comp.Find("input").Click();
+            // clicking day buttons to select a date range
+            await comp.InvokeAsync(() => comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).Click());
+            await comp.InvokeAsync(() => comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("11")).Click());
+            // wait for picker to close
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(0));
+            form.IsTouched.Should().Be(true);
+            form.IsValid.Should().Be(true);
+            form.Errors.Length.Should().Be(0);
+            dateRangePicker.Error.Should().BeFalse();
+            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            // clear selection
+            comp.SetParam(x => x.DateRange, null);
+            form.IsValid.Should().Be(false);
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Required");
+            dateRangePicker.Error.Should().BeTrue();
+            dateRangePicker.ErrorText.Should().Be("Required");
+        }
+
+        /// <summary>
         /// TimePicker should be validated like every other form component
         /// </summary>
         [Test]
@@ -623,25 +691,25 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
-            var dateComp = comp.FindComponent<MudTimePicker>();
-            var datepicker = comp.FindComponent<MudTimePicker>().Instance;
+            var timePickerComp = comp.FindComponent<MudTimePicker>();
+            var timePicker = comp.FindComponent<MudTimePicker>().Instance;
             // check initial state: form should not be valid because datepicker is required
             form.IsValid.Should().Be(false);
-            datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.Error.Should().BeFalse();
+            timePicker.ErrorText.Should().BeNullOrEmpty();
             // input a date
-            dateComp.Find("input").Change("09:30");
+            timePickerComp.Find("input").Change("09:30");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
-            datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.Error.Should().BeFalse();
+            timePicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam(x => x.Time, null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
-            datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().Be("Required");
+            timePicker.Error.Should().BeTrue();
+            timePicker.ErrorText.Should().Be("Required");
         }
 
         /// <summary>
@@ -652,21 +720,21 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
-            var dateComp = comp.FindComponent<MudTimePicker>();
-            var datepicker = comp.FindComponent<MudTimePicker>().Instance;
-            dateComp.SetParam(x => x.Validation, new Func<TimeSpan?, string>(time => time != null && time.Value.Minutes == 0 ? null : "Only full hours allowed"));
-            dateComp.Find("input").Change("09:00");
+            var timeComp = comp.FindComponent<MudTimePicker>();
+            var timePicker = comp.FindComponent<MudTimePicker>().Instance;
+            timeComp.SetParam(x => x.Validation, new Func<TimeSpan?, string>(time => time != null && time.Value.Minutes == 0 ? null : "Only full hours allowed"));
+            timeComp.Find("input").Change("09:00");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
-            datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.Error.Should().BeFalse();
+            timePicker.ErrorText.Should().BeNullOrEmpty();
             // set invalid date:
             comp.SetParam(x => x.Time, (TimeSpan?)new TimeSpan(0, 17, 05, 00)); // "17:05"
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Only full hours allowed");
-            datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().Be("Only full hours allowed");
+            timePicker.Error.Should().BeTrue();
+            timePicker.ErrorText.Should().Be("Only full hours allowed");
         }
 
         /// <summary>
@@ -677,9 +745,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
-            var timeComp = comp.FindComponent<MudTimePicker>();
             var timePicker = comp.FindComponent<MudTimePicker>().Instance;
-            // check initial state: form should not be valid because datepicker is required
+            // check initial state: form should not be valid because timePicker is required
             form.IsValid.Should().Be(false);
             timePicker.Error.Should().BeFalse();
             timePicker.ErrorText.Should().BeNullOrEmpty();

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -54,6 +54,8 @@ namespace MudBlazor
                     return;
                 }
 
+                Touched = true;
+
                 _dateRange = range;
                 _value = range?.End;
 
@@ -76,6 +78,7 @@ namespace MudBlazor
 
                 await DateRangeChanged.InvokeAsync(_dateRange);
                 BeginValidate();
+                FieldChanged(_value);
             }
         }
 


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes an issue where the `MudDateRangePicker` component would keep a `MudForm` invalid unless its value was changed via the text input.

The `MudDateRangePicker` component is now considered `Touched` if its value is changed via the picker itself.

Also included some light renaming.

Fixes: #6194
## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested the same way as I did for #5884, including the fix from #5924.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
