### PR TITLE
MudOverlay: Fix AutoClose property comment

### DIFF
--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -61,7 +61,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// If true overlay will set Visible false on click.
+        /// Sets absolute position to the component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.ClickAction)]


### PR DESCRIPTION
## Description
Fixes the documentation comment for MudOverlay.AutoClose. Seems to be a copy and paste error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
