### PR TITLE
MudDateRangePicker: Add missing properties: PlaceholderStart/End and SeparatorIcon

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -38,6 +38,45 @@ namespace MudBlazor.UnitTests.Components
             picker.FixYear.Should().Be(null);
             picker.FixMonth.Should().Be(null);
             picker.FixDay.Should().Be(null);
+            picker.PlaceholderStart.Should().Be(null);
+            picker.PlaceholderEnd.Should().Be(null);
+            picker.SeparatorIcon.Should().Be(Icons.Material.Filled.ArrowRightAlt);
+        }
+
+        [Test]
+        public void DateRangePickerPlaceHolders()
+        {
+            var comp = Context.RenderComponent<MudDateRangePicker>();
+            comp.SetParametersAndRender(
+                parameters =>
+                parameters
+                .Add(picker => picker.PlaceholderStart, "Start")
+                .Add(picker => picker.PlaceholderEnd, "End")
+                );
+
+            var startInput = comp.Find("input").Attributes["placeholder"].Value.Should().Be("Start");
+            var endInput = comp.FindAll("input").Skip(1).First().Attributes["placeholder"].Value.Should().Be("End");
+        }
+
+        [Test]
+        public void DateRangePickerSeparatorIcon()
+        {
+            var newIcon = Icons.Material.Filled.Star;
+            var comp = Context.RenderComponent<MudDateRangePicker>();
+            comp.SetParametersAndRender(
+                parameters =>
+                parameters
+                .Add(picker => picker.SeparatorIcon, newIcon)
+                );
+            var markup = comp.Markup;
+
+            // Only check first svg section
+            string startText = "<svg", endText = "</svg>";
+            var sectionStart = markup.IndexOf(startText);
+            var length = markup.IndexOf(endText) - sectionStart + endText.Length;
+            var section = markup.Substring(sectionStart, length);
+
+            section.Should().Contain(newIcon);
         }
 
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -13,7 +13,7 @@
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"
-                                   Clearable="Clearable"/>
+                                   PlaceholderStart="@PlaceholderStart" PlaceholderEnd="@PlaceholderEnd" SeparatorIcon="@SeparatorIcon" Clearable="Clearable"/>
                </InputContent>
            </MudInputControl>;
     

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -22,6 +22,27 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// The short hint displayed in the start input before the user enters a value.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public string PlaceholderStart { get; set; }
+
+        /// <summary>
+        /// The short hint displayed in the end input before the user enters a value.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public string PlaceholderEnd { get; set; }
+
+        /// <summary>
+        /// Custom separator icon, leave null for default.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string SeparatorIcon { get; set; } = Icons.Material.Filled.ArrowRightAlt;
+
+        /// <summary>
         /// Fired when the DateFormat changes.
         /// </summary>
         [Parameter] public EventCallback<DateRange> DateRangeChanged { get; set; }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes: https://github.com/MudBlazor/MudBlazor/issues/5324
Added `PlaceholderStart`, `PlaceholderEnd` and `SeparatorIcon` properties to `MudDateRangePicker`.

This properties are used by `MudRangeInput` so even without this change it is possible to set them.
For example this code works just fine: https://try.mudblazor.com/snippet/wEQnEnkJxCIfABKW

But they were not present on the API docs and are not visible to user (I mean as autocompletion in IDE).
You could only deduce that they are present by looking into RangeInput source code). 



## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
