### PR TITLE
MudDatePicker: Add disabling months if day is fixed (#6336)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -15,7 +15,10 @@
                OpenTo="@OpenTo" 
                FixDay="@FixDay"
                FixMonth="@FixMonth"
-               FixYear="@FixYear"/> }
+               FixYear="@FixYear"
+               MinDate="@MinDate"
+               MaxDate="@MaxDate" />
+}
             else
             {
 <MudDatePicker @ref="_picker"
@@ -26,26 +29,33 @@
                OpenTo="@OpenTo"
                FixDay="@FixDay"
                FixMonth="@FixMonth"
-               FixYear="@FixYear"/>}
-@code { private MudDatePicker _picker;
+               FixYear="@FixYear"
+               MinDate="@MinDate"
+               MaxDate="@MaxDate" />
+}
+@code {
+    private MudDatePicker _picker;
 
-            public DateTime? Date { get; set; }
+    public DateTime? Date { get; set; }
 
-            private async Task HandleDateChanged(DateTime? input)
-            {
-                Date = input;
-                await DateChanged.InvokeAsync(input);
-            }
+    private async Task HandleDateChanged(DateTime? input)
+    {
+        Date = input;
+        await DateChanged.InvokeAsync(input);
+    }
 
-            [Parameter] public DateTime? PickerMonth { get; set; }
-            [Parameter] public EventCallback<DateTime?> DateChanged { get; set; }
-            [Parameter] public bool Readonly { get; set; } = false;
-            [Parameter] public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
-            [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
-            [Parameter] public int? FixDay { get; set; }
-            [Parameter] public int? FixMonth { get; set; }
-            [Parameter] public int? FixYear { get; set; }
+    [Parameter] public DateTime? PickerMonth { get; set; }
+    [Parameter] public EventCallback<DateTime?> DateChanged { get; set; }
+    [Parameter] public bool Readonly { get; set; } = false;
+    [Parameter] public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
+    [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
+    [Parameter] public int? FixDay { get; set; }
+    [Parameter] public int? FixMonth { get; set; }
+    [Parameter] public int? FixYear { get; set; }
+    [Parameter] public DateTime? MinDate { get; set; }
+    [Parameter] public DateTime? MaxDate { get; set; }
 
 
             public async Task Open() => await InvokeAsync(() => _picker.Open());
-            public async Task Close() => await InvokeAsync(() => _picker.Close()); }
+            public async Task Close() => await InvokeAsync(() => _picker.Close()); 
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -662,6 +662,50 @@ namespace MudBlazor.UnitTests.Components
                 .Should().ContainInConsecutiveOrder(expectedResult);
         }
 
+        [TestCase(30, 3, 2)]
+        [TestCase(31, 3, 2)]
+        [TestCase(1, 4, 3)]
+        [TestCase(2, 4, 3)]
+        public void MinDateEffectOnDisablingMonthsIfDayNotFixed(int minDatesDay, int month, int disabledOnes)
+        {
+            var currentYear = DateTime.Now.Year;
+            var minDate = new DateTime(currentYear, month, minDatesDay);
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.MinDate), minDate),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+            });
+
+            var expectedResult = new bool[12];
+            for (var i = 0; i < disabledOnes; ++i) expectedResult[i] = true;
+
+            comp.Instance.MinDate.Should().Be(minDate);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().ContainInConsecutiveOrder(expectedResult);
+        }
+
+        [TestCase(1, 10, 2)]
+        [TestCase(2, 10, 2)]
+        [TestCase(30, 9, 3)]
+        [TestCase(29, 9, 3)]
+        public void MaxDateEffectOnDisablingMonthsIfDayNotFixed(int maxDatesDay, int month, int disabledOnes)
+        {
+            var currentYear = DateTime.Now.Year;
+            var maxDate = new DateTime(currentYear, month, maxDatesDay);
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.MaxDate), maxDate),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+            });
+
+            var expectedResult = new bool[12];
+            for (var i = 0; i < disabledOnes; ++i) expectedResult[11 - i] = true;
+
+            comp.Instance.MaxDate.Should().Be(maxDate);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().ContainInConsecutiveOrder(expectedResult);
+        }
+
         [Test]
         public void IsDateDisabledFunc_SettingDateToADisabledDateYieldsNull()
         {

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2,6 +2,7 @@
 #pragma warning disable BL0005 // Set parameter outside component
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudDatePicker>();
             var picker = comp.Instance;
-            
+
             picker.Text.Should().Be(null);
             picker.Date.Should().Be(null);
             picker.MaxDate.Should().Be(null);
@@ -51,7 +52,7 @@ namespace MudBlazor.UnitTests.Components
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Picker");
         }
-        
+
         [Test]
         public void DatePickerLabelFor()
         {
@@ -59,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
             var label = comp.Find(".mud-input-label");
             label.Attributes.GetNamedItem("for")?.Value.Should().Be("datePickerLabelTest");
         }
