### PR TITLE
Feature/optional key interception on mud numeric field

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -115,5 +115,8 @@
     <Content Remove="compilerconfig.json" />
     <Content Remove="excubowebcompiler.json" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Pages\Components\NumericField\Code\NumericFieldWithKeyOptionsReplacementsCode.html" />
+  </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldWithKeyOptionsReplacements.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldWithKeyOptionsReplacements.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using MudBlazor.Services;
+@using System.Globalization;
+
+<MudText>Non-immediate: Enter '100.00'.</MudText>
+<MudNumericField Immediate="false" Label="Will fail" Format="N2" Culture="@_fr" FullWidth
+                 T="double?" @bind-Value="_valueBadFr" HelperText="@_valueBadFr.ToString()" />
+<MudNumericField Immediate="false" Label="Won't fail." Format="N2" Culture="@_fr" FullWidth
+                 T="double?" @bind-Value="_valueFr" HelperText="@_valueFr.ToString()" LocalKeyOverrides="@LocalKeyOverrides" />
+
+<MudText>Immediate: Enter '100.00'.</MudText>
+<MudNumericField Immediate Label="Will fail." Format="N2" Culture="@_fr" FullWidth
+                 T="double?" @bind-Value="_valueImmediateBadFr" HelperText="@_valueImmediateBadFr.ToString()" />
+<MudNumericField Immediate Label="Won't fail." Format="N2" Culture="@_fr" FullWidth
+                 T="double?" @bind-Value="_valueImmediateFr" HelperText="@_valueImmediateFr.ToString()" LocalKeyOverrides="@LocalKeyOverrides" />
+
+@code {
+    public CultureInfo _fr = CultureInfo.GetCultureInfo("fr-FR");
+
+    public double? _valueImmediateFr = 0;
+    public double? _valueImmediateBadFr = 0;
+    public double? _valueFr = 0;
+    public double? _valueBadFr = 0;
+
+    public IList<KeyOptions> LocalKeyOverrides = new List<KeyOptions>() { new KeyOptions() { Key = ".", Replace = "," } };
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
@@ -45,6 +45,21 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Replacing input characters in real time.">
+                <Description>
+                    If you have an issue with a specific key type not being accepted with your culture, you can override it by setting up some KeyOptions to intercept problematic keys and replace them. 
+                    <br/>
+                    <br />
+                    A perfect example is using the French (<CodeInline>fr-FR</CodeInline>) culture, if you input a <CodeInline>.</CodeInline> character while using the numpad <CodeInline>.</CodeInline> key, it will break Validation.  This technique allows you to remove quirks with your
+                    culture of choice when you run across them.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="NumericFieldWithKeyOptionsReplacements" ShowCode="false">
+                <NumericFieldWithKeyOptionsReplacements />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Binding Value Types vs Nullables">
                 <Description>
                     When you bind value types, the numeric field will not be empty even if the user hasn't entered a value yet because a value type always has a value, even when unassigned.

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
@@ -47,7 +47,7 @@
         <DocsPageSection>
             <SectionHeader Title="Replacing input characters in real time.">
                 <Description>
-                    If you have an issue with a specific key type not being accepted with your culture, you can override it by setting up some KeyOptions to intercept problematic keys and replace them. 
+                    If you have an issue with a specific key type not being accepted with your culture, you can override it by setting up some <CodeInline>KeyOptions</CodeInline> to intercept problematic keys and replace them. 
                     <br/>
                     <br />
                     A perfect example is using the French (<CodeInline>fr-FR</CodeInline>) culture, if you input a <CodeInline>.</CodeInline> character while using the numpad <CodeInline>.</CodeInline> key, it will break Validation.  This technique allows you to remove quirks with your

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldImmediateCultureTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldImmediateCultureTest.razor
@@ -4,9 +4,9 @@
 <MudText>@German.Text</MudText>
 <MudText>@French.Text</MudText>
 
-<MudNumericField id="English" @ref="English" T="double?" @bind-Value="_value" Label="English" Format="N2" Culture="_english" />
-<MudNumericField id="German" @ref="German" T="double?" @bind-Value="_value2" Label="German" Format="N2" Culture="_german" />
-<MudNumericField id="French" @ref="French" T="double?" @bind-Value="_value3" Label="French" Format="N2" Culture="_french" />
+<MudNumericField id="English" @ref="English" T="double?" @bind-Value="_value" Immediate Label="English" Format="N2" Culture="_english" />
+<MudNumericField id="German" @ref="German" T="double?" @bind-Value="_value2" Immediate Label="German" Format="N2" Culture="_german" />
+<MudNumericField id="French" @ref="French" T="double?" @bind-Value="_value3" Immediate Label="French" Format="N2" Culture="_french" />
 
 @code {
     public CultureInfo _german = CultureInfo.GetCultureInfo("de-DE");

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldImmediateLocalKeyOverrideCultureTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldImmediateLocalKeyOverrideCultureTest.razor
@@ -1,0 +1,30 @@
+﻿@using System.Globalization
+@using MudBlazor.Services;
+
+<MudText>@English.Text</MudText>
+<MudText>@German.Text</MudText>
+<MudText>@French.Text</MudText>
+
+<MudNumericField id="English" @ref="English" T="double?" Immediate @bind-Value="_value" Label="English" Format="N2" Culture="_english" />
+<MudNumericField id="German" @ref="German" T="double?" Immediate @bind-Value="_value2" Label="German" Format="N2" Culture="_german" />
+<MudNumericField id="French" @ref="French" T="double?" Immediate @bind-Value="_value3" Label="French" Format="N2" Culture="_french" LocalKeyOverrides="@_frenchAdditionalKeyOptions" />
+
+@code {
+    public CultureInfo _german = CultureInfo.GetCultureInfo("de-DE");
+    public CultureInfo _english = CultureInfo.GetCultureInfo("en-US");
+    public CultureInfo _french = CultureInfo.GetCultureInfo("fr-FR");
+
+    public double? _value { get; set; }
+    public double? _value2 { get; set; }
+    public double? _value3 { get; set; }
+
+    public IList<KeyOptions>? _additionalKeyOptions = null;
+    public IList<KeyOptions>? _frenchAdditionalKeyOptions = new List<KeyOptions>()
+    {
+        new KeyOptions() { Key = ".", Replace = "," }
+    };
+
+    public MudNumericField<double?> English { get; set; }
+    public MudNumericField<double?> German { get; set; }
+    public MudNumericField<double?> French { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldLocalKeyOverrideCultureTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldLocalKeyOverrideCultureTest.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Globalization
+@using MudBlazor.Services;
 
 <MudText>@English.Text</MudText>
 <MudText>@German.Text</MudText>
@@ -6,7 +7,7 @@
 
 <MudNumericField id="English" @ref="English" T="double?" @bind-Value="_value" Label="English" Format="N2" Culture="_english" />
 <MudNumericField id="German" @ref="German" T="double?" @bind-Value="_value2" Label="German" Format="N2" Culture="_german" />
-<MudNumericField id="French" @ref="French" T="double?" @bind-Value="_value3" Label="French" Format="N2" Culture="_french" />
+<MudNumericField id="French" @ref="French" T="double?" @bind-Value="_value3" Label="French" Format="N2" Culture="_french" LocalKeyOverrides="@_frenchAdditionalKeyOptions" />
 
 @code {
     public CultureInfo _german = CultureInfo.GetCultureInfo("de-DE");
@@ -16,6 +17,12 @@
     public double? _value { get; set; }
     public double? _value2 { get; set; }
     public double? _value3 { get; set; }
+
+    public IList<KeyOptions>? _additionalKeyOptions = null;
+    public IList<KeyOptions>? _frenchAdditionalKeyOptions = new List<KeyOptions>()
+    {
+        new KeyOptions() { Key = ".", Replace = "," }
+    };
 
     public MudNumericField<double?> English { get; set; }
     public MudNumericField<double?> German { get; set; }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Docs.Server", "MudBlazor.Docs.Server\MudBlazor.Docs.Server.csproj", "{90B6D51A-133A-4744-A5FE-FF398F0D6BAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -78,5 +78,10 @@ namespace MudBlazor.Services
         public string PreventUp { get; set; } = "none";
         public string StopDown { get; set; } = "none";
         public string StopUp { get; set; } = "none";
+
+        /// <summary>
+        /// Replaces the Key that was pressed and delivers this value instead.  Overwrites behavior of StopDown.
+        /// </summary>
+        public string Replace { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
It provides a pathway to set some KeyOptions up on a MudNumericField and if that list is not null, we can parse it to replace problematic characters by leveraging a new KeyOptions.Replace field to scrub the string prior to setting it as the new value.

I was unable to understand why the numpad . wouldn't work like the general . on the main part of the keyboard for the fr-FR culture, but I believe it to be baked into the CultureInfo behavior and not MudBlazor (unless I missed something).  

I'm willing to take any and all feedback or suggestions for different ways to achieve this.

I did refactor some tests to generify them and simplify them, which is - I believe - the only rule I broke on the commit list, however, I preserved the original tests in doing so.  They are now just row tests instead.

I do wonder about making a KeyOptionsFactory to assist in building the KeyOptions list to replace keystrokes, I also wonder if maybe this should be put in the MudInput so it could be leveraged by other fields.

I originally looked to try and leverage the Javascript to achieve this with the KeyInterceptor, but I wasn't able to see how to get that pathway to fire off.

Let me know where to take this, if you want me to reimagine how I'm achieving the desired result.

<!-- Note any issues that are resolved by this PR -->
This resolves #6181 

<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
This contains many new unit tests via row tests.  

<!-- Please describe how you tested your changes. -->

- bUnit tests for the MudNumeric field components.
- Additional confirmation of the test changes by updating the Docs with an example and confirming it's reproduceable.

<!-- Have you created new tests or updated existing ones? -->
It did contain a mild refactor of 3 different tests that had multiple types of features on display with immediate/non-immediate, resulting in separation into two different pathways for TestComponents housing all Immediates together and all Non-Immediates together across 3 different types of tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
