### PR TITLE
MudPopover: Fix flickering in delayed bss (#6345)

### DIFF
--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -164,16 +164,17 @@ namespace MudBlazor
 
         private MudPopoverHandler _handler;
 
+        private bool _afterFirstRender;
+
         protected override void OnInitialized()
         {
             _handler = Service.Register(ChildContent ?? new RenderFragment((x) => { }));
-            _handler.SetComponentBaseParameters(this, PopoverClass, PopoverStyles, Open);
             base.OnInitialized();
         }
 
-        protected override void OnParametersSet()
+        protected override async Task OnParametersSetAsync()
         {
-            base.OnParametersSet();
+            await base.OnParametersSetAsync();
 
             // henon: this change by PR #3776 caused problems on BSS (#4303)
             //// Only update the fragment if the popover is currently shown or will show
@@ -181,7 +182,7 @@ namespace MudBlazor
             //if (!_handler.ShowContent && !Open)
             //    return;
 
-            _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
+            if (_afterFirstRender) await _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -190,6 +191,8 @@ namespace MudBlazor
             {
                 await _handler.Initialize();
                 await Service.InitializeIfNeeded();
+                await _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
+                _afterFirstRender = true;
             }
 
             await base.OnAfterRenderAsync(firstRender);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #6345.

I've changed popover so that it's content is rendered after js interop initialization.

This change caused race condition in MudPopoverHandler so I've added synchronization in UpdateFragment method.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit, visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Before
![popover_before](https://user-images.githubusercontent.com/50521366/221375377-91ec6f33-b3b7-4dad-bb62-6c5e70d7327f.gif)

### After
![popover_after](https://user-images.githubusercontent.com/50521366/221375391-0d2ab3df-b700-4177-a54e-9eb3056f8807.gif)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
