### PR TITLE
MudDataGrid: Allow user to use a custom IComparer<object> for sorting

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -125,6 +125,20 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Advanced Sorting">
+                <Description>
+                    The <CodeInline>&lt;MudDataGrid></CodeInline> allows you to provide your own <CodeInline>Comparer</CodeInline> for advanced sorting. Keep in mind that the <CodeInline>Comparer</CodeInline>
+                    will use the same object passed by the <CodeInline>SortBy</CodeInline> parameter. If <CodeInline>SortBy</CodeInline> is not supplied, it will use the column item for its comparison.
+                    You can also manually call <CodeInline>SetSortAsync</CodeInline> on the DataGrid while passing your <CodeInline>Comparer</CodeInline>.
+                    <CodeInline>Comparer</CodeInline> must implement <CodeInline>IComparer&lt;object></CodeInline>. This example uses a natural sorting algorithm to sort strings with numbers properly.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="DataGridCustomSortingExample" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridCustomSortingExample />
+            </SectionContent>
+        </DocsPageSection>
+
          <DocsPageSection>
             <SectionHeader Title="Filtering">
                 <Description>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridCustomSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridCustomSortingExample.razor
@@ -1,0 +1,235 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System.Globalization;
+
+<MudDataGrid @ref="DataGrid" Items="@_items" Sortable="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new NaturalComparer() : null)" />
+        <PropertyColumn Property="x => x.Value" />
+        <PropertyColumn Property="x => x.Misc" />
+    </Columns>
+</MudDataGrid>
+<MudStack Row="true">
+    <MudSwitch T="bool" Checked="@NaturalSortingEnabled" CheckedChanged="OnCheckedChanged">Enable Natural Sorting</MudSwitch>
+</MudStack>
+
+@code {
+    private MudDataGrid<Item> DataGrid;
+
+    private bool NaturalSortingEnabled = true;
+
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("1", 42, "555"), 
+        new Item("10", 73, "7"), 
+        new Item("2", 11, "4444"), 
+        new Item("1_10", 33, "33333"),
+        new Item("1_2", 99, "66"), 
+        new Item("1_11", 44, "1111111"),
+        new Item("0", 55, "222222")
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender)
+        {
+            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+        }
+    }
+
+    private async Task OnCheckedChanged(bool value)
+    {
+        NaturalSortingEnabled = value;
+        if (DataGrid.SortDefinitions.ContainsKey(nameof(Item.Name)))
+        {
+            if (DataGrid.SortDefinitions[nameof(Item.Name)].Descending)
+            {
+                DataGrid.SortDefinitions.Clear();
+                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Descending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+            }
+            else
+            {
+                DataGrid.SortDefinitions.Clear();
+                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+            }
+        }
+        else
+        {
+            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+        }
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public string Misc { get; set; }
+
+        public Item(string name, int value, String misc)
+        {
+            Name = name;
+            Value = value;
+            Misc = misc;
+        }
+    }
+
+    public class NaturalComparer : IComparer<object>
+    {
+        public int Compare(object x, object y)
+        {
+            // Check if the objects are null
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+            else if (x == null)
+            {
+                return -1;
+            }
+            else if (y == null)
+            {
+                return 1;
+            }
+
+            //This is the piece of custom sorting to add
+            if(x is string && y is string)
+            {
+                return CompareNatural((string)x, (string)y);                
+            }
+            else if (x is IComparable && y is IComparable)
+            {
+                return ((IComparable)x).CompareTo(y);
+            }
+            else
+            {
+                return x.ToString().CompareTo(y.ToString());
+            }
+            
+        }
+
+    }
+
+    /// <summary>
+    /// Credit goes to user J.D. and user Ian Kemp from StackOverFlow for this algorithm https://stackoverflow.com/a/7048016
+    /// </summary>
+    /// <param name="strA"></param>
+    /// <param name="strB"></param>
+    /// <returns></returns>
+    public static int CompareNatural(string strA, string strB)
+    {
+        return CompareNatural(strA, strB, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+    }
+
+    public static int CompareNatural(string strA, string strB, CultureInfo culture, CompareOptions options)
+    {
+        CompareInfo cmp = culture.CompareInfo;
+        int iA = 0;
+        int iB = 0;
+        int softResult = 0;
+        int softResultWeight = 0;
+        while (iA < strA.Length && iB < strB.Length)
+        {
+            bool isDigitA = Char.IsDigit(strA[iA]);
+            bool isDigitB = Char.IsDigit(strB[iB]);
+            if (isDigitA != isDigitB)
+            {
+                return cmp.Compare(strA, iA, strB, iB, options);
+            }
+            else if (!isDigitA && !isDigitB)
+            {
+                int jA = iA + 1;
+                int jB = iB + 1;
+                while (jA < strA.Length && !Char.IsDigit(strA[jA])) jA++;
+                while (jB < strB.Length && !Char.IsDigit(strB[jB])) jB++;
+                int cmpResult = cmp.Compare(strA, iA, jA - iA, strB, iB, jB - iB, options);
+                if (cmpResult != 0)
+                {
+                    // Certain strings may be considered different due to "soft" differences that are
+                    // ignored if more significant differences follow, e.g. a hyphen only affects the
+                    // comparison if no other differences follow
+                    string sectionA = strA.Substring(iA, jA - iA);
+                    string sectionB = strB.Substring(iB, jB - iB);
+                    if (cmp.Compare(sectionA + "1", sectionB + "2", options) ==
+                        cmp.Compare(sectionA + "2", sectionB + "1", options))
+                    {
+                        return cmp.Compare(strA, iA, strB, iB, options);
+                    }
+                    else if (softResultWeight < 1)
+                    {
+                        softResult = cmpResult;
+                        softResultWeight = 1;
+                    }
+                }
+                iA = jA;
+                iB = jB;
+            }
+            else
+            {
+                char zeroA = (char)(strA[iA] - (int)Char.GetNumericValue(strA[iA]));
+                char zeroB = (char)(strB[iB] - (int)Char.GetNumericValue(strB[iB]));
+                int jA = iA;
+                int jB = iB;
+                while (jA < strA.Length && strA[jA] == zeroA) jA++;
+                while (jB < strB.Length && strB[jB] == zeroB) jB++;
+                int resultIfSameLength = 0;
+                do
+                {
+                    isDigitA = jA < strA.Length && Char.IsDigit(strA[jA]);
+                    isDigitB = jB < strB.Length && Char.IsDigit(strB[jB]);
+                    int numA = isDigitA ? (int)Char.GetNumericValue(strA[jA]) : 0;
+                    int numB = isDigitB ? (int)Char.GetNumericValue(strB[jB]) : 0;
+                    if (isDigitA && (char)(strA[jA] - numA) != zeroA) isDigitA = false;
+                    if (isDigitB && (char)(strB[jB] - numB) != zeroB) isDigitB = false;
+                    if (isDigitA && isDigitB)
+                    {
+                        if (numA != numB && resultIfSameLength == 0)
+                        {
+                            resultIfSameLength = numA < numB ? -1 : 1;
+                        }
+                        jA++;
+                        jB++;
+                    }
+                }
+                while (isDigitA && isDigitB);
+                if (isDigitA != isDigitB)
+                {
+                    // One number has more digits than the other (ignoring leading zeros) - the longer
+                    // number must be larger
+                    return isDigitA ? 1 : -1;
+                }
+                else if (resultIfSameLength != 0)
+                {
+                    // Both numbers are the same length (ignoring leading zeros) and at least one of
+                    // the digits differed - the first difference determines the result
+                    return resultIfSameLength;
+                }
+                int lA = jA - iA;
+                int lB = jB - iB;
+                if (lA != lB)
+                {
+                    // Both numbers are equivalent but one has more leading zeros
+                    return lA > lB ? -1 : 1;
+                }
+                else if (zeroA != zeroB && softResultWeight < 2)
+                {
+                    softResult = cmp.Compare(strA, iA, 1, strB, iB, 1, options);
+                    softResultWeight = 2;
+                }
+                iA = jA;
+                iB = jB;
+            }
+        }
+        if (iA < strA.Length || iB < strB.Length)
+        {
+            return iA < strA.Length ? 1 : -1;
+        }
+        else if (softResult != 0)
+        {
+            return softResult;
+        }
+        return 0;
+    }
+
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridCustomSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridCustomSortingExample.razor
@@ -3,7 +3,7 @@
 
 <MudDataGrid @ref="DataGrid" Items="@_items" Sortable="true">
     <Columns>
-        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new NaturalComparer() : null)" />
+        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null)" />
         <PropertyColumn Property="x => x.Value" />
         <PropertyColumn Property="x => x.Misc" />
     </Columns>
