### PR TITLE
MudDateRangePicker: Add support for AdditionalDateClassesFunc

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -1,38 +1,40 @@
-﻿@using System.Globalization;
+﻿﻿@using System.Globalization;
 @namespace MudBlazor.UnitTests.TestComponents
 
 <MudPopoverProvider></MudPopoverProvider>
 
 @if (IsDateDisabledFunc != null)
 {
+    <MudDatePicker @ref="_picker"
+                   Date="@Date"
+                   DateChanged="HandleDateChanged"
+                   ReadOnly="Readonly"
+                   @bind-PickerMonth="PickerMonth"
+                   IsDateDisabledFunc="IsDateDisabledFunc"
+                   OpenTo="@OpenTo"
+                   FixDay="@FixDay"
+                   FixMonth="@FixMonth"
+                   FixYear="@FixYear"
+                   MinDate="@MinDate"
+                   MaxDate="@MaxDate"
+                   AdditionalDateClassesFunc="@AdditionalDateClassesFunc" />
+}
+else
+{
+    <MudDatePicker @ref="_picker"
+                   Date="@Date"
+                   DateChanged="HandleDateChanged"
+                   ReadOnly="Readonly"
+                   @bind-PickerMonth="PickerMonth"
+                   OpenTo="@OpenTo"
+                   FixDay="@FixDay"
+                   FixMonth="@FixMonth"
+                   FixYear="@FixYear"
+                   MinDate="@MinDate"
+                   MaxDate="@MaxDate"
+                   AdditionalDateClassesFunc="@AdditionalDateClassesFunc" />
+}
 
