### PR TITLE
Show how to display seconds when InputType is been set to Date or DateTimeLocal in MudTextField

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldNativeInputsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldNativeInputsExample.razor
@@ -2,7 +2,7 @@
 
 <MudTextField T="string" Label="Color"  InputType="InputType.Color" />
 <MudTextField T="DateTime?" Format="yyyy-MM-dd" Label="Date"  InputType="InputType.Date"/>
-<MudTextField T="DateTime?" Format="s" Label="DateTimeLocal" InputType="InputType.DateTimeLocal"/>
+<MudTextField T="DateTime?" Format="s" Label="DateTimeLocal" InputType="InputType.DateTimeLocal" Step="1"/>
 <MudTextField T="string" Label="Month" InputType="InputType.Month"/>
 <MudTextField T="string" Label="Time" InputType="InputType.Time"/>
 <MudTextField T="string" Label="Week" InputType="InputType.Week"/>


### PR DESCRIPTION
Show how to display seconds when InputType is been set to Date or DateTimeLocal in MudTextField

Document modify

![image](https://user-images.githubusercontent.com/13539500/219292510-1818de4f-a2f3-4c55-ba7c-e23821a33f18.png)