@@ -34,7 +34,7 @@
 
         if (firstRender)
         {
-            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null);
         }
     }
 
@@ -46,17 +46,17 @@
             if (DataGrid.SortDefinitions[nameof(Item.Name)].Descending)
             {
                 DataGrid.SortDefinitions.Clear();
-                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Descending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Descending, x => x.Name, NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null);
             }
             else
             {
                 DataGrid.SortDefinitions.Clear();
-                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+                await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null);
             }
         }
         else
         {
-            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new NaturalComparer() : null);
+            await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null);
         }
     }
 
@@ -72,164 +72,5 @@
             Value = value;
             Misc = misc;
         }
-    }
-
-    public class NaturalComparer : IComparer<object>
-    {
-        public int Compare(object x, object y)
-        {
-            // Check if the objects are null
-            if (x == null && y == null)
-            {
-                return 0;
-            }
-            else if (x == null)
-            {
-                return -1;
-            }
-            else if (y == null)
-            {
-                return 1;
-            }
-
-            //This is the piece of custom sorting to add
-            if(x is string && y is string)
-            {
-                return CompareNatural((string)x, (string)y);                
-            }
-            else if (x is IComparable && y is IComparable)
-            {
-                return ((IComparable)x).CompareTo(y);
-            }
-            else
-            {
-                return x.ToString().CompareTo(y.ToString());
-            }
-            
-        }
-
-    }
-
-    /// <summary>
-    /// Credit goes to user J.D. and user Ian Kemp from StackOverFlow for this algorithm https://stackoverflow.com/a/7048016
-    /// </summary>
-    /// <param name="strA"></param>
-    /// <param name="strB"></param>
-    /// <returns></returns>
-    public static int CompareNatural(string strA, string strB)
-    {
-        return CompareNatural(strA, strB, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
-    }
-
-    public static int CompareNatural(string strA, string strB, CultureInfo culture, CompareOptions options)
-    {
-        CompareInfo cmp = culture.CompareInfo;
-        int iA = 0;
-        int iB = 0;
-        int softResult = 0;
-        int softResultWeight = 0;
-        while (iA < strA.Length && iB < strB.Length)
-        {
-            bool isDigitA = Char.IsDigit(strA[iA]);
-            bool isDigitB = Char.IsDigit(strB[iB]);
-            if (isDigitA != isDigitB)
-            {
-                return cmp.Compare(strA, iA, strB, iB, options);
-            }
-            else if (!isDigitA && !isDigitB)
-            {
-                int jA = iA + 1;
-                int jB = iB + 1;
-                while (jA < strA.Length && !Char.IsDigit(strA[jA])) jA++;
-                while (jB < strB.Length && !Char.IsDigit(strB[jB])) jB++;
-                int cmpResult = cmp.Compare(strA, iA, jA - iA, strB, iB, jB - iB, options);
-                if (cmpResult != 0)
-                {
-                    // Certain strings may be considered different due to "soft" differences that are
-                    // ignored if more significant differences follow, e.g. a hyphen only affects the
-                    // comparison if no other differences follow
-                    string sectionA = strA.Substring(iA, jA - iA);
-                    string sectionB = strB.Substring(iB, jB - iB);
-                    if (cmp.Compare(sectionA + "1", sectionB + "2", options) ==
-                        cmp.Compare(sectionA + "2", sectionB + "1", options))
-                    {
-                        return cmp.Compare(strA, iA, strB, iB, options);
-                    }
-                    else if (softResultWeight < 1)
-                    {
-                        softResult = cmpResult;
-                        softResultWeight = 1;
-                    }
-                }
-                iA = jA;
-                iB = jB;
-            }
-            else
-            {
-                char zeroA = (char)(strA[iA] - (int)Char.GetNumericValue(strA[iA]));
-                char zeroB = (char)(strB[iB] - (int)Char.GetNumericValue(strB[iB]));
-                int jA = iA;
-                int jB = iB;
-                while (jA < strA.Length && strA[jA] == zeroA) jA++;
-                while (jB < strB.Length && strB[jB] == zeroB) jB++;
-                int resultIfSameLength = 0;
-                do
-                {
-                    isDigitA = jA < strA.Length && Char.IsDigit(strA[jA]);
-                    isDigitB = jB < strB.Length && Char.IsDigit(strB[jB]);
-                    int numA = isDigitA ? (int)Char.GetNumericValue(strA[jA]) : 0;
-                    int numB = isDigitB ? (int)Char.GetNumericValue(strB[jB]) : 0;
-                    if (isDigitA && (char)(strA[jA] - numA) != zeroA) isDigitA = false;
-                    if (isDigitB && (char)(strB[jB] - numB) != zeroB) isDigitB = false;
-                    if (isDigitA && isDigitB)
-                    {
-                        if (numA != numB && resultIfSameLength == 0)
-                        {
-                            resultIfSameLength = numA < numB ? -1 : 1;
-                        }
-                        jA++;
-                        jB++;
-                    }
-                }
-                while (isDigitA && isDigitB);
-                if (isDigitA != isDigitB)
-                {
-                    // One number has more digits than the other (ignoring leading zeros) - the longer
-                    // number must be larger
-                    return isDigitA ? 1 : -1;
-                }
-                else if (resultIfSameLength != 0)
-                {
-                    // Both numbers are the same length (ignoring leading zeros) and at least one of
-                    // the digits differed - the first difference determines the result
-                    return resultIfSameLength;
-                }
-                int lA = jA - iA;
-                int lB = jB - iB;
-                if (lA != lB)
-                {
-                    // Both numbers are equivalent but one has more leading zeros
-                    return lA > lB ? -1 : 1;
-                }
-                else if (zeroA != zeroB && softResultWeight < 2)
-                {
-                    softResult = cmp.Compare(strA, iA, 1, strB, iB, 1, options);
-                    softResultWeight = 2;
-                }
-                iA = jA;
-                iB = jB;
-            }
-        }
-        if (iA < strA.Length || iB < strB.Length)
-        {
-            return iA < strA.Length ? 1 : -1;
-        }
-        else if (softResult != 0)
-        {
-            return softResult;
-        }
-        return 0;
-    }
-
-
+    }   
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
@@ -3,7 +3,7 @@
 
 <MudDataGrid @ref="DataGrid" Items="@_items" Sortable="true">
     <Columns>
