### PR TITLE
MudDataGrid: Improve nullability, encapsulation and some nits

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2525,7 +2525,7 @@ namespace MudBlazor.UnitTests.Components
             filterDefinition3.Column.dataType.Should().Be(typeof(Severity?));
             await comp.InvokeAsync(() => internalFilter.NumberValueChanged(35));
             filterDefinition3.Value.Should().Be(35);
-            internalFilter.isEnum.Should().Be(true);
+            internalFilter.IsEnum.Should().Be(true);
             // test internal filter class for bool data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, filterDefinition4, null);
             filterDefinition4.Column.dataType.Should().Be(typeof(bool?));
@@ -3025,9 +3025,9 @@ namespace MudBlazor.UnitTests.Components
             cell._cellContext.IsSelected.Should().Be(true);
 
             cell._cellContext.Actions.ToggleHierarchyVisibilityForItem();
-            cell._cellContext.openHierarchies.Should().Contain(item);
+            cell._cellContext.OpenHierarchies.Should().Contain(item);
             cell._cellContext.Actions.ToggleHierarchyVisibilityForItem();
-            cell._cellContext.openHierarchies.Should().NotContain(item);
+            cell._cellContext.OpenHierarchies.Should().NotContain(item);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -11,6 +11,19 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class ExpansionPanelTests : BunitTest
     {
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            AssertionOptions.FormattingOptions.MaxDepth = 100;
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            AssertionOptions.FormattingOptions.MaxDepth = 5;
+        }
+
         /// <summary>
         /// Expansion panel must expand and collapse in the right order
         /// Here we are open the first, then the third and then the second

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using System;
+using FluentAssertions;
 using MudBlazor.UnitTests.Dummy;
 using NUnit.Framework;
 
