### PR TITLE
Autocomplete: Fix Autocomplete opening on Reset

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -497,7 +497,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             await comp.InvokeAsync(() => autocomplete.Clear().Wait());
             comp.Markup.Should().NotContain("mud-popover-open");
-            autocomplete.Value.Should().Be("");
+            autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");
 
             // now let's type a different state
@@ -510,7 +510,7 @@ namespace MudBlazor.UnitTests.Components
             // Clearing it and check the close status text and value again
             await comp.InvokeAsync(() => autocomplete.Clear().Wait());
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            autocomplete.Value.Should().Be("");
+            autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");
         }
 
@@ -577,7 +577,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => autocomplete.Reset());
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Value.Should().Be(null);
-            autocomplete.Text.Should().Be(null);
+            autocomplete.Text.Should().Be("");
 
             // now let's type a different state
             autocompletecomp.Find("input").Input("Calif");
@@ -590,7 +590,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => autocomplete.Reset());
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             autocomplete.Value.Should().Be(null);
-            autocomplete.Text.Should().Be(null);
+            autocomplete.Text.Should().Be("");
         }
 
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -491,7 +491,7 @@ namespace MudBlazor
 
         protected override void ResetValue()
         {
-            SetTextAsync(null, updateValue: true).AndForget();
+            SetTextAsync(string.Empty, updateValue: true).AndForget();
             this._isDirty = false;
             base.ResetValue();
         }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -491,7 +491,7 @@ namespace MudBlazor
 
         protected override void ResetValue()
         {
-            SetTextAsync(string.Empty, updateValue: true).AndForget();
+            SetTextAsync(null, updateValue: true).AndForget();
             this._isDirty = false;
             base.ResetValue();
         }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -537,7 +537,7 @@ namespace MudBlazor
         {
             _isCleared = true;
             IsOpen = false;
-            await SetTextAsync(string.Empty, updateValue: false);
+            await SetTextAsync(null, updateValue: false);
             await CoerceValueToText();
             if (_elementReference != null)
                 await _elementReference.SetText("");
@@ -548,7 +548,6 @@ namespace MudBlazor
         protected override async void ResetValue()
         {
             await Clear();
-            base.ResetValue();
         }
 
 
@@ -740,7 +739,7 @@ namespace MudBlazor
         protected override void Dispose(bool disposing)
         {
             _timer?.Dispose();
-            
+
             if (_cancellationTokenSrc != null)
             {
                 try

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -537,7 +537,7 @@ namespace MudBlazor
         {
             _isCleared = true;
             IsOpen = false;
-            await SetTextAsync(null, updateValue: false);
+            await SetTextAsync(string.Empty, updateValue: false);
             await CoerceValueToText();
             if (_elementReference != null)
                 await _elementReference.SetText("");

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -537,7 +537,7 @@ namespace MudBlazor
         {
             _isCleared = true;
             IsOpen = false;
-            await SetTextAsync(string.Empty, updateValue: false);
+            await SetTextAsync(null, updateValue: false);
             await CoerceValueToText();
             if (_elementReference != null)
                 await _elementReference.SetText("");


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

In some cases on Blazor server, an Autocomplete would reopen when Reset from its parent `MudForm`. I believe this only occurs on Blazor server and is a consequence of `AndForget` in MudBaseInput.

Going forward, Autocomplete needs to be updated to support `OnlyValidateIfDirty`.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

All existing tests pass. I needed to adjust two unit tests to assert that `Value` is null, and `Text` is String.Empty, respectively, when Reset or Cleared.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
