### PR TITLE
Docs: Landing page real data

### DIFF
--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -49,6 +49,7 @@
                              https://fonts.gstatic.com;
                    connect-src 'self'
                                https://api.github.com
+                               https://azuresearch-usnc.nuget.org
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com

--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -50,10 +50,13 @@
                    connect-src 'self'
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
+                               https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
-                               wss://localhost:*;
+                               http://localhost:*
+                               wss://localhost:*
+                               ws://localhost:*;
                    upgrade-insecure-requests;">
     <base href="/" />
     <link rel="apple-touch-icon" sizes="180x180" href="_content/MudBlazor.Docs/apple-touch-icon.png">

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -45,6 +45,7 @@
                              https://fonts.gstatic.com;
                    connect-src 'self'
                                https://api.github.com
+                               https://azuresearch-usnc.nuget.org
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -46,10 +46,13 @@
                    connect-src 'self'
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
+                               https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
-                               wss://localhost:*;
+                               http://localhost:*
+                               wss://localhost:*
+                               ws://localhost:*;
                    upgrade-insecure-requests;">
     <base href="/" />
     <link rel="apple-touch-icon" sizes="180x180" href="_content/MudBlazor.Docs/apple-touch-icon.png">

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -54,6 +54,7 @@
                              https://fonts.gstatic.com;
                    connect-src 'self'
                                https://api.github.com
+                               https://azuresearch-usnc.nuget.org
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -55,10 +55,13 @@
                    connect-src 'self'
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
+                               https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
                                https://*.google-analytics.com
-                               wss://localhost:*;
+                               http://localhost:*
+                               wss://localhost:*
+                               ws://localhost:*;
                    upgrade-insecure-requests;">
     <base href="/" />
     <link rel="apple-touch-icon" sizes="180x180" href="_content/MudBlazor.Docs/apple-touch-icon.png">

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -32,6 +32,7 @@ namespace MudBlazor.Docs.Extensions
 #pragma warning restore 0618
             });
 
+            services.AddScoped<DiscordApiClient>();
             services.AddScoped<NugetApiClient>();
             services.AddScoped<GitHubApiClient>();
             services.AddSingleton<IApiLinkService, ApiLinkService>();

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -32,6 +32,7 @@ namespace MudBlazor.Docs.Extensions
 #pragma warning restore 0618
             });
 
+            services.AddScoped<NugetApiClient>();
             services.AddScoped<GitHubApiClient>();
             services.AddSingleton<IApiLinkService, ApiLinkService>();
             services.AddSingleton<IMenuService, MenuService>();

