### PR TITLE
MudDataGrid: Make AggregateDefinition work with nullable values and cover with tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
@@ -1,0 +1,341 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+#nullable enable
+    [TestFixture]
+    public class AggregateDefinitionTests
+    {
+        public record AccountingModel(long Id, int Position, decimal Salary);
+        public record AccountingNullableModel(long? Id, int? Position, decimal? Salary);
+
+        private readonly List<AccountingModel> _accountingModels = new()
+        {
+            new AccountingModel(47219479, 1, 50_000.00M),
+            new AccountingModel(45376824, 3, 75_000.00M),
+            new AccountingModel(72746864, 8, 102_000.00M),
+            new AccountingModel(9434843, 20, 132_000.00M),
+            new AccountingModel(44279196, 23, 245_100.00M),
+            new AccountingModel(18223533, 28, 500_000.00M),
+            new AccountingModel(67898330, 30, 1_000_000.00M),
+        };
+
+        private readonly List<AccountingNullableModel> _accountingNullableModels = new()
+        {
+            new AccountingNullableModel(null, null, null),
+            new AccountingNullableModel(47219479, 1, 50_000.00M),
+            new AccountingNullableModel(45376824, 3, 75_000.00M),
+            new AccountingNullableModel(72746864, 8, 102_000.00M),
+            new AccountingNullableModel(9434843, 20, 132_000.00M),
+            new AccountingNullableModel(44279196, 23, 245_100.00M),
+            new AccountingNullableModel(18223533, 28, 500_000.00M),
+            new AccountingNullableModel(67898330, 30, 1_00_000.00M),
+        };
+
+        [Test]
+        public void AggregateDefinition_Cache_Returns_SameObject_Test()
+        {
+            Expression<Func<AccountingModel, decimal?>> propertyExpression1 = model => model.Salary;
+            Expression<Func<AccountingModel, decimal?>> propertyExpression2 = model => model.Salary;
+            var cache = new AggregateDefinition<AccountingModel>.AggregateDefinitionExpressionCache();
+
+            var expression1 = cache.CachedCompile(propertyExpression1);
+            var expression2 = cache.CachedCompile(propertyExpression2);
+
+            propertyExpression1.Equals(propertyExpression2).Should().BeFalse();
+            expression1.Equals(expression2).Should().BeTrue();
+        }
+
+        [Test]
+        public void AggregateDefinition_Cache_Returns_DifferentObject_Test()
+        {
+            Expression<Func<AccountingModel, decimal?>> propertyExpression1 = model => model.Salary;
+            Expression<Func<AccountingModel, decimal?>> propertyExpression2 = model => model.Id;
+            var cache = new AggregateDefinition<AccountingModel>.AggregateDefinitionExpressionCache();
+
+            var expression1 = cache.CachedCompile(propertyExpression1);
+            var expression2 = cache.CachedCompile(propertyExpression2);
+
+            propertyExpression1.Equals(propertyExpression2).Should().BeFalse();
+            expression1.Equals(expression2).Should().BeFalse();
+        }
+
+        [Test]
+        public void AggregateDefinition_Decimal_NullList_Test()
+        {
+            Expression<Func<AccountingModel, decimal>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>();
+            var value = aggregateDefinitionAverage.GetValue(propertyExpression, null);
+
+            value.Should().Be("0");
+        }
+
+        [Test]
+        public void AggregateDefinition_Decimal_EmptyList_Test()
+        {
+            Expression<Func<AccountingModel, decimal>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>();
+            var value = aggregateDefinitionAverage.GetValue(propertyExpression, Array.Empty<AccountingModel>());
+
+            value.Should().Be("0");
+        }
+
+        [Test]
+        public void AggregateDefinition_Decimal_NullExpression_Test()
+        {
+            var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>();
+            var value = aggregateDefinitionAverage.GetValue(null, _accountingModels);
+
+            value.Should().Be("0");
+        }
+
+        [Test]
+        public void AggregateDefinition_Decimal_Test()
+        {
+            Expression<Func<AccountingModel, decimal>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingModels);
+
+            var expectedAverage = _accountingModels.Select(x => x.Salary).Average();
+            var expectedMin = _accountingModels.Select(x => x.Salary).Min();
+            var expectedMax = _accountingModels.Select(x => x.Salary).Max();
+            var expectedCount = _accountingModels.Select(x => x.Salary).Count();
+            var expectedSum = _accountingModels.Select(x => x.Salary).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_NullableDecimal_Test()
+        {
+            Expression<Func<AccountingNullableModel, decimal?>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingNullableModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingNullableModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingNullableModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingNullableModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingNullableModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingNullableModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingNullableModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingNullableModels);
+
+            var expectedAverage = _accountingNullableModels.Select(x => x.Salary).Average();
+            var expectedMin = _accountingNullableModels.Select(x => x.Salary).Min();
+            var expectedMax = _accountingNullableModels.Select(x => x.Salary).Max();
+            var expectedCount = _accountingNullableModels.Select(x => x.Salary).Count();
+            var expectedSum = _accountingNullableModels.Select(x => x.Salary).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_Integer_Test()
+        {
+            Expression<Func<AccountingModel, int>> propertyExpression = model => model.Position;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingModels);
+
+            //Need to cast to get decimal precision, inside AggregateDefinition.GetValue casts to decimal 
+            var expectedAverage = _accountingModels.Select(x => (decimal)x.Position).Average();
+            var expectedMin = _accountingModels.Select(x => x.Position).Min();
+            var expectedMax = _accountingModels.Select(x => x.Position).Max();
+            var expectedCount = _accountingModels.Select(x => x.Position).Count();
+            var expectedSum = _accountingModels.Select(x => x.Position).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_NullableInteger_Test()
+        {
+            Expression<Func<AccountingNullableModel, int?>> propertyExpression = model => model.Position;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingNullableModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingNullableModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingNullableModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingNullableModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingNullableModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingNullableModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingNullableModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingNullableModels);
+
+            //Need to cast to get decimal precision, inside AggregateDefinition.GetValue casts to decimal 
+            var expectedAverage = _accountingNullableModels.Select(x => (decimal?)x.Position).Average();
+            var expectedMin = _accountingNullableModels.Select(x => x.Position).Min();
+            var expectedMax = _accountingNullableModels.Select(x => x.Position).Max();
+            var expectedCount = _accountingNullableModels.Select(x => x.Position).Count();
+            var expectedSum = _accountingNullableModels.Select(x => x.Position).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_Long_Test()
+        {
+            Expression<Func<AccountingModel, long>> propertyExpression = model => model.Id;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingModels);
+
+            //Need to cast to get decimal precision, inside AggregateDefinition.GetValue casts to decimal 
+            var expectedAverage = _accountingModels.Select(x => (decimal)x.Id).Average();
+            var expectedMin = _accountingModels.Select(x => x.Id).Min();
+            var expectedMax = _accountingModels.Select(x => x.Id).Max();
+            var expectedCount = _accountingModels.Select(x => x.Id).Count();
+            var expectedSum = _accountingModels.Select(x => x.Id).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_NullableLong_Test()
+        {
+            Expression<Func<AccountingNullableModel, long?>> propertyExpression = model => model.Id;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingNullableModel>.SimpleAvg();
+            var aggregateDefinitionMin = AggregateDefinition<AccountingNullableModel>.SimpleMin();
+            var aggregateDefinitionMax = AggregateDefinition<AccountingNullableModel>.SimpleMax();
+            var aggregateDefinitionCount = AggregateDefinition<AccountingNullableModel>.SimpleCount();
+            var aggregateDefinitionSum = AggregateDefinition<AccountingNullableModel>.SimpleSum();
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingNullableModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingNullableModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingNullableModels);
+
+            //Need to cast to get decimal precision, inside AggregateDefinition.GetValue casts to decimal 
+            var expectedAverage = _accountingNullableModels.Select(x => (decimal?)x.Id).Average();
+            var expectedMin = _accountingNullableModels.Select(x => x.Id).Min();
+            var expectedMax = _accountingNullableModels.Select(x => x.Id).Max();
+            var expectedCount = _accountingNullableModels.Select(x => x.Id).Count();
+            var expectedSum = _accountingNullableModels.Select(x => x.Id).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage}");
+            valueMin.Should().Be($"Min {expectedMin}");
+            valueMax.Should().Be($"Max {expectedMax}");
+            valueCount.Should().Be($"Total {expectedCount}");
+            valueSum.Should().Be($"Sum {expectedSum}");
+        }
+
+        [Test]
+        public void AggregateDefinition_Custom_Test()
+        {
+            var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>
+            {
+                Type = AggregateType.Custom,
+                CustomAggregate = model =>
+                {
+                    var accountingModels = model as AccountingModel[] ?? model.ToArray();
+                    var highestSalary = accountingModels.Max(z => z.Salary);
+                    var countOver100Grand = accountingModels.Count(z => z.Salary > 100_000);
+                    return $"Highest: {highestSalary.ToString(NumberFormatInfo.InvariantInfo)} | {countOver100Grand.ToString(NumberFormatInfo.InvariantInfo)} Over {100000.ToString(NumberFormatInfo.InvariantInfo)}";
+                }
+            };
+
+            var value = aggregateDefinitionAverage.GetValue(null, _accountingModels);
+
+            value.Should().Be("Highest: 1000000.00 | 5 Over 100000");
+        }
+
+        [Test]
+        public void AggregateDefinition_InvalidType_Test()
+        {
+            Expression<Func<AccountingModel, decimal>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>
+            {
+                Type = (AggregateType)(-1)
+            };
+
+            var value = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingModels);
+
+            value.Should().Be("0");
+        }
+
+        [Test(Description = "This is to ensure that we do not return same cached compiled expression and get same results after passing different expression")]
+        public void AggregateDefinition_ReuseDefinition_With_Different_Expressions_Test()
+        {
+            Expression<Func<AccountingModel, long>> propertyExpressionId = model => model.Id;
+            Expression<Func<AccountingModel, decimal>> propertyExpressionSalary = model => model.Salary;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingModel>.SimpleMin();
+
+            var expectedIdMin = _accountingModels.Select(x => x.Id).Min();
+            var expectedSalaryMin = _accountingModels.Select(x => x.Salary).Min();
+
+            var valueIdMin = aggregateDefinitionAverage.GetValue(propertyExpressionId, _accountingModels);
+            var valueSalaryMin = aggregateDefinitionAverage.GetValue(propertyExpressionSalary, _accountingModels);
+
+            valueIdMin.Should().Be($"Min {expectedIdMin}");
+            valueSalaryMin.Should().Be($"Min {expectedSalaryMin}");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq.Expressions;
+using System;
+using FluentAssertions;
+using MudBlazor.Utilities.Expressions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Expressions
+{
+#nullable enable
+    [TestFixture]
+    public class ExpressionHasherTests
+    {
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class ExpressionTestClass
+        {
+            public string? Name => null;
+
+            public string? Convert(int a, int[] arr) => null;
+        }
+
+        [Test]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test] public void ExpressionHasherTests_Get_Null_HashCode_Test()
+        {
+            Expression<Func<ExpressionTestClass, string?>>? exp1 = null;
+            Expression<Func<ExpressionTestClass, string?>>? exp2 = null;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Name + x.Convert(2, Array.Empty<int>());
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
@@ -4,6 +4,7 @@
 
 using System.Linq.Expressions;
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Utilities.Expressions;
 using NUnit.Framework;
@@ -14,19 +15,197 @@ namespace MudBlazor.UnitTests.Utilities.Expressions
     [TestFixture]
     public class ExpressionHasherTests
     {
-        // ReSharper disable once ClassNeverInstantiated.Local
         private class ExpressionTestClass
         {
-            public string? Name => null;
+            // ReSharper disable once ClassNeverInstantiated.Local
+            public class SubClass
+            {
+                // ReSharper disable once PropertyCanBeMadeInitOnly.Local
+                // ReSharper disable once UnusedAutoPropertyAccessor.Local
+                public string SubMember1 { get; set; } = string.Empty;
+            }
 
-            public string? Convert(int a, int[] arr) => null;
+            // ReSharper disable MemberCanBeMadeStatic.Local
+            // ReSharper disable once PropertyCanBeMadeInitOnly.Local
+            public string? FirstName { get; set; }
+
+            public string LastName => string.Empty;
+
+            // ReSharper disable once PropertyCanBeMadeInitOnly.Local
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public SubClass Nested1 { get; } = new();
+
+            public List<ExpressionTestClass> Children { get; } = new();
+
+            public ExpressionTestClass(string? name) => FirstName = name;
+
+            public ExpressionTestClass() : this(null) { }
+
+            // ReSharper disable UnusedParameter.Local
+            public string? Convert(int[] arr) => null;
+            // ReSharper restore UnusedParameter.Local
+            // ReSharper restore MemberCanBeMadeStatic.Local
+
+            // ReSharper disable MemberCanBeMadeStatic.Local
+            public void Method1() { }
+
+            public void Method2() { }
+
+            // ReSharper disable once UnusedParameter.Local
+            public void MethodParam(int a) { }
+            // ReSharper restore MemberCanBeMadeStatic.Local
+        }
+
+        [Test(Description = "VisitMethodCall")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test1()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.FirstName;
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.FirstName;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitMethodCall")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test2()
+        {
+            Expression<Action<ExpressionTestClass>> exp1 = x => x.Method1();
+            Expression<Action<ExpressionTestClass>> exp2 = x => x.Method1();
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitParameter")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test3()
+        {
+            Expression<Action<ExpressionTestClass>> exp1 = x => x.MethodParam(1);
+            Expression<Action<ExpressionTestClass>> exp2 = x => x.MethodParam(1);
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitNewArray")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test4()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Convert(new[] { 1, 2, 3 });
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Convert(new[] { 1, 2, 3 });
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitConstant")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test5()
+        {
+            const string ConstEmptyString = "";
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => ConstEmptyString;
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => ConstEmptyString;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "Checks VisitConstant -> UpdateHash(node.Value) where values is null")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test6()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => null;
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => null;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitNew")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test7()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass("Name");
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass("Name");
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
         }
 
         [Test]
-        public void ExpressionHasherTests_Get_Same_HashCode_Test()
+        public void ExpressionHasherTests_Get_Same_HashCode_Test8()
         {
-            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
-            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
+            Expression<Func<ExpressionTestClass, bool>> exp1 = x => string.Equals(x.FirstName, string.Empty, StringComparison.Ordinal);
+            Expression<Func<ExpressionTestClass, bool>> exp2 = x => string.Equals(x.FirstName, string.Empty, StringComparison.Ordinal);
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test9()
+        {
+            Expression<Func<bool?>> exp1 = () => 4 < 5;
+            Expression<Func<bool?>> exp2 = () => 4 < 5;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitMemberAssignment")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test10()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { FirstName = "assignment" };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { FirstName = "assignment" };
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitTypeBinary")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test11()
+        {
+            Expression<Func<ExpressionTestClass, bool>> exp1 = x => x.Children[0] is ICloneable;
+            Expression<Func<ExpressionTestClass, bool>> exp2 = x => x.Children[0] is ICloneable;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitMemberMemberBinding")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test12()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { Nested1 = { SubMember1 = "MemberMemberBinding" } };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { Nested1 = { SubMember1 = "MemberMemberBinding" } };
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeTrue();
+        }
+
+        [Test(Description = "VisitMemberListBinding")]
+        public void ExpressionHasherTests_Get_Same_HashCode_Test13()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { Children = { new ExpressionTestClass(), new ExpressionTestClass() } };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { Children = { new ExpressionTestClass(), new ExpressionTestClass() } };
 
             var h1 = ExpressionHasher.GetHashCode(exp1);
             var h2 = ExpressionHasher.GetHashCode(exp2);
@@ -46,11 +225,145 @@ namespace MudBlazor.UnitTests.Utilities.Expressions
             h1.Equals(h2).Should().BeTrue();
         }
 
-        [Test]
-        public void ExpressionHasherTests_Get_NotSame_HashCode_Test()
+        [Test(Description = "VisitMethodCall")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test1()
         {
-            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Name + x.Convert(2, Array.Empty<int>());
-            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Name + "123" + x.Convert(2, new[] { 1, 2, 3 });
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.FirstName;
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.LastName;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitMethodCall")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test2()
+        {
+            Expression<Action<ExpressionTestClass>> exp1 = x => x.Method1();
+            Expression<Action<ExpressionTestClass>> exp2 = x => x.Method2();
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitParameter")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test3()
+        {
+            Expression<Action<ExpressionTestClass>> exp1 = x => x.MethodParam(1);
+            Expression<Action<ExpressionTestClass>> exp2 = x => x.MethodParam(2);
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitNewArray")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test4()
+        {
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => x.Convert(Array.Empty<int>());
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => x.Convert(new[] { 1, 2, 3 });
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test5()
+        {
+            Expression<Func<ExpressionTestClass, bool>> exp1 = x => string.Equals(x.FirstName, "Test1", StringComparison.Ordinal);
+            Expression<Func<ExpressionTestClass, bool>> exp2 = x => string.Equals(x.FirstName, "Test2", StringComparison.Ordinal);
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitConstant")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test6()
+        {
+            const string ConstString1 = "Test1";
+            const string ConstString2 = "Test2";
+            Expression<Func<ExpressionTestClass, string?>> exp1 = x => ConstString1;
+            Expression<Func<ExpressionTestClass, string?>> exp2 = x => ConstString2;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitNew")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test7()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass("Name1");
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass("Name2");
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test8()
+        {
+            Expression<Func<bool?>> exp1 = () => 4 < 5;
+            Expression<Func<bool?>> exp2 = () => 4 > 5;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitMemberAssignment")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test9()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { FirstName = "assignment1" };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { FirstName = "assignment2" };
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitTypeBinary")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test10()
+        {
+            Expression<Func<ExpressionTestClass, bool>> exp1 = x => x.Children[0] is ICloneable;
+            Expression<Func<ExpressionTestClass, bool>> exp2 = x => x.Children[0] is IComparable;
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitMemberMemberBinding")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test11()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { Nested1 = { SubMember1 = "MemberMemberBinding1" } };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { Nested1 = { SubMember1 = "MemberMemberBinding2" } };
+
+            var h1 = ExpressionHasher.GetHashCode(exp1);
+            var h2 = ExpressionHasher.GetHashCode(exp2);
+
+            h1.Equals(h2).Should().BeFalse();
+        }
+
+        [Test(Description = "VisitMemberListBinding")]
+        public void ExpressionHasherTests_Get_NotSame_HashCode_Test12()
+        {
+            Expression<Func<ExpressionTestClass>> exp1 = () => new ExpressionTestClass { Children = { new ExpressionTestClass() } };
+            Expression<Func<ExpressionTestClass>> exp2 = () => new ExpressionTestClass { Children = { new ExpressionTestClass(), new ExpressionTestClass() } };
 
             var h1 = ExpressionHasher.GetHashCode(exp1);
             var h2 = ExpressionHasher.GetHashCode(exp2);

--- a/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
@@ -34,7 +34,8 @@ namespace MudBlazor.UnitTests.Utilities.Expressions
             h1.Equals(h2).Should().BeTrue();
         }
 
-        [Test] public void ExpressionHasherTests_Get_Null_HashCode_Test()
+        [Test]
+        public void ExpressionHasherTests_Get_Null_HashCode_Test()
         {
             Expression<Func<ExpressionTestClass, string?>>? exp1 = null;
             Expression<Func<ExpressionTestClass, string?>>? exp2 = null;

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -3,19 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using MudBlazor.Utilities.Expressions;
 
 namespace MudBlazor
 {
 #nullable enable
     public class AggregateDefinition<T>
     {
-        private AggregateType? _cachedType;
-        private Func<T, decimal>? _compiledAvgExpression;
-        private Func<T, object>? _compiledMinMaxExpression;
-        private Func<T, decimal>? _compiledSumExpression;
+        private readonly AggregateDefinitionExpressionCache _expressionCache = new();
 
         public AggregateType Type { get; set; } = AggregateType.Count;
 
@@ -33,82 +32,50 @@ namespace MudBlazor
                 return DisplayFormat.Replace("{value}", "0");
             }
 
-            object? value = null;
-
-            if (_cachedType != Type)
+            if (Type == AggregateType.Custom && CustomAggregate is not null)
             {
-                _cachedType = Type;
-
-                if (Type == AggregateType.Avg)
-                {
-                    _compiledAvgExpression = propertyExpression?.ChangeExpressionReturnType<T, decimal>().Compile();
-                    if (_compiledAvgExpression is not null)
-                    {
-                        value = itemsArray.Average(_compiledAvgExpression);
-                    }
-                }
-                else if (Type == AggregateType.Count)
-                {
-                    value = itemsArray.Length;
-                }
-                else if (Type == AggregateType.Custom && CustomAggregate is not null)
-                {
-                    return CustomAggregate.Invoke(itemsArray);
-                }
-                else if (Type == AggregateType.Max)
-                {
-                    _compiledMinMaxExpression = propertyExpression?.ChangeExpressionReturnType<T, object>().Compile();
-                    if (_compiledMinMaxExpression is not null)
-                    {
-                        value = itemsArray.Max(_compiledMinMaxExpression);
-                    }
-                }
-                else if (Type == AggregateType.Min)
-                {
-                    _compiledMinMaxExpression = propertyExpression?.ChangeExpressionReturnType<T, object>().Compile();
-                    if (_compiledMinMaxExpression is not null)
-                    {
-                        value = itemsArray.Min(_compiledMinMaxExpression);
-                    }
-                }
-                else if (Type == AggregateType.Sum)
-                {
-                    _compiledSumExpression = propertyExpression?.ChangeExpressionReturnType<T, decimal>().Compile();
-                    if (_compiledSumExpression is not null)
-                    {
-                        value = itemsArray.Sum(_compiledSumExpression);
-                    }
-                }
-            }
-            else
-            {
-                if (Type == AggregateType.Avg && _compiledAvgExpression is not null)
-                {
-                    value = itemsArray.Average(_compiledAvgExpression);
-                }
-                else if (Type == AggregateType.Count)
-                {
-                    value = itemsArray.Length;
-                }
-                else if (Type == AggregateType.Custom && CustomAggregate is not null)
-                {
-                    return CustomAggregate.Invoke(itemsArray);
-                }
-                else if (Type == AggregateType.Max && _compiledMinMaxExpression is not null)
-                {
-                    value = itemsArray.Max(_compiledMinMaxExpression);
-                }
-                else if (Type == AggregateType.Min && _compiledMinMaxExpression is not null)
-                {
-                    value = itemsArray.Min(_compiledMinMaxExpression);
-                }
-                else if (Type == AggregateType.Sum && _compiledSumExpression is not null)
-                {
-                    value = itemsArray.Sum(_compiledSumExpression);
-                }
+                return CustomAggregate.Invoke(itemsArray);
             }
 
-            return DisplayFormat.Replace("{value}", (value ?? "").ToString());
+            if (propertyExpression is null)
+            {
+                return DisplayFormat.Replace("{value}", "0");
+            }
+
+            if (Type == AggregateType.Count)
+            {
+                var value = itemsArray.Length;
+                return DisplayFormat.Replace("{value}", value.ToString());
+            }
+
+            var expression = propertyExpression.ChangeExpressionReturnType<T, decimal?>();
+            var compiledExpression = _expressionCache.CachedCompile(expression);
+
+            if (Type == AggregateType.Avg)
+            {
+                var value = itemsArray.Average(compiledExpression);
+                return DisplayFormat.Replace("{value}", value.ToString());
+            }
+
+            if (Type == AggregateType.Max)
+            {
+                var value = itemsArray.Max(compiledExpression);
+                return DisplayFormat.Replace("{value}", value.ToString());
+            }
+
+            if (Type == AggregateType.Min)
+            {
+                var value = itemsArray.Min(compiledExpression);
+                return DisplayFormat.Replace("{value}", value.ToString());
+            }
+
+            if (Type == AggregateType.Sum)
+            {
+                var value = itemsArray.Sum(compiledExpression);
+                return DisplayFormat.Replace("{value}", value.ToString());
+            }
+
+            return DisplayFormat.Replace("{value}", "0");
         }
 
         public static AggregateDefinition<T> SimpleAvg()
@@ -154,6 +121,21 @@ namespace MudBlazor
                 Type = AggregateType.Sum,
                 DisplayFormat = "Sum {value}"
             };
+        }
+
+        internal class AggregateDefinitionExpressionCache
+        {
+            //Concrete type since all Functions convert Func<T, decimal?>
+            //Could be used Delegate, but then we will lose some performance
+            private readonly ConcurrentDictionary<int, Func<T, decimal?>> _cache = new();
+
+            public Func<T, decimal?> CachedCompile(Expression<Func<T, decimal?>> expression)
+            {
+                var cacheKey = ExpressionHasher.GetHashCode(expression);
+                var cacheObject = _cache.GetOrAdd(cacheKey, _ => expression.Compile());
+                
+                return cacheObject;
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -125,8 +125,8 @@ namespace MudBlazor
 
         internal class AggregateDefinitionExpressionCache
         {
-            //Concrete type since all Functions convert Func<T, decimal?>
-            //Could be used Delegate, but then we will lose some performance
+            //Concrete type since all Functions converts to Func<T, decimal?>
+            //"Delegate" could be used, but then we will lose some performance
             private readonly ConcurrentDictionary<int, Func<T, decimal?>> _cache = new();
 
             public Func<T, decimal?> CachedCompile(Expression<Func<T, decimal?>> expression)

--- a/src/MudBlazor/Utilities/Expressions/ExpressionHasher.cs
+++ b/src/MudBlazor/Utilities/Expressions/ExpressionHasher.cs
@@ -28,43 +28,33 @@ namespace MudBlazor.Utilities.Expressions
 
         private sealed class HashVisitor : ExpressionVisitor
         {
-            private int _hashCode;
+            private HashCode _hashCode;
 
             public HashVisitor()
             {
-                _hashCode = 0;
+                _hashCode = new HashCode();
             }
 
-            public int ToHashCode()
-            {
-                return _hashCode;
-            }
+            public int ToHashCode() => _hashCode.ToHashCode();
 
-            private void UpdateHash(int value)
-            {
-                _hashCode = HashCode.Combine(_hashCode, value);
-            }
+            private void UpdateHash(int value) => _hashCode.Add(value);
 
             private void UpdateHash(object? component)
             {
-                int? componentHash;
-
                 if (component is MemberInfo member)
                 {
-                    componentHash = member.Name.GetHashCode();
+                    _hashCode.Add(member.Name.GetHashCode());
 
                     var declaringType = member.DeclaringType;
                     if (declaringType?.AssemblyQualifiedName is not null)
                     {
-                        componentHash = HashCode.Combine(componentHash, declaringType.AssemblyQualifiedName.GetHashCode());
+                        _hashCode.Add(declaringType.AssemblyQualifiedName.GetHashCode());
                     }
                 }
                 else
                 {
-                    componentHash = component?.GetHashCode();
+                    _hashCode.Add(component);
                 }
-
-                _hashCode = HashCode.Combine(_hashCode, componentHash);
             }
 
             [return: NotNullIfNotNull(nameof(node))]

--- a/src/MudBlazor/Utilities/Expressions/ExpressionHasher.cs
+++ b/src/MudBlazor/Utilities/Expressions/ExpressionHasher.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace MudBlazor.Utilities.Expressions
+{
+#nullable enable
+    internal static class ExpressionHasher
+    {
+        private const int NullHashCode = 0x61E04917;
+
+        public static int GetHashCode(Expression? expression)
+        {
+            if (expression is null)
+                return NullHashCode;
+
+            var visitor = new HashVisitor();
+
+            visitor.Visit(expression);
+
+            return visitor.HashCode;
+        }
+
+        [ExcludeFromCodeCoverage]
+        private sealed class HashVisitor : ExpressionVisitor
+        {
+            private int _hashCode;
+
+            public int HashCode { get => _hashCode; }
+
+            public HashVisitor()
+            {
+                _hashCode = 0;
+            }
+
+            private void UpdateHash(int value)
+            {
+                unchecked
+                {
+                    _hashCode = (_hashCode * 397) ^ value;
+                }
+            }
+
+            private void UpdateHash(object? component)
+            {
+                int componentHash;
+
+                if (component is null)
+                {
+                    componentHash = NullHashCode;
+                }
+                else
+                {
+                    if (component is MemberInfo member)
+                    {
+                        componentHash = member.Name.GetHashCode();
+
+                        var declaringType = member.DeclaringType;
+                        if (declaringType?.AssemblyQualifiedName is not null)
+                            componentHash = (componentHash * 397) ^ declaringType.AssemblyQualifiedName.GetHashCode();
+                    }
+                    else
+                    {
+                        componentHash = component.GetHashCode();
+                    }
+                }
+
+                unchecked
+                {
+                    _hashCode = (_hashCode * 397) ^ componentHash;
+                }
+            }
+
+            [return: NotNullIfNotNull(nameof(node))]
+            public override Expression? Visit(Expression? node)
+            {
+                if (node is null)
+                    return base.Visit(node);
+
+                UpdateHash((int)node.NodeType);
+                return base.Visit(node);
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                UpdateHash(node.Value);
+                return base.VisitConstant(node);
+            }
+
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                UpdateHash(node.Member);
+                return base.VisitMember(node);
+            }
+
+            protected override MemberAssignment VisitMemberAssignment(MemberAssignment node)
+            {
+                UpdateHash(node.Member);
+                return base.VisitMemberAssignment(node);
+            }
+
+            protected override MemberBinding VisitMemberBinding(MemberBinding node)
+            {
+                UpdateHash((int)node.BindingType);
+                UpdateHash(node.Member);
+                return base.VisitMemberBinding(node);
+            }
+
+            protected override MemberListBinding VisitMemberListBinding(MemberListBinding node)
+            {
+                UpdateHash((int)node.BindingType);
+                UpdateHash(node.Member);
+                return base.VisitMemberListBinding(node);
+            }
+
+            protected override MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding node)
+            {
+                UpdateHash((int)node.BindingType);
+                UpdateHash(node.Member);
+                return base.VisitMemberMemberBinding(node);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                UpdateHash(node.Method);
+                return base.VisitMethodCall(node);
+            }
+
+            protected override Expression VisitNew(NewExpression node)
+            {
+                UpdateHash(node.Constructor);
+                return base.VisitNew(node);
+            }
+
+            protected override Expression VisitNewArray(NewArrayExpression node)
+            {
+                UpdateHash(node.Type);
+                return base.VisitNewArray(node);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                UpdateHash(node.Type);
+                return base.VisitParameter(node);
+            }
+
+            protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+            {
+                UpdateHash(node.Type);
+                return base.VisitTypeBinary(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR allows to have nullable types in `AggregateDefinition`. Original LINQ methods are able to work with `int?`, `long?`, `decimal?` etc when calculating `Min`, `Max`, `Average`, `Sum`. Previous implementation would throw exception.
For this I changed `ChangeExpressionReturnType<T, decimal>` to `ChangeExpressionReturnType<T, decimal?>`.
I'm also kinda curious why `ChangeExpressionReturnType<T, object>` was used, is there any reason behind it?

I redid the cache. It's calculating the hash of the expression and stores it basically in a dictionary.
Previous one had a drawback, if you change the expression, but do not change the `AggregateType`, then it would evaluate the previous expression for this type, now you can reuse the same instance of `AggregateDefinition` without a problem.

I know I had a really brief talk with [adameste](https://github.com/adameste) where I proposed the idea of expression cache class, and he had valid points against it. But I still decided to give it a try, because: we can make it not centralized, about the performance (slow read) - `AggregateDefinition` is not a hot spot class, as well we can drop `ConcurrentDictionary` and use something like `DictionarySlim` that has a single lookup for `GetOrAdd` and performs better for value type keys. I didn't go for it because it's much more code and if only one class is going to use it then it's an overkill.
Ofc this is all negotiable whatever we need this or not.

I made many unit tests to make sure everything works correctly, they should be readable and pretty straightforward. All existing unit tests that covered this before are also working. 

I made a dedicated folder "DataGrid" in test project, since the DataGrid test file is already big, and since the component is really huge and important I would encourage in future to split it and test it class by class instead.

## How Has This Been Tested?
New unit tests + existing unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
