### PR TITLE
Docs: Fix release page and roadmap page

### DIFF
--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -50,6 +50,7 @@
                    connect-src 'self'
                                https://api.github.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
                                wss://localhost:*;
                    upgrade-insecure-requests;">

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -46,6 +46,7 @@
                    connect-src 'self'
                                https://api.github.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
                                wss://localhost:*;
                    upgrade-insecure-requests;">

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -55,6 +55,7 @@
                    connect-src 'self'
                                https://api.github.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
                                wss://localhost:*;
                    upgrade-insecure-requests;">

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -34,7 +34,6 @@
 </DocsPage>
 
 @code {
-
     private GitHubReleases[] _githubReleases;
 
     protected override async Task OnInitializedAsync()
@@ -45,14 +44,13 @@
 
     private string GetBody(string value)
     {
-        string output = value;
-        output = Regex.Replace(output, @"((#{3}\s)(?<subtitle>.+))", "<h3>${subtitle}</h3>");
-        output = Regex.Replace(output, @"((#{2}\s)(?<title>.+))", "<h2>${title}</h2>");
-        output = Regex.Replace(output, @"(([*] )(?<row>.+))", "<div><b class=\"mx-3\">•</b>${row}</div>");
-        output = Regex.Replace(output, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"github-user\">@$2</a>");
-        output = Regex.Replace(output, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\">#$1</a>");
-        output = Regex.Replace(output, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a>");
-        return output;
+        value = Regex.Replace(value, @"((###\s)(?<subtitle>.+))(?<items>.*(?:\r?\n[*] .*)*)", "<h6 class=\"mud-typography mud-typography-h6\">${subtitle}</h6><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
+        value = Regex.Replace(value, @"((##\s)(?<title>.+))(?<items>.*(?:\r?\n[*] .*)*)", "<h5 class=\"mud-typography mud-typography-h5\">${title}</h5><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
+        value = Regex.Replace(value, @"(([*]\s)(?<row>.+))", "<li>${row}</li>");
+        value = Regex.Replace(value, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"mud-link mud-default-text mud-link-underline-hover\"><b>@$2</b></a>");
+        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
+        value = Regex.Replace(value, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<p class=\"mud-typography mud-typography-body1\">Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a></p>");
+        return value;
     }
 
 }

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -12,13 +12,13 @@
         }
         else
         {
-            <MudGrid>
+            <MudGrid Class="docs-github-releases">
                 @foreach (var release in _githubReleases)
                 {
                     <MudItem xs="12" md="4">
                         <div class="docs-sticky-info">
                             <MudText Typo="Typo.h5" Inline="true">Version </MudText>
-                            <MudText Typo="Typo.h5" Inline="true" Color="Color.Primary"><b>@release.name</b></MudText>
+                            <MudText Typo="Typo.h5" Inline="true" Color="Color.Primary"><b>@release.tag_name</b></MudText>
                             <MudText Typo="Typo.subtitle1">Released on @release.published_at.ToString("MMMM MM, yyyy")</MudText>
                         </div>
                     </MudItem>
@@ -36,7 +36,7 @@
 @code {
 
     private GitHubReleases[] _githubReleases;
-    
+
     protected override async Task OnInitializedAsync()
     {
         _githubReleases = await _gitHubApiClient.GetReleasesAsync();
@@ -46,18 +46,12 @@
     private string GetBody(string value)
     {
         string output = value;
-        output = Regex.Replace(output, @"(^|\n)# .+", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">$&</h5>");
-        output = Regex.Replace(output, @"(^|\n)## .+", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">$&</h5>");
-        output = Regex.Replace(output, @"(^|\n)### .+", "<h6 class=\"mud-typography mud-typography-h6 mud-inherit-text\">$&</h6>");
-        // Markdown links
-        output = Regex.Replace(output, @"\[(.*?)\]\((.*?)\)", "<a target=\"_blank\" href=\"$2\">$1</a>");
-        // Http links
-        output = Regex.Replace(output, @"(?<!"")(?>https?:\/\/)[^\s<>]+(?:[\w\d]+|(?>[^[\p{P}\s]|\/))", "<a target=\"_blank\" href=\"$0\">$0</a>");
-        // Issue / PR links
-        output = Regex.Replace(output, @"(#){1}([0-9]{4}){1}", "<a target=\"_blank\" href=\"https://github.com/MudBlazor/MudBlazor/pull/$2\">#$2</a>");
-        output = output.Replace("- **", "<b class=\"mx-3\">•</b><b>").Replace("**:",":</b>");
-        output = output.Replace("### ", "").Replace("## ","").Replace("# ","#");
-        output = output.Replace(">#MudBlazor", ">MudBlazor");
+        output = Regex.Replace(output, @"((#{3}\s)(?<subtitle>.+))", "<h3>${subtitle}</h3>");
+        output = Regex.Replace(output, @"((#{2}\s)(?<title>.+))", "<h2>${title}</h2>");
+        output = Regex.Replace(output, @"(([*] )(?<row>.+))", "<div><b class=\"mx-3\">•</b>${row}</div>");
+        output = Regex.Replace(output, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"github-user\">@$2</a>");
+        output = Regex.Replace(output, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\">#$1</a>");
+        output = Regex.Replace(output, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a>");
         return output;
     }
 

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -3,6 +3,8 @@
 
 @inject GitHubApiClient _gitHubApiClient;
 
+<PageTitle>Releases - MudBlazor</PageTitle>
+
 <DocsPage DisplayFooter="true">
     <DocsPageHeader Title="Releases" />
     <DocsPageContent>
@@ -52,5 +54,4 @@
         value = Regex.Replace(value, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<p class=\"mud-typography mud-typography-body1\">Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a></p>");
         return value;
     }
-
 }

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -25,18 +25,28 @@
                         </div>
                     </MudItem>
                     <MudItem xs="12" md="8">
-                        <div class="docs-github-release-body">
-                            @((MarkupString)GetBody(release.body))
-                        </div>
+                            @if (release.published_at > _oldReleases)
+                            {
+                                <div class="docs-github-release-body">
+                                    @((MarkupString)GetBody(release.body))
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="docs-github-release-body old-releases">
+                                    @((MarkupString)GetOldBody(release.body))
+                                </div>
+                            }
                     </MudItem>
                 }
-        </MudGrid>
+            </MudGrid>
         }
     </DocsPageContent>
 </DocsPage>
 
 @code {
     private GitHubReleases[] _githubReleases;
+    private DateTime _oldReleases = DateTime.Parse("2022-11-09");
 
     protected override async Task OnInitializedAsync()
     {
@@ -50,8 +60,21 @@
         value = Regex.Replace(value, @"((##\s)(?<title>.+))(?<items>.*(?:\r?\n[*] .*)*)", "<h5 class=\"mud-typography mud-typography-h5\">${title}</h5><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
         value = Regex.Replace(value, @"(([*]\s)(?<row>.+))", "<li>${row}</li>");
         value = Regex.Replace(value, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"mud-link mud-default-text mud-link-underline-hover\"><b>@$2</b></a>");
-        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
+        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
         value = Regex.Replace(value, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<p class=\"mud-typography mud-typography-body1\">Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a></p>");
+        return value;
+    }
+
+    private string GetOldBody(string value)
+    {
+        value = Regex.Replace(value, @"((###\s)(?<subtitle>.+))(?<items>.*(?:\r?\n-\s[*][*].*)*)", "<h6 class=\"mud-typography mud-typography-h6\">${subtitle}</h6><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
+        value = Regex.Replace(value, @"^(#\s)(?<title>.+)", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">${title}</h5>");
+        value = Regex.Replace(value, @"((-\s[*][*])(?<row>.+))", "<li>${row}</li>");
+        value = Regex.Replace(value, @"(#){1}([0-9]{4}){1}", "<a target=\"_blank\" href=\"https://github.com/MudBlazor/MudBlazor/pull/$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$2</b></a>");
+        value = Regex.Replace(value, @"\[(.*?)\]\((.*?)\)", "<a target=\"_blank\" href=\"$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\">$1</a>");
+        value = Regex.Replace(value, @"(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<a target=\"_blank\" href=\"$1$2\" class=\"docs-code docs-code-primary\">$2</a>");
+        value = Regex.Replace(value, @"(https://github.com/MudBlazor/MudBlazor/milestone/)(.+)", "<a target=\"_blank\" href=\"$1$2\" class=\"docs-code docs-code-primary\">Milestone</a>");
+        value = value.Replace("**","");
         return value;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
@@ -1,27 +1,38 @@
 ﻿@page "/mud/project/roadmap"
+@using System.Text.RegularExpressions
 
 <PageTitle>Roadmap - MudBlazor</PageTitle>
 
-<DocsPage>
+<DocsPage DisplayFooter="true">
+    <DocsPageHeader Title="Roadmap" />
     <DocsPageContent>
-        <DocsPageSection>
-            <div class="docs-roadmap-container d-flex justify-center">
-                <div class="d-flex justify-center flex-column align-center docs-roadmap-2022">
-                    <img src="_content/MudBlazor.Docs/images/roadmap2022.png" alt="Roadmap 2022">
-                    <MudText Typo="Typo.subtitle1" Align="Align.Center" Class="my-6">
-                        The roadmap is still in the making as we want to get some feedback from you and made the survey.<br>
-                        Once the survey is closed and the data collected the team will piece everything together.
-                    </MudText>
-                </div>
-                <div class="roadmap-world">
-                    <div class="roadmap-grid">
-                        @for (int i = 0; i < 100; i++)
-                        {
-                            <div class="roadmap-grid-item"></div>
-                        }
-                    </div>
-                </div>
-            </div>
-        </DocsPageSection>
+        @if (string.IsNullOrEmpty(_roadMap))
+        {
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        }
+        else
+        {
+            <MudStack Spacing="2" Class="mud-typography mud-typography-body1">
+                @((MarkupString)GetBody(_roadMap))
+            </MudStack>
+        }
     </DocsPageContent>
 </DocsPage>
+
+@code {
+    private string _roadMap;
+    [Inject] HttpClient HttpClient { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md");
+        _roadMap = await response.Content.ReadAsStringAsync();
+    }
+
+    private string GetBody(string value)
+    {
+        value = Regex.Replace(value, @"(##\s)(?<title>.+)", "<h5 class=\"mud-typography mud-typography-h5 mt-3\"><b>${title}</b></h5><hr class=\"mud-divider mud-divider-fullwidth\">");
+        value = Regex.Replace(value, @"(#\s)(?<title>.+)", "<h4 class=\"mud-typography mud-typography-h4\"><b>${title}</b></h4><hr class=\"mud-divider mud-divider-fullwidth\">");
+        return value;
+    }
+}

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -6,16 +6,27 @@
     }
     .docs-github-release-body {
         padding-bottom: 24px;
-    
+
+        &.old-releases{
+            font-size: var(--mud-typography-body1-size);
+            font-weight: var(--mud-typography-body1-weight);
+
+            h6 {
+                margin-top:24px;
+            }
+        }
+
         h5 {
             &:first-child {
                 padding: 12px 0;
                 margin-bottom: 24px;
                 border-top: var(--mud-palette-lines-default) 1px solid;
                 border-bottom: var(--mud-palette-lines-default) 1px solid;
+                font-size: var(--mud-typography-h5-size);
+                font-weight: var(--mud-typography-h5-weight);
             }
         }
-        
+
         ul{
             list-style: disc;
             font-size: var(--mud-typography-body1-size);

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -1,41 +1,13 @@
 ﻿.docs-github-releases{
     .mud-grid-item-md-4:first-child + .mud-grid-item-md-8 {
-        h2:first-child {
+        h5:first-child {
             border-top: none !important;
         }
     }
     .docs-github-release-body {
-        font-size: var(--mud-typography-body1-size);
-        font-family: var(--mud-typography-body1-family);
-        font-weight: var(--mud-typography-body1-weight);
-        line-height: var(--mud-typography-body1-lineheight);
-        letter-spacing: var(--mud-typography-body1-letterspacing);
-        text-transform: var(--mud-typography-body1-text-transform);
         padding-bottom: 24px;
     
-        a {
-            color: var(--mud-palette-primary);
-            line-height: normal;
-            font-weight: 500;
-    
-            &:hover {
-                cursor: pointer;
-                text-decoration: underline;
-            }
-
-            &.docs-code{
-                font-weight: 700;
-            }
-        }
-    
-        h2 {
-            font-size: var(--mud-typography-h5-size);
-            font-family: var(--mud-typography-h5-family);
-            font-weight: 500;
-            line-height: normal;
-            letter-spacing: var(--mud-typography-h5-letterspacing);
-            text-transform: var(--mud-typography-h5-text-transform);
-    
+        h5 {
             &:first-child {
                 padding: 12px 0;
                 margin-bottom: 24px;
@@ -43,14 +15,10 @@
                 border-bottom: var(--mud-palette-lines-default) 1px solid;
             }
         }
-    
-        strong {
-            font-weight: 500;
-        }
-    
-        ul {
-            padding: 12px 0 24px 24px;
+        
+        ul{
             list-style: disc;
+            font-size: var(--mud-typography-body1-size);
         }
 
         .github-user {
@@ -59,4 +27,3 @@
         }
     }
 }
-

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -1,29 +1,62 @@
-﻿.docs-github-release-body{
-  white-space: pre-line;
-  font-size: var(--mud-typography-body1-size);
-  font-family: var(--mud-typography-body1-family);
-  font-weight: var(--mud-typography-body1-weight);
-  line-height: var(--mud-typography-body1-lineheight);
-  letter-spacing: var(--mud-typography-body1-letterspacing);
-  text-transform: var(--mud-typography-body1-text-transform);
-  
-  a{
-    color:var(--mud-palette-primary);
-    line-height: normal;
-    font-weight: 500;
-    
-    &:hover{
-      cursor:pointer;
-      text-decoration: underline;
+﻿.docs-github-releases{
+    .mud-grid-item-md-4:first-child + .mud-grid-item-md-8 {
+        h2:first-child {
+            border-top: none !important;
+        }
     }
-  }
-  
-  h5{
-    margin-bottom: -12px;
-  }
-  
-  h6{
-    margin-top: -25px;
-    margin-bottom: -15px;
-  }
+    .docs-github-release-body {
+        font-size: var(--mud-typography-body1-size);
+        font-family: var(--mud-typography-body1-family);
+        font-weight: var(--mud-typography-body1-weight);
+        line-height: var(--mud-typography-body1-lineheight);
+        letter-spacing: var(--mud-typography-body1-letterspacing);
+        text-transform: var(--mud-typography-body1-text-transform);
+        padding-bottom: 24px;
+    
+        a {
+            color: var(--mud-palette-primary);
+            line-height: normal;
+            font-weight: 500;
+    
+            &:hover {
+                cursor: pointer;
+                text-decoration: underline;
+            }
+
+            &.docs-code{
+                font-weight: 700;
+            }
+        }
+    
+        h2 {
+            font-size: var(--mud-typography-h5-size);
+            font-family: var(--mud-typography-h5-family);
+            font-weight: 500;
+            line-height: normal;
+            letter-spacing: var(--mud-typography-h5-letterspacing);
+            text-transform: var(--mud-typography-h5-text-transform);
+    
+            &:first-child {
+                padding: 12px 0;
+                margin-bottom: 24px;
+                border-top: var(--mud-palette-lines-default) 1px solid;
+                border-bottom: var(--mud-palette-lines-default) 1px solid;
+            }
+        }
+    
+        strong {
+            font-weight: 500;
+        }
+    
+        ul {
+            padding: 12px 0 24px 24px;
+            list-style: disc;
+        }
+
+        .github-user {
+            font-weight: 700;
+            color: var(--mud-palette-text-primary);
+        }
+    }
 }
+


### PR DESCRIPTION
## Description
The [release page](https://mudblazor.com/mud/project/releases) on docs have been "broken" since we started with auto generated release notes. Corrected the regex so it displays just like on GitHub.
I added two different methods for converting the Markdown since the old release notes where done a little bit differently. I tried to make it look as the new ones but there might be some that looks weird if you scroll far enough.

The roadmap page on docs have been a dummy blank one for a long time, since we now have a roadmap.md file on GitHub i pull the data directly from it.

### New
![RelesesFixed](https://user-images.githubusercontent.com/10367109/224552536-f3902bdd-eb47-4c32-8b89-599262ab3db1.png)
### Old
![RelesesBroken](https://user-images.githubusercontent.com/10367109/224552543-0fb06aea-ecf9-4eb4-b963-7bb7f3709962.png)
### Roadmap
![localhost_5001_mud_project_roadmap](https://user-images.githubusercontent.com/10367109/224552617-9ff073a0-8f01-451d-8821-d66ff778b770.png)


## How Has This Been Tested?
Manually tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