--- a/src/MudBlazor.Docs/Extensions/NumericExtensions.cs
+++ b/src/MudBlazor.Docs/Extensions/NumericExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace MudBlazor.Docs.Extensions
+{
+    public static class NumericExtensions
+    {
+        public static string RoundedToString(this decimal num)
+        {
+            if (num > 999999999 || num < -999999999)
+            {
+                return num.ToString("0,,,.#B", CultureInfo.InvariantCulture);
+            }
+            else if (num > 999999 || num < -999999)
+            {
+                return num.ToString("0,,.#M", CultureInfo.InvariantCulture);
+            }
+            else if (num > 9999 || num < -9999)
+            {
+                return num.ToString("0,k", CultureInfo.InvariantCulture);
+            }
+            else if (num > 999 || num < -999)
+            {
+                return num.ToString("0,.#k", CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                return num.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Models/DiscordInvite.cs
+++ b/src/MudBlazor.Docs/Models/DiscordInvite.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Docs.Models;
+
+public class DiscordInvite
+{
+    public int approximate_member_count { get; set; }
+    public int approximate_presence_count { get; set; }
+}
+

--- a/src/MudBlazor.Docs/Models/DiscordInvite.cs
+++ b/src/MudBlazor.Docs/Models/DiscordInvite.cs
@@ -2,11 +2,16 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace MudBlazor.Docs.Models;
 
 public class DiscordInvite
 {
-    public int approximate_member_count { get; set; }
-    public int approximate_presence_count { get; set; }
+    [JsonPropertyName("approximate_member_count")]
+    public int ApproximateMemberCount { get; set; }
+
+    [JsonPropertyName("approximate_presence_count")]
+    public int ApproximatePresenceCount { get; set; }
 }
 

--- a/src/MudBlazor.Docs/Models/GitHubRepository.cs
+++ b/src/MudBlazor.Docs/Models/GitHubRepository.cs
@@ -2,10 +2,13 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace MudBlazor.Docs.Models;
 
 public class GitHubRepository
 {
-    public int stargazers_count { get; set; }
+    [JsonPropertyName("stargazers_count")]
+    public int StargazersCount { get; set; }
 }
 

--- a/src/MudBlazor.Docs/Models/GitHubRepository.cs
+++ b/src/MudBlazor.Docs/Models/GitHubRepository.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Docs.Models;
+
+public class GitHubRepository
+{
+    public int stargazers_count { get; set; }
+}
+

--- a/src/MudBlazor.Docs/Models/NugetPackage.cs
+++ b/src/MudBlazor.Docs/Models/NugetPackage.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MudBlazor.Docs.Models;
+
+public class NugetRespons
+{
+    public int totalHits { get; set; }
+    public List<NugetPackage> data { get; set; }
+}
+public class NugetPackage
+{
+    [JsonPropertyName("@id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("@type")]
+    public string type { get; set; }
+    public string registration { get; set; }
+    public string id { get; set; }
+    public string version { get; set; }
+    public string description { get; set; }
+    public string summary { get; set; }
+    public string title { get; set; }
+    public string iconUrl { get; set; }
+    public string licenseUrl { get; set; }
+    public string projectUrl { get; set; }
+    public List<string> tags { get; set; }
+    public List<string> authors { get; set; }
+    public List<string> owners { get; set; }
+    public int totalDownloads { get; set; }
+    public bool verified { get; set; }
+    public List<PackageType> packageTypes { get; set; }
+    public List<Version> versions { get; set; }
+
+    public class Version
+    {
+        public string version { get; set; }
+        public int downloads { get; set; }
+
+        [JsonPropertyName("@id")]
+        public string id { get; set; }
+    }
+
+    public class PackageType
+    {
+        public string name { get; set; }
+    }
+}
+

--- a/src/MudBlazor.Docs/Models/NugetPackage.cs
+++ b/src/MudBlazor.Docs/Models/NugetPackage.cs
@@ -9,45 +9,41 @@ namespace MudBlazor.Docs.Models;
 
 public class NugetRespons
 {
-    public int totalHits { get; set; }
-    public List<NugetPackage> data { get; set; }
+    public int TotalHits { get; set; }
+    public List<NugetPackage> Data { get; set; }
 }
 public class NugetPackage
 {
-    [JsonPropertyName("@id")]
-    public string Id { get; set; }
-
     [JsonPropertyName("@type")]
-    public string type { get; set; }
-    public string registration { get; set; }
-    public string id { get; set; }
-    public string version { get; set; }
-    public string description { get; set; }
-    public string summary { get; set; }
-    public string title { get; set; }
-    public string iconUrl { get; set; }
-    public string licenseUrl { get; set; }
-    public string projectUrl { get; set; }
-    public List<string> tags { get; set; }
-    public List<string> authors { get; set; }
-    public List<string> owners { get; set; }
-    public int totalDownloads { get; set; }
-    public bool verified { get; set; }
-    public List<PackageType> packageTypes { get; set; }
-    public List<Version> versions { get; set; }
-
-    public class Version
-    {
-        public string version { get; set; }
-        public int downloads { get; set; }
-
-        [JsonPropertyName("@id")]
-        public string id { get; set; }
-    }
-
-    public class PackageType
-    {
-        public string name { get; set; }
-    }
+    public string Type { get; set; }
+    public string Registration { get; set; }
+    public string Id { get; set; }
+    public string Version { get; set; }
+    public string Description { get; set; }
+    public string Summary { get; set; }
+    public string Title { get; set; }
+    public string IconUrl { get; set; }
+    public string LicenseUrl { get; set; }
+    public string ProjectUrl { get; set; }
+    public List<string> Tags { get; set; }
+    public List<string> Authors { get; set; }
+    public List<string> Owners { get; set; }
+    public int TotalDownloads { get; set; }
+    public bool Verified { get; set; }
+    public List<PackageType> PackageTypes { get; set; }
+    public List<Versions> Versions { get; set; }
 }
 
+public class Versions
+{
+    public string Version { get; set; }
+    public int Downloads { get; set; }
+
+    [JsonPropertyName("@id")]
+    public string Id { get; set; }
+}
+
+public class PackageType
+{
+    public string Name { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -1,6 +1,9 @@
 ﻿@page "/"
 @layout LandingLayout
+@inject NugetApiClient _nugetApiClient;
+@inject GitHubApiClient _gitHubApiClient;
 @using MudBlazor.Docs.Components.LandingPage
+@using MudBlazor.Docs.Extensions
 
 <LandingSection SectionClass="top-section" BackgroundClass="sweet">
     <ChildContent>
@@ -286,16 +289,16 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">84K</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_nugetPackage.totalDownloads)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDownloads"/>
-                    <MudText Typo="Typo.body1" Class="ml-4">Monthly Downloads</MudText>
+                    <MudText Typo="Typo.body1" Class="ml-4">Total Downloads</MudText>
                 </div>
             </div>
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">4.3K+</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_gitHubRepo.stargazers_count)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpGitHub"/>
                     <MudText Typo="Typo.body1" Class="ml-4">GitHub Stars</MudText>
@@ -304,7 +307,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">212</MudText>
+                <MudText Typo="Typo.h3" Color="Color.Primary">@_gitHubTotalContributors</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpContributors"/>
                     <MudText Typo="Typo.body1" Class="ml-4">Contributors</MudText>
@@ -313,7 +316,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">3,098</MudText>
+                <MudText Typo="Typo.h3" Color="Color.Primary">3.4K+</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDiscord"/>
                     <MudText Typo="Typo.body1" Class="ml-4">Discord Members</MudText>
@@ -353,7 +356,7 @@
     </div>
 </LandingSection>
 
-@code {
+    @code {
     private string lpIconCode = "<path d=\"M8.52 21C8.2 21 7.92 20.8806 7.68 20.6417L0.36 13.356C-0.12 12.8782 -0.12 12.1218 0.36 11.6838L7.68 4.35831C8.16 3.88056 8.92 3.88056 9.36 4.35831C9.84 4.83607 9.84 5.59251 9.36 6.03044L2.88 12.4801L9.36 18.9297C9.84 19.4075 9.84 20.1639 9.36 20.6019C9.16 20.8806 8.84 21 8.52 21Z\" fill=\"#5E5BF0\"/><path d=\"M15.48 21C15.16 21 14.88 20.8806 14.64 20.6417C14.16 20.1639 14.16 19.4075 14.64 18.9696L21.12 12.5199L14.6 6.03044C14.12 5.55269 14.12 4.79625 14.6 4.35831C15.08 3.88056 15.84 3.88056 16.28 4.35831L23.6 11.6838C24.08 12.1616 24.08 12.918 23.6 13.356L16.32 20.6417C16.08 20.8806 15.76 21 15.48 21Z\" fill=\"#66EDE5\"/>";
     private string lpIconTemplates = "<g clip-path=\"url(#clip0_95_632)\"><path d=\"M12.0182 22C11.8723 22 11.7264 21.9642 11.6169 21.9283L1.6932 18.0215C1.29187 17.8423 1 17.448 1 17.0179V6.98208C1 6.37276 1.4743 5.90681 2.09453 5.90681C2.71476 5.90681 3.18905 6.37276 3.18905 6.98208V16.2652L12.0182 19.7419L20.8474 16.2652V6.98208C20.8474 6.37276 21.3217 5.90681 21.942 5.90681C22.5622 5.90681 23.0365 6.37276 23.0365 6.98208V17.0179C23.0365 17.448 22.7811 17.8423 22.3433 18.0215L12.4196 21.9283C12.2736 21.9642 12.1642 22 12.0182 22Z\" fill=\"#5E5BF0\"/><path d=\"M17.199 9.99283C17.0531 9.99283 16.9436 9.95699 16.7977 9.92115L6.8375 6.01434C6.29024 5.79928 5.99836 5.15412 6.21727 4.61649C6.47266 4.07885 7.09289 3.79211 7.64015 4.00717L17.5639 7.91398C18.1111 8.12903 18.403 8.77419 18.1841 9.31183C18.0382 9.74194 17.6368 9.99283 17.199 9.99283Z\" fill=\"#66EDE5\"/><path d=\"M12.0182 12.0009C11.8723 12.0009 11.7264 11.9651 11.6169 11.9292L1.6932 7.98656C1.25539 7.84319 1 7.44893 1 6.98298C1 6.51703 1.25539 6.1586 1.6932 5.97939L11.5804 2.07258C11.8358 1.96505 12.1277 1.96505 12.3831 2.07258L22.3068 5.97939C22.7081 6.1586 23 6.55287 23 6.98298C23 7.41308 22.7446 7.80735 22.3068 7.98656L12.4196 11.8934C12.2736 11.9651 12.1277 12.0009 12.0182 12.0009ZM5.01327 6.98298L11.9818 9.74283L18.9502 6.98298L12.0182 4.22312L5.01327 6.98298Z\" fill=\"#5E5BF0\"/><path d=\"M12.0182 22C11.398 22 10.9237 21.5341 10.9237 20.9247V10.8889C10.9237 10.2796 11.398 9.81362 12.0182 9.81362C12.6385 9.81362 13.1128 10.2796 13.1128 10.8889V20.9247C13.1128 21.5341 12.602 22 12.0182 22Z\" fill=\"#5E5BF0\"/></g><defs><clipPath id=\"clip0_95_632\"><rect width=\"22\" height=\"20\" fill=\"white\" transform=\"translate(1 2)\"/></clipPath></defs>";
     private string lpIconTemplatesFilled = "<g clip-path=\"url(#clip0_137_279)\"><path d=\"M18.2935 7.55172L21.9784 6.17241C22.1609 6.10345 22.1609 5.86207 21.9784 5.7931L12.0912 2C12.0182 2 11.9817 2 11.9088 2L8.18738 3.37931C8.00496 3.44828 8.00496 3.68966 8.18738 3.75862L18.1476 7.55172C18.1841 7.58621 18.257 7.58621 18.2935 7.55172Z\" fill=\"#66EDE5\"/><path d=\"M6.10778 4.20653L1.98506 5.79273C1.80264 5.8617 1.80264 6.10308 1.98506 6.17204L11.9088 9.93066C11.9453 9.96515 12.0182 9.96515 12.0912 9.93066L16.2504 8.34446C16.4328 8.27549 16.4328 8.03411 16.2504 7.96515L6.2902 4.20653C6.25372 4.17204 6.18075 4.17204 6.10778 4.20653Z\" fill=\"#66EDE5\"/><path d=\"M11.325 10.8274L1.32831 7.0343C1.14589 6.96533 0.999954 7.06878 0.999954 7.24119V16.5171V16.9653C0.999954 17.0688 1.07292 17.1377 1.14589 17.1722L11.1426 20.9653C11.2885 21.0343 11.4344 20.9309 11.4344 20.7584V11.0343C11.4709 10.9308 11.398 10.8619 11.325 10.8274Z\" fill=\"#5E5BF0\"/><path d=\"M12.5655 11.0343V20.793C12.5655 20.9309 12.7114 21.0343 12.8574 20.9998L22.8905 17.1723C22.9635 17.1378 23.0365 17.0688 23.0365 16.9654V7.20674C23.0365 7.06881 22.8905 6.96536 22.7446 6.99985L12.7479 10.793C12.602 10.8619 12.5655 10.9309 12.5655 11.0343Z\" fill=\"#5E5BF0\"/></g><defs><clipPath id=\"clip0_137_279\"><rect width=\"22\" height=\"19\" fill=\"white\" transform=\"translate(0.999954 2)\"/></clipPath></defs>";
@@ -363,6 +366,16 @@
     private string lpDiscord = "<path d=\"M9.37,4.77C9.18,3.57,8.09,3.9,7,4.19A8.39,8.39,0,0,0,4.24,5.53c-1,.72-1.78,3.75-2.12,5.26a19.35,19.35,0,0,0-.66,5.37c.08.69,1.12,1.46,2.62,2.21A6,6,0,0,0,7,19c.47-.14,1-1.4,1.17-1.82\" style=\"fill:none;stroke:#5e5bf0;stroke-miterlimit:10;stroke-width:1.5px\"/><path d=\"M14.31,4.77c.19-1.2,1.28-.87,2.4-.58a6.79,6.79,0,0,1,2.73,1.34c.89.82,1.79,3.75,2.12,5.26a19.35,19.35,0,0,1,.66,5.37c-.08.69-1.12,1.46-2.62,2.21a6,6,0,0,1-2.91.59c-.48-.14-1-1.4-1.17-1.82\" style=\"fill:none;stroke:#5e5bf0;stroke-miterlimit:10;stroke-width:1.5px\"/><ellipse cx=\"8.82\" cy=\"12.31\" rx=\"1.72\" ry=\"2.01\" style=\"fill:none;stroke:#66ede5;stroke-miterlimit:10;stroke-width:1.2px\"/><ellipse cx=\"15.04\" cy=\"12.22\" rx=\"1.72\" ry=\"2.01\" style=\"fill:none;stroke:#66ede5;stroke-miterlimit:10;stroke-width:1.2px\"/><path d=\"M4.35,15.05a.8.8,0,0,1,1.1-.15,11.93,11.93,0,0,0,12.65,0,.8.8,0,0,1,1.1.15.78.78,0,0,1-.31,1.11,13.39,13.39,0,0,1-14.23,0A.79.79,0,0,1,4.35,15.05Z\" style=\"fill:#5e5bf0\"/><path d=\"M5.24,7.3a.78.78,0,0,1,.32-1.11,12.06,12.06,0,0,1,12.65,0,.78.78,0,0,1,.33,1.11.83.83,0,0,1-1.11.16,10.55,10.55,0,0,0-11.09,0A.83.83,0,0,1,5.24,7.3Z\" style=\"fill:#5e5bf0\"/>";
 
     private bool _showTestimonials { get; set; }
+    private int _gitHubTotalContributors { get; set; }
+    private NugetPackage _nugetPackage { get; set; } = new();
+    private GitHubRepository _gitHubRepo { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _nugetPackage = await _nugetApiClient.GetPackageAsync("mudblazor");
+        _gitHubRepo = await _gitHubApiClient.GetRepositoryAsync("MudBlazor", "MudBlazor");
+        _gitHubTotalContributors = await _gitHubApiClient.GetContributorsCountAsync("MudBlazor", "MudBlazor");
+    }
 
     private void ToggleTestimonials()
     {

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -290,7 +290,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_nugetPackage.totalDownloads)</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_nugetPackage.TotalDownloads)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDownloads"/>
                     <MudText Typo="Typo.body1" Class="ml-4">Total Downloads</MudText>
@@ -299,7 +299,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_gitHubRepo.stargazers_count)</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_gitHubRepo.StargazersCount)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpGitHub"/>
                     <MudText Typo="Typo.body1" Class="ml-4">GitHub Stars</MudText>
@@ -317,7 +317,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_discordInvite.approximate_member_count)</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_discordInvite.ApproximateMemberCount)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDiscord"/>
                     <MudText Typo="Typo.body1" Class="ml-4">Discord Members</MudText>

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @layout LandingLayout
+@inject DiscordApiClient _discordApiClient;
 @inject NugetApiClient _nugetApiClient;
 @inject GitHubApiClient _gitHubApiClient;
 @using MudBlazor.Docs.Components.LandingPage
@@ -316,7 +317,7 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">3.4K+</MudText>
+                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_discordInvite.approximate_member_count)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDiscord"/>
                     <MudText Typo="Typo.body1" Class="ml-4">Discord Members</MudText>
@@ -367,11 +368,13 @@
 
     private bool _showTestimonials { get; set; }
     private int _gitHubTotalContributors { get; set; }
+    private DiscordInvite _discordInvite { get; set; } = new();
     private NugetPackage _nugetPackage { get; set; } = new();
     private GitHubRepository _gitHubRepo { get; set; } = new();
 
     protected override async Task OnInitializedAsync()
     {
+        _discordInvite = await _discordApiClient.GetDiscordInviteAsync();
         _nugetPackage = await _nugetApiClient.GetPackageAsync("mudblazor");
         _gitHubRepo = await _gitHubApiClient.GetRepositoryAsync("MudBlazor", "MudBlazor");
         _gitHubTotalContributors = await _gitHubApiClient.GetContributorsCountAsync("MudBlazor", "MudBlazor");

--- a/src/MudBlazor.Docs/Services/DiscordApiClient.cs
+++ b/src/MudBlazor.Docs/Services/DiscordApiClient.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using MudBlazor.Docs.Models;
+
+namespace MudBlazor.Docs.Services
+{
+    public class DiscordApiClient
+    {
+        private readonly HttpClient _http;
+
+        public DiscordApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+        public async Task<DiscordInvite> GetDiscordInviteAsync()
+        {
+            try
+            {
+                var result = await _http.GetFromJsonAsync<DiscordInvite>($"https://discord.com/api/v10/invites/mudblazor?with_counts=true");
+                return result;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Services/GitHubApiClient.cs
+++ b/src/MudBlazor.Docs/Services/GitHubApiClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
@@ -45,6 +46,38 @@ namespace MudBlazor.Docs.Services
             {
                 Console.WriteLine(e.Message);
                 return new GitHubReleases[0];
+            }
+        }
+
+        public async Task<GitHubRepository> GetRepositoryAsync(string owner, string repo)
+        {
+            try
+            {
+                var result = await _http.GetFromJsonAsync<GitHubRepository>($"https://api.github.com/repos/{owner}/{repo}");
+                return result;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return null;
+            }
+        }
+
+        public async Task<int> GetContributorsCountAsync(string owner, string repo)
+        {
+            try
+            {
+                var result = await _http.GetAsync($"https://api.github.com/repos/{owner}/{repo}/contributors?per_page=1&anon=true");
+                var value = result.Headers.GetValues("Link").FirstOrDefault();
+                value = value.Substring(value.LastIndexOf("page=") + 5);
+                value = value.Substring(0, value.LastIndexOf(">;"));
+
+                return int.Parse(value);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return 0;
             }
         }
     }

--- a/src/MudBlazor.Docs/Services/GitHubApiClient.cs
+++ b/src/MudBlazor.Docs/Services/GitHubApiClient.cs
@@ -53,7 +53,7 @@ namespace MudBlazor.Docs.Services
         {
             try
             {
-                var result = await _http.GetFromJsonAsync<GitHubRepository>($"https://api.github.com/repos/{owner}/{repo}");
+                var result = await _http.GetFromJsonAsync<GitHubRepository>($"https://api.github.com:443/repos/{owner}/{repo}");
                 return result;
             }
             catch (Exception e)
@@ -67,7 +67,7 @@ namespace MudBlazor.Docs.Services
         {
             try
             {
-                var result = await _http.GetAsync($"https://api.github.com/repos/{owner}/{repo}/contributors?per_page=1&anon=true");
+                var result = await _http.GetAsync($"https://api.github.com:443/repos/{owner}/{repo}/contributors?per_page=1&anon=true");
                 var value = result.Headers.GetValues("Link").FirstOrDefault();
                 value = value.Substring(value.LastIndexOf("page=") + 5);
                 value = value.Substring(0, value.LastIndexOf(">;"));

--- a/src/MudBlazor.Docs/Services/NugetApiClient.cs
+++ b/src/MudBlazor.Docs/Services/NugetApiClient.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.Docs.Services
             try
             {
                 var result = await _http.GetFromJsonAsync<NugetRespons>($"https://azuresearch-usnc.nuget.org/query?q=packageid:{packageName}&take=1");
-                return result.data.FirstOrDefault();
+                return result.Data.FirstOrDefault();
             }
             catch (Exception e)
             {

--- a/src/MudBlazor.Docs/Services/NugetApiClient.cs
+++ b/src/MudBlazor.Docs/Services/NugetApiClient.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using MudBlazor.Docs.Models;
+
+namespace MudBlazor.Docs.Services
+{
+    public class NugetApiClient
+    {
+        private readonly HttpClient _http;
+
+        public NugetApiClient(HttpClient http)
+        {
+            _http = http;
+            http.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Mobile Safari/537.36");
+        }
+        public async Task<NugetPackage> GetPackageAsync(string packageName)
+        {
+            try
+            {
+                var result = await _http.GetFromJsonAsync<NugetRespons>($"https://azuresearch-usnc.nuget.org/query?q=packageid:{packageName}&take=1");
+                return result.data.FirstOrDefault();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Services/NugetApiClient.cs
+++ b/src/MudBlazor.Docs/Services/NugetApiClient.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -19,7 +18,6 @@ namespace MudBlazor.Docs.Services
         public NugetApiClient(HttpClient http)
         {
             _http = http;
-            http.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Mobile Safari/537.36");
         }
         public async Task<NugetPackage> GetPackageAsync(string packageName)
         {


### PR DESCRIPTION
## Description
The data in the landing page section "MudBlazor is growing quickly" was hardcoded and did not update.
Added two new services to docs for Nuget and Discord data as well as added new methods to GitHubApiClient.
Added a new extension to docs for converting numbers from 3491 -> 3.5k and so on.

## How Has This Been Tested?
Manually

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![mudblazor com_](https://user-images.githubusercontent.com/10367109/227773054-e82c9303-ee1d-40df-9093-ba298f3a9271.png)
After:
![localhost_5001_](https://user-images.githubusercontent.com/10367109/227773057-3a58c3a7-e827-4688-8961-9a003296a22f.png)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