-<MudDatePicker @ref="_picker"
-               Date="@Date"
-               DateChanged="HandleDateChanged"
-               ReadOnly="Readonly"
-               @bind-PickerMonth="PickerMonth"
-               IsDateDisabledFunc="IsDateDisabledFunc"
-               OpenTo="@OpenTo" 
-               FixDay="@FixDay"
-               FixMonth="@FixMonth"
-               FixYear="@FixYear"
-               MinDate="@MinDate"
-               MaxDate="@MaxDate" />
-}
-            else
-            {
-<MudDatePicker @ref="_picker"
-               Date="@Date"
-               DateChanged="HandleDateChanged"
-               ReadOnly="Readonly"
-               @bind-PickerMonth="PickerMonth"
-               OpenTo="@OpenTo"
-               FixDay="@FixDay"
-               FixMonth="@FixMonth"
-               FixYear="@FixYear"
-               MinDate="@MinDate"
-               MaxDate="@MaxDate" />
-}
 @code {
     private MudDatePicker _picker;
 
@@ -54,8 +56,8 @@
     [Parameter] public int? FixYear { get; set; }
     [Parameter] public DateTime? MinDate { get; set; }
     [Parameter] public DateTime? MaxDate { get; set; }
+    [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
 
-
-            public async Task Open() => await InvokeAsync(() => _picker.Open());
-            public async Task Close() => await InvokeAsync(() => _picker.Close()); 
+    public async Task Open() => await InvokeAsync(() => _picker.Open());
+    public async Task Close() => await InvokeAsync(() => _picker.Close());
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
@@ -5,31 +5,34 @@
 
 @if (IsDateDisabledFunc != null)
 {
-	<MudDateRangePicker @ref="_picker"
-					@bind-DateRange="@DateRange"
-					IsDateDisabledFunc="IsDateDisabledFunc"
-					@bind-PickerMonth="PickerMonth"
-					OpenTo="@OpenTo"
-					StartMonth="@StartMonth" />
+    <MudDateRangePicker @ref="_picker"
+                        @bind-DateRange="@DateRange"
+                        IsDateDisabledFunc="IsDateDisabledFunc"
+                        @bind-PickerMonth="PickerMonth"
+                        OpenTo="@OpenTo"
+                        StartMonth="@StartMonth"
+                        AdditionalDateClassesFunc="@AdditionalDateClassesFunc" />
 }
 else
 {
-	<MudDateRangePicker @ref="_picker"
-					@bind-DateRange="@DateRange"
-					@bind-PickerMonth="PickerMonth"
-					OpenTo="@OpenTo"
-					StartMonth="@StartMonth" />
+    <MudDateRangePicker @ref="_picker"
+                        @bind-DateRange="@DateRange"
+                        @bind-PickerMonth="PickerMonth"
+                        OpenTo="@OpenTo"
+                        StartMonth="@StartMonth"
+                        AdditionalDateClassesFunc="@AdditionalDateClassesFunc" />
 }
 @code {
-	private MudDateRangePicker _picker;
+    private MudDateRangePicker _picker;
 
-	[Parameter] public DateRange DateRange { get; set; }
-	[Parameter] public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
-	[Parameter] public DateTime? PickerMonth { get; set; }
-	[Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
-	[Parameter] public DateTime? StartMonth { get; set; }
+    [Parameter] public DateRange DateRange { get; set; }
+    [Parameter] public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
+    [Parameter] public DateTime? PickerMonth { get; set; }
+    [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
+    [Parameter] public DateTime? StartMonth { get; set; }
+    [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
 
-	public async Task Open() => await InvokeAsync(() => _picker.Open());
-	public async Task Close() => await InvokeAsync(() => _picker.Close());
+    public async Task Open() => await InvokeAsync(() => _picker.Open());
+    public async Task Close() => await InvokeAsync(() => _picker.Close());
 
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -765,14 +765,15 @@ namespace MudBlazor.UnitTests.Components
         public void AdditionalDateClassesFunc_ClassIsAdded()
         {
             Func<DateTime, string> additionalDateClassesFunc = date => "__addedtestclass__";
-            var comp = Context.RenderComponent<MudDatePicker>(
-                Parameter(nameof(MudDatePicker.AdditionalDateClassesFunc), additionalDateClassesFunc));
+            
+            var comp = OpenPicker(Parameter(nameof(MudDatePicker.AdditionalDateClassesFunc), additionalDateClassesFunc));
 
-            var daysCount = comp.FindAll("button.mud-picker-calendar-day").Select(button =>
-                ((IHtmlBaseElement)button)).Count();
+            var daysCount = comp.FindAll("button.mud-picker-calendar-day")
+                                .Select(button => (IHtmlButtonElement)button)
+                                .Count();
 
-            comp.FindAll("button.mud-picker-calendar-day").Select(button =>
-                ((IHtmlBaseElement)button).ClassName.Contains("__addedtestclass__"))
+            comp.FindAll("button.mud-picker-calendar-day")
+                .Where(button => ((IHtmlButtonElement)button).ClassName.Contains("__addedtestclass__"))
                 .Should().HaveCount(daysCount);
         }
 

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -452,7 +452,23 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == false);
         }
+        
+        [Test]
+        public void AdditionalDateClassesFunc_ClassIsAdded()
+        {
+            Func<DateTime, string> additionalDateClassesFunc = date => "__addedtestclass__";
+            
+            var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.AdditionalDateClassesFunc), additionalDateClassesFunc));
 
+            var daysCount = comp.FindAll("button.mud-picker-calendar-day")
+                                .Select(button => (IHtmlButtonElement)button)
+                                .Count();
+
+            comp.FindAll("button.mud-day")
+                .Where(button => ((IHtmlButtonElement)button).ClassName.Contains("__addedtestclass__"))
+                .Should().HaveCount(daysCount);
+        }
+        
         [Test]
         public void SetRangeTextFunc_NullInputNoError()
         {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -175,6 +175,7 @@ namespace MudBlazor
         protected override string GetDayClasses(int month, DateTime day)
         {
             var b = new CssBuilder("mud-day");
+            b.AddClass(AdditionalDateClassesFunc?.Invoke(day) ?? string.Empty);
             if (day < GetMonthStart(month) || day > GetMonthEnd(month))
             {
                 return b.AddClass("mud-hidden").Build();


### PR DESCRIPTION
I also fixed the rather bad formatting of `SimpleMudDatePickerTest.razor`, hope that is ok. The date range one was fine 🤷‍♂️
I can squash the commits if required - thought it might be preferred to have them separate?

Note `DatePickerTests.AdditionalDateClassesFunc_ClassIsAdded()` was a false positive test before - it was passing because it wasn't actually doing any checks.

## Description
Fixes #6202
Allows for using AdditionalDateClassesFunc to apply additional classes to date picker days.

## How Has This Been Tested?
New tests
Updated existing
Visually (uncommitted)
![image](https://user-images.githubusercontent.com/41730826/214050178-a6d4260a-01d8-44f4-961c-ea7f9077b1af.png)


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
