### PR TITLE
MudTable: Add filtered items cache for each render.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -8,6 +8,7 @@ using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Moq;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
@@ -232,6 +233,28 @@ namespace MudBlazor.UnitTests.Components
             searchString.Change(string.Empty);
             table.GetFilteredItemsCount().Should().Be(59);
             comp.FindAll("tr").Count.Should().Be(59);
+        }
+
+        [Test]
+        public void TableFilterCachingTest()
+        {
+            var comp = Context.RenderComponent<TableFilterTest1>();
+            // print the generated html      
+            var table = comp.FindComponent<MudTable<string>>().Instance;
+            var searchString = comp.Find("#searchString");
+            table.FilteringRunCount.Should().Be(1);
+            // should return 3 items
+            searchString.Change("Ala");
+            table.FilteringRunCount.Should().Be(2);
+            // no matches
+            searchString.Change("ZZZ");
+            table.FilteringRunCount.Should().Be(3);
+            // should return 1 item
+            searchString.Change("Alaska");
+            table.FilteringRunCount.Should().Be(4);
+            // clear search
+            searchString.Change(string.Empty);
+            table.FilteringRunCount.Should().Be(5);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -3,7 +3,7 @@
 @using MudBlazor.Utilities
 @typeparam T
 
-@(_currentRenderFilteredItems = null) @*Clear filtered items cache for this render*@
+@(_currentRenderFilteredItemsCached = false) @*Clear filtered items cache for this render*@
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
 @if (Items != null || ServerData != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -2,6 +2,9 @@
 @inherits MudTableBase
 @using MudBlazor.Utilities
 @typeparam T
+
+@(_currentRenderFilteredItems = null) @*Clear filtered items cache for this render*@
+
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
 @if (Items != null || ServerData != null)
 {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -347,16 +347,16 @@ namespace MudBlazor
         [Category(CategoryTypes.Table.Grouping)]
         public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
 
-        private IEnumerable<T> _preEditSort { get; set; } = null;
+        private IEnumerable<T> _preEditSort;
         private IEnumerable<T> _currentRenderFilteredItems;
-        private bool _hasPreEditSort => _preEditSort != null;
+        private bool HasPreEditSort => _preEditSort != null;
 
         public IEnumerable<T> FilteredItems
         {
             get
             {
                 if (_currentRenderFilteredItems != null) return _currentRenderFilteredItems;
-                if (IsEditing && _hasPreEditSort)
+                if (IsEditing && HasPreEditSort)
                     return _preEditSort;
                 if (HasServerData)
                     _preEditSort = _server_data.Items?.ToList();

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -348,26 +348,24 @@ namespace MudBlazor
         public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
 
         private IEnumerable<T> _preEditSort { get; set; } = null;
+        private IEnumerable<T> _currentRenderFilteredItems;
         private bool _hasPreEditSort => _preEditSort != null;
 
         public IEnumerable<T> FilteredItems
         {
             get
             {
+                if (_currentRenderFilteredItems != null) return _currentRenderFilteredItems;
                 if (IsEditing && _hasPreEditSort)
                     return _preEditSort;
                 if (HasServerData)
-                {
                     _preEditSort = _server_data.Items?.ToList();
-                    return _preEditSort;
-                }
-
-                if (Filter == null)
-                {
+                else if (Filter == null)
                     _preEditSort = Context.Sort(Items).ToList();
-                    return _preEditSort;
-                }
-                _preEditSort = Context.Sort(Items.Where(Filter)).ToList();
+                else
+                    _preEditSort = Context.Sort(Items.Where(Filter)).ToList();
+
+                _currentRenderFilteredItems = _preEditSort;
                 return _preEditSort;
             }
         }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -348,14 +348,14 @@ namespace MudBlazor
         public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
 
         private IEnumerable<T> _preEditSort;
-        private IEnumerable<T> _currentRenderFilteredItems;
+        private bool _currentRenderFilteredItemsCached;
         private bool HasPreEditSort => _preEditSort != null;
 
         public IEnumerable<T> FilteredItems
         {
             get
             {
-                if (_currentRenderFilteredItems != null) return _currentRenderFilteredItems;
+                if (_currentRenderFilteredItemsCached) return _preEditSort;
                 if (IsEditing && HasPreEditSort)
                     return _preEditSort;
                 if (HasServerData)
@@ -365,7 +365,7 @@ namespace MudBlazor
                 else
                     _preEditSort = Context.Sort(Items.Where(Filter)).ToList();
 
-                _currentRenderFilteredItems = _preEditSort;
+                _currentRenderFilteredItemsCached = true;
                 return _preEditSort;
             }
         }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -351,6 +351,13 @@ namespace MudBlazor
         private bool _currentRenderFilteredItemsCached;
         private bool HasPreEditSort => _preEditSort != null;
 
+        /// <summary>
+        /// For unit testing the filtering cache mechanism.
+        /// </summary>
+        public uint FilteringRunCount { get; private set; } = 0;
+
+
+
         public IEnumerable<T> FilteredItems
         {
             get
@@ -366,6 +373,7 @@ namespace MudBlazor
                     _preEditSort = Context.Sort(Items.Where(Filter)).ToList();
 
                 _currentRenderFilteredItemsCached = true;
+                unchecked { FilteringRunCount++; }
                 return _preEditSort;
             }
         }


### PR DESCRIPTION
## Description
Added MudTable.FilteredItems cache check. Cache clears before render (in .razor file) - clearing it in after render event doesn't work. Reason for this is FilteredItems being requested multiple times before render, each of which results in sorting & filtering &converting to list, which causes really noticeable performance impact especially when sorting large collections (about 70K rows).

I measured around 60+ calls to create this collection per single render, with this it is reduced to 1.

## How Has This Been Tested?
- Unit tests are already in-place and working

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