-        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new NaturalComparer() : null)" />
+        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null)" />
         <PropertyColumn Property="x => x.Value" />
         <PropertyColumn Property="x => x.Misc" />
     </Columns>
@@ -31,7 +31,7 @@
 
     private async Task CallSort()
     {
-        await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, new NaturalComparer());
+        await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, new MudBlazor.Utilities.NaturalComparer());
     }
 
     public class Item
@@ -47,163 +47,4 @@
             Misc = misc;
         }
     }
-
-    public class NaturalComparer : IComparer<object>
-    {
-        public int Compare(object x, object y)
-        {
-            // Check if the objects are null
-            if (x == null && y == null)
-            {
-                return 0;
-            }
-            else if (x == null)
-            {
-                return -1;
-            }
-            else if (y == null)
-            {
-                return 1;
-            }
-
-            //This is the piece of custom sorting to add
-            if(x is string && y is string)
-            {
-                return CompareNatural((string)x, (string)y);                
-            }
-            else if (x is IComparable && y is IComparable)
-            {
-                return ((IComparable)x).CompareTo(y);
-            }
-            else
-            {
-                return x.ToString().CompareTo(y.ToString());
-            }
-            
-        }
-
-    }
-
-    /// <summary>
-    /// Credit goes to user J.D. and user Ian Kemp from StackOverFlow for this algorithm https://stackoverflow.com/a/7048016
-    /// </summary>
-    /// <param name="strA"></param>
-    /// <param name="strB"></param>
-    /// <returns></returns>
-    public static int CompareNatural(string strA, string strB)
-    {
-        return CompareNatural(strA, strB, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
-    }
-
-    public static int CompareNatural(string strA, string strB, CultureInfo culture, CompareOptions options)
-    {
-        CompareInfo cmp = culture.CompareInfo;
-        int iA = 0;
-        int iB = 0;
-        int softResult = 0;
-        int softResultWeight = 0;
-        while (iA < strA.Length && iB < strB.Length)
-        {
-            bool isDigitA = Char.IsDigit(strA[iA]);
-            bool isDigitB = Char.IsDigit(strB[iB]);
-            if (isDigitA != isDigitB)
-            {
-                return cmp.Compare(strA, iA, strB, iB, options);
-            }
-            else if (!isDigitA && !isDigitB)
-            {
-                int jA = iA + 1;
-                int jB = iB + 1;
-                while (jA < strA.Length && !Char.IsDigit(strA[jA])) jA++;
-                while (jB < strB.Length && !Char.IsDigit(strB[jB])) jB++;
-                int cmpResult = cmp.Compare(strA, iA, jA - iA, strB, iB, jB - iB, options);
-                if (cmpResult != 0)
-                {
-                    // Certain strings may be considered different due to "soft" differences that are
-                    // ignored if more significant differences follow, e.g. a hyphen only affects the
-                    // comparison if no other differences follow
-                    string sectionA = strA.Substring(iA, jA - iA);
-                    string sectionB = strB.Substring(iB, jB - iB);
-                    if (cmp.Compare(sectionA + "1", sectionB + "2", options) ==
-                        cmp.Compare(sectionA + "2", sectionB + "1", options))
-                    {
-                        return cmp.Compare(strA, iA, strB, iB, options);
-                    }
-                    else if (softResultWeight < 1)
-                    {
-                        softResult = cmpResult;
-                        softResultWeight = 1;
-                    }
-                }
-                iA = jA;
-                iB = jB;
-            }
-            else
-            {
-                char zeroA = (char)(strA[iA] - (int)Char.GetNumericValue(strA[iA]));
-                char zeroB = (char)(strB[iB] - (int)Char.GetNumericValue(strB[iB]));
-                int jA = iA;
-                int jB = iB;
-                while (jA < strA.Length && strA[jA] == zeroA) jA++;
-                while (jB < strB.Length && strB[jB] == zeroB) jB++;
-                int resultIfSameLength = 0;
-                do
-                {
-                    isDigitA = jA < strA.Length && Char.IsDigit(strA[jA]);
-                    isDigitB = jB < strB.Length && Char.IsDigit(strB[jB]);
-                    int numA = isDigitA ? (int)Char.GetNumericValue(strA[jA]) : 0;
-                    int numB = isDigitB ? (int)Char.GetNumericValue(strB[jB]) : 0;
-                    if (isDigitA && (char)(strA[jA] - numA) != zeroA) isDigitA = false;
-                    if (isDigitB && (char)(strB[jB] - numB) != zeroB) isDigitB = false;
-                    if (isDigitA && isDigitB)
-                    {
-                        if (numA != numB && resultIfSameLength == 0)
-                        {
-                            resultIfSameLength = numA < numB ? -1 : 1;
-                        }
-                        jA++;
-                        jB++;
-                    }
-                }
-                while (isDigitA && isDigitB);
-                if (isDigitA != isDigitB)
-                {
-                    // One number has more digits than the other (ignoring leading zeros) - the longer
-                    // number must be larger
-                    return isDigitA ? 1 : -1;
-                }
-                else if (resultIfSameLength != 0)
-                {
-                    // Both numbers are the same length (ignoring leading zeros) and at least one of
-                    // the digits differed - the first difference determines the result
-                    return resultIfSameLength;
-                }
-                int lA = jA - iA;
-                int lB = jB - iB;
-                if (lA != lB)
-                {
-                    // Both numbers are equivalent but one has more leading zeros
-                    return lA > lB ? -1 : 1;
-                }
-                else if (zeroA != zeroB && softResultWeight < 2)
-                {
-                    softResult = cmp.Compare(strA, iA, 1, strB, iB, 1, options);
-                    softResultWeight = 2;
-                }
-                iA = jA;
-                iB = jB;
-            }
-        }
-        if (iA < strA.Length || iB < strB.Length)
-        {
-            return iA < strA.Length ? 1 : -1;
-        }
-        else if (softResult != 0)
-        {
-            return softResult;
-        }
-        return 0;
-    }
-
-
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
@@ -1,0 +1,209 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Globalization;
+
+<MudDataGrid @ref="DataGrid" Items="@_items" Sortable="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new NaturalComparer() : null)" />
+        <PropertyColumn Property="x => x.Value" />
+        <PropertyColumn Property="x => x.Misc" />
+    </Columns>
+</MudDataGrid>
+<MudButton OnClick="CallSort" Variant="Variant.Outlined">Set Sort on Name Column</MudButton>
+<MudSwitch @bind-Checked="@NaturalSortingEnabled">Enable Natural Sorting</MudSwitch>
+
+@code {
+    public static string __description__ = @"Test in browser custom sorting of DataGrid. Note that the 'Name' column is being sorted using a natural sorting algorithm.";
+    private MudDataGrid<Item> DataGrid;
+
+    private bool NaturalSortingEnabled = true;
+
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("1", 42, "555"), 
+        new Item("10", 73, "7"), 
+        new Item("2", 11, "4444"), 
+        new Item("1_10", 33, "33333"),
+        new Item("1_2", 99, "66"), 
+        new Item("1_11", 44, "1111111"),
+        new Item("0", 55, "222222")
+    };
+   
+
+    private async Task CallSort()
+    {
+        await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, new NaturalComparer());
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public string Misc { get; set; }
+
+        public Item(string name, int value, String misc)
+        {
+            Name = name;
+            Value = value;
+            Misc = misc;
+        }
+    }
+
+    public class NaturalComparer : IComparer<object>
+    {
+        public int Compare(object x, object y)
+        {
+            // Check if the objects are null
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+            else if (x == null)
+            {
+                return -1;
+            }
+            else if (y == null)
+            {
+                return 1;
+            }
+
+            //This is the piece of custom sorting to add
+            if(x is string && y is string)
+            {
+                return CompareNatural((string)x, (string)y);                
+            }
+            else if (x is IComparable && y is IComparable)
+            {
+                return ((IComparable)x).CompareTo(y);
+            }
+            else
+            {
+                return x.ToString().CompareTo(y.ToString());
+            }
+            
+        }
+
+    }
+
+    /// <summary>
+    /// Credit goes to user J.D. and user Ian Kemp from StackOverFlow for this algorithm https://stackoverflow.com/a/7048016
+    /// </summary>
+    /// <param name="strA"></param>
+    /// <param name="strB"></param>
+    /// <returns></returns>
+    public static int CompareNatural(string strA, string strB)
+    {
+        return CompareNatural(strA, strB, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+    }
+
+    public static int CompareNatural(string strA, string strB, CultureInfo culture, CompareOptions options)
+    {
+        CompareInfo cmp = culture.CompareInfo;
+        int iA = 0;
+        int iB = 0;
+        int softResult = 0;
+        int softResultWeight = 0;
+        while (iA < strA.Length && iB < strB.Length)
+        {
+            bool isDigitA = Char.IsDigit(strA[iA]);
+            bool isDigitB = Char.IsDigit(strB[iB]);
+            if (isDigitA != isDigitB)
+            {
+                return cmp.Compare(strA, iA, strB, iB, options);
+            }
+            else if (!isDigitA && !isDigitB)
+            {
+                int jA = iA + 1;
+                int jB = iB + 1;
+                while (jA < strA.Length && !Char.IsDigit(strA[jA])) jA++;
+                while (jB < strB.Length && !Char.IsDigit(strB[jB])) jB++;
+                int cmpResult = cmp.Compare(strA, iA, jA - iA, strB, iB, jB - iB, options);
+                if (cmpResult != 0)
+                {
+                    // Certain strings may be considered different due to "soft" differences that are
+                    // ignored if more significant differences follow, e.g. a hyphen only affects the
+                    // comparison if no other differences follow
+                    string sectionA = strA.Substring(iA, jA - iA);
+                    string sectionB = strB.Substring(iB, jB - iB);
+                    if (cmp.Compare(sectionA + "1", sectionB + "2", options) ==
+                        cmp.Compare(sectionA + "2", sectionB + "1", options))
+                    {
+                        return cmp.Compare(strA, iA, strB, iB, options);
+                    }
+                    else if (softResultWeight < 1)
+                    {
+                        softResult = cmpResult;
+                        softResultWeight = 1;
+                    }
+                }
+                iA = jA;
+                iB = jB;
+            }
+            else
+            {
+                char zeroA = (char)(strA[iA] - (int)Char.GetNumericValue(strA[iA]));
+                char zeroB = (char)(strB[iB] - (int)Char.GetNumericValue(strB[iB]));
+                int jA = iA;
+                int jB = iB;
+                while (jA < strA.Length && strA[jA] == zeroA) jA++;
+                while (jB < strB.Length && strB[jB] == zeroB) jB++;
+                int resultIfSameLength = 0;
+                do
+                {
+                    isDigitA = jA < strA.Length && Char.IsDigit(strA[jA]);
+                    isDigitB = jB < strB.Length && Char.IsDigit(strB[jB]);
+                    int numA = isDigitA ? (int)Char.GetNumericValue(strA[jA]) : 0;
+                    int numB = isDigitB ? (int)Char.GetNumericValue(strB[jB]) : 0;
+                    if (isDigitA && (char)(strA[jA] - numA) != zeroA) isDigitA = false;
+                    if (isDigitB && (char)(strB[jB] - numB) != zeroB) isDigitB = false;
+                    if (isDigitA && isDigitB)
+                    {
+                        if (numA != numB && resultIfSameLength == 0)
+                        {
+                            resultIfSameLength = numA < numB ? -1 : 1;
+                        }
+                        jA++;
+                        jB++;
+                    }
+                }
+                while (isDigitA && isDigitB);
+                if (isDigitA != isDigitB)
+                {
+                    // One number has more digits than the other (ignoring leading zeros) - the longer
+                    // number must be larger
+                    return isDigitA ? 1 : -1;
+                }
+                else if (resultIfSameLength != 0)
+                {
+                    // Both numbers are the same length (ignoring leading zeros) and at least one of
+                    // the digits differed - the first difference determines the result
+                    return resultIfSameLength;
+                }
+                int lA = jA - iA;
+                int lB = jB - iB;
+                if (lA != lB)
+                {
+                    // Both numbers are equivalent but one has more leading zeros
+                    return lA > lB ? -1 : 1;
+                }
+                else if (zeroA != zeroB && softResultWeight < 2)
+                {
+                    softResult = cmp.Compare(strA, iA, 1, strB, iB, 1, options);
+                    softResultWeight = 2;
+                }
+                iA = jA;
+                iB = jB;
+            }
+        }
+        if (iA < strA.Length || iB < strB.Length)
+        {
+            return iA < strA.Length ? 1 : -1;
+        }
+        else if (softResult != 0)
+        {
+            return softResult;
+        }
+        return 0;
+    }
+
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3355,14 +3355,14 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.SortMode = SortMode.Single;
             dataGrid.Instance.SortMode.Should().Be(SortMode.Single);
 
-            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Ascending, x => x.Value, new DataGridCustomSortableTest.NaturalComparer()));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Ascending, x => x.Value, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.FindAll("th .sortable-column-header")[1].TextContent.Trim().Should().Be("Value");
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(false);
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-asc").Should().Be(true);
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Ascending);
 
