### PR TITLE
InputBase: Add ForceUpdate (fixes #5132)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
@@ -1,42 +1,36 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSelect T="string" Label="Coffee" AnchorOrigin="Origin.BottomCenter">
+<MudSelect @ref="_select" T="string" ValueChanged="ValueChange" Label="Coffee" AnchorOrigin="Origin.BottomCenter">
     <MudSelectItem Value="@("Cappuccino")" />
     <MudSelectItem Value="@("Cafe Latte")" />
     <MudSelectItem Value="@("Espresso")" />
 </MudSelect>
-<MudSelect T="double" Label="Price" Variant="Variant.Outlined" AnchorOrigin="Origin.BottomCenter">
-    <MudSelectItem T="double" Value="4.50"/>
-    <MudSelectItem T="double" Value="4.99"/>
-    <MudSelectItem T="double" Value="3.60"/>
-</MudSelect>
-<MudSelect T="Pizza" Label="Pizza" Variant="Variant.Filled" AnchorOrigin="Origin.BottomCenter">
-    <MudSelectItem Value="@(new Pizza("Cardinale"))" />
-    <MudSelectItem Value="@(new Pizza("Diavolo"))" />
-    <MudSelectItem Value="@(new Pizza("Margarita"))" />
-    <MudSelectItem Value="@(new Pizza("Spinaci"))" />
-</MudSelect>
+
+<MudButton OnClick="ChangeValue">Change Value</MudButton>
+<MudText>@changeCount</MudText>
+<MudText>Current Value: @_select?.Value</MudText>
 
 @code {
-    public class Pizza
+    MudSelect<string> _select;
+    int changeCount;
+
+    private void ChangeValue()
     {
-        public Pizza(string name)
+        if (_select.Value == "Cappuccino")
         {
-            Name = name;
+            _select.Value = "Cafe Latte";
+            _select.ForceUpdate();
         }
-
-        public readonly string Name;
-
-        // Note: this is important so the MudSelect can compare pizzas
-        public override bool Equals(object o) {
-            var other = o as Pizza;
-            return other?.Name==Name;
+        else
+        {
+            _select.Value = "Cappuccino";
+            _select.ForceUpdate();
         }
+        StateHasChanged();
+    }
 
-        // Note: this is important too!
-        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
-
-        // Implement this for the Pizza to display correctly in MudSelect
-        public override string ToString() => Name;
+    private void ValueChange()
+    {
+        changeCount++;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectVariantsExample.razor
@@ -1,36 +1,43 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSelect @ref="_select" T="string" ValueChanged="ValueChange" Label="Coffee" AnchorOrigin="Origin.BottomCenter">
+<MudSelect T="string" Label="Coffee" AnchorOrigin="Origin.BottomCenter">
     <MudSelectItem Value="@("Cappuccino")" />
     <MudSelectItem Value="@("Cafe Latte")" />
     <MudSelectItem Value="@("Espresso")" />
 </MudSelect>
-
-<MudButton OnClick="ChangeValue">Change Value</MudButton>
-<MudText>@changeCount</MudText>
-<MudText>Current Value: @_select?.Value</MudText>
+<MudSelect T="double" Label="Price" Variant="Variant.Outlined" AnchorOrigin="Origin.BottomCenter">
+    <MudSelectItem T="double" Value="4.50" />
+    <MudSelectItem T="double" Value="4.99" />
+    <MudSelectItem T="double" Value="3.60" />
+</MudSelect>
+<MudSelect T="Pizza" Label="Pizza" Variant="Variant.Filled" AnchorOrigin="Origin.BottomCenter">
+    <MudSelectItem Value="@(new Pizza("Cardinale"))" />
+    <MudSelectItem Value="@(new Pizza("Diavolo"))" />
+    <MudSelectItem Value="@(new Pizza("Margarita"))" />
+    <MudSelectItem Value="@(new Pizza("Spinaci"))" />
+</MudSelect>
 
 @code {
-    MudSelect<string> _select;
-    int changeCount;
-
-    private void ChangeValue()
+    public class Pizza
     {
-        if (_select.Value == "Cappuccino")
+        public Pizza(string name)
         {
-            _select.Value = "Cafe Latte";
-            _select.ForceUpdate();
+            Name = name;
         }
-        else
-        {
-            _select.Value = "Cappuccino";
-            _select.ForceUpdate();
-        }
-        StateHasChanged();
-    }
 
-    private void ValueChange()
-    {
-        changeCount++;
+        public readonly string Name;
+
+        // Note: this is important so the MudSelect can compare pizzas
+        public override bool Equals(object o)
+        {
+            var other = o as Pizza;
+            return other?.Name == Name;
+        }
+
+        // Note: this is important too!
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+
+        // Implement this for the Pizza to display correctly in MudSelect
+        public override string ToString() => Name;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectEventCountTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectEventCountTest.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+<MudSelect @ref="_select" T="string" ValueChanged="ValueChanged" SelectedValuesChanged="ValuesChanged" MultiSelection="MultiSelection">
+    <MudSelectItem @ref="FirstItem" T="string" Value="@("1")" />
+    <MudSelectItem @ref="SecondItem" T="string" Value="@("2")" />
+    <MudSelectItem @ref="ThirdItem" T="string" Value="@("3")" />
+    <MudSelectItem T="string" Value="@("4")" Disabled="true" />
+</MudSelect>
+
+@code {
+    [Parameter]
+    public bool MultiSelection { get; set; }
+
+    public int ValueChangeCount { get; set; }
+    public int ValuesChangeCount { get; set; }
+    public int ItemChangeCount { get; set; }
+    public int ItemsChangeCount { get; set; }
+
+    MudSelect<string> _select;
+    MudSelectItem<string> FirstItem { get; set; }
+    MudSelectItem<string> SecondItem { get; set; }
+    MudSelectItem<string> ThirdItem { get; set; }
+
+    private void ValueChanged()
+    {
+        ValueChangeCount++;
+    }
+
+    private void ValuesChanged()
+    {
+        ValuesChangeCount++;
+    }
+
+    private void ItemChanged()
+    {
+        ItemChangeCount++;
+    }
+
+    private void ItemsChanged()
+    {
+        ItemsChangeCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectEventCountTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectEventCountTest.razor.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudExtensions;
+
+namespace MudExtensions.UnitTests.TestComponents
+{
+    public partial class SelectEventCountTest
+    {
+        
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1045,6 +1045,33 @@ namespace MudBlazor.UnitTests.Components
             sut.Instance.Items.Should().HaveCountGreaterOrEqualTo(4);
         }
 
+        [Test]
+        public async Task Select_ValueChangeEventCountTest()
+        {
+            var comp = Context.RenderComponent<SelectEventCountTest>(x =>
+            {
+                x.Add(c => c.MultiSelection, false);
+            });
+            var select = comp.FindComponent<MudSelect<string>>();
+            var input = comp.Find("div.mud-input-control");
+
+            comp.Instance.ValueChangeCount.Should().Be(0);
+            comp.Instance.ValuesChangeCount.Should().Be(0);
+
+            await comp.InvokeAsync(() => select.SetParam("Value", "1"));
+            await comp.InvokeAsync(() => select.Instance.ForceUpdate());
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(1));
+            comp.Instance.ValuesChangeCount.Should().Be(1);
+            select.Instance.Value.Should().Be("1");
+
+            // Changing value programmatically without ForceUpdate should change value, but should not fire change events
+            // Its by design, so this part can be change if design changes
+            await comp.InvokeAsync(() => select.SetParam("Value", "2"));
+            comp.WaitForAssertion(() => comp.Instance.ValueChangeCount.Should().Be(1));
+            comp.Instance.ValuesChangeCount.Should().Be(1);
+            select.Instance.Value.Should().Be("2");
+        }
+
         /// <summary>
         /// When MultiSelection and Required are True with no selected values, required validation should fail.
         /// </summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -343,9 +343,9 @@ namespace MudBlazor
             set => _value = value;
         }
 
-        protected virtual async Task SetValueAsync(T value, bool updateText = true)
+        protected virtual async Task SetValueAsync(T value, bool updateText = true, bool force = false)
         {
-            if (!EqualityComparer<T>.Default.Equals(Value, value))
+            if (!EqualityComparer<T>.Default.Equals(Value, value) || force == true)
             {
                 _isDirty = true;
                 Value = value;
@@ -355,6 +355,15 @@ namespace MudBlazor
                 BeginValidate();
                 FieldChanged(Value);
             }
+        }
+
+        /// <summary>
+        /// Sync the value, values and text, calls validation manually. Useful to call after user changes value or text programmatically.
+        /// </summary>
+        /// <returns></returns>
+        public virtual async Task ForceUpdate()
+        {
+            await SetValueAsync(Value, force: true);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -143,7 +143,7 @@ namespace MudBlazor
             return _elementReference.SelectRangeAsync(pos1, pos2);
         }
 
-        protected override Task SetValueAsync(T value, bool updateText = true)
+        protected override Task SetValueAsync(T value, bool updateText = true, bool force = false)
         {
             bool valueChanged;
             (value, valueChanged) = ConstrainBoundaries(value);

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1084,5 +1084,19 @@ namespace MudBlazor
             else
                 return base.HasValue(value);
         }
+
+        public override async Task ForceUpdate()
+        {
+            await base.ForceUpdate();
+            if (MultiSelection == false)
+            {
+                SelectedValues = new HashSet<T>(_comparer) { Value };
+            }
+            else
+            {
+                await SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer));
+            }
+        }
+
     }
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -127,7 +127,7 @@ namespace MudBlazor
             }
         }
 
-        protected override Task SetValueAsync(T value, bool updateText = true)
+        protected override Task SetValueAsync(T value, bool updateText = true, bool force = false)
         {
             if (_mask != null)
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #5132

As the issue mentioned before, our value - text updating design doesn't support programmatically changes. And all kind of `SetValueAsync` methods are internal. So if users change value programmatically, there is no way to update and render the component.

The ForceUpdate method fixes this. When users change the value programmatically, they call the `{_elementReference}.ForceUpdate();` and it updates the value, begins validation and fires the ValueChanged event.

The PR also has the specialized select solution for fires SelectedValuesChanged when multiselection is true.

Note: This code is taken by MudSelectExtended component and also tested with the extended component.


https://user-images.githubusercontent.com/78308169/216440042-1d68685d-0e15-426b-9310-53c433431325.mp4



## How Has This Been Tested?
A unit test added for select.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