-        
+
         [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void DatePicker_Render_Performance()
@@ -178,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
             picker.Text.Should().Be("26 10 2020");
         }
 
-        [Test]        
+        [Test]
         public async Task DatePicker_Should_Clear()
         {
             var comp = Context.RenderComponent<MudDatePicker>();
@@ -562,6 +563,106 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void IsDateDisabledFunc_DisablesCalendarMonthButtons()
+        {
+            Func<DateTime, bool> isDisabledFunc = date => true;
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+                Parameter(nameof(MudDatePicker.FixDay), 1)
+            });
+
+            comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().OnlyContain(disabled => disabled == true);
+
+            // None should be selected
+            comp.FindAll("button.mud-picker-month > .mud-typography").Select(
+                text => ((IHtmlElement)text).ClassList.Any(cls => cls == "mud-picker-month-select" || cls == "mud-primary-text"))
+                .Should().OnlyContain(selected => selected == false);
+        }
+
+        [Test]
+        public void IsDateDisabledFunc_DoesNotHaveEffectOnMonthsIfDayNotFixed()
+        {
+            Func<DateTime, bool> isDisabledFunc = date => true;
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month)
+            });
+
+            comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().OnlyContain(disabled => disabled == false);
+        }
+
+        [Test]
+        public void IsDateDisabledFunc_DoesNotHaveEffectOnMonthsIfFuncReturnsFalse()
+        {
+            Func<DateTime, bool> isDisabledFunc = date => false;
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+                Parameter(nameof(MudDatePicker.FixDay), 1)
+            });
+
+            comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().OnlyContain(disabled => disabled == false);
+        }
+
+        [TestCase(10, 8, 2, 2)]
+        [TestCase(10, 9, 2, 2)]
+        [TestCase(10, 10, 2, 1)]
+        [TestCase(10, 11, 2, 1)]
+        public void MinDateEffectOnDisablingMonthsIfDayFixed(int minDatesDay, int fixedDay,
+            int month, int disabledOnes)
+        {
+            var currentDate = DateTime.Now;
+            var minDate = new DateTime(currentDate.Year, month, minDatesDay);
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.MinDate), minDate),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+                Parameter(nameof(MudDatePicker.FixDay), fixedDay),
+            });
+
+            var expectedResult = new bool[12];
+            for (var i = 0; i < disabledOnes; ++i) expectedResult[i] = true;
+
+            comp.Instance.MinDate.Should().Be(minDate);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().ContainInConsecutiveOrder(expectedResult);
+        }
+
+        [TestCase(10, 9, 11, 1)]
+        [TestCase(10, 10, 11, 1)]
+        [TestCase(10, 11, 11, 2)]
+        [TestCase(10, 12, 11, 2)]
+        public void MaxDateEffectOnDisablingMonthsIfDayFixed(int maxDatesDay, int fixedDay,
+            int month, int disabledOnes)
+        {
+            var currentDate = DateTime.Now;
+            var maxDate = new DateTime(currentDate.Year, month, maxDatesDay);
+            var comp = OpenPicker(new[]
+            {
+                Parameter(nameof(MudDatePicker.MaxDate), maxDate),
+                Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),
+                Parameter(nameof(MudDatePicker.FixDay), fixedDay),
+            });
+
+            var expectedResult = new bool[12];
+            for (var i = 0; i < disabledOnes; ++i) expectedResult[11 - i] = true;
+
+            comp.Instance.MaxDate.Should().Be(maxDate);
+            comp.FindAll("button.mud-picker-month").Select(button => ((IHtmlButtonElement)button).IsDisabled)
+                .Should().ContainInConsecutiveOrder(expectedResult);
+        }
+
+        [Test]
         public void IsDateDisabledFunc_SettingDateToADisabledDateYieldsNull()
         {
             var wasEventCallbackCalled = false;
@@ -602,7 +703,20 @@ namespace MudBlazor.UnitTests.Components
                 .Should().OnlyContain(disabled => disabled == false);
         }
 
+
         
