### PR TITLE
MudDatagrid: Fix grouping to work with filtered items cache.

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -688,6 +688,7 @@ namespace MudBlazor
 
                 _currentRenderFilteredItemsCache = Sort(items).ToList(); // To list to ensure evaluation only once per render
                 unchecked { FilteringRunCount++; }
+                GroupItems(noStateChange: true);
                 return _currentRenderFilteredItemsCache;
             }
         }
@@ -1225,12 +1226,12 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void GroupItems()
+        public void GroupItems(bool noStateChange = false)
         {          
             if (GroupedColumn == null)
             {
                 _groups = new List<GroupDefinition<T>>();
-                if (_isFirstRendered)
+                if (_isFirstRendered && !noStateChange)
                     StateHasChanged();
                 return;
             }
@@ -1255,7 +1256,7 @@ namespace MudBlazor
             _groups = groupings.Select(x => new GroupDefinition<T>(x,
                 _groupExpansions.Contains(x.Key))).ToList();
 
-            if (_isFirstRendered || ServerData != null)
+            if ((_isFirstRendered || ServerData != null) && !noStateChange)
                 StateHasChanged();
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fix datagrid grouping breaked by previous PR #6495.
GroupDefinitions were initialized with previous lazy-evaluated linq query and thus updated with every render.
With cache they get a list, which stays the same and groups don't update properly.
Fixed it by updating groupings after new items cache is created, added parameter to not update component state - that would cause infinite rendering loop.
Maybe a better solution involving more work is possible (pass function to GroupDefinition? possibly slower). This should work just fine.  

## How Has This Been Tested?
- Existing unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