@@ -7,6 +9,17 @@ namespace MudBlazor.UnitTests.Extensions
     [TestFixture]
     public class EnumExtensionsTests
     {
+        [Test]
+        [TestCase(typeof(Adornment), new[] { "None", "Start", "End" })]
+        [TestCase(typeof(Adornment?), new[] { "None", "Start", "End" })]
+        [TestCase(typeof(string), new string[0])]
+        public void GetSafeEnumValues_Test(Type type, string[] expectedNames)
+        {
+            var values = MudBlazor.Extensions.EnumExtensions.GetSafeEnumValues(type);
+            var stringValues = values.Select(x => x.ToString());
+            stringValues.Should().BeEquivalentTo(expectedNames);
+        }
+
         [Test]
         public void ToDescriptionStringNew()
         {

--- a/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
+++ b/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Other
+{
+    [TestFixture]
+    public class TypeIdentifierTests
+    {
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
+        [TestCase(typeof(string), true)]
+        public void IsString_Test(Type type, bool expected)
+        {
+            var isString = TypeIdentifier.IsString(type);
+            isString.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(DateTime), false)]
+        [TestCase(typeof(DateTime?), false)]
+        [TestCase(typeof(int), true)]
+        [TestCase(typeof(double), true)]
+        [TestCase(typeof(decimal), true)]
+        [TestCase(typeof(long), true)]
+        [TestCase(typeof(short), true)]
+        [TestCase(typeof(sbyte), true)]
+        [TestCase(typeof(byte), true)]
+        [TestCase(typeof(ulong), true)]
+        [TestCase(typeof(ushort), true)]
+        [TestCase(typeof(uint), true)]
+        [TestCase(typeof(float), true)]
+        [TestCase(typeof(BigInteger), true)]
+        [TestCase(typeof(int?), true)]
+        [TestCase(typeof(double?), true)]
+        [TestCase(typeof(decimal?), true)]
+        [TestCase(typeof(long?), true)]
+        [TestCase(typeof(short?), true)]
+        [TestCase(typeof(sbyte?), true)]
+        [TestCase(typeof(byte?), true)]
+        [TestCase(typeof(ulong?), true)]
+        [TestCase(typeof(ushort?), true)]
+        [TestCase(typeof(uint?), true)]
+        [TestCase(typeof(float?), true)]
+        [TestCase(typeof(BigInteger?), true)]
+        public void IsNumber_Test(Type type, bool expected)
+        {
+            var isNumber = TypeIdentifier.IsNumber(type);
+            isNumber.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
+        [TestCase(typeof(Adornment), true)]
+        [TestCase(typeof(Adornment?), true)]
+        public void IsEnum_Test(Type type, bool expected)
+        {
+            var isEnum = TypeIdentifier.IsEnum(type);
+            isEnum.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
+        [TestCase(typeof(DateTime), true)]
+        [TestCase(typeof(DateTime?), true)]
+        public void IsDateTime_Test(Type type, bool expected)
+        {
+            var isDateTime = TypeIdentifier.IsDateTime(type);
+            isDateTime.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
+        [TestCase(typeof(bool), true)]
+        [TestCase(typeof(bool?), true)]
+        public void IsBoolean_Test(Type type, bool expected)
+        {
+            var isBoolean = TypeIdentifier.IsBoolean(type);
+            isBoolean.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
+        [TestCase(typeof(Guid), true)]
+        [TestCase(typeof(Guid?), true)]
+        public void IsGuid_Test(Type type, bool expected)
+        {
+            var isGuid = TypeIdentifier.IsGuid(type);
+            isGuid.Should().Be(expected);
+        }
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -3,28 +3,26 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+#nullable enable
     internal class Cell<T>
     {
         private readonly MudDataGrid<T> _dataGrid;
         private readonly Column<T> _column;
         internal T _item;
-        internal string _valueString;
+        internal string? _valueString;
         internal double? _valueNumber;
         internal bool _isEditing;
         internal CellContext<T> _cellContext;
 
         #region Computed Properties
 
-        internal object ComputedValue
+        internal object? ComputedValue
         {
             get
             {
@@ -91,30 +89,31 @@ namespace MudBlazor
 
         private void OnStartedEditingItem()
         {
-
-            if (ComputedValue != null)
+            if (ComputedValue is null)
             {
-                if (ComputedValue.GetType() == typeof(JsonElement))
+                return;
+            }
+
+            if (ComputedValue is JsonElement element)
+            {
+                if (_column.dataType == typeof(string))
                 {
-                    if (_column.dataType == typeof(string))
-                    {
-                        _valueString = ((JsonElement)ComputedValue).GetString();
-                    }
-                    else if (_column.isNumber)
-                    {
-                        _valueNumber = ((JsonElement)ComputedValue).GetDouble();
-                    }
+                    _valueString = element.GetString();
                 }
-                else
+                else if (_column.isNumber)
                 {
-                    if (_column.dataType == typeof(string))
-                    {
-                        _valueString = (string)ComputedValue;
-                    }
-                    else if (_column.isNumber)
-                    {
-                        _valueNumber = Convert.ToDouble(ComputedValue);
-                    }
+                    _valueNumber = element.GetDouble();
+                }
+            }
+            else
+            {
+                if (_column.dataType == typeof(string))
+                {
+                    _valueString = (string)ComputedValue;
+                }
+                else if (_column.isNumber)
+                {
+                    _valueNumber = Convert.ToDouble(ComputedValue);
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -7,31 +7,31 @@ using System.Collections.Generic;
 
 namespace MudBlazor
 {
+#nullable enable
     public class CellContext<T>
     {
-        internal HashSet<T> selection;
-        internal HashSet<T> openHierarchies;
+        private readonly HashSet<T> _selection;
+
+        internal HashSet<T> OpenHierarchies { get; }
+
         public T Item { get; set; }
-        public CellActions Actions { get; internal set; }
+
+        public CellActions Actions { get; }
+
         public bool IsSelected
         {
             get
             {
-                if (selection != null)
-                {
-                    return selection.Contains(Item);
-                }
-
-                return false;
+                return _selection.Contains(Item);
             }
         }
 
         public CellContext(MudDataGrid<T> dataGrid, T item)
         {
-            selection = dataGrid.Selection;
-            openHierarchies = dataGrid._openHierarchies;
+            _selection = dataGrid.Selection;
+            OpenHierarchies = dataGrid._openHierarchies;
             Item = item;
-            Actions = new CellContext<T>.CellActions
+            Actions = new CellActions
             {
                 SetSelectedItem = async (x) => await dataGrid.SetSelectedItemAsync(x, item),
                 StartEditingItem = async () => await dataGrid.SetEditingItemAsync(item),
@@ -42,10 +42,10 @@ namespace MudBlazor
 
         public class CellActions
         {
-            public Action<bool> SetSelectedItem { get; internal set; }
-            public Action StartEditingItem { get; internal set; }
-            public Action CancelEditingItem { get; internal set; }
-            public Action ToggleHierarchyVisibilityForItem { get; internal set; }
+            public Action<bool>? SetSelectedItem { get; internal set; }
+            public Action? StartEditingItem { get; internal set; }
+            public Action? CancelEditingItem { get; internal set; }
+            public Action? ToggleHierarchyVisibilityForItem { get; internal set; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
@@ -218,7 +217,7 @@ namespace MudBlazor
         {
             get
             {
-                return FilterOperator.NumericTypes.Contains(PropertyType);
+                return TypeIdentifier.IsNumber(PropertyType);
             }
         }
 
@@ -393,7 +392,10 @@ namespace MudBlazor
         }
 
         public virtual string PropertyName { get; }
-        protected internal virtual string ContentFormat { get; }
+
+#nullable enable
+        protected internal virtual string? ContentFormat { get; }
+#nullable disable
 
         protected internal abstract object CellContent(T item);
 

--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {
+#nullable enable
     internal sealed class DataGridColumnResizeService<T>
     {
         private const string EventMouseMove = "mousemove";
@@ -19,12 +20,11 @@ namespace MudBlazor
         private readonly IEventListener _eventListener;
         private ResizeMode _resizeMode;
 
-        private IList<Column<T>> _columns;
         private double _currentX;
         private double _startWidth;
         private double _nextStartWidth;
-        private Column<T> _startColumn;
-        private Column<T> _nextColumn;
+        private Column<T>? _startColumn;
+        private Column<T>? _nextColumn;
         private Guid _mouseMoveSubscriptionId;
         private Guid _mouseUpSubscriptionId;
 
@@ -36,10 +36,9 @@ namespace MudBlazor
 
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX, IList<Column<T>> columns, ResizeMode columnResizeMode)
         {
-            if ((headerCell?.Column?.Resizable ?? false) || columnResizeMode == ResizeMode.None || _mouseMoveSubscriptionId != default || _mouseUpSubscriptionId != default)
+            if ((headerCell.Column?.Resizable ?? false) || columnResizeMode == ResizeMode.None || _mouseMoveSubscriptionId != default || _mouseUpSubscriptionId != default)
                 return false;
 
-            _columns = columns;
             _resizeMode = columnResizeMode;
             _currentX = clientX;
 
@@ -49,12 +48,15 @@ namespace MudBlazor
             if (_resizeMode == ResizeMode.Column)
             {
                 // In case resize mode is column, we have to find any column right of the current one that can also be resized and is not hidden.
-                var nextResizableColumn = _columns.Skip(_columns.IndexOf(headerCell.Column) + 1).FirstOrDefault(c => (c.Resizable ?? true) && !c.Hidden);
-                if (null == nextResizableColumn)
-                    return false;
+                if (headerCell.Column is not null)
+                {
+                    var nextResizableColumn = columns.Skip(columns.IndexOf(headerCell.Column) + 1).FirstOrDefault(c => (c.Resizable ?? true) && !c.Hidden);
+                    if (nextResizableColumn == null)
+                        return false;
 
-                _nextStartWidth = await nextResizableColumn.HeaderCell.GetCurrentCellWidth();
-                _nextColumn = nextResizableColumn;
+                    _nextStartWidth = await nextResizableColumn.HeaderCell.GetCurrentCellWidth();
+                    _nextColumn = nextResizableColumn;
+                }
             }
 
             _mouseMoveSubscriptionId = await _eventListener.SubscribeGlobal<MouseEventArgs>(EventMouseMove, 0, OnApplicationMouseMove);
@@ -112,7 +114,11 @@ namespace MudBlazor
                 // Easy case: ResizeMode is container, we simply update the width of the resized column
                 if (_resizeMode == ResizeMode.Container)
                 {
-                    await _startColumn.HeaderCell.UpdateColumnWidth(targetWidth, gridHeight, finish);
+                    if (_startColumn is not null)
+                    {
+                        await _startColumn.HeaderCell.UpdateColumnWidth(targetWidth, gridHeight, finish);
+                    }
+
                     return;
                 }
 
@@ -122,10 +128,22 @@ namespace MudBlazor
 
                 // In case we shrink the current column, make sure to not shrink further after min width has been reached:
                 if (deltaX < 0)
-                    await ResizeColumns(_startColumn, _nextColumn, targetWidth, nextTargetWidth, gridHeight, finish);
+                {
+                    if (_startColumn is not null && _nextColumn is not null)
+                    {
+                        await ResizeColumns(_startColumn, _nextColumn, targetWidth, nextTargetWidth, gridHeight,
+                            finish);
+                    }
+                }
                 // In case we enlarge, we first shrink the following column and ensure it is not shrinked beyond min width:
                 else
-                    await ResizeColumns(_nextColumn, _startColumn, nextTargetWidth, targetWidth, gridHeight, finish);
+                {
+                    if (_nextColumn is not null && _startColumn is not null)
+                    {
+                        await ResizeColumns(_nextColumn, _startColumn, nextTargetWidth, targetWidth, gridHeight,
+                            finish);
+                    }
+                }
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
@@ -7,11 +7,20 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {
+#nullable enable
     public class DataGridRowClickEventArgs<T> : EventArgs
     {
-        public MouseEventArgs MouseEventArgs { get; set; }
-        public T Item { get; set; }
-        public int RowIndex { get; set; }
+        public MouseEventArgs MouseEventArgs { get; }
 
+        public T Item { get; }
+
+        public int RowIndex { get; }
+
+        public DataGridRowClickEventArgs(MouseEventArgs mouseEventArgs, T item, int rowIndex)
+        {
+            MouseEventArgs = mouseEventArgs;
+            Item = item;
+            RowIndex = rowIndex;
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor
+{
+#nullable enable
+    public class FieldType
+    {
+        public bool IsString { get; set; }
+
+        public bool IsNumber { get; set; }
+
+        public bool IsEnum { get; set; }
+
+        public bool IsDateTime { get; set; }
+
+        public bool IsBoolean { get; set; }
+
+        public bool IsGuid { get; set; }
+
+        public static FieldType Identify(Type? type)
+        {
+            var filedType = new FieldType
+            {
+                IsString = TypeIdentifier.IsString(type),
+                IsNumber = TypeIdentifier.IsNumber(type),
+                IsEnum = TypeIdentifier.IsEnum(type),
+                IsDateTime = TypeIdentifier.IsDateTime(type),
+                IsBoolean = TypeIdentifier.IsBoolean(type),
+                IsGuid = TypeIdentifier.IsGuid(type)
+            };
+
+            return filedType;
+        }
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -126,7 +126,6 @@ namespace MudBlazor
             {
                 var date = _valueDate.Value.Date;
 
-
                 // get the time component and add it to the date.
                 if (_valueTime is not null)
                 {

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -7,52 +7,44 @@ using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     internal class Filter<T>
     {
-        private MudDataGrid<T> _dataGrid;
-        internal readonly FilterDefinition<T> _filterDefinition;
-        private Column<T> _column;
+        private readonly MudDataGrid<T> _dataGrid;
+        private readonly FilterDefinition<T> _filterDefinition;
+        private readonly Column<T>? _column;
 
-        internal string _valueString;
+        internal string? _valueString;
         internal double? _valueNumber;
-        internal Enum _valueEnum = null;
+        internal Enum? _valueEnum;
         internal bool? _valueBool;
         internal DateTime? _valueDate;
         internal TimeSpan? _valueTime;
-        
-        internal bool isNumber
-        {
-            get
-            {
-                return FilterOperator.IsNumber(_filterDefinition.dataType);
-            }
-        }
-        internal bool isEnum
-        {
-            get
-            {
-                return FilterOperator.IsEnum(_filterDefinition.dataType);
-            }
-        }
 
-        internal Column<T> filterColumn =>
-            _column ?? (_dataGrid.RenderedColumns?.FirstOrDefault(c => c.PropertyName == _filterDefinition.Column.PropertyName));
+        internal bool IsNumber => TypeIdentifier.IsNumber(_filterDefinition.dataType);
 
-        public Filter(MudDataGrid<T> dataGrid, FilterDefinition<T> filterDefinition, Column<T> column)
+        internal bool IsEnum => TypeIdentifier.IsEnum(_filterDefinition.dataType);
+
+        internal Column<T>? FilterColumn =>
+            _column ?? (_dataGrid.RenderedColumns?.FirstOrDefault(c => c.PropertyName == _filterDefinition.Column?.PropertyName));
+
+        public Filter(MudDataGrid<T> dataGrid, FilterDefinition<T> filterDefinition, Column<T>? column)
         {
             _dataGrid = dataGrid;
             _filterDefinition = filterDefinition;
             _column = column;
 
-            if (_filterDefinition.dataType == typeof(string))
-                _valueString = _filterDefinition.Value == null ? null : _filterDefinition.Value.ToString();
-            else if (isNumber)
+            var fieldType = FieldType.Identify(_filterDefinition.dataType);
+
+            if (fieldType.IsString)
+                _valueString = _filterDefinition.Value?.ToString();
+            else if (fieldType.IsNumber)
                 _valueNumber = _filterDefinition.Value == null ? null : Convert.ToDouble(_filterDefinition.Value);
-            else if (isEnum)
-                _valueEnum = _filterDefinition.Value == null ? null : (Enum)_filterDefinition.Value;
-            else if (_filterDefinition.dataType == typeof(bool))
+            else if (fieldType.IsEnum)
+                _valueEnum = (Enum?)_filterDefinition.Value;
+            else if (fieldType.IsBoolean)
                 _valueBool = _filterDefinition.Value == null ? null : Convert.ToBoolean(_filterDefinition.Value);
-            else if (_filterDefinition.dataType == typeof(DateTime) || _filterDefinition.dataType == typeof(DateTime?))
+            else if (fieldType.IsDateTime)
             {
                 var dateTime = Convert.ToDateTime(_filterDefinition.Value);
                 _valueDate = _filterDefinition.Value == null ? null : dateTime;
@@ -108,12 +100,12 @@ namespace MudBlazor
         {
             _valueDate = value;
 
-            if (value != null)
+            if (value is not null)
             {
                 var date = value.Value.Date;
 
                 // get the time component and add it to the date.
-                if (_valueTime != null)
+                if (_valueTime is not null)
                 {
                     date = date.Add(_valueTime.Value);
                 }
@@ -130,13 +122,13 @@ namespace MudBlazor
         {
             _valueTime = value;
 
-            if (_valueDate != null)
+            if (_valueDate is not null)
             {
                 var date = _valueDate.Value.Date;
 
 
                 // get the time component and add it to the date.
-                if (_valueTime != null)
+                if (_valueTime is not null)
                 {
                     date = date.Add(_valueTime.Value);
                 }

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -7,10 +7,15 @@ using System.Collections.Generic;
 
 namespace MudBlazor
 {
+#nullable enable
     public class FilterContext<T>
     {
-        internal MudDataGrid<T> _dataGrid;
-        internal HeaderCell<T> _headerCell;
+        private readonly MudDataGrid<T> _dataGrid;
+
+        internal FilterDefinition<T>? FilterDefinition { get; set; }
+
+        internal HeaderCell<T>? HeaderCell { get; set; }
+
         public IEnumerable<T> Items
         {
             get
@@ -18,6 +23,7 @@ namespace MudBlazor
                 return _dataGrid.Items;
             }
         }
+
         public List<FilterDefinition<T>> FilterDefinitions
         {
             get
@@ -25,27 +31,27 @@ namespace MudBlazor
                 return _dataGrid.FilterDefinitions;
             }
         }
-        internal FilterDefinition<T> FilterDefinition { get; set; }
-        public FilterActions Actions { get; internal set; }
+
+        public FilterActions Actions { get; }
 
         public FilterContext(MudDataGrid<T> dataGrid)
         {
             _dataGrid = dataGrid;
-            Actions = new FilterContext<T>.FilterActions
+            Actions = new FilterActions
             {
-                ApplyFilter = x => _headerCell.ApplyFilter(x),
-                ApplyFilters = x => _headerCell.ApplyFilters(x),
-                ClearFilter = x => _headerCell.ClearFilter(x),
-                ClearFilters = x => _headerCell.ClearFilters(x),
+                ApplyFilter = x => HeaderCell?.ApplyFilter(x),
+                ApplyFilters = x => HeaderCell?.ApplyFilters(x),
+                ClearFilter = x => HeaderCell?.ClearFilter(x),
+                ClearFilters = x => HeaderCell?.ClearFilters(x),
             };
         }
 
         public class FilterActions
         {
-            public Action<FilterDefinition<T>> ApplyFilter { get; internal set; }
-            public Action<IEnumerable<FilterDefinition<T>>> ApplyFilters { get; internal set; }
-            public Action<FilterDefinition<T>> ClearFilter { get; internal set; }
-            public Action<IEnumerable<FilterDefinition<T>>> ClearFilters { get; internal set; }
+            public Action<FilterDefinition<T>>? ApplyFilter { get; internal set; }
+            public Action<IEnumerable<FilterDefinition<T>>>? ApplyFilters { get; internal set; }
+            public Action<FilterDefinition<T>>? ClearFilter { get; internal set; }
+            public Action<IEnumerable<FilterDefinition<T>>>? ClearFilters { get; internal set; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
@@ -7,102 +7,101 @@ using System.Linq.Expressions;
 
 namespace MudBlazor
 {
+#nullable enable
     public class FilterDefinition<T>
     {
-        private int cachedExpressionHashCode;
-        private Func<T, bool> cachedFilterFunction = null;
+        private int _cachedExpressionHashCode;
+        private Func<T, bool>? _cachedFilterFunction;
 
-        internal MudDataGrid<T> DataGrid { get; set; }
-#nullable enable
+        internal MudDataGrid<T>? DataGrid { get; set; }
+
         internal LambdaExpression? PropertyExpression { get; set; }
-#nullable disable
 
         public Guid Id { get; set; } = Guid.NewGuid();
-        public Column<T> Column { get; set; }
-        //public string Field { get; set; }
-        public string Title { get; set; }
-        //public Type FieldType { get; set; }
-        public string Operator { get; set; }
-        public object Value { get; set; }
-        public Func<T, bool> FilterFunction { get; set; }
+
+        public Column<T>? Column { get; set; }
+        public string? Title { get; set; }
+        public string? Operator { get; set; }
+        public object? Value { get; set; }
+        public Func<T, bool>? FilterFunction { get; set; }
 
         internal Type dataType
         {
             get
             {
-                if (Column == null)
+                if (Column is null)
                     return typeof(object);
 
                 return Column.PropertyType;
             }
         }
 
-        internal Type underlyingDataType
-        {
-            get
-            {
-                return Nullable.GetUnderlyingType(dataType) ?? dataType;
-            }
-        }
-
         public Func<T, bool> GenerateFilterFunction()
         {
-            if (FilterFunction != null)
+            if (FilterFunction is not null)
                 return FilterFunction;
 
-            if (Column != null)
+            if (Column is null)
+                return x => true;
+
+            // We need a PropertyExpression to filter. This allows us to pass in an arbitrary PropertyExpression.
+            // Although, it would be better in that case to simple use the FilterFunction so that we do not 
+            // have to generate and compile anything.
+            PropertyExpression ??= Column.PropertyExpression;
+
+            var hash = HashCode.Combine(PropertyExpression, Operator, Value);
+
+            if (_cachedExpressionHashCode == hash && _cachedFilterFunction is not null)
             {
-                // We need a PropertyExpression to filter. This allows us to pass in an arbitrary PropertyExpression.
-                // Although, it would be better in that case to simple use the FilterFunction so that we do not 
-                // have to generate and compile anything.
-                PropertyExpression ??= Column.PropertyExpression;
-
-                var hash = HashCode.Combine(PropertyExpression, Operator, Value);
-
-                if (cachedExpressionHashCode == hash)
-                    return cachedFilterFunction;
-
-                var expression = GenerateFilterExpression();
-                var f = expression.Compile();                
-                cachedExpressionHashCode = hash;
-                cachedFilterFunction = f;
-
-                return f;
+                return _cachedFilterFunction;
             }
 
-            return x => true;
+            var expression = GenerateFilterExpression();
+            var f = expression.Compile();
+            _cachedExpressionHashCode = hash;
+            _cachedFilterFunction = f;
+
+            return f;
         }
 
         public Expression<Func<T, bool>> GenerateFilterExpression()
         {
-            if (dataType == typeof(string))
-            {
-                string value = Value == null ? null : Value.ToString();
-                var stringComparer = DataGrid.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var fieldType = FieldType.Identify(dataType);
 
-                if (value == null && Operator != FilterOperator.String.Empty && Operator != FilterOperator.String.NotEmpty)
+            if (PropertyExpression is null)
+            {
+                return x => true;
+            }
+
+            if (fieldType.IsString)
+            {
+                var value = Value?.ToString();
+                var stringComparer = DataGrid?.FilterCaseSensitivity == DataGridFilterCaseSensitivity.Default ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+                if (value is null && Operator != FilterOperator.String.Empty && Operator != FilterOperator.String.NotEmpty)
                     return x => true;
 
                 return Operator switch
                 {
                     FilterOperator.String.Contains =>
-                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && x.Contains(value, stringComparer))),
+                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => value != null && x != null && x.Contains(value, stringComparer))),
                     FilterOperator.String.NotContains =>
-                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && !x.Contains(value, stringComparer))),
+                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => value != null && x != null && !x.Contains(value, stringComparer))),
                     FilterOperator.String.Equal =>
                         PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && x.Equals(value, stringComparer))),
                     FilterOperator.String.NotEqual =>
                         PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && !x.Equals(value, stringComparer))),
                     FilterOperator.String.StartsWith =>
-                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && x.StartsWith(value, stringComparer))),
+                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => value != null && x != null && x.StartsWith(value, stringComparer))),
                     FilterOperator.String.EndsWith =>
-                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => x != null && x.EndsWith(value, stringComparer))),
+                        PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => value != null && x != null && x.EndsWith(value, stringComparer))),
                     FilterOperator.String.Empty => PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => string.IsNullOrWhiteSpace(x))),
                     FilterOperator.String.NotEmpty => PropertyExpression.Modify<T>((Expression<Func<string?, bool>>)(x => !string.IsNullOrWhiteSpace(x))),
                     _ => x => true
                 };
             }
-            else if (isNumber)
+
+            if (fieldType.IsNumber)
             {
                 if (Value == null && Operator != FilterOperator.Number.Empty && Operator != FilterOperator.Number.NotEmpty)
                     return x => true;
@@ -120,7 +119,8 @@ namespace MudBlazor
                     _ => x => true
                 };
             }
-            else if (isDateTime)
+
+            if (fieldType.IsDateTime)
             {
                 if (Value == null && Operator != FilterOperator.DateTime.Empty && Operator != FilterOperator.DateTime.NotEmpty)
                     return x => true;
@@ -138,7 +138,8 @@ namespace MudBlazor
                     _ => x => true
                 };
             }
-            else if (isBoolean)
+
+            if (fieldType.IsBoolean)
             {
                 if (Value == null)
                     return x => true;
@@ -149,7 +150,8 @@ namespace MudBlazor
                     _ => x => true
                 };
             }
-            else if (isEnum)
+
+            if (fieldType.IsEnum)
             {
                 if (Value == null)
                     return x => true;
@@ -161,7 +163,8 @@ namespace MudBlazor
                     _ => x => true
                 };
             }
-            else if (isGuid)
+
+            if (fieldType.IsGuid)
             {
                 return Operator switch
                 {
@@ -174,49 +177,9 @@ namespace MudBlazor
             return x => true;
         }
 
-        private bool isNumber
-        {
-            get
-            {
-                return FilterOperator.IsNumber(dataType);
-            }
-        }
-
-        private bool isEnum
-        {
-            get
-            {
-                return FilterOperator.IsEnum(dataType);
-            }
-        }
-
-        private bool isDateTime
-        {
-            get
-            {
-                return FilterOperator.IsDateTime(dataType);
-            }
-        }
-
-        private bool isBoolean
-        {
-            get
-            {
-                return FilterOperator.IsBoolean(dataType);
-            }
-        }
-
-        private bool isGuid
-        {
-            get
-            {
-                return FilterOperator.IsGuid(dataType);
-            }
-        }
-
         public FilterDefinition<T> Clone()
         {
-            return new()
+            return new FilterDefinition<T>
             {
                 Column = Column,
                 DataGrid = DataGrid,

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -77,7 +77,7 @@ namespace MudBlazor
         {
             get
             {
-                return FilterOperator.IsNumber(dataType);
+                return TypeIdentifier.IsNumber(dataType);
             }
         }
 
@@ -85,7 +85,7 @@ namespace MudBlazor
         {
             get
             {
-                return FilterOperator.IsEnum(dataType);
+                return TypeIdentifier.IsEnum(dataType);
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/FilterOperator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterOperator.cs
@@ -3,13 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Numerics;
 
 namespace MudBlazor
 {
+#nullable enable
     public static class FilterOperator
     {
         public static class String
@@ -67,9 +64,11 @@ namespace MudBlazor
 
         internal static string[] GetOperatorByDataType(Type type)
         {
-            if (type == typeof(string))
+            var fieldType = FieldType.Identify(type);
+
+            if (fieldType.IsString)
             {
-                return new []
+                return new[]
                 {
                     String.Contains,
                     String.NotContains,
@@ -81,7 +80,7 @@ namespace MudBlazor
                     String.NotEmpty,
                 };
             }
-            if (IsNumber(type))
+            if (fieldType.IsNumber)
             {
                 return new[]
                 {
@@ -95,21 +94,21 @@ namespace MudBlazor
                     Number.NotEmpty,
                 };
             }
-            if (IsEnum(type))
+            if (fieldType.IsEnum)
             {
                 return new[] {
                     Enum.Is,
                     Enum.IsNot,
                 };
             }
-            if (type == typeof(bool))
+            if (fieldType.IsBoolean)
             {
                 return new[]
                 {
                     Boolean.Is,
                 };
             }
-            if (type == typeof(System.DateTime))
+            if (fieldType.IsDateTime)
             {
                 return new[]
                 {
@@ -123,7 +122,7 @@ namespace MudBlazor
                     DateTime.NotEmpty,
                 };
             }
-            if (type == typeof(System.Guid))
+            if (fieldType.IsGuid)
             {
                 return new[]
                 {
@@ -133,79 +132,7 @@ namespace MudBlazor
             }
 
             // default
-            return new string[] { };
-        }
-
-        internal static readonly HashSet<Type> NumericTypes = new HashSet<Type>
-        {
-            typeof(int),
-            typeof(double),
-            typeof(decimal),
-            typeof(long),
-            typeof(short),
-            typeof(sbyte),
-            typeof(byte),
-            typeof(ulong),
-            typeof(ushort),
-            typeof(uint),
-            typeof(float),
-            typeof(BigInteger),
-            typeof(int?),
-            typeof(double?),
-            typeof(decimal?),
-            typeof(long?),
-            typeof(short?),
-            typeof(sbyte?),
-            typeof(byte?),
-            typeof(ulong?),
-            typeof(ushort?),
-            typeof(uint?),
-            typeof(float?),
-            typeof(BigInteger?),
-        };
-
-        internal static bool IsNumber(Type type)
-        {
-            return NumericTypes.Contains(type);
-        }
-
-        internal static bool IsEnum(Type type)
-        {
-            if (null == type)
-                return false;
-
-            if (type.IsEnum)
-                return true;
-
-            Type u = Nullable.GetUnderlyingType(type);
-            return (u != null) && u.IsEnum;
-        }
-
-        internal static bool IsDateTime(Type type)
-        {
-            if (type == typeof(System.DateTime))
-                return true;
-
-            Type u = Nullable.GetUnderlyingType(type);
-            return (u != null) && u == typeof(System.DateTime);
-        }
-
-        internal static bool IsBoolean(Type type)
-        {
-            if (type == typeof(bool))
-                return true;
-
-            Type u = Nullable.GetUnderlyingType(type);
-            return (u != null) && u == typeof(bool);
-        }
-
-        internal static bool IsGuid(Type type)
-        {
-            if (type == typeof(System.Guid))
-                return true;
-
-            Type u = Nullable.GetUnderlyingType(type);
-            return (u != null) && u == typeof(System.Guid);
+            return Array.Empty<string>();
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -8,9 +8,11 @@ using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     public class FooterContext<T>
     {
-        internal MudDataGrid<T> _dataGrid;
+        private readonly MudDataGrid<T> _dataGrid;
+
         public IEnumerable<T> Items
         {
             get
@@ -18,13 +20,15 @@ namespace MudBlazor
                 return _dataGrid.Items;
             }
         }
-        public FooterActions Actions { get; internal set; }
+
+        public FooterActions Actions { get; }
+
         public bool IsAllSelected
         {
             get
             {
                 
-                if (_dataGrid.Selection != null && Items != null)
+                if (_dataGrid.Selection is not null && Items is not null)
                 {
                     return _dataGrid.Selection.Count == Items.Count();
                 }
@@ -36,7 +40,7 @@ namespace MudBlazor
         public FooterContext(MudDataGrid<T> dataGrid)
         {
             _dataGrid = dataGrid;
-            Actions = new FooterContext<T>.FooterActions
+            Actions = new FooterActions
             {
                 SetSelectAll = async (x) => await _dataGrid.SetSelectAllAsync(x),
             };
@@ -44,7 +48,7 @@ namespace MudBlazor
 
         public class FooterActions
         {
-            public Action<bool> SetSelectAll { get; internal set; }
+            public Action<bool>? SetSelectAll { get; internal set; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/GridState.cs
+++ b/src/MudBlazor/Components/DataGrid/GridState.cs
@@ -3,23 +3,26 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     public class GridState<T>
     {
         public int Page { get; set; }
 
         public int PageSize { get; set; }
 
-        public ICollection<SortDefinition<T>> SortDefinitions { get; set; }
+        public ICollection<SortDefinition<T>> SortDefinitions { get; set; } = new List<SortDefinition<T>>();
 
-        public ICollection<FilterDefinition<T>> FilterDefinitions { get; set; }
+        public ICollection<FilterDefinition<T>> FilterDefinitions { get; set; } = new List<FilterDefinition<T>>();
     }
 
     public class GridData<T>
     {
-        public IEnumerable<T> Items { get; set; }
+        public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
+
         public int TotalItems { get; set; }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     public class GroupDefinition<T>
     {
         public IGrouping<object, T> Grouping { get; set; }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -205,7 +205,7 @@ namespace MudBlazor
 
                 if (Column.filterable)
                 {
-                    Column.FilterContext._headerCell = this;
+                    Column.FilterContext.HeaderCell = this;
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -8,9 +8,11 @@ using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     public class HeaderContext<T>
     {
-        internal MudDataGrid<T> _dataGrid;
+        private readonly MudDataGrid<T> _dataGrid;
+
         public IEnumerable<T> Items
         {
             get
@@ -18,7 +20,9 @@ namespace MudBlazor
                 return _dataGrid.Items;
             }
         }
-        public HeaderActions Actions { get; internal set; }
+
+        public HeaderActions Actions { get; }
+
         public bool IsAllSelected
         {
             get
@@ -36,7 +40,7 @@ namespace MudBlazor
         public HeaderContext(MudDataGrid<T> dataGrid)
         {
             _dataGrid = dataGrid;
-            Actions = new HeaderContext<T>.HeaderActions
+            Actions = new HeaderActions
             {
                 SetSelectAll = async (x) => await _dataGrid.SetSelectAllAsync(x),
             };
@@ -45,7 +49,7 @@ namespace MudBlazor
 
         public class HeaderActions
         {
-            public Action<bool> SetSelectAll { get; internal set; }
+            public Action<bool>? SetSelectAll { get; internal set; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -7,7 +7,7 @@
     <CellTemplate>
         <label class="ma-n3">
             <MudIconButton
-            Icon="@(context.openHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
+            Icon="@(context.OpenHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
             OnClick="context.Actions.ToggleHierarchyVisibilityForItem"
             Size="@IconSize"
             Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -2,6 +2,7 @@
 @inherits MudComponentBase
 @typeparam T
 @using MudBlazor.Utilities
+@using MudBlazor.Extensions
 
 <CascadingValue IsFixed="true" Value="this">@Columns</CascadingValue>
 
@@ -260,7 +261,7 @@
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
                                   Required="true" Variant="@Variant.Outlined" Disabled="@(!column.IsEditable || ReadOnly)" Class="mt-4" />
                             }
-                            else if (FilterOperator.NumericTypes.Contains(propertyType))
+                            else if (TypeIdentifier.IsNumber(propertyType))
                             {
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
                                      Required="true" Variant="@Variant.Outlined" Disabled="@(!column.IsEditable || ReadOnly)" Class="mt-4" />
@@ -411,17 +412,17 @@
                     <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
                       Immediate="true" Class="filter-input" />
                 }
-                else if (filter.isNumber && !(f.Operator ?? "").EndsWith("empty"))
+                else if (filter.IsNumber && !(f.Operator ?? "").EndsWith("empty"))
                 {
                     <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                         Immediate="true" Class="filter-input" Culture="@filter.filterColumn?.Culture" />
+                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
                 }
-                else if (filter.isEnum)
+                else if (filter.IsEnum)
                 {
                     <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                    Class="filter-input">
                         <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                        @foreach (var item in Enum.GetValues(f.underlyingDataType))
+                        @foreach (var item in EnumExtensions.GetSafeEnumValues(f.dataType))
                         {
                             <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
                         }
@@ -471,12 +472,12 @@
                     <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
                       Immediate="true" Class="filter-input" />
                 }
-                else if (filter.isNumber && !(f.Operator ?? "").EndsWith("empty"))
+                else if (filter.IsNumber && !(f.Operator ?? "").EndsWith("empty"))
                 {
                     <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
-                         Immediate="true" Class="filter-input" Culture="@filter.filterColumn?.Culture" />
+                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
                 }
-                else if (filter.isEnum)
+                else if (filter.IsEnum)
                 {
                     <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                    Class="filter-input">

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -954,12 +954,7 @@ namespace MudBlazor
 
         internal async Task OnRowClickedAsync(MouseEventArgs args, T item, int rowIndex)
         {
-            await RowClick.InvokeAsync(new DataGridRowClickEventArgs<T>
-            {
-                MouseEventArgs = args,
-                Item = item,
-                RowIndex = rowIndex
-            });
+            await RowClick.InvokeAsync(new DataGridRowClickEventArgs<T>(args, item, rowIndex));
 
             if (EditMode != DataGridEditMode.Cell && EditTrigger == DataGridEditTrigger.OnRowClick)
                 await SetEditingItemAsync(item);
@@ -1319,12 +1314,7 @@ namespace MudBlazor
         {
             get
             {
-                if (null == _resizeService)
-                {
-                    _resizeService = new DataGridColumnResizeService<T>(this, EventListener);
-                }
-
-                return _resizeService;
+                return _resizeService ??= new DataGridColumnResizeService<T>(this, EventListener);
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -15,8 +15,11 @@ namespace MudBlazor
     /// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
     public partial class PropertyColumn<T, TProperty> : Column<T>
     {
-        [Parameter] public Expression<Func<T, TProperty>> Property { get; set; } = default!;
-        [Parameter] public string Format { get; set; }
+        [Parameter]
+        [EditorRequired]
+        public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
+
+        [Parameter] public string? Format { get; set; }
 
         private Expression<Func<T, TProperty>>? _lastAssignedProperty;
         private Func<T, object?>? _cellContentFunc;
@@ -33,22 +36,16 @@ namespace MudBlazor
                 _cellContentFunc = item => compiledPropertyExpression!(item);
             }
 
-            if (Property != null)
+            if (Property.Body is MemberExpression memberExpression)
             {
-                if (Property.Body is MemberExpression memberExpression)
-                {
-                    _fullPropertyName = Property.Body.ToString();
-                    _propertyName = memberExpression.Member.Name;
+                _fullPropertyName = Property.Body.ToString();
+                _propertyName = memberExpression.Member.Name;
 
-                    if (Title is null)
-                    {
-                        Title = _propertyName;
-                    }
-                }
-                else
-                {
-                    _propertyName = _fullPropertyName = Property.Body.ToString();
-                }
+                Title ??= _propertyName;
+            }
+            else
+            {
+                _propertyName = _fullPropertyName = Property.Body.ToString();
             }
 
             CompileGroupBy();
@@ -60,7 +57,7 @@ namespace MudBlazor
         public override string? PropertyName
             => _propertyName;
 
-        protected internal override string ContentFormat
+        protected internal override string? ContentFormat
             => Format;
 
         protected internal override object? CellContent(T item)
@@ -77,22 +74,11 @@ namespace MudBlazor
 
         protected internal override void SetProperty(object item, object value)
         {
-            var memberExpression = Property.Body as MemberExpression;
-
-            if (memberExpression != null)
+            if (Property.Body is MemberExpression { Member: PropertyInfo propertyInfo })
             {
-                var propertyInfo = memberExpression.Member as PropertyInfo;
-
-                if (propertyInfo != null)
-                {
-                    var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
-                    propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
-                }
+                var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
+                propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
             }
         }
-
-
     }
-
-#nullable disable
 }

--- a/src/MudBlazor/Components/DataGrid/SortDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/SortDefinition.cs
@@ -6,5 +6,6 @@ using System;
 
 namespace MudBlazor
 {
+#nullable enable
     public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc);
 }

--- a/src/MudBlazor/Components/DataGrid/TemplateColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/TemplateColumn.cs
@@ -2,12 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace MudBlazor
 {
 #nullable enable
-
     /// <typeparam name="T">The type of data represented by each row in the data grid.</typeparam>
     public partial class TemplateColumn<T> : Column<T>
     {
@@ -19,9 +16,6 @@ namespace MudBlazor
 
         protected internal override void SetProperty(object item, object value)
         {
-
         }
     }
-
-#nullable disable
 }

--- a/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
+++ b/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace MudBlazor
+{
+#nullable enable
+    internal class TypeIdentifier
+    {
+        private static readonly HashSet<Type> _numericTypes = new()
+        {
+            typeof(int),
+            typeof(double),
+            typeof(decimal),
+            typeof(long),
+            typeof(short),
+            typeof(sbyte),
+            typeof(byte),
+            typeof(ulong),
+            typeof(ushort),
+            typeof(uint),
+            typeof(float),
+            typeof(BigInteger),
+            typeof(int?),
+            typeof(double?),
+            typeof(decimal?),
+            typeof(long?),
+            typeof(short?),
+            typeof(sbyte?),
+            typeof(byte?),
+            typeof(ulong?),
+            typeof(ushort?),
+            typeof(uint?),
+            typeof(float?),
+            typeof(BigInteger?),
+        };
+
+        internal static bool IsString(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(string))
+                return true;
+
+            return false;
+        }
+
+        public static bool IsNumber(Type? type)
+        {
+            return type is not null && _numericTypes.Contains(type);
+        }
+
+        public static bool IsEnum(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type.IsEnum)
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is { IsEnum: true };
+        }
+
+        public static bool IsDateTime(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(DateTime))
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is not null && underlyingType == typeof(DateTime);
+        }
+
+        public static bool IsBoolean(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(bool))
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is not null && underlyingType == typeof(bool);
+        }
+
+        public static bool IsGuid(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(Guid))
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is not null && underlyingType == typeof(Guid);
+        }
+    }
+}

--- a/src/MudBlazor/Extensions/DataGridExtensions.cs
+++ b/src/MudBlazor/Extensions/DataGridExtensions.cs
@@ -7,26 +7,30 @@ using System.Linq;
 
 namespace MudBlazor
 {
+#nullable enable
     public static class DataGridExtensions
     {
         public static IEnumerable<T> OrderBySortDefinitions<T>(this IEnumerable<T> source, GridState<T> state)
-            => OrderBySortDefinitions(source, state?.SortDefinitions);
+            => OrderBySortDefinitions(source, state.SortDefinitions);
 
         public static IEnumerable<T> OrderBySortDefinitions<T>(this IEnumerable<T> source, ICollection<SortDefinition<T>> sortDefinitions)
         {
-            if (null == source || !source.Any())
-                return source;
+            //avoid multiple enumeration
+            var sourceArray = source as T[] ?? source.ToArray();
 
-            if (null == sortDefinitions || 0 == sortDefinitions.Count)
-                return source;
+            if (sourceArray.Length == 0)
+                return sourceArray;
 
-            IOrderedEnumerable<T> orderedEnumerable = null;
+            if (sortDefinitions.Count == 0)
+                return sourceArray;
+
+            IOrderedEnumerable<T>? orderedEnumerable = null;
 
             foreach (var sortDefinition in sortDefinitions)
             {
-                if (null == orderedEnumerable)
-                    orderedEnumerable = sortDefinition.Descending ? source.OrderByDescending(sortDefinition.SortFunc)
-                        : source.OrderBy(sortDefinition.SortFunc);
+                if (orderedEnumerable is null)
+                    orderedEnumerable = sortDefinition.Descending ? sourceArray.OrderByDescending(sortDefinition.SortFunc)
+                        : sourceArray.OrderBy(sortDefinition.SortFunc);
                 else
                     orderedEnumerable = sortDefinition.Descending ? orderedEnumerable.ThenByDescending(sortDefinition.SortFunc)
                         : orderedEnumerable.ThenBy(sortDefinition.SortFunc);
@@ -35,7 +39,7 @@ namespace MudBlazor
             return orderedEnumerable ?? source;
         }
 
-        public static Column<T> GetColumnByPropertyName<T>(this MudDataGrid<T> dataGrid, string propertyName)
+        public static Column<T>? GetColumnByPropertyName<T>(this MudDataGrid<T> dataGrid, string propertyName)
         {
             return dataGrid.RenderedColumns.FirstOrDefault(x => x.PropertyName == propertyName);
         }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace MudBlazor.Extensions
 {
@@ -20,6 +22,25 @@ namespace MudBlazor.Extensions
             return attributes is { Length: > 0 }
                 ? attributes[0].Description
                 : value.ToString().ToLower();
+        }
+
+        /// <summary>
+        /// Universal method that retrieves an array of the values of the constant in specified enumeration, works with nullable and non-nullable enums.
+        /// Original <see cref="Enum.GetValues"/> works only with non-nullable enums and will throw exception.
+        /// </summary>
+        /// <returns>An array that contains the values of constant in type</returns>
+        internal static IEnumerable<Enum> GetSafeEnumValues(Type type)
+        {
+            if (type.IsEnum)
+                return Enum.GetValues(type).Cast<Enum>();
+
+            if (type.IsGenericType && typeof(Nullable<>) == type.GetGenericTypeDefinition())
+            {
+                var actualType = type.GetGenericArguments()[0];
+                return Enum.GetValues(actualType).Cast<Enum>();
+            }
+
+            return Enumerable.Empty<Enum>();
         }
     }
 }


### PR DESCRIPTION
## Description
Most problems were caught and fixed through Resharper.

Change justification / explanation

**FilterOperator**:
1. Changed `return new string[] { }` to zero allocation `Array.Empty<string>()`
2. Moved `IsNumber`, `IsEnum`, `IsString` etc. in own class `TypeIdentifier`. 
Reasoning: it's weird that they were in `FilterOperator` since here should belong methods related with operators not type identification, it's better when XYZ class is doing only certain job. They were internal, so it's not breaking.
`FieldType` is an addition to `TypeIdentifier` to check for all types at once, this is done multiple times in the code, and it's convenient to have a class that does this for you.

**PropertyColumn**:
1. Added `EditorRequired` to `Property` meaning that user is forced to set this property, the `default!` was hinting on that.
2. Replaced `default!` to an empty expression. The IDE was confused since `default!` says it's not nullable and checking for null is unnecessary, but if you remove the null check then it would throw an exception(during call of `SetParameters` in tests), now it's safe.

**CellContext**:
1. Improved encapsulation. The `selection` can be private readonly since nothing outside used this property, also it's never null since `dataGrid.Selection` initializes empty `HashSet`.
The internal set for `Actions` is also not needed, the value is set only in the constructor.

**FooterContext, HeaderContext, FilterContext**, 
1. Same story as with `CellContext`.

**Cell**:
1.  Used pattern matching, which is better in general.

**GridState**:
1. Initialize empty collections, good practice to avoid nulls (no need to mark them with "?").

**ExpressionModifier**:
1. Better parameter naming.
2. to, from can be readonly.
3. Improved nullability.

**DataGridRowClickEventArgs**:
1. It's better to make EventArgs immutable  (counteracts nulls as well), I would use the new required with init, but since we support .net6 we can't.

**AggregateDefinition**:
1. Avoid multiple enumeration, I'd say that items should be an array from start, but let's leave it as it for now.
2. `propertyExpression` can be null, and we need to check for that.

**DataGridColumnResizeService**:
1. Removed `IList<Column<T>> _columns` idk why we cache that if the value is not used
2. If we do not call `StartResizeColumn` the `_startColumn` and `_nextColumn` will be null.
3. `HeaderCeell` can't be null, but the `HeaderCell.Column` can, need to add null check.

**FilterDefinition**:
1. PropertyExpression can be null if `GenerateFilterExpression` is called not within the `GenerateFilterFunction`. In my opinion, `GenerateFilterExpression` should be private and `FilterDefinition` should expose only `GenerateFilterExpression` as public api.
2. I removed `underlyingDataType` because it's used only once for the `Enum.GetValues` (which works only with not nullable type that's why it  extracts  underlying type), but it's better to have Extension method `GetSafeEnumValues` for this case rather than exposing a property even if it's internal. In general, it's better to avoid  this amount of internal properties.

**Miscellaneous**:
Some internal properties are in lowercase. In C# historically all properties are with uppercase even if it's internal. I didn't rename in all places, but it will come later.

**Future**:
There are still places that requires attention, in fact I want to add nullability to whole DataGrid, but this PR is already massive and it's better if we split.

## How Has This Been Tested?
Current Unit tests, manual tests to see there is no major regression.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
