### PR TITLE
MudAutocomplete: Fix the highlight of selected item when Strict is set to false (#6412)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
@@ -1,0 +1,37 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider />
+
+<MudAutocomplete T="string" SearchFunc="@Search" ItemDisabledFunc="@ItemDisabledFunc" @bind-Value="@Fruit" Strict="false" />
+
+@code {
+	public string Fruit { get; set; }
+
+	public string[] Fruits = new string[]
+	{
+		"apple",
+		"banana",
+		"pear",
+		"carrot",
+		"cherry",
+		"raspberry",
+		"peach"
+	};
+
+	public Func<string, bool> ItemDisabledFunc = (string text) =>
+	{
+		return text.Equals("carrot", StringComparison.InvariantCulture);
+	};
+
+	public async Task<IEnumerable<string>> Search(string text)
+	{
+		await Task.Delay(100);
+
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return Fruits;
+		}
+
+		return Fruits.Where(x => x.Contains(text, StringComparison.InvariantCulture));
+	}
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1127,5 +1127,43 @@ namespace MudBlazor.UnitTests.Components
             //Assert
             result.Count.Should().Be(2);
         }
+
+        /// <summary>
+        /// Test case for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/6412"/>
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Highlight_Selected_Item_After_Disabled()
+        {
+            var disabledItemSelector = "mud-list-item-disabled";
+            var selectedItemSelector = "mud-selected-item";
+            var popoverSelector = "div.mud-popover";
+
+            var selectedItemString = "peach";
+            var disabledItemString = "carrot";
+
+            var comp = Context.RenderComponent<AutocompleteStrictFalseSelectedHighlight>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // Select the peach list item
+            autocompletecomp.Find("input").Input(selectedItemString);
+            comp.WaitForAssertion(() => comp.Find(popoverSelector).ClassList.Should().Contain("mud-popover-open"));
+            await comp.InvokeAsync(async () => await autocomplete.OnInputKeyUp(new KeyboardEventArgs() { Key = "Enter" }));
+            autocomplete.Text.Should().Be(selectedItemString);
+            autocomplete.Value.Should().Be(selectedItemString);
+
+            // Opening the list of autocomplete
+            autocompletecomp.Find("input").Click();
+            comp.WaitForAssertion(() => comp.Find(popoverSelector).ClassList.Should().Contain("mud-popover-open"));
+            var listItems = comp.FindComponents<MudListItem>().ToArray();
+
+            // Ensure that the carrot list item is disabled
+            var disabledItem = listItems.Single(x => x.Markup.Contains(disabledItemSelector));
+            disabledItem.Markup.Should().Contain(disabledItemString);
+
+            // Assert if the peach is highlighted
+            var selectedItem = listItems.Single(x => x.Markup.Contains(selectedItemSelector));
+            selectedItem.Markup.Should().Contain(selectedItemString);
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -509,7 +509,7 @@ namespace MudBlazor
             _enabledItemIndices = enabledItems.Select(tuple => tuple.idx).ToList();
             if (searchingWhileSelected) //compute the index of the currently select value, if it exists
             {
-                _selectedListItemIndex = enabledItems.Select(x => x.item).ToList().IndexOf(Value);
+                _selectedListItemIndex = Array.IndexOf(_items, Value);
             }
             else
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves #6412.

The highlight of selected item is based on index.
Initially, the filtering of the selected item was done on enabled items.
However, if we use disabled items, then the index of selected item can mismatch.
For example, the 2nd item is disabled and the user selects the 5th item. Using the previous implementation, the 4th item would be highlighted.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

By unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

![image](https://user-images.githubusercontent.com/74978649/226132807-33312f0c-25b3-41b1-8a62-8b9f3270f8de.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
