### PR TITLE
Tabs: Fix disabling prevButton after upsizing (#6235)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="true" Position="Position">
+<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="AlwaysShowScrollButtons" Position="Position">
 @foreach (var tab in _tabs)
 {
     <MudTabPanel @key="tab" Text="@tab">
@@ -10,7 +10,7 @@
 </MudTabs>
 
 @code
-{ 
+    {
     private MudTabs _tabElement;
 
     public static string __description__ = "scrolling should work";
@@ -18,11 +18,14 @@
     [Parameter]
     public Position Position { get; set; } = Position.Top;
 
+    [Parameter]
+    public bool AlwaysShowScrollButtons { get; set; } = true;
+
     private List<string> _tabs = new List<string> { "1", "2", "3", "4", "5", "6" };
 
     public void  SetPanelActive(int index)
     {
-      InvokeAsync(() => _tabElement.ActivatePanel(index));
+        InvokeAsync(() => _tabElement.ActivatePanel(index));
     }
 
     public async Task AddPanel()

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -471,6 +471,104 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void BackButtonAfterResizing_AlwaysShowScrollButtons()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200.0,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            comp.Instance.SetPanelActive(5);
+
+            observer.UpdateTotalPanelSize(601.0);
+
+            var scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons[0].Instance.Disabled.Should().BeFalse();
+
+            var expectedTranslation = 0.0;
+            scrollButtons[0].Find("button").Click();
+
+            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            toolbarWrapper.Should().NotBeNull();
+            toolbarWrapper.HasAttribute("style").Should().Be(true);
+            var styleAttr = toolbarWrapper.GetAttribute("style");
+
+            styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
+            scrollButtons[0].Instance.Disabled.Should().BeTrue();
+        }
+
+
+        [Test]
+        public void BackButtonAfterResizing_Without_AlwaysShowScrollButtons()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200.0,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.AlwaysShowScrollButtons, false));
+            comp.Instance.SetPanelActive(5);
+
+
+            observer.UpdateTotalPanelSize(601.0);
+
+            var scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons[0].Instance.Disabled.Should().BeFalse();
+
+            var expectedTranslation = 0.0;
+            scrollButtons[0].Find("button").Click();
+
+            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            toolbarWrapper.Should().NotBeNull();
+            toolbarWrapper.HasAttribute("style").Should().Be(true);
+            var styleAttr = toolbarWrapper.GetAttribute("style");
+
+            styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
+            comp.FindComponents<MudIconButton>().Should().HaveCount(0);
+        }
+
+        [Test]
+        public void ButtonsNotVisibleAfterResizing_Without_AlwaysShowScrollButtons()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200.0,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.AlwaysShowScrollButtons, false));
+            comp.Instance.SetPanelActive(5);
+
+
+            observer.UpdateTotalPanelSize(601.0);
+            comp.Instance.SetPanelActive(5);
+
+            var expectedTranslation = 0.0;
+
+            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            toolbarWrapper.Should().NotBeNull();
+            toolbarWrapper.HasAttribute("style").Should().Be(true);
+            var styleAttr = toolbarWrapper.GetAttribute("style");
+
+            styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
+            comp.FindComponents<MudIconButton>().Should().HaveCount(0);
+        }
+
+        [Test]
         public void Handle_ResizeOfElement()
         {
             var observer = new MockResizeObserver

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -419,6 +419,7 @@ namespace MudBlazor
 
                 CenterScrollPositionAroundSelectedItem();
                 SetSliderState();
+                SetScrollButtonVisibility();
                 SetScrollabilityStates();
                 StateHasChanged();
             }
@@ -627,13 +628,14 @@ namespace MudBlazor
 
         private void SetScrollButtonVisibility()
         {
-            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _toolbarContentSize;
+            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _toolbarContentSize || _scrollIndex != 0;
         }
 
         private void ScrollPrev()
         {
             _scrollIndex = Math.Max(_scrollIndex - GetVisiblePanels(), 0);
             ScrollToItem(_panels[_scrollIndex]);
+            SetScrollButtonVisibility();
             SetScrollabilityStates();
         }
 
@@ -745,7 +747,7 @@ namespace MudBlazor
             if (isEnoughSpace)
             {
                 _nextButtonDisabled = true;
-                _prevButtonDisabled = true;
+                _prevButtonDisabled = _scrollIndex == 0;
             }
             else
             {


### PR DESCRIPTION
## Description
fixes #6235
Prev button remains visible after upsizing.


## How Has This Been Tested?
unit | visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Before
![before](https://user-images.githubusercontent.com/50521366/215222208-1a681428-e7aa-40de-ae44-70ef920ca8b4.gif)

### After
![fix](https://user-images.githubusercontent.com/50521366/215222267-3ed33b01-b0a8-42a2-a2ca-9cdc11cecb42.gif)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
