### PR TITLE
MudDataGrid: Fix missing content/error in Cell edit mode for HierarchyColumn (#6024)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -3,7 +3,8 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid Items="@Elements">
+<MudDataGrid Items="@Elements"
+             ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     <Columns>
         <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" />
         <PropertyColumn Property="x => x.Number" Title="Nr" />
@@ -30,6 +31,11 @@
     </PagerContent>
 </MudDataGrid>
 
+<div class="d-flex flex-wrap mt-4">
+    <MudSwitch T="bool" @bind-Checked="@_isReadOnly" Color="@Color.Primary">Read Only</MudSwitch>
+</div>
+
+
 @code { 
     private IEnumerable<Element> Elements = new List<Element>();
 
@@ -37,4 +43,7 @@
     {
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
     }
+
+        private bool _isReadOnly = true;
+
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-    Filterable="false">
+    Filterable="false" IsEditable="false">
     <CellTemplate>
         <label class="ma-n3">
             <MudIconButton

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -325,7 +325,7 @@
             var cell = new Cell<T>(this, column, item);
         }
         <td data-label="@column.Title" class="@cell.computedClass" style="@cell.computedStyle">
-            @if (column.IsEditable && !ReadOnly && DataGridEditMode.Cell == EditMode)
+            @if (column.IsEditable && !ReadOnly && EditMode == DataGridEditMode.Cell)
             {
                 if (column.EditTemplate != null)
                 {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
 - Fixes #6024 ;

 - Changed Inner TemplateColumn of the HierarchyColumn to be not editable, setting `IsEditable="false"`, because the rendering process was trying to render column's EditTemplate, and it's null (and should continue to be). By this change, MudDataGrid rendering process will look just for the CellTemplate, and will render column's MudIconButton (arrows);

 - Updated [DataGridDetailRowExample.razor](https://github.com/MudBlazor/MudBlazor/compare/dev...HClausing:fix_%236024?expand=1#diff-321a6b71d2db1fd2088366a053efc7c44a46e5d008b5c3aa23b606c572ac0046) to test the behavior.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually tests only, since it's relative simple.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
