### PR TITLE
MudMenu: Fix Touch Bubbling Which Causes Other Unwanted Click Event Firing on Mobile Devices

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuSimpleExample.razor
@@ -1,13 +1,47 @@
 ﻿@namespace MudBlazor.Docs.Examples
+@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@inject ISnackbar Snackbar
+@inject HttpClient httpClient
+<MudMenu Label="Open Menu" Dense="true" LockScroll="true" AnchorOrigin="@Origin.BottomCenter" TransformOrigin="@Origin.TopCenter">
 
-<MudMenu Label="Open Menu">
-    <MudMenuItem>Enlist</MudMenuItem>
-    <MudMenuItem>Barracks</MudMenuItem>
-    <MudMenuItem>Armory</MudMenuItem>
-</MudMenu>
+    <MudMenuItem OnClick="() => GenerateCSV()">Menu1</MudMenuItem>
+    <MudMenuItem OnClick="() => GenerateCSV()">Menu2</MudMenuItem>
+    <MudMenuItem OnClick="() => GenerateCSV()">Menu3</MudMenuItem>
 
-<MudMenu Label="Open Dense Menu" Dense="true">
-    <MudMenuItem>Dense Stuff</MudMenuItem>
-    <MudMenuItem>Stuff is Dense</MudMenuItem>
-    <MudMenuItem>Soo Dense</MudMenuItem>
 </MudMenu>
+<MudTable Items="@Elements" Hover="true" SortLabel="Sort By">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel Enabled="@enabled" SortBy="new Func<Element, object>(x=>x.Sign)">Sign</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Molar)">Mass</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
+    </PagerContent>
+</MudTable>
+
+<MudSwitch @bind-Checked="enabled" Color="Color.Info">Enable sorting on the Sign Column</MudSwitch>
+
+@code {
+    private bool enabled = true;
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+    private async Task GenerateCSV()
+    {
+        Snackbar.Add("Clicked");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuSimpleExample.razor
@@ -1,47 +1,13 @@
 ﻿@namespace MudBlazor.Docs.Examples
-@using System.Net.Http.Json
-@using MudBlazor.Examples.Data.Models
-@inject ISnackbar Snackbar
-@inject HttpClient httpClient
-<MudMenu Label="Open Menu" Dense="true" LockScroll="true" AnchorOrigin="@Origin.BottomCenter" TransformOrigin="@Origin.TopCenter">
 
-    <MudMenuItem OnClick="() => GenerateCSV()">Menu1</MudMenuItem>
-    <MudMenuItem OnClick="() => GenerateCSV()">Menu2</MudMenuItem>
-    <MudMenuItem OnClick="() => GenerateCSV()">Menu3</MudMenuItem>
-
+<MudMenu Label="Open Menu">
+    <MudMenuItem>Enlist</MudMenuItem>
+    <MudMenuItem>Barracks</MudMenuItem>
+    <MudMenuItem>Armory</MudMenuItem>
 </MudMenu>
-<MudTable Items="@Elements" Hover="true" SortLabel="Sort By">
-    <HeaderContent>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel Enabled="@enabled" SortBy="new Func<Element, object>(x=>x.Sign)">Sign</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Molar)">Mass</MudTableSortLabel></MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Nr">@context.Number</MudTd>
-        <MudTd DataLabel="Sign">@context.Sign</MudTd>
-        <MudTd DataLabel="Name">@context.Name</MudTd>
-        <MudTd DataLabel="Position">@context.Position</MudTd>
-        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
-    </RowTemplate>
-    <PagerContent>
-        <MudTablePager PageSizeOptions="new int[]{50, 100}" />
-    </PagerContent>
-</MudTable>
 
-<MudSwitch @bind-Checked="enabled" Color="Color.Info">Enable sorting on the Sign Column</MudSwitch>
-
-@code {
-    private bool enabled = true;
-    private IEnumerable<Element> Elements = new List<Element>();
-
-    protected override async Task OnInitializedAsync()
-    {
-        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-    }
-    private async Task GenerateCSV()
-    {
-        Snackbar.Add("Clicked");
-    }
-}
+<MudMenu Label="Open Dense Menu" Dense="true">
+    <MudMenuItem>Dense Stuff</MudMenuItem>
+    <MudMenuItem>Stuff is Dense</MudMenuItem>
+    <MudMenuItem>Soo Dense</MudMenuItem>
+</MudMenu>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -37,7 +37,7 @@
         <MudIconButton Variant="@Variant" Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" DisableElevation="@DisableElevation" @onclick="@ToggleMenu" @ontouchend="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuTouch : null)" @oncontextmenu="@(ActivationEvent==MouseEvent.RightClick ? ToggleMenu : null)" />
     }
     @* The portal has to include  the cascading values inside, because it's not able to teletransport the cascade *@
-    <MudPopover Open="@_isOpen" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@PopoverStyle">
+    <MudPopover Open="@_isOpen" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@PopoverStyle" @ontouchend:stopPropagation>
         <CascadingValue Value="@this">
             <MudList Class="@ListClass" Clickable="true" Dense="@Dense"  
                 @onmouseenter="@MouseEnter"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixes #4549, Fixes #5170 
Need to look at also #4398

This is a very common and known bug.

Before this i remembered that adding some `ontouchend: stopPropagation` on the menu item. This time i add the stopPropagation on the popover of MudMenu and it look like works.


https://user-images.githubusercontent.com/78308169/220175513-cfb6f895-2dc7-4e64-a87b-c9cc1f9526b3.mp4



## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
