### PR TITLE
MudTabPanel: Add ShowCloseIcon property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -4,34 +4,38 @@
                 AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
                 AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
                 PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
-    @foreach (var item in UserTabs)
+    @foreach (var tab in UserTabs)
     {
-        <MudTabPanel ID="@item.Id" Text="@item.Label">@item.Content</MudTabPanel>
+        <MudTabPanel ID="@tab.Id" Text="@tab.Label" ShowCloseIcon="@tab.ShowCloseIcon">@tab.Content</MudTabPanel>
     }
 </MudDynamicTabs>
 <MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
+<MudSwitch T="bool" Checked="@_showCloseIcon" CheckedChanged="@ToggleShowCloseIcon">Show tab B close icon</MudSwitch>
 <MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
 <MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
 
-@code {
+    @code {
 
     public class TabView
     {
         public string Label { get; set; }
         public string Content { get; set; }
         public Guid Id { get; set; }
+        public bool ShowCloseIcon { get; set; } = true;
     }
 
     public MudDynamicTabs DynamicTabs;
     public List<TabView> UserTabs = new();
     public int UserIndex;
     bool _stateHasChanged;
+    bool _showCloseIcon = false;
+    string _closeToggableTab = "Tab B";
 
     void RestoreUserTabs()
     {
         UserTabs.Clear();
         UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content"});
-        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab B", Content = "Tab B content"});
+        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = _closeToggableTab, Content = $"{_closeToggableTab} content", ShowCloseIcon = _showCloseIcon });
         UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content"});
         UserIndex = 1; // Start on 2nd tab: "Tab B"
         _stateHasChanged = true;
@@ -51,6 +55,13 @@
             _stateHasChanged = false;
             StateHasChanged();
         }
+    }
+
+    private void ToggleShowCloseIcon(bool show)
+    {
+        var tab = UserTabs?.SingleOrDefault(t => t.Label.Equals(_closeToggableTab));
+        if (tab is not null) tab.ShowCloseIcon = show;
+        _showCloseIcon = show;
     }
 
     public void AddTab(Guid id)

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -10,7 +10,7 @@
     }
 </MudDynamicTabs>
 <MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
-<MudSwitch T="bool" Checked="@_showCloseIcon" CheckedChanged="@ToggleShowCloseIcon">Show tab B close icon</MudSwitch>
+<MudSwitch T="bool" Color="Color.Primary" Checked="@_showCloseIcon" CheckedChanged="@ToggleShowCloseIcon">@($"Show {_closeToggableTab}'s close icon")</MudSwitch>
 <MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
 <MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
 

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -112,7 +112,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Simple Dynamic Tabs">
-                <Description>A browser like tab experience, where uses can add new tabs and close existing ones. Add and Close needs to be provided as callbacks.</Description>
+                <Description>
+                    A browser like tab experience, where users can add new tabs and close existing ones. Add and Close needs to be provided as callbacks.
+                    <br /> To hide the close icon, set <CodeInline>ShowCloseIcon = false</CodeInline>
+                </Description>
             </SectionHeader>
             <SectionContent Code="DynamicTabsSimpleExample" ShowCode="false"  Block="true">
                 <DynamicTabsSimpleExample />

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1070,5 +1070,16 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.UserIndex.Should().Be(-1);
             mudTabs.ActivePanelIndex.Should().Be(-1);
         }
+
+
+        [Test]
+        public async Task TabPanel_ShowCloseIconTest()
+        {
+            var comp = Context.RenderComponent<DynamicTabsSimpleExample>();
+            var tabs = comp.FindAll("div.mud-tab");
+            tabs[0].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeTrue();
+            tabs[1].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeFalse(); // The close icon is not shown.
+            tabs[2].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
@@ -30,12 +30,12 @@
             if (string.IsNullOrEmpty(CloseIconToolTip) == false)
             {
                 <MudTooltip Text="@CloseIconToolTip">
-                    <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+                    <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, async () => await CloseTab.InvokeAsync(context))" />
                 </MudTooltip>
             }
             else
             {
-                <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+                <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, async () => await CloseTab.InvokeAsync(context))" />
             }
         }
     }

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
@@ -1,44 +1,44 @@
 ﻿@namespace MudBlazor
 @inherits MudTabs
 
-@{ 
+@{
     base.BuildRenderTree(__builder);
 }
 
 @code {
-
-
-	protected override void OnInitialized()
+    protected override void OnInitialized()
     {
-		base.Header = (context) => 
-	@:@{
-			if (string.IsNullOrEmpty(AddIconToolTip) == false)
-			{
-				<MudTooltip Text="@AddIconToolTip">
-					<MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
-				</MudTooltip>
-			}
-			else
-			{
-				<MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
-			}
-		}
-		;
-
-        base.TabPanelHeader = (context) =>  
-	@:@{
-			if (string.IsNullOrEmpty(CloseIconToolTip) == false)
-			{
-				<MudTooltip Text="@CloseIconToolTip">
-					<MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
-				</MudTooltip>
-			}
-			else
-			{
-				<MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle"  OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
-			}
-		}
-		;
+        base.Header = (context) =>
+    @:@{
+        if (string.IsNullOrEmpty(AddIconToolTip) == false)
+        {
+            <MudTooltip Text="@AddIconToolTip">
+                <MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
+            </MudTooltip>
+        }
+        else
+        {
+            <MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
+        }
     }
+    ;
 
+        base.TabPanelHeader = (context) =>
+    @:@{
+        if (context.ShowCloseIcon)
+        {
+            if (string.IsNullOrEmpty(CloseIconToolTip) == false)
+            {
+                <MudTooltip Text="@CloseIconToolTip">
+                    <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+                </MudTooltip>
+            }
+            else
+            {
+                <MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+            }
+        }
+    }
+    ;
+    }
 }

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
@@ -24,7 +24,7 @@ namespace MudBlazor
         [Parameter] public EventCallback AddTab { get; set; }
 
         /// <summary>
-        /// The callback, when the a close button has been clicked
+        /// The callback, when the close button has been clicked
         /// </summary>
         [Parameter] public EventCallback<MudTabPanel> CloseTab { get; set; }
 

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
         public string AddTabIcon { get; set; } = Icons.Material.Filled.Add;
 
         /// <summary>
-        /// the icon used of the close button
+        /// The icon used for the close button
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Tabs.Appearance)]

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -47,6 +47,13 @@ else
     public bool Disabled { get; set; }
 
     /// <summary>
+    /// MudDynamicTabs: If true, shows the close icon in the TabPanel.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Tabs.Behavior)]
+    public bool ShowCloseIcon { get; set; } = true;
+
+    /// <summary>
     /// Optional information to be showed into a badge
     /// </summary>
     [Parameter] 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Resolves #6196: MudTabPanel: Add ShowCloseIcon property
Retry from #6062

This PR adds the `ShowCloseIcon=true` property to `MudTabPanel` to show/hide the close icon
when using `MudDynamicTabs`.

Use cases:
-Sometimes we just need to prevent closing a tab, e.g. stuff still in progress;
-Sometimes a minimal tab of 1 is mandatory;

![image](https://user-images.githubusercontent.com/10358198/210024755-99ac4e62-ecca-4860-919c-40771a29e4a6.png)

![image](https://user-images.githubusercontent.com/10358198/210024696-7a98c106-1c87-495e-a228-73ed303a2f73.png)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit | visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Properly await `CloseTab.InvokeAsync()` method
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
