### PR TITLE
MudDatePicker: Add disabled functionality for months only picker

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
@@ -901,6 +902,30 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => datePicker.GoToDate());
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2023, 04, 21)));
+        }
+
+        [Test]
+        public async Task DatePickerTest_CheckIfMonthsAreDisabled()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var datePicker = comp.FindComponent<MudDatePicker>().Instance;
+
+            datePicker.MinDate = DateTime.Now.AddDays(-1);
+            datePicker.MaxDate = DateTime.Now.AddDays(1);
+            
+
+            // Open the datepicker
+            await comp.InvokeAsync(datePicker.Open);
+
+            comp.Find("button.mud-button-month").Click();
+            comp.WaitForAssertion(() => comp.FindAll("button.mud-picker-month").Any(x => x.IsDisabled()).Should().Be(true));
+
+            comp.FindAll("button.mud-picker-month").First(x => x.IsDisabled()).Click();
+
+            var months = comp.FindAll("button.mud-picker-month");
+            months.Should().NotBeNull();
+            comp.Instance.Date.Should().BeNull();
+            
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -61,21 +61,13 @@
                                     }
                                 </div>
                             </div>
-                            <div class="mud-picker-month-container">
+                            <div class="mud-picker-month-container mud-button-root">
                                 @foreach (var month in GetAllMonths())
                                 {
-                                    @if ((month < MinDate) || (month > MaxDate))
-                                    {
-                                        <button type="button" disabled="true" aria-label="@GetMonthName(month)" class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
-                                            <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
-                                        </button>
-                                    }
-                                    else
-                                    {
-                                        <button type="button" aria-label="@GetMonthName(month)" class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
-                                            <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
-                                        </button>
-                                    }
+                                    <button type="button" disabled=@(month < MinDate || month > MaxDate) aria-label="@GetMonthName(month)" class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                        <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
+                                    </button>
+
                                 }
                             </div>
                         }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -5,14 +5,14 @@
 
 @Render
 
-@code{
+@code {
 
     protected override RenderFragment PickerContent =>
     @<CascadingValue Value="@this" IsFixed="true">
         <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
-         </MudPickerToolbar>
+        </MudPickerToolbar>
         <MudPickerContent>
             <div class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
                 @{
@@ -53,16 +53,29 @@
                                         <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition" @onclick="OnYearClick" @onclick:stopPropagation="true">
                                             <MudText Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
                                         </button>
-                                        <MudIconButton aria-label="@nextLabel" Icon="@NextIcon" OnClick="OnNextYearClick" Class="mud-flip-x-rtl" /> }
-                                    else{ <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>}
+                                        <MudIconButton aria-label="@nextLabel" Icon="@NextIcon" OnClick="OnNextYearClick" Class="mud-flip-x-rtl" />
+                                    }
+                                    else
+                                    {
+                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
+                                    }
                                 </div>
                             </div>
                             <div class="mud-picker-month-container">
                                 @foreach (var month in GetAllMonths())
                                 {
-                                    <button type="button" aria-label="@GetMonthName(month)" class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
-                                        <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
-                                    </button>
+                                    @if ((month < MinDate) || (month > MaxDate))
+                                    {
+                                        <button type="button" disabled="true" aria-label="@GetMonthName(month)" class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                            <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button type="button" aria-label="@GetMonthName(month)" class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                            <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
+                                        </button>
+                                    }
                                 }
                             </div>
                         }
@@ -79,8 +92,12 @@
                                         <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition mud-button-month" @onclick="(() => OnMonthClicked(tempMonth))" @onclick:stopPropagation="true">
                                             <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
                                         </button>
-                                        <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" /> }
-                                    else { <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>}
+                                        <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" />
+                                    }
+                                    else
+                                    {
+                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
+                                    }
                                 </div>
                                 <div class="mud-picker-calendar-header-day">
                                     @if (ShowWeekNumbers)
@@ -116,20 +133,20 @@
                                             {
                                                 var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
                                                 <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
-                                                        @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
-                                                        @onclick:stopPropagation="true"
-                                                        aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
-                                                        onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(!firstMonthFirstYear ? tempId: tempId + 1));"
-                                                        disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
+                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
+                                    @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
+                                    @onclick:stopPropagation="true"
+                                aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
+                                onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(!firstMonthFirstYear ? tempId: tempId + 1));"
+                                disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
                                                     <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(selectedDay)</p>
                                                 </button>
                                             }
                                             else
                                             {
                                                 <button @key="0" type="button" style="--day-id: 1;"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
-                                                        aria-label='' disabled>
+                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
+                                aria-label='' disabled>
                                                     <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
                                                 </button>
                                             }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -547,6 +547,8 @@ namespace MudBlazor
 
         private string GetMonthClasses(DateTime month)
         {
+            if (month < MinDate || month > MaxDate)
+                return "mud-text-disabled";
             if (GetMonthStart(0) == month)
                 return $"mud-picker-month-selected mud-{Color.ToDescriptionString()}-text";
             return null;
@@ -554,13 +556,10 @@ namespace MudBlazor
 
         private Typo GetMonthTypo(DateTime month)
         {
-            if (GetMonthStart(0) == month)
+            if (GetMonthStart(0) == month && (month > MinDate || month < MaxDate))
                 return Typo.h5;
             return Typo.subtitle1;
         }
-
-        
-
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -547,7 +547,7 @@ namespace MudBlazor
 
         private string GetMonthClasses(DateTime month)
         {
-            if (month < MinDate || month > MaxDate)
+            if (month <= MinDate || month >= MaxDate)
                 return "mud-text-disabled";
             if (GetMonthStart(0) == month)
                 return $"mud-picker-month-selected mud-{Color.ToDescriptionString()}-text";


### PR DESCRIPTION
Added functionality to disable Months in date picker Issue #6381 

## Description
Disables months if they are outside the min-max date range.

## How Has This Been Tested?
Visually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![image](https://user-images.githubusercontent.com/15570865/223455688-e9345999-de95-4a3b-9489-568abfcb6501.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
