### PR TITLE
MudChart: Fix cut off Y-axis labels and add custom formatter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -14,7 +14,7 @@
                 <BarExample1 />
             </SectionContent>
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader Title="Custom SVG Content">
                 <Description></Description>
@@ -23,6 +23,15 @@
                 <BarCustomGraphicsExample/>
             </SectionContent>
         </DocsPageSection>
-        
+
+        <DocsPageSection>
+            <SectionHeader Title="Custom Y-axis formatter">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent ShowCode="false" Code="BarExample2">
+                <BarExample2/>
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample2.razor
@@ -1,0 +1,34 @@
+﻿@using System.Globalization
+@namespace MudBlazor.Docs.Examples
+
+<div>
+    <MudChart ChartType="ChartType.Bar" ChartSeries="@Series" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="options"></MudChart>
+</div>
+
+@code {
+    private readonly ChartOptions options = new()
+    {
+        YAxisLabelSpace = 50.0,
+        YAxisFormat = new CustomFormatter(),
+        YAxisTicks = 1000
+    };
+    
+    private readonly List<ChartSeries> Series = new()
+    {
+        new ChartSeries() { Name = "Series 1", Data = new double[] { 4000, 2000, 2500, 2700, 4600, 6000, 4800, 8000, 1500 } },
+        new ChartSeries() { Name = "Series 2", Data = new double[] { 1900, 2400, 3500, 1300, 2800, 1500, 1300, 1600, 3100 } },
+        new ChartSeries() { Name = "Series 3", Data = new double[] { 800, 600, 1100, 1300, 400, 1600, 1000, 1600, 1800 } },
+    };
+
+    private readonly string[] XAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
+    
+    private class CustomFormatter : IYAxisFormatter
+    {
+        private readonly CultureInfo usCultureInfo = new("en-US");
+
+        public string Format(double value)
+        {
+            return (value / 1000).ToString("N2", usCultureInfo) + "k";
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample3.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample3.razor
@@ -23,7 +23,8 @@
     protected override void OnInitialized()
     {
         options.InterpolationOption = InterpolationOption.NaturalSpline;
-        options.YAxisFormat = "c2";
+        options.YAxisFormat = new StandardNumericFormatStringsYAxisFormatter("c2");
+        options.YAxisLabelSpace = 75.0;
     }
 
     public void RandomizeData()
@@ -47,6 +48,4 @@
         options.InterpolationOption = interpolationOption;
         StateHasChanged();
     }
-
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample4.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample4.razor
@@ -1,0 +1,31 @@
+﻿@using System.Globalization
+@namespace MudBlazor.Docs.Examples
+
+<div>
+    <MudChart ChartType="ChartType.Line" ChartSeries="@series" XAxisLabels="@XAxisLabels" Width="100%" Height="350" ChartOptions="options"></MudChart>
+</div>
+
+@code {
+    private readonly ChartOptions options = new()
+    {
+        YAxisLabelSpace = 50.0,
+        YAxisFormat = new CustomFormatter()
+    };
+    
+    private readonly List<ChartSeries> series = new()
+    {
+        new ChartSeries() { Name = "Series 1", Data = new double[] { 9000, 7900, 7200, 6900, 6200, 6200, 5500, 6500, 7000 } },
+        new ChartSeries() { Name = "Series 2", Data = new double[] { 3500, 4100, 3500, 5100, 4900, 6200, 6900, 9100, 14800 } },
+    };
+    private readonly string[] XAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
+
+    private class CustomFormatter : IYAxisFormatter
+    {
+        private readonly CultureInfo usCultureInfo = new("en-US");
+
+        public string Format(double value)
+        {
+            return (value / 1000).ToString("N2", usCultureInfo) + "k";
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -11,16 +11,16 @@
                 <Description></Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="LineExample1">
-                <LineExample1 />
+                <LineExample1/>
             </SectionContent>
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader Title="Line Widths">
                 <Description></Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="LineWidthExample">
-                <LineWidthExample />
+                <LineWidthExample/>
             </SectionContent>
         </DocsPageSection>
 
@@ -29,7 +29,7 @@
                 <Description></Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="LineExample2">
-                <LineExample2 />
+                <LineExample2/>
             </SectionContent>
         </DocsPageSection>
 
@@ -38,7 +38,16 @@
                 <Description></Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="LineExample3">
-                <LineExample3 />
+                <LineExample3/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Custom Y-axis formatter">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent ShowCode="false" Code="LineExample4">
+                <LineExample4/>
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -97,7 +97,7 @@ namespace MudBlazor.UnitTests.Components
             yaxis[0].Children[0].InnerHtml.Trim().Should().Be("0");
 
             // now, we will apply currency format
-            options.YAxisFormat = "c2";
+            options.YAxisFormat = new StandardNumericFormatStringsYAxisFormatter("c2");
             comp.SetParametersAndRender(parameters => parameters
               .Add(p => p.ChartType, ChartType.Line)
               .Add(p => p.ChartSeries, series)
@@ -111,7 +111,7 @@ namespace MudBlazor.UnitTests.Components
             yaxis[0].Children[0].InnerHtml.Trim().Should().Be($"{0:c2}");
 
             //number format
-            options.YAxisFormat = "n6";
+            options.YAxisFormat = new StandardNumericFormatStringsYAxisFormatter("n6");
             comp.SetParametersAndRender(parameters => parameters
               .Add(p => p.ChartType, ChartType.Line)
               .Add(p => p.ChartSeries, series)

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -28,9 +28,20 @@ namespace MudBlazor.Charts
             _verticalValues.Clear();
             _legends.Clear();
             _bars.Clear();
+            
+            IYAxisFormatter yAxisFormatter;
+            var horizontalStartSpace = 30.0;
 
             if (MudChartParent != null)
+            {
                 _series = MudChartParent.ChartSeries;
+                yAxisFormatter = MudChartParent.ChartOptions.YAxisFormat;
+                horizontalStartSpace = MudChartParent.ChartOptions.YAxisLabelSpace;
+            }
+            else
+            {
+                yAxisFormatter = new DefaultYAxisFormatter();
+            }
 
             var maxY = 0.0;
             var numValues = 0;
@@ -61,7 +72,6 @@ namespace MudBlazor.Charts
             var numHorizontalLines = ((int)(maxY / gridYUnits)) + 1;
 
             var verticalStartSpace = 25.0;
-            var horizontalStartSpace = 30.0;
             var verticalEndSpace = 25.0;
             var horizontalEndSpace = 30.0;
 
@@ -80,7 +90,7 @@ namespace MudBlazor.Charts
                 };
                 _horizontalLines.Add(line);
 
-                var lineValue = new SvgText() { X = (horizontalStartSpace - 10), Y = (boundHeight - y + 5), Value = ToS(startGridY, MudChartParent?.ChartOptions.YAxisFormat) };
+                var lineValue = new SvgText() { X = (horizontalStartSpace - 10), Y = (boundHeight - y + 5), Value = yAxisFormatter.Format(startGridY) };
                 _horizontalValues.Add(lineValue);
 
                 startGridY += gridYUnits;

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -33,9 +33,20 @@ namespace MudBlazor.Charts
             _legends.Clear();
             _chartLines.Clear();
 
+            IYAxisFormatter yAxisFormatter;
+            var horizontalStartSpace = 30.0;
+            
             if (MudChartParent != null)
+            {
                 _series = MudChartParent.ChartSeries;
-
+                yAxisFormatter = MudChartParent.ChartOptions.YAxisFormat;
+                horizontalStartSpace = MudChartParent.ChartOptions.YAxisLabelSpace;
+            }
+            else
+            {
+                yAxisFormatter = new DefaultYAxisFormatter();
+            }
+                
             var maxY = 0.0;
             var numValues = 0;
             var numXLabels = XAxisLabels.Length;
@@ -75,7 +86,6 @@ namespace MudBlazor.Charts
             }
 
             var verticalStartSpace = 25.0;
-            var horizontalStartSpace = 30.0;
             var verticalEndSpace = 25.0;
             var horizontalEndSpace = 30.0;
 
@@ -95,7 +105,7 @@ namespace MudBlazor.Charts
                 };
                 _horizontalLines.Add(line);
 
-                var lineValue = new SvgText() { X = (horizontalStartSpace - 10), Y = (boundHeight - y + 5), Value = ToS(startGridY, MudChartParent?.ChartOptions.YAxisFormat) };
+                var lineValue = new SvgText() { X = (horizontalStartSpace - 10), Y = (boundHeight - y + 5), Value = yAxisFormatter.Format(startGridY) };
                 _horizontalValues.Add(lineValue);
 
                 startGridY += gridYUnits;

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -12,9 +12,15 @@
         /// </summary>
         public int MaxNumYAxisTicks { get; set; } = 20;
 
-        public string YAxisFormat { get; set; }
+        public IYAxisFormatter YAxisFormat { get; set; } = new DefaultYAxisFormatter();
+        
         public bool YAxisLines { get; set; } = true;
         public bool XAxisLines { get; set; }
+
+        /// <summary>
+        /// Space for the Y-axis label.
+        /// </summary>
+        public double YAxisLabelSpace { get; set; } = 30.0;
 
         /// <summary>
         /// If true, legend will not be displayed.

--- a/src/MudBlazor/Components/Chart/Models/DefaultYAxisFormatter.cs
+++ b/src/MudBlazor/Components/Chart/Models/DefaultYAxisFormatter.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+using System.Globalization;
+
+public class DefaultYAxisFormatter : IYAxisFormatter
+{
+    public string Format(double value)
+    {
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/MudBlazor/Components/Chart/Models/IYAxisFormatter.cs
+++ b/src/MudBlazor/Components/Chart/Models/IYAxisFormatter.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+public interface IYAxisFormatter
+{
+    public string Format(double value);
+}

--- a/src/MudBlazor/Components/Chart/Models/StandardNumericFormatStringsYAxisFormatter.cs
+++ b/src/MudBlazor/Components/Chart/Models/StandardNumericFormatStringsYAxisFormatter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+public class StandardNumericFormatStringsYAxisFormatter : IYAxisFormatter
+{
+    private readonly string _format;
+
+    public StandardNumericFormatStringsYAxisFormatter(string format)
+    {
+        _format = format;
+    }
+    
+    public string Format(double value)
+    {
+        return value.ToString(_format);
+    }
+}


### PR DESCRIPTION
## Description

Fix issue #6530

Now the width can be set via the chart options. So that the value does not take up too much space with large numbers, the value can be adjusted via a custom formatting.

The documentation was adapted.

## How Has This Been Tested?

- Unittest updated
- Bar char and line chart examples added
- existing examples adapted

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Breaking Change:**
ChartOptions.YAxisFormat is no longer a string but an IYAxisFormatter. There are two implementations (DefaultYAxisFormatter and StandardNumericFormatStringsYAxisFormatter ) to cover the old function. If this setting is used, after a nuget update the code must be migrated as follows:

ChartOptions.YAxisFormat = "c" to ChartOptions.YAxisFormat = new StandardNumericFormatStringsYAxisFormatter("c")

before:
![current](https://user-images.githubusercontent.com/15650359/227723215-fba55e53-fad6-4555-b809-20b30b3504b5.png)

new/fix:
![fix](https://user-images.githubusercontent.com/15650359/227723241-d2c9fbcf-477f-465b-9617-f73cf5b3919b.png)
![fix2](https://user-images.githubusercontent.com/15650359/227723243-910fdb1e-8bd3-4ad2-8f79-6a463537a186.png)
![doc1](https://user-images.githubusercontent.com/15650359/227723272-1a6a7ae7-255a-44b9-b2ed-219e5d9de36d.png)
![doc2](https://user-images.githubusercontent.com/15650359/227723279-d63e4040-5081-42d3-81f2-1b2a6980c4f9.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
