### PR TITLE
MudOverlay: Fix Absolute property comment

### DIFF
--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -96,7 +96,7 @@ namespace MudBlazor
         public bool LightBackground { get; set; }
 
         /// <summary>
-        /// Sets the absolute position of the component.
+        /// If tue, use absolute positioning for the overlay.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -96,7 +96,7 @@ namespace MudBlazor
         public bool LightBackground { get; set; }
 
         /// <summary>
-        /// If tue, use absolute positioning for the overlay.
+        /// If true, use absolute positioning for the overlay.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -96,7 +96,7 @@ namespace MudBlazor
         public bool LightBackground { get; set; }
 
         /// <summary>
-        /// Sets absolute position to the component.
+        /// Sets the absolute position of the component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -96,7 +96,7 @@ namespace MudBlazor
         public bool LightBackground { get; set; }
 
         /// <summary>
-        /// Icon class names, separated by space
+        /// Sets absolute position to the component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]


### PR DESCRIPTION
## Description
Fixes the documentation comment on Absolute property. Seems to be a copy and paste error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