-            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Descending, x => x.Value, new DataGridCustomSortableTest.NaturalComparer()));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Descending, x => x.Value, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Descending);
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(false);
@@ -3375,13 +3375,13 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Ascending);
 
-            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => x.Name, new DataGridCustomSortableTest.NaturalComparer()));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => x.Name, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.Ascending);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.None);
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(true);
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-asc").Should().Be(false);
 
-            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => x.Name, new DataGridCustomSortableTest.NaturalComparer()));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => x.Name, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.Descending);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.None);
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-desc").Should().Be(true);
@@ -3392,7 +3392,7 @@ namespace MudBlazor.UnitTests.Components
 
             //Assign a comparer to a column
             var column = dataGrid.FindComponent<Column<DataGridCustomSortableTest.Item>>();
-            await comp.InvokeAsync(() => column.Instance.Comparer = new DataGridCustomSortableTest.NaturalComparer());
+            await comp.InvokeAsync(() => column.Instance.Comparer = new MudBlazor.Utilities.NaturalComparer());
             //Clear sorting
             await comp.InvokeAsync(() => dataGrid.Instance.RemoveSortAsync("Name"));
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);

--- a/src/MudBlazor.UnitTests/Utilities/NaturalComparerTest.cs
+++ b/src/MudBlazor.UnitTests/Utilities/NaturalComparerTest.cs
@@ -1,0 +1,406 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using MudBlazor.Utilities;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities
+{
+    public class NaturalComparerTest
+    {
+
+        Func<string, string> _expand = (s) => {
+            int o; while ((o = s.IndexOf('\\')) != -1)
+            {
+                int p = o + 1;
+                int z = 1; while (s[p] == '0') { z++; p++; }
+                int c = Int32.Parse(s.Substring(p, z));
+                s = s.Substring(0, o) + new string(s[o - 1], c) + s.Substring(p + z);
+            }
+            return s;
+        };
+
+        private static string s_encodedFileNames =
+                "KDEqLW4xMiotbjEzKjAwMDFcMDY2KjAwMlwwMTcqMDA5XDAxNyowMlwwMTcqMDlcMDE3KjEhKjEtISox" +
+                "LWEqMS4yNT8xLjI1KjEuNT8xLjUqMSoxXDAxNyoxXDAxOCoxXDAxOSoxXDA2NioxXDA2NyoxYSoyXDAx" +
+                "NyoyXDAxOCo5XDAxNyo5XDAxOCo5XDA2Nio9MSphMDAxdGVzdDAxKmEwMDF0ZXN0aW5nYTBcMzEqYTAw" +
+                "Mj9hMDAyIGE/YTAwMiBhKmEwMDIqYTAwMmE/YTAwMmEqYTAxdGVzdGluZ2EwMDEqYTAxdnNmcyphMSph" +
+                "MWEqYTF6KmEyKmIwMDAzcTYqYjAwM3E0KmIwM3E1KmMtZSpjZCpjZipmIDEqZipnP2cgMT9oLW4qaG8t" +
+                "bipJKmljZS1jcmVhbT9pY2VjcmVhbT9pY2VjcmVhbS0/ajBcNDE/ajAwMWE/ajAxP2shKmsnKmstKmsx" +
+                "KmthKmxpc3QqbTAwMDNhMDA1YSptMDAzYTAwMDVhKm0wMDNhMDA1Km0wMDNhMDA1YSpuMTIqbjEzKm8t" +
+                "bjAxMypvLW4xMipvLW40P28tbjQhP28tbjR6P28tbjlhLWI1Km8tbjlhYjUqb24wMTMqb24xMipvbjQ/" +
+                "b240IT9vbjR6P29uOWEtYjUqb245YWI1Km/CrW4wMTMqb8KtbjEyKnAwMCpwMDEqcDAxwr0hKnAwMcK9" +
+                "KnAwMcK9YSpwMDHCvcK+KnAwMipwMMK9KnEtbjAxMypxLW4xMipxbjAxMypxbjEyKnItMDAhKnItMDAh" +
+                "NSpyLTAwIe+8lSpyLTAwYSpyLe+8kFwxIS01KnIt77yQXDEhLe+8lSpyLe+8kFwxISpyLe+8kFwxITUq" +
+                "ci3vvJBcMSHvvJUqci3vvJBcMWEqci3vvJBcMyE1KnIwMCEqcjAwLTUqcjAwLjUqcjAwNSpyMDBhKnIw" +
+                "NSpyMDYqcjQqcjUqctmg2aYqctmkKnLZpSpy27Dbtipy27Qqctu1KnLfgN+GKnLfhCpy34UqcuClpuCl" +
+                "rCpy4KWqKnLgpasqcuCnpuCnrCpy4KeqKnLgp6sqcuCppuCprCpy4KmqKnLgqasqcuCrpuCrrCpy4Kuq" +
+                "KnLgq6sqcuCtpuCtrCpy4K2qKnLgrasqcuCvpuCvrCpy4K+qKnLgr6sqcuCxpuCxrCpy4LGqKnLgsasq" +
+                "cuCzpuCzrCpy4LOqKnLgs6sqcuC1puC1rCpy4LWqKnLgtasqcuC5kOC5lipy4LmUKnLguZUqcuC7kOC7" +
+                "lipy4LuUKnLgu5UqcuC8oOC8pipy4LykKnLgvKUqcuGBgOGBhipy4YGEKnLhgYUqcuGCkOGClipy4YKU" +
+                "KnLhgpUqcuGfoOGfpipy4Z+kKnLhn6UqcuGgkOGglipy4aCUKnLhoJUqcuGlhuGljCpy4aWKKnLhpYsq" +
+                "cuGnkOGnlipy4aeUKnLhp5UqcuGtkOGtlipy4a2UKnLhrZUqcuGusOGutipy4a60KnLhrrUqcuGxgOGx" +
+                "hipy4bGEKnLhsYUqcuGxkOGxlipy4bGUKnLhsZUqcuqYoFwx6pilKnLqmKDqmKUqcuqYoOqYpipy6pik" +
+                "KnLqmKUqcuqjkOqjlipy6qOUKnLqo5UqcuqkgOqkhipy6qSEKnLqpIUqcuqpkOqplipy6qmUKnLqqZUq" +
+                "cvCQkqAqcvCQkqUqcvCdn5gqcvCdn50qcu+8kFwxISpy77yQXDEt77yVKnLvvJBcMS7vvJUqcu+8kFwx" +
+                "YSpy77yQXDHqmKUqcu+8kFwx77yO77yVKnLvvJBcMe+8lSpy77yQ77yVKnLvvJDvvJYqcu+8lCpy77yV" +
+                "KnNpKnPEsSp0ZXN02aIqdGVzdNmi2aAqdGVzdNmjKnVBZS0qdWFlKnViZS0qdUJlKnVjZS0xw6kqdWNl" +
+                "McOpLSp1Y2Uxw6kqdWPDqS0xZSp1Y8OpMWUtKnVjw6kxZSp3ZWlhMSp3ZWlhMip3ZWlzczEqd2Vpc3My" +
+                "KndlaXoxKndlaXoyKndlacOfMSp3ZWnDnzIqeSBhMyp5IGE0KnknYTMqeSdhNCp5K2EzKnkrYTQqeS1h" +
+                "Myp5LWE0KnlhMyp5YTQqej96IDA1MD96IDIxP3ohMjE/ejIwP3oyMj96YTIxP3rCqTIxP1sxKl8xKsKt" +
+                "bjEyKsKtbjEzKsSwKg==";
+
+
+        private static string[] s_orderedFileNames = new string[]
+        {
+            "_1.txt"
+            ,"-n12.txt"
+            ,"-n13.txt"
+            ,"(1.txt"
+            ,"[1.txt"
+            ,"=1.txt"
+            ,"1-!.txt"
+            ,"1-a.txt"
+            ,"1!.txt"
+            ,"1.5"
+            ,"1.5.txt"
+            ,"1.25"
+            ,"1.25.txt"
+            ,"1.txt"
+            ,"1a.txt"
+            ,"111111111111111111.txt"
+            ,"00222222222222222222.txt"
+            ,"0222222222222222222.txt"
+            ,"222222222222222222.txt"
+            ,"00999999999999999999.txt"
+            ,"0999999999999999999.txt"
+            ,"999999999999999999.txt"
+            ,"1111111111111111111.txt"
+            ,"2222222222222222222.txt"
+            ,"9999999999999999999.txt"
+            ,"11111111111111111111.txt"
+            ,"0001111111111111111111111111111111111111111111111111111111111111111111.txt"
+            ,"1111111111111111111111111111111111111111111111111111111111111111111.txt"
+            ,"9999999999999999999999999999999999999999999999999999999999999999999.txt"
+            ,"11111111111111111111111111111111111111111111111111111111111111111111.txt"
+            ,"a001test01.txt"
+            ,"a001testinga00001.txt"
+            ,"a01testinga001.txt"
+            ,"a01vsfs.txt"
+            ,"a1.txt"
+            ,"a1a.txt"
+            ,"a1z.txt"
+            ,"a002"
+            ,"a002 a"
+            ,"a002 a.txt"
+            ,"a002.txt"
+            ,"a002a"
+            ,"a002a.txt"
+            ,"a2.txt"
+            ,"b0003q6.txt"
+            ,"b003q4.txt"
+            ,"b03q5.txt"
+            ,"c-e.txt"
+            ,"cd.txt"
+            ,"cf.txt"
+            ,"f 1.txt"
+            ,"f.txt"
+            ,"g"
+            ,"g 1"
+            ,"h-n.txt"
+            ,"ho-n.txt"
+            ,"I.txt"
+            ,"İ.txt"
+            ,"ice-cream"
+            ,"icecream"
+            ,"icecream-"
+            ,"j000001"
+            ,"j001a"
+            ,"j01"
+            ,"k-.txt"
+            ,"k!.txt"
+            ,"k'.txt"
+            ,"k1.txt"
+            ,"ka.txt"
+            ,"list.txt"
+            ,"m0003a005a.txt"
+            ,"m003a0005a.txt"
+            ,"m003a005.txt"
+            ,"m003a005a.txt"
+            ,"n12.txt"
+            ,"­n12.txt"
+            ,"n13.txt"
+            ,"­n13.txt"
+            ,"o-n4"
+            ,"o-n4!"
+            ,"o-n4z"
+            ,"o-n9a-b5.txt"
+            ,"o-n9ab5.txt"
+            ,"o-n12.txt"
+            ,"o-n013.txt"
+            ,"on4"
+            ,"on4!"
+            ,"on4z"
+            ,"on9a-b5.txt"
+            ,"on9ab5.txt"
+            ,"on12.txt"
+            ,"o­n12.txt"
+            ,"on013.txt"
+            ,"o­n013.txt"
+            ,"p00.txt"
+            ,"p0½.txt"
+            ,"p01.txt"
+            ,"p01½!.txt"
+            ,"p01½.txt"
+            ,"p01½¾.txt"
+            ,"p01½a.txt"
+            ,"p02.txt"
+            ,"q-n12.txt"
+            ,"q-n013.txt"
+            ,"qn12.txt"
+            ,"qn013.txt"
+            ,"r-００００!5.txt"
+            ,"r-００!-5.txt"
+            ,"r-００!-５.txt"
+            ,"r-00!.txt"
+            ,"r-００!.txt"
+            ,"r-00!5.txt"
+            ,"r-00!５.txt"
+            ,"r-００!5.txt"
+            ,"r-００!５.txt"
+            ,"r-00a.txt"
+            ,"r-００a.txt"
+            ,"r𐒠.txt"
+            ,"r𝟘.txt"
+            ,"r00-5.txt"
+            ,"r００-５.txt"
+            ,"r00!.txt"
+            ,"r００!.txt"
+            ,"r00.5.txt"
+            ,"r００.５.txt"
+            ,"r００．５.txt"
+            ,"r００꘥.txt"
+            ,"r00a.txt"
+            ,"r００a.txt"
+            ,"r4.txt"
+            ,"r٤.txt"
+            ,"r۴.txt"
+            ,"r߄.txt"
+            ,"r४.txt"
+            ,"r৪.txt"
+            ,"r੪.txt"
+            ,"r૪.txt"
+            ,"r୪.txt"
+            ,"r௪.txt"
+            ,"r౪.txt"
+            ,"r೪.txt"
+            ,"r൪.txt"
+            ,"r๔.txt"
+            ,"r໔.txt"
+            ,"r༤.txt"
+            ,"r၄.txt"
+            ,"r႔.txt"
+            ,"r៤.txt"
+            ,"r᠔.txt"
+            ,"r᥊.txt"
+            ,"r᧔.txt"
+            ,"r᭔.txt"
+            ,"r᮴.txt"
+            ,"r᱄.txt"
+            ,"r᱔.txt"
+            ,"r꘤.txt"
+            ,"r꣔.txt"
+            ,"r꤄.txt"
+            ,"r꩔.txt"
+            ,"r４.txt"
+            ,"r005.txt"
+            ,"r꘠꘠꘥.txt"
+            ,"r００５.txt"
+            ,"r05.txt"
+            ,"r꘠꘥.txt"
+            ,"r０５.txt"
+            ,"r5.txt"
+            ,"r٥.txt"
+            ,"r۵.txt"
+            ,"r߅.txt"
+            ,"r५.txt"
+            ,"r৫.txt"
+            ,"r੫.txt"
+            ,"r૫.txt"
+            ,"r୫.txt"
+            ,"r௫.txt"
+            ,"r౫.txt"
+            ,"r೫.txt"
+            ,"r൫.txt"
+            ,"r๕.txt"
+            ,"r໕.txt"
+            ,"r༥.txt"
+            ,"r၅.txt"
+            ,"r႕.txt"
+            ,"r៥.txt"
+            ,"r᠕.txt"
+            ,"r᥋.txt"
+            ,"r᧕.txt"
+            ,"r᭕.txt"
+            ,"r᮵.txt"
+            ,"r᱅.txt"
+            ,"r᱕.txt"
+            ,"r꘥.txt"
+            ,"r꣕.txt"
+            ,"r꤅.txt"
+            ,"r꩕.txt"
+            ,"r５.txt"
+            ,"r06.txt"
+            ,"r٠٦.txt"
+            ,"r۰۶.txt"
+            ,"r߀߆.txt"
+            ,"r०६.txt"
+            ,"r০৬.txt"
+            ,"r੦੬.txt"
+            ,"r૦૬.txt"
+            ,"r୦୬.txt"
+            ,"r௦௬.txt"
+            ,"r౦౬.txt"
+            ,"r೦೬.txt"
+            ,"r൦൬.txt"
+            ,"r๐๖.txt"
+            ,"r໐໖.txt"
+            ,"r༠༦.txt"
+            ,"r၀၆.txt"
+            ,"r႐႖.txt"
+            ,"r០៦.txt"
+            ,"r᠐᠖.txt"
+            ,"r᥆᥌.txt"
+            ,"r᧐᧖.txt"
+            ,"r᭐᭖.txt"
+            ,"r᮰᮶.txt"
+            ,"r᱀᱆.txt"
+            ,"r᱐᱖.txt"
+            ,"r꘠꘦.txt"
+            ,"r꣐꣖.txt"
+            ,"r꤀꤆.txt"
+            ,"r꩐꩖.txt"
+            ,"r０６.txt"
+            ,"r𐒥.txt"
+            ,"r𝟝.txt"
+            ,"si.txt"
+            ,"sı.txt"
+            ,"test٢.txt"
+            ,"test٣.txt"
+            ,"test٢٠.txt"
+            ,"uAe-.txt"
+            ,"uae.txt"
+            ,"ube-.txt"
+            ,"uBe.txt"
+            ,"uce-1é.txt"
+            ,"ucé-1e.txt"
+            ,"uce1é-.txt"
+            ,"ucé1e-.txt"
+            ,"uce1é.txt"
+            ,"ucé1e.txt"
+            ,"weia1.txt"
+            ,"weia2.txt"
+            ,"weiss1.txt"
+            ,"weiß1.txt"
+            ,"weiss2.txt"
+            ,"weiß2.txt"
+            ,"weiz1.txt"
+            ,"weiz2.txt"
+            ,"y a3.txt"
+            ,"y a4.txt"
+            ,"y-a3.txt"
+            ,"y-a4.txt"
+            ,"y'a3.txt"
+            ,"y'a4.txt"
+            ,"y+a3.txt"
+            ,"y+a4.txt"
+            ,"ya3.txt"
+            ,"ya4.txt"
+            ,"z"
+            ,"z 21"
+            ,"z 050"
+            ,"z!21"
+            ,"z©21"
+            ,"z20"
+            ,"z22"
+            ,"za21"
+        };
+
+        /// <summary>
+        /// Test if comparer works as intended
+        /// </summary>
+        [Test]
+        public void SortFiles()
+        {
+            string[] fileNames = Encoding.UTF8.GetString(Convert.FromBase64String(s_encodedFileNames))
+                .Replace("*", ".txt?").Split(new[] { "?" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(n => _expand(n)).ToArray();
+
+            string[] orderedFiles = fileNames.OrderBy(x => x, new NaturalComparer()).ToArray();
+            
+            orderedFiles.Should().NotBeEmpty();
+            orderedFiles.Should().ContainInOrder(s_orderedFileNames);
+        }
+
+        /// <summary>
+        /// Test if Comparer may receive non string, but comparable types
+        /// </summary>
+        [Test]
+        public void SortNonStringButComparableTypes()
+        {
+            var items = new List<int>() { 1, 8, 7, 9, 63, 4, 0 };
+            var orderedItems = items.OrderBy(x => x, new NaturalComparer());
+
+            orderedItems.Should().NotBeNull();
+            orderedItems.Should().NotBeEmpty();
+
+            var expectedOrder = new int[] { 0, 1, 4, 7, 8, 9, 63 };
+            orderedItems.Should().ContainInOrder(expectedOrder);
+        }
+
+        private record NonEquatable(int Index, string Value)
+        {
+            public override string ToString()
+            {
+                return Index.ToString() + Value;
+            }
+        }
+
+        /// <summary>
+        /// Test if Comparer may receive non string that do not implement Equals
+        /// </summary>
+        [Test]
+        public void SortNonEquatable()
+        {
+            var items = new List<NonEquatable>() { new NonEquatable(1, "un"), new NonEquatable(3, "trois"), new NonEquatable(2, "deux") };
+
+            var orderedItems = items.OrderBy(x => x, new NaturalComparer()).Select(x => x.ToString());
+
+            orderedItems.Should().NotBeNull();
+            orderedItems.Should().NotBeEmpty();
+
+            var expectedOrders = new string[] { "1un", "2deux", "3trois" };
+            orderedItems.Should().ContainInOrder(expectedOrders);
+        }
+
+        /// <summary>
+        /// Test when there are null values sent to be compared
+        /// </summary>
+        [Test]
+        public void NullTest()
+        {
+            var naturalComparer = new NaturalComparer();
+
+            naturalComparer.Compare(null, null).Should().Be(0);
+            naturalComparer.Compare(null, 1).Should().Be(-1);
+            naturalComparer.Compare(1, null).Should().Be(1);
+        }
+
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -80,6 +80,13 @@ namespace MudBlazor
         [Parameter] public bool? ShowColumnOptions { get; set; }
 
         [Parameter]
+        public IComparer<object> Comparer
+        {
+            get => _comparer;
+            set => _comparer = value;
+        }
+
+        [Parameter]
         public Func<T, object> SortBy
         {
             get
@@ -91,7 +98,6 @@ namespace MudBlazor
                 _sortBy = value;
             }
         }
-
         [Parameter] public SortDirection InitialDirection { get; set; } = SortDirection.None;
         [Parameter] public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
 
@@ -243,6 +249,7 @@ namespace MudBlazor
         internal int SortIndex { get; set; } = -1;
         internal HeaderCell<T> HeaderCell { get; set; }
 
+        private IComparer<object> _comparer = null;
         private Func<T, object> _sortBy;
         internal Func<T, object> groupBy;
         internal HeaderContext<T> headerContext;

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -313,9 +313,9 @@ namespace MudBlazor
             };
 
             if (args.CtrlKey && DataGrid.SortMode == SortMode.Multiple)
-                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc()));
+                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc(), Column.Comparer));
             else