+        [Test]
+        //mud-button-root added for greying out and making buttons not clickable if month is disabled
+        public void MonthButtons_ButtonRootClassPresent()
+        {
+            var comp = OpenPicker(Parameter(nameof(MudDatePicker.FixDay), 1));
+            var monthsCount = 12;
+
+            comp.FindAll("button.mud-picker-month").Select(button =>
+                ((IHtmlButtonElement)button).ClassName.Contains("mud-button-root"))
+                .Should().HaveCount(monthsCount);
+        }
+
         [Test]
         public void AdditionalDateClassesFunc_ClassIsAdded()
         {
@@ -649,7 +763,7 @@ namespace MudBlazor.UnitTests.Components
             datePicker.Instance.Date.Should().Be(now);
 
             // Close the datepicker without submitting the date
-            // The date of the datepicker remains equal to now 
+            // The date of the datepicker remains equal to now
             await comp.InvokeAsync(() => datePicker.Instance.Close(false));
 
             await comp.InvokeAsync(() => datePicker.Instance.Open());

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -64,7 +64,7 @@
                             <div class="mud-picker-month-container">
                                 @foreach (var month in GetAllMonths())
                                 {
-                                    <button type="button" aria-label="@GetMonthName(month)" disabled="@(IsMonthDisabled(month))"
+                                    <button type="button" aria-label="@GetMonthName(month)" disabled="@IsMonthDisabled(month)"
                                     class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
                                     </button>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -61,13 +61,13 @@
                                     }
                                 </div>
                             </div>
-                            <div class="mud-picker-month-container mud-button-root">
+                            <div class="mud-picker-month-container">
                                 @foreach (var month in GetAllMonths())
                                 {
-                                    <button type="button" disabled=@(month < MinDate || month > MaxDate) aria-label="@GetMonthName(month)" class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                    <button type="button" aria-label="@GetMonthName(month)" disabled="@(IsMonthDisabled(month))"
+                                    class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
                                     </button>
-
                                 }
                             </div>
                         }
@@ -125,20 +125,20 @@
                                             {
                                                 var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
                                                 <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
-                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
-                                    @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
-                                    @onclick:stopPropagation="true"
-                                aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
-                                onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(!firstMonthFirstYear ? tempId: tempId + 1));"
-                                disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
+                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
+                                                        @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
+                                                        @onclick:stopPropagation="true"
+                                                        aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
+                                                        onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(!firstMonthFirstYear ? tempId: tempId + 1));"
+                                                        disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
                                                     <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(selectedDay)</p>
                                                 </button>
                                             }
                                             else
                                             {
                                                 <button @key="0" type="button" style="--day-id: 1;"
-                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
-                                aria-label='' disabled>
+                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
+                                                        aria-label='' disabled>
                                                     <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
                                                 </button>
                                             }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -393,11 +393,14 @@ namespace MudBlazor
         /// <summary>
         /// Check if month is disabled
         /// </summary>
-        /// <param name="month"></param>
-        /// <returns></returns>
+        /// <param name="month">Month given with first day of the month</param>
+        /// <returns>True if month should be disabled, false otherwise</returns>
         private bool IsMonthDisabled(DateTime month)
         {
-            if (!FixDay.HasValue) return false;
+            if (!FixDay.HasValue)
+            {
+                return month.EndOfMonth(Culture) < MinDate || month > MaxDate;
+            }
             var day = new DateTime(month.Year, month.Month, FixDay!.Value);
             return day < MinDate || day > MaxDate || IsDateDisabledFunc(day);
         }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -391,6 +391,18 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Check if month is disabled
+        /// </summary>
+        /// <param name="month"></param>
+        /// <returns></returns>
+        private bool IsMonthDisabled(DateTime month)
+        {
+            if (!FixDay.HasValue) return false;
+            var day = new DateTime(month.Year, month.Month, FixDay!.Value);
+            return day < MinDate || day > MaxDate || IsDateDisabledFunc(day);
+        }
+
+        /// <summary>
         /// return Mo, Tu, We, Th, Fr, Sa, Su in the right culture
         /// </summary>
         /// <returns></returns>
@@ -547,16 +559,14 @@ namespace MudBlazor
 
         private string GetMonthClasses(DateTime month)
         {
-            if (month <= MinDate || month >= MaxDate)
-                return "mud-text-disabled";
-            if (GetMonthStart(0) == month)
+            if (GetMonthStart(0) == month && !IsMonthDisabled(month))
                 return $"mud-picker-month-selected mud-{Color.ToDescriptionString()}-text";
             return null;
         }
 
         private Typo GetMonthTypo(DateTime month)
         {
-            if (GetMonthStart(0) == month && (month > MinDate || month < MaxDate))
+            if (GetMonthStart(0) == month)
                 return Typo.h5;
             return Typo.subtitle1;
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Closes #6336.
To disable months I'm using IsDateDisabledFunc with combination with FixDay.

In case of validation month is disabled iff FixDay is set and isDateDisabledFunc returns true for this month (it is enough to disable day which is fixed).

MinDate and MaxDate parameters are also taken into account.

To make buttons really disabled(greyed out and not clickable) I've added `mud-button-root` to month button classes.

To not make current month blue I've added check to not apply additional classes on top of current month.

I've left applying different typo to current month as in my opinion this one should be highlighted somehow.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

### Before
![image](https://user-images.githubusercontent.com/50521366/219404097-abe79f50-9e29-48ff-8183-6455d6469d3d.png)


### After
![image](https://user-images.githubusercontent.com/50521366/219404509-7417184f-e02c-4f3c-bec7-57da58352807.png)



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
