### PR TITLE
MudDataGrid: Sorting and filtering performance improvements.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3155,6 +3155,7 @@ namespace MudBlazor.UnitTests.Components
                 //Value = "invalid guid", cannot be a string here...
                 Value = Guid.Empty
             });
+            comp.Render();
             grid.FilteredItems.Count().Should().Be(0);
 
             grid.FilterDefinitions.Clear();
@@ -3164,6 +3165,7 @@ namespace MudBlazor.UnitTests.Components
                 Operator = "equals",
                 Value = comp.Instance.Guid1,
             });
+            comp.Render();
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()?.Id.Should().Be(comp.Instance.Guid1);
 
@@ -3174,6 +3176,7 @@ namespace MudBlazor.UnitTests.Components
                 Operator = "not equals",
                 Value = comp.Instance.Guid1,
             });
+            comp.Render();
             grid.FilteredItems.Count().Should().Be(1);
             grid.FilteredItems.FirstOrDefault()?.Id.Should().Be(comp.Instance.Guid2);
         }
@@ -3388,6 +3391,53 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => column.Format = "C0");
             comp.Find(".mud-switch-input").Change(new ChangeEventArgs { Value = true });
             comp.FindAll("tbody.mud-table-body td")[3].TextContent.Should().Be("$87,000");
+        }
+
+        [Test]
+        public async Task DataGridFilteredItemsCacheTest()
+        {
+            var comp = Context.RenderComponent<DataGridSortableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
+
+            var initialFilterCount = dataGrid.Instance.FilteringRunCount;
+            
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => { return x.Name; }));
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 1);
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => { return x.Name; }));
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 2);
+
+            await comp.InvokeAsync(() => dataGrid.Instance.RemoveSortAsync("Name"));
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 3);
+
+
+            var column = dataGrid.FindComponent<Column<DataGridSortableTest.Item>>();
+            await comp.InvokeAsync(() => column.Instance.SortBy = x => { return x.Name; });
+            dataGrid.Render();
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 4);
+
+            // sort through the sort icon
+            dataGrid.Find(".column-options button").Click();
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 5);
+
+            // test other sort methods
+            var headerCell = dataGrid.FindComponent<HeaderCell<DataGridSortableTest.Item>>();
+            await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs()));
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 6);
+
+            //await comp.InvokeAsync(() => headerCell.Instance.GetDataType());
+            await comp.InvokeAsync(() => headerCell.Instance.RemoveSortAsync());
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 7);
+            await comp.InvokeAsync(() => headerCell.Instance.AddFilter());
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 8);
+            await comp.InvokeAsync(() => headerCell.Instance.OpenFilters());
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 9);
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SortMode = SortMode.None);
+            dataGrid.Render();
+            dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 10);
+            // Since Sortable is now false, the click handler (and element holding it) should no longer exist.
+            dataGrid.FindAll(".column-header .sortable-column-header").Should().BeEmpty();
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -3,6 +3,10 @@
 @typeparam T
 @using MudBlazor.Utilities
 
+@{
+    _currentRenderFilteredItemsCache = null;
+}
+
 <CascadingValue IsFixed="true" Value="this">@Columns</CascadingValue>
 
 <CascadingValue IsFixed="true" Value="this">

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -22,6 +22,8 @@ namespace MudBlazor
         private Func<T, object?>? _cellContentFunc;
         private string? _propertyName;
         private string? _fullPropertyName;
+        private Func<T, TProperty> _compiledPropertyFunc;
+        private Expression<Func<T, TProperty>> _compiledPropertyFuncFor;
 
         protected override void OnParametersSet()
         {
@@ -66,8 +68,17 @@ namespace MudBlazor
         protected internal override object? CellContent(T item)
             => _cellContentFunc!(item);
 
+
         protected internal override object? PropertyFunc(T item)
-            => Property.Compile()(item);
+        {
+            if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
+            {
+                _compiledPropertyFunc = Property.Compile();
+                _compiledPropertyFuncFor = Property;
+            }
+            return _compiledPropertyFunc(item);
+
+        }
 
         protected internal override Type PropertyType
             => typeof(TProperty);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Similar to PR #6470 as mentioned in discussion adding FilteredItems caching mechanism to speed up performance.
The caching doesn't introduce performance improvements that great as for MudTable, as I measured ~6 FilteredItems calls per render but are nice to have anyway. I tested MudDataGrid on a larger collection and sorting performance was atrocious, the bottleneck was in the PropertyColumn.PropertyFunc which compiled the column expression every time which I fixed by checking for already compiled version and using that when possible. This alone fixed any perceivable performance issues for me.

## How Has This Been Tested?
- All already existing tests are passing (except one, that didn't render the component when adding item and checked directly the output of fitlered items - I updated that test with render calls).
- As in #6470 I added test that checks how many times was the collection updated using a counter.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