-                await InvokeAsync(() => DataGrid.SetSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc()));
+                await InvokeAsync(() => DataGrid.SetSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc(), Column.Comparer));
         }
 
         internal async Task RemoveSortAsync()

--- a/src/MudBlazor/Components/DataGrid/SortDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/SortDefinition.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace MudBlazor
 {
 #nullable enable
-    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc);
+    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc, IComparer<object> Comparer = null);
 }

--- a/src/MudBlazor/Utilities/NaturalComparer.cs
+++ b/src/MudBlazor/Utilities/NaturalComparer.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace MudBlazor.Utilities
+{
+    public class NaturalComparer : IComparer<object>
+    {
+        public int Compare(object x, object y)
+        {
+            // Check if the objects are null
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+            else if (x == null)
+            {
+                return -1;
+            }
+            else if (y == null)
+            {
+                return 1;
+            }
+
+            //This is the piece of custom sorting to add
+            if (x is string xString && y is string yString)
+            {
+                return CompareNatural(xString, yString);
+            }
+            else if (x is IComparable && y is IComparable)
+            {
+                return ((IComparable)x).CompareTo(y);
+            }
+            else
+            {
+                return x.ToString().CompareTo(y.ToString());
+            }
+
+        }
+
+        /// <summary>
+        /// Credit goes to user J.D. and user Ian Kemp from StackOverFlow for this algorithm https://stackoverflow.com/a/7048016
+        /// </summary>
+        /// <param name="strA"></param>
+        /// <param name="strB"></param>
+        /// <returns></returns>
+        public static int CompareNatural(string strA, string strB)
+        {
+            return CompareNatural(strA, strB, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+        }
+
+        public static int CompareNatural(string strA, string strB, CultureInfo culture, CompareOptions options)
+        {
+            CompareInfo cmp = culture.CompareInfo;
+            int iA = 0;
+            int iB = 0;
+            int softResult = 0;
+            int softResultWeight = 0;
+            while (iA < strA.Length && iB < strB.Length)
+            {
+                bool isDigitA = char.IsDigit(strA[iA]);
+                bool isDigitB = char.IsDigit(strB[iB]);
+                if (isDigitA != isDigitB)
+                {
+                    return cmp.Compare(strA, iA, strB, iB, options);
+                }
+                else if (!isDigitA && !isDigitB)
+                {
+                    int jA = iA + 1;
+                    int jB = iB + 1;
+                    while (jA < strA.Length && !char.IsDigit(strA[jA])) jA++;
+                    while (jB < strB.Length && !char.IsDigit(strB[jB])) jB++;
+                    int cmpResult = cmp.Compare(strA, iA, jA - iA, strB, iB, jB - iB, options);
+                    if (cmpResult != 0)
+                    {
+                        // Certain strings may be considered different due to "soft" differences that are
+                        // ignored if more significant differences follow, e.g. a hyphen only affects the
+                        // comparison if no other differences follow
+                        string sectionA = strA.Substring(iA, jA - iA);
+                        string sectionB = strB.Substring(iB, jB - iB);
+                        if (cmp.Compare(sectionA + "1", sectionB + "2", options) ==
+                            cmp.Compare(sectionA + "2", sectionB + "1", options))
+                        {
+                            return cmp.Compare(strA, iA, strB, iB, options);
+                        }
+                        else if (softResultWeight < 1)
+                        {
+                            softResult = cmpResult;
+                            softResultWeight = 1;
+                        }
+                    }
+                    iA = jA;
+                    iB = jB;
+                }
+                else
+                {
+                    char zeroA = (char)(strA[iA] - (int)char.GetNumericValue(strA[iA]));
+                    char zeroB = (char)(strB[iB] - (int)char.GetNumericValue(strB[iB]));
+                    int jA = iA;
+                    int jB = iB;
+                    while (jA < strA.Length && strA[jA] == zeroA) jA++;
+                    while (jB < strB.Length && strB[jB] == zeroB) jB++;
+                    int resultIfSameLength = 0;
+                    do
+                    {
+                        isDigitA = jA < strA.Length && char.IsDigit(strA[jA]);
+                        isDigitB = jB < strB.Length && char.IsDigit(strB[jB]);
+                        int numA = isDigitA ? (int)char.GetNumericValue(strA[jA]) : 0;
+                        int numB = isDigitB ? (int)char.GetNumericValue(strB[jB]) : 0;
+                        if (isDigitA && (char)(strA[jA] - numA) != zeroA) isDigitA = false;
+                        if (isDigitB && (char)(strB[jB] - numB) != zeroB) isDigitB = false;
+                        if (isDigitA && isDigitB)
+                        {
+                            if (numA != numB && resultIfSameLength == 0)
+                            {
+                                resultIfSameLength = numA < numB ? -1 : 1;
+                            }
+                            jA++;
+                            jB++;
+                        }
+                    }
+                    while (isDigitA && isDigitB);
+                    if (isDigitA != isDigitB)
+                    {
+                        // One number has more digits than the other (ignoring leading zeros) - the longer
+                        // number must be larger
+                        return isDigitA ? 1 : -1;
+                    }
+                    else if (resultIfSameLength != 0)
+                    {
+                        // Both numbers are the same length (ignoring leading zeros) and at least one of
+                        // the digits differed - the first difference determines the result
+                        return resultIfSameLength;
+                    }
+                    int lA = jA - iA;
+                    int lB = jB - iB;
+                    if (lA != lB)
+                    {
+                        // Both numbers are equivalent but one has more leading zeros
+                        return lA > lB ? -1 : 1;
+                    }
+                    else if (zeroA != zeroB && softResultWeight < 2)
+                    {
+                        softResult = cmp.Compare(strA, iA, 1, strB, iB, 1, options);
+                        softResultWeight = 2;
+                    }
+                    iA = jA;
+                    iB = jB;
+                }
+            }
+            if (iA < strA.Length || iB < strB.Length)
+            {
+                return iA < strA.Length ? 1 : -1;
+            }
+            else if (softResult != 0)
+            {
+                return softResult;
+            }
+            return 0;
+        }
+
+    }
+
+   
+}


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Proposition to add a IComparer to the SortDefinition record class in DataGrid. User can either set their custom Comparer as a Column Parameter or they can set it once with SetSortAsync Task or the SortDefinitions Dictionary.

This feature is optional to be used. It's a tool to allow advanced sorting. Those wishing to use a custom comparer have to implement their own Comparer class like the one I made for my example and my test unit.
![image](https://user-images.githubusercontent.com/29356866/220725358-d58b946d-b637-42ef-886e-d13373d00cbe.png)

The reason why I did this was to allow custom Comparer like the StrCmpLogicalW from the Shlwapi.dll on Windows so we can properly sort filenames or string with a hierarchical pattern (e.g.: {"1", "1.1", "1.1.2", "1.2", "1.10"})

Since OrderBy and OrderByDescending both takes a nullable IComparer<TKey> parameter, we can default it as null without causing a breaking change. That way, if comparer is not supplied, OrderBy and OrderByDescending will use the default comparer for the type.

Here's the proposed documentation addition with it:
(default string sorting)
![image](https://user-images.githubusercontent.com/29356866/220721736-14265fb1-f0e2-4a47-8cd0-ac2eafd29184.png)

(natural sorting enabled by the Comparer Parameter)
![image](https://user-images.githubusercontent.com/29356866/220721864-1d54752e-c1fc-43f7-bd5d-abee4cb6b88e.png)

We can see that 10 comes now after 2 and 1_2 comes now before 1_10 and 1_11

Ordering using a IComparer is not supported for Linq to Entities operations, but I don't think that is ever the case here unless a Column can sort directly from a Linq query ?

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I created a unit test to validate calling SetSortAsync works with and without the comparer on different field types. I also tested assigning a comparer to a column and validated that the ordering was the one expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
