### PR TITLE
Docs: MudSwitch: Add a separate section for the Size param

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchSizeExample.razor
@@ -1,0 +1,10 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwitch T="bool" Label="Small" Size="Size.Small"/>
+<MudSwitch T="bool" Label="Medium"/>
+<MudSwitch T="bool" Label="Large" Size="Size.Large"/>
+<MudSwitch @bind-Checked="@Label_Switch" T="bool" Label="Switches from small to large" Size="@(Label_Switch ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
+
+@code{
+    public bool Label_Switch { get; set; } = false;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
@@ -4,10 +4,6 @@
 <MudSwitch @bind-Checked="@Label_Switch2" Label="Success" Color="Color.Success" />
 <MudSwitch @bind-Checked="@Label_Switch3" Label="Warning" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Small" Size="Size.Small" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Medium" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Large" Size="Size.Large" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" Color="Color.Info" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Switches from small to large" Size="@(Label_Switch2 ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
 
 @code{
     public bool Label_Switch1 { get; set; } = false;

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -79,6 +79,17 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Size">
+                <Description>
+                    <MudText>MudSwitch size can be changed with the <CodeInline>Size</CodeInline> parameter.</MudText>          
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="SwitchSizeExample" ShowCode="false">
+                <SwitchSizeExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>
 

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
 using MudBlazor.Extensions;
+using MudBlazor.UnitTests.TestComponents.Switch;
 using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
 
@@ -105,7 +106,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SwitchLabelTextSizeTest()
         {
-            var comp = Context.RenderComponent<SwitchWithLabelExample>();
+            var comp = Context.RenderComponent<MudSwitchTest>();
             var switches = comp.FindAll("label.mud-switch", true);
             var inputs = comp.FindAll("input");
             switches[3].Children[1].ClassList.Should().Contain("mud-switch-label-medium"); //4th switch doesn't have size set, it should be at default values


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
In my MudSwitch Size Parameter PR, I modified the Docs MudSwitch label example in order to test the size changing effect. I changed the label section back to what is was before and moved the rest to a new Size section.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually in the Doc Server

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs (non-breaking changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
 ## Screenshot before the change
![image](https://user-images.githubusercontent.com/29356866/218272878-935a7c1c-b35c-4ca1-a53e-c1d63f5e419f.png)

## Screenshot after the change
now back to what is was
![image](https://user-images.githubusercontent.com/29356866/218272899-fd099a91-0592-47c2-8db0-5a8dac7fc0fc.png)
and the new section
![image](https://user-images.githubusercontent.com/29356866/218272912-6dbd8e9b-2ba8-4f9b-9dee-ed2a4099f550.png)
![image](https://user-images.githubusercontent.com/29356866/218272915-72e4e1e0-ab8c-4818-8218-e03918abfd2d.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. (visual testing in this case)
