### PR TITLE
Fix analyzer NullReferenceException in old ToDescriptionString, add test scanrio for it.

### DIFF
--- a/src/MudBlazor.UnitTests/Dummy/DummyEnumEmpty.cs
+++ b/src/MudBlazor.UnitTests/Dummy/DummyEnumEmpty.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.UnitTests.Dummy
+{
+    public enum DummyEnumEmpty
+    {
+        //Empty
+    }
+}

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using MudBlazor.UnitTests.Dummy;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Extensions
@@ -19,9 +20,11 @@ namespace MudBlazor.UnitTests.Extensions
         [Test]
         public void ToDescriptionStringOld()
         {
+            DummyEnumEmpty? dummyNullEnum = 0;
             MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Adornment.Start).Should().Be("start");
             MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Align.Inherit).Should().Be("inherit");
             MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Breakpoint.Sm).Should().Be("sm");
+            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(dummyNullEnum).Should().Be("0");
         }
 #pragma warning restore CS0618
     }

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -7,11 +7,22 @@ namespace MudBlazor.UnitTests.Extensions
     public class EnumExtensionsTests
     {
         [Test]
-        public void ToDescriptionString()
+        public void ToDescriptionStringNew()
         {
             Adornment.Start.ToDescriptionString().Should().Be("start");
             Align.Inherit.ToDescriptionString().Should().Be("inherit");
             Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
         }
+
+#pragma warning disable CS0618
+        /// <remarks>Remove during The Big Break: Breaking Changes in v7</remarks>>
+        [Test]
+        public void ToDescriptionStringOld()
+        {
+            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Adornment.Start).Should().Be("start");
+            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Align.Inherit).Should().Be("inherit");
+            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Breakpoint.Sm).Should().Be("sm");
+        }
+#pragma warning restore CS0618
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Extensions
         }
 
 #pragma warning disable CS0618
-        /// <remarks>Remove during The Big Break: Breaking Changes in v7</remarks>>
+        /// <remarks>Remove this test(including DummyEnumEmpty) during The Big Break: Breaking Changes in v7</remarks>>
         [Test]
         public void ToDescriptionStringOld()
         {

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,11 +1,5 @@
 ﻿using FluentAssertions;
-using MudBlazor.Extensions;
-
-
 using NUnit.Framework;
-// Disable obsolete warning of the extension method for this unit test.
-#pragma warning disable CS0618
-
 
 namespace MudBlazor.UnitTests.Extensions
 {
@@ -15,9 +9,9 @@ namespace MudBlazor.UnitTests.Extensions
         [Test]
         public void ToDescriptionString()
         {
-            EnumExtensions.ToDescriptionString(Adornment.Start).Should().Be("start");
-            EnumExtensions.ToDescriptionString(Align.Inherit).Should().Be("inherit");
-            EnumExtensions.ToDescriptionString(Breakpoint.Sm).Should().Be("sm");
+            Adornment.Start.ToDescriptionString().Should().Be("start");
+            Align.Inherit.ToDescriptionString().Should().Be("inherit");
+            Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
         }
     }
 }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -3,16 +3,23 @@ using System.ComponentModel;
 
 namespace MudBlazor.Extensions
 {
+#nullable enable
     public static class EnumExtensions
     {
         [Obsolete("Please use the auto-generated ToDescriptionString method instead or implement your own extension method.")]
-        public static string ToDescriptionString(this Enum val)
+        public static string ToDescriptionString(this Enum value)
         {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
+            var field = value.GetType().GetField(value.ToString());
+            if (field is null)
+            {
+                return value.ToString().ToLower();
+            }
 
-            return attributes.Length > 0
+            var attributes = Attribute.GetCustomAttributes(field, typeof(DescriptionAttribute), false) as DescriptionAttribute[];
+
+            return attributes is { Length: > 0 }
                 ? attributes[0].Description
-                : val.ToString().ToLower();
+                : value.ToString().ToLower();
         }
     }
 }


### PR DESCRIPTION
## Description
Resharper was giving NullReferenceException in old `ToDescriptionString`.
Added a fix and test scenario for it.
Added remark that the whole test should be removed during [The Big Break](https://github.com/MudBlazor/MudBlazor/projects/13) since the `EnumExtensions.ToDescriptionString` will be removed from public API.

@henon 

## How Has This Been Tested?
Expanded existing unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
