### PR TITLE
MudSwitch: Show Validation ErrorText (#6247)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3927,14 +3927,14 @@ namespace MudBlazor.UnitTests.Components
             switches[0].Instance.Checked.Should().BeTrue();
             switches[1].Instance.Checked.Should().BeTrue();
             // 2 columns, 2 hidden
-            dataGrid.FindAll(".mud-input-control-input-container").Count.Should().Be(0);
+            dataGrid.FindAll(".filter-header-cell .mud-input-control-input-container").Count.Should().Be(0);
 
             // this is the show all button
             buttons[1].Find("button").Click();
             switches[0].Instance.Checked.Should().BeFalse();
             switches[1].Instance.Checked.Should().BeFalse();
             // 2 columns, 0 hidden
-            dataGrid.FindAll(".mud-input-control-input-container").Count.Should().Be(2);
+            dataGrid.FindAll(".filter-header-cell .mud-input-control-input-container").Count.Should().Be(2);
 
             dataGrid.Instance.RenderedColumns[0].Filterable = false;
             await comp.InvokeAsync(dataGrid.Instance.ExternalStateHasChanged);
@@ -3942,7 +3942,7 @@ namespace MudBlazor.UnitTests.Components
             //If the column is visible and Filterable is false there still shouldďbe the cell
             //without the input
             dataGrid.FindAll(".mud-table-cell.filter-header-cell").Count.Should().Be(2);
-            dataGrid.FindAll(".mud-input-control-input-container").Count.Should().Be(1);
+            dataGrid.FindAll(".filter-header-cell .mud-input-control-input-container").Count.Should().Be(1);
         }
 
         [Test]

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -2,32 +2,39 @@
 @inherits MudBooleanInput<T>
 @typeparam T
 
-<label class="@Classname" style="@Style" @onkeydown="@HandleKeyDown" id="@_elementId">
-    <span class="@SpanClassname">
-        <span tabindex="0" class="@SwitchClassname">
-            <span class="mud-switch-button">
-                <input tabindex="-1" @attributes="UserAttributes" aria-checked="@((BoolValue == true).ToString().ToLower())" aria-readonly="@(Disabled.ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>
-                <span class="@ThumbClassname">
-                    @if (!string.IsNullOrEmpty(ThumbIcon))
-                    {
-                        <MudIcon Color="@ThumbIconColor" Icon="@ThumbIcon" Style="padding: 2px; height:inherit; width: inherit;" />
-                    }
+
+<MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
+    <InputContent>
+        <label class="@LabelClassname" style="@Style" @onkeydown="@HandleKeyDown" id="@_elementId">
+            <span class="@SpanClassname">
+                <span tabindex="0" class="@SwitchClassname">
+                    <span class="mud-switch-button">
+                        <input tabindex="-1" @attributes="UserAttributes" aria-checked="@((BoolValue == true).ToString().ToLower())" aria-readonly="@(Disabled.ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>
+                        <span class="@ThumbClassname">
+                            @if (!string.IsNullOrEmpty(ThumbIcon))
+                            {
+                                <MudIcon Color="@ThumbIconColor" Icon="@ThumbIcon" Style="padding: 2px; height:inherit; width: inherit;" />
+                            }
+                        </span>
+                    </span>
                 </span>
+                <span class="@TrackClassname"></span>
             </span>
-        </span>
-        <span class="@TrackClassname"></span>
-    </span>
-    @if (!String.IsNullOrEmpty(Label))
-    {
-        <MudText Class="@SwitchLabelClassname">@Label</MudText>
-    }
-    @if (ChildContent != null)
-    {
-        <MudText Class="@SwitchLabelClassname">
-            @ChildContent
-        </MudText>
-    }
-</label>
+            @if (!String.IsNullOrEmpty(Label))
+            {
+                <MudText Class="@SwitchLabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                    @Label
+                </MudText>
+            }
+            @if (ChildContent != null)
+            {
+                <MudText Class="@SwitchLabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                    @ChildContent
+                </MudText>
+            }
+        </label>
+    </InputContent>
+</MudInputControl>
 
 @code
 {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -13,11 +13,15 @@ namespace MudBlazor
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
         protected string Classname =>
-        new CssBuilder("mud-switch")
-            .AddClass($"mud-disabled", Disabled)
-            .AddClass($"mud-readonly", ReadOnly)
-            .AddClass(LabelPosition == LabelPosition.End ? "mud-ltr" : "mud-rtl", true)
+        new CssBuilder("mud-input-control-boolean-input")
             .AddClass(Class)
+            .Build();
+        
+        protected string LabelClassname =>
+        new CssBuilder("mud-switch")
+            .AddClass("mud-disabled", Disabled)
+            .AddClass("mud-readonly", ReadOnly)
+            .AddClass(LabelPosition == LabelPosition.End ? "mud-ltr" : "mud-rtl", true)
         .Build();
 
         protected string SwitchLabelClassname =>


### PR DESCRIPTION
## Description

Applied the same logic to `MudSwitch` as was done for `MudCheckbox` in #4084, meaning using the `MudInputControl` for error validation display.

I had to adapt one of the datagrid tests because of this change as there was an assertion clash on testing for CSS class presence (`mud-input-control-...`).

Fixes: #6247

## How Has This Been Tested?

This was visually tested by adapting (temporarily) the simple form validation form to use a `MudSwitch` instead of a `MudCheckbox` and validating its behaviour, as well as double-checking the look and feel of the `MudSwitch` usage docs locally vs. [mudblazor.com](https://mudblazor.com). Also added a screenshot validating the actual user reported issue using a `FluentValidation` validator.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

https://user-images.githubusercontent.com/15004223/216458483-839bea03-e8fd-4855-949c-afa60d6ef70e.mp4

https://user-images.githubusercontent.com/15004223/216458520-fb6c92fe-aa1f-4084-b27d-8225d5a3f6fc.mp4

![image](https://user-images.githubusercontent.com/15004223/216461408-54f3d650-e7db-4269-949a-7d61e7817254.png)


## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests. (Visually tested)
