### PR TITLE
MudBaseInput: Obsolete OnKeyPress, to be removed in v7

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -294,8 +295,10 @@ namespace MudBlazor
         /// <summary>
         /// Fired on the KeyPress event.
         /// </summary>
+        [Obsolete("This will be removed in v7")]
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyPress { get; set; }
 
+        [Obsolete("This will be removed in v7")]
         protected virtual void InvokeKeyPress(KeyboardEventArgs obj)
         {
             OnKeyPress.InvokeAsync(obj).AndForget();
@@ -306,6 +309,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
+        [Obsolete("This will be removed in v7")]
         public bool KeyPressPreventDefault { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Description
According to Mozilla https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event the keypress event is deprecated. I scheduled it for removal in [the big break](https://github.com/MudBlazor/MudBlazor/projects/13)
