### PR TITLE
MudDropZone: Add nullable annotation and fix #6551, #4695.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             container.DraggingClass.Should().BeNullOrEmpty();
             container.ItemDraggingClass.Should().BeNullOrEmpty();
             container.ItemIsDisabled.Should().BeNull();
-            container.Items.Should().BeNull();
+            container.Items.Should().BeEmpty();
             container.ItemsSelector.Should().BeNull();
             container.NoDropClass.Should().BeNullOrEmpty();
         }
@@ -74,7 +74,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DropZone_GenerelView()
+        public void DropZone_GeneralView()
         {
             var comp = Context.RenderComponent<DropzoneBasicTest>();
 
@@ -106,20 +106,20 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DropZone_TestJsCalls()
         {
-            Mock<IJSRuntime> _jsruntimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+            var jsRuntimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
 
-            Context.Services.AddSingleton(typeof(IJSRuntime), _jsruntimeMock.Object);
+            Context.Services.AddSingleton(typeof(IJSRuntime), jsRuntimeMock.Object);
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudDragAndDrop.initDropZone", It.Is<object[]>(y => y.Length == 1 && Guid.Parse(y[0].ToString()) != Guid.Empty)))
+            jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudDragAndDrop.initDropZone", It.Is<object[]>(y => y.Length == 1 && Guid.Parse(y[0].ToString()) != Guid.Empty)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(200)).Verifiable();
 
             var comp = Context.RenderComponent<DropzoneBasicTest>();
 
-            _jsruntimeMock.Verify();
+            jsRuntimeMock.Verify();
         }
 
         [Test]
-        public void DropZone_DropzoneOverrideContainerRendered()
+        public void DropZone_DropZoneOverrideContainerRendered()
         {
             var comp = Context.RenderComponent<DropzoneCustomItemSelectorTest>();
 
@@ -323,25 +323,25 @@ namespace MudBlazor.UnitTests.Components
             firstDropZone.ClassList.Should().NotContain("my-special-dragging-class");
             firstDropItem.ClassList.Should().NotContain("my-special-item-dragging-class");
         }
-        
+
         [Test]
         public async Task DropZone_DropItem_DragEnterNotTrackedItem()
         {
             var comp = Context.RenderComponent<DropzoneBasicTest>();
-            
+
             var tempContainer = comp.Find(".mud-drop-container");
             tempContainer.Children.Should().HaveCount(2);
 
             var firstDropZone = tempContainer.Children[0];
             var firstDropItem = firstDropZone.Children[1];
-            
+
             await firstDropItem.DragEnterAsync(new DragEventArgs());
-            
+
             tempContainer.Children.Should().HaveCount(2);
             tempContainer.Children[0].Children.Should().HaveCount(2);
             tempContainer.Children[1].Children.Should().HaveCount(3);
         }
-        
+
         [Test]
         public async Task DropZone_DropNotTrackedItem()
         {
@@ -625,7 +625,7 @@ namespace MudBlazor.UnitTests.Components
             thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
             thirdDropZone.ClassList.Should().Contain("no-drop-class-from-container");
         }
-        
+
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragFinished()
         {
@@ -643,10 +643,10 @@ namespace MudBlazor.UnitTests.Components
 
             //start dragging
             await dragItem.DragStartAsync(new DragEventArgs());
-            
+
             //enter second drop zone
             await secondDropZone.DragEnterAsync(new DragEventArgs());
-            
+
             //drop to second drop zone
             await secondDropZone.DropAsync(new DragEventArgs());
 
@@ -662,7 +662,7 @@ namespace MudBlazor.UnitTests.Components
             thirdDropZone.ClassList.Should().NotContain("can-drop-from-container");
             thirdDropZone.ClassList.Should().NotContain("no-drop-class-from-container");
         }
-        
+
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragCanceled()
         {
@@ -680,7 +680,7 @@ namespace MudBlazor.UnitTests.Components
 
             //start dragging
             await dragItem.DragStartAsync(new DragEventArgs());
-            
+
             //cancel drag transaction
             await dragItem.DragEndAsync(new DragEventArgs());
 
@@ -1144,35 +1144,35 @@ namespace MudBlazor.UnitTests.Components
             firstDropZone.Children[3].TextContent.Should().Be("Item 3");
             firstDropZone.Children[4].TextContent.Should().Be("Item 4");
         }
-        
+
         [Test]
         public async Task DropZone_DragFinished_DropNotAllowed_KeepOrder()
         {
             var comp = Context.RenderComponent<DropzoneDraggingTestCantDropSecondZoneTest>();
-        
+
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
-        
+
             var firstDropZone = container.Children[0];
             var secondDropZone = container.Children[1];
-        
+
             secondDropZone.Children.Should().HaveCount(3);
             var secondDropItem = secondDropZone.Children[1];
             var secondDropItemText = secondDropItem.Children[0].TextContent;
-            
+
             secondDropItemText.Should().Be("Second Item");
-            
+
             await secondDropItem.DragStartAsync(new DragEventArgs());
-        
+
             //drop item in first zone
             await firstDropZone.DropAsync(new DragEventArgs());
-        
+
             //reload DOM references
             container = comp.Find(".mud-drop-container");
             secondDropZone = container.Children[1];
             secondDropItem = secondDropZone.Children[1];
             secondDropItemText = secondDropItem.Children[0].TextContent;
-            
+
             secondDropItemText.Should().Be("Second Item");
         }
     }

--- a/src/MudBlazor/Components/DropZone/MudDragAndDropIndexChangedEventArgs.cs
+++ b/src/MudBlazor/Components/DropZone/MudDragAndDropIndexChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor;
+
+#nullable enable
+public class MudDragAndDropIndexChangedEventArgs : EventArgs
+{
+    public string ZoneIdentifier { get; }
+
+    public int Index { get; }
+
+    public string OldZoneIdentifier { get; }
+
+    public MudDragAndDropIndexChangedEventArgs(string zoneIdentifier, string oldZoneIdentifier, int index)
+    {
+        ZoneIdentifier = zoneIdentifier;
+        Index = index;
+        OldZoneIdentifier = oldZoneIdentifier;
+    }
+}

--- a/src/MudBlazor/Components/DropZone/MudDragAndDropItemTransaction.cs
+++ b/src/MudBlazor/Components/DropZone/MudDragAndDropItemTransaction.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace MudBlazor;
+
+#nullable enable
+/// <summary>
+/// Used to encapsulate data for a drag and drop transaction
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class MudDragAndDropItemTransaction<T>
+{
+    private readonly Func<Task> _commitCallback;
+    private readonly Func<Task> _cancelCallback;
+
+    /// <summary>
+    /// The Item that is dragged during the transaction
+    /// </summary>
+    public T? Item { get; init; }
+
+    /// <summary>
+    /// The index of the item in the current drop zone
+    /// </summary>
+    public int Index { get; private set; }
+
+    /// <summary>
+    /// The index of the item when the transaction started
+    /// </summary>
+    public int SourceIndex { get; }
+
+    /// <summary>
+    /// Identifier for drop zone where the transaction started
+    /// </summary>
+    public string SourceZoneIdentifier { get; init; }
+
+    public string CurrentZone { get; private set; }
+
+    /// <summary>
+    /// create a new instance of a drag and drop transaction encapsulating the item and source
+    /// </summary>
+    /// <param name="item">The item of this transaction</param>
+    /// <param name="identifier">The identifier of the drop zone, where the transaction started</param>
+    /// <param name="index">The source index</param>
+    /// <param name="commitCallback">A callback that is invoked when the transaction has been successful</param>
+    /// <param name="cancelCallback">A callback that is invoked when the transaction has been canceled</param>
+    public MudDragAndDropItemTransaction(T? item, string identifier, int index, Func<Task> commitCallback, Func<Task> cancelCallback)
+    {
+        Item = item;
+        SourceZoneIdentifier = identifier;
+        CurrentZone = identifier;
+        Index = index;
+        SourceIndex = index;
+
+        _commitCallback = commitCallback;
+        _cancelCallback = cancelCallback;
+    }
+
+    /// <summary>
+    /// Cancel the transaction 
+    /// </summary>
+    /// <returns></returns>
+    public Task Cancel() => _cancelCallback.Invoke();
+
+    /// <summary>
+    /// Commit this transaction as successful
+    /// </summary>
+    /// <returns></returns>
+    public Task Commit() => _commitCallback.Invoke();
+
+    internal bool UpdateIndex(int index)
+    {
+        if (Index == index)
+        {
+            return false;
+        }
+
+        Index = index;
+
+        return true;
+    }
+
+    internal bool UpdateZone(string identifier)
+    {
+        if (CurrentZone == identifier)
+        {
+            return false;
+        }
+
+        CurrentZone = identifier;
+        Index = -1;
+
+        return true;
+    }
+}

--- a/src/MudBlazor/Components/DropZone/MudDragAndDropTransactionFinishedEventArgs.cs
+++ b/src/MudBlazor/Components/DropZone/MudDragAndDropTransactionFinishedEventArgs.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor;
+
+#nullable enable
+public class MudDragAndDropTransactionFinishedEventArgs<T> : EventArgs
+{
+    public T? Item { get; }
+
+    public bool Success { get; }
+
+    public string OriginatedDropzoneIdentifier { get; }
+
+    public string DestinationDropzoneIdentifier { get; }
+
+    public int OriginIndex { get; }
+
+    public int DestinationIndex { get; }
+
+    public MudDragAndDropTransactionFinishedEventArgs(string destinationDropZoneIdentifier, bool success, MudDragAndDropItemTransaction<T> transaction)
+    {
+        Item = transaction.Item;
+        Success = success;
+        OriginatedDropzoneIdentifier = transaction.SourceZoneIdentifier;
+        DestinationDropzoneIdentifier = destinationDropZoneIdentifier;
+        OriginIndex = transaction.SourceIndex;
+        DestinationIndex = transaction.Index;
+    }
+
+    public MudDragAndDropTransactionFinishedEventArgs(MudDragAndDropItemTransaction<T> transaction) :
+        this(string.Empty, false, transaction)
+    {
+    }
+}

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -5,153 +5,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public class MudDragAndDropIndexChangedEventArgs : EventArgs
-    {
-        public MudDragAndDropIndexChangedEventArgs(string zoneIdentifier, string oldZoneIdentifier, int index)
-        {
-            ZoneIdentifier = zoneIdentifier;
-            Index = index;
-            OldZoneIdentifier = oldZoneIdentifier;
-        }
-
-        public string ZoneIdentifier { get; }
-        public int Index { get; }
-        public string OldZoneIdentifier { get; }
-    }
-
-    /// <summary>
-    /// Used to encapsulate data for a drag and drop transaction
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class MudDragAndDropItemTransaction<T>
-    {
-        private Func<Task> _commitCallback;
-        private Func<Task> _cancelCallback;
-
-        /// <summary>
-        /// The Item that is dragged during the transaction
-        /// </summary>
-        public T Item { get; init; }
-
-        /// <summary>
-        /// The index of the item in the current drop zone
-        /// </summary>
-        public int Index { get; private set; }
-
-        /// <summary>
-        /// The index of the item when the transaction started
-        /// </summary>
-        public int SourceIndex { get; private set; }
-
-        /// <summary>
-        /// Identifier for drop zone where the transaction started
-        /// </summary>
-        public string SourceZoneIdentifier { get; init; }
-
-        public string CurrentZone { get; private set; }
-
-        /// <summary>
-        /// create a new instance of a drag and drop transaction encapsulating the item and source
-        /// </summary>
-        /// <param name="item">The item of this transaction</param>
-        /// <param name="identifier">The identifier of the drop zone, where the transaction started</param>
-        /// <param name="index">The source index</param>
-        /// <param name="commitCallback">A callback that is invokde when the transaction has been successful</param>
-        /// <param name="cancelCallback">A callback that is inviked when the transaction has been canceled</param>
-        public MudDragAndDropItemTransaction(T item, string identifier, int index, Func<Task> commitCallback, Func<Task> cancelCallback)
-        {
-            Item = item;
-            SourceZoneIdentifier = identifier;
-            CurrentZone = identifier;
-            Index = index;
-            SourceIndex = index;
-
-            _commitCallback = commitCallback;
-            _cancelCallback = cancelCallback;
-        }
-
-        /// <summary>
-        /// Cancel the transaction 
-        /// </summary>
-        /// <returns></returns>
-        public async Task Cancel() => await _cancelCallback.Invoke();
-
-        /// <summary>
-        /// Commit this transaction as succesful
-        /// </summary>
-        /// <returns></returns>
-        public async Task Commit() => await _commitCallback.Invoke();
-
-        internal bool UpdateIndex(int index)
-        {
-            if (Index == index) { return false; }
-
-            Index = index;
-            return true;
-        }
-
-        internal bool UpdateZone(string idenfifer)
-        {
-            if (CurrentZone == idenfifer) { return false; }
-
-            CurrentZone = idenfifer;
-            Index = -1;
-            return true;
-        }
-    }
-
-    /// <summary>
-    /// Record encaplusalting data regaring a completed transaction
-    /// </summary>
-    /// <typeparam name="T">Type of dragged item</typeparam>
-    /// <param name="Item">The dragged item during the transaction</param>
-    /// <param name="DropzoneIdentifier">Identifier of the zone where the transaction started</param>
-    /// <param name="IndexInZone">The index of the item within in the dropzone</param>
-    public record MudItemDropInfo<T>(T Item, string DropzoneIdentifier, int IndexInZone);
-
-    public class MudDragAndDropTransactionFinishedEventArgs<T> : EventArgs
-    {
-        public MudDragAndDropTransactionFinishedEventArgs(MudDragAndDropItemTransaction<T> transaction) :
-            this(string.Empty, false, transaction)
-        {
-
-        }
-
-        public MudDragAndDropTransactionFinishedEventArgs(string destinationDropzoneIdentifier, bool success, MudDragAndDropItemTransaction<T> transaction)
-        {
-            Item = transaction.Item;
-            Success = success;
-            OriginatedDropzoneIdentifier = transaction.SourceZoneIdentifier;
-            DestinationDropzoneIdentifier = destinationDropzoneIdentifier;
-            OriginIndex = transaction.SourceIndex;
-            DestinationIndex = transaction.Index;
-        }
-
-        public T Item { get; }
-        public bool Success { get; }
-        public string OriginatedDropzoneIdentifier { get; }
-        public string DestinationDropzoneIdentifier { get; }
-        public int OriginIndex { get; }
-        public int DestinationIndex { get; }
-    }
-
-
+#nullable enable
     /// <summary>
     /// The container of a drag and drop zones
     /// </summary>
-    /// <typeparam name="T">Datetype of items</typeparam>
+    /// <typeparam name="T">Type of items</typeparam>
     public partial class MudDropContainer<T> : MudComponentBase
     {
-        private MudDragAndDropItemTransaction<T> _transaction;
-
-        internal Dictionary<string, MudDropZone<T>> MudDropZones { get; set; } = new Dictionary<string, MudDropZone<T>>();
+        private MudDragAndDropItemTransaction<T>? _transaction;
+        private Dictionary<string, MudDropZone<T>> _mudDropZones = new();
 
         protected string Classname =>
         new CssBuilder("mud-drop-container")
@@ -163,28 +31,28 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Appearance)]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// The items that can be drag and dropped within the container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Items)]
-        public IEnumerable<T> Items { get; set; }
+        public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
 
         /// <summary>
         /// The render fragment (template) that should be used to render the items within a drop zone
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Items)]
-        public RenderFragment<T> ItemRenderer { get; set; }
+        public RenderFragment<T>? ItemRenderer { get; set; }
 
         /// <summary>
         /// The method is used to determinate if an item can be dropped within a drop zone
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Items)]
-        public Func<T, string, bool> ItemsSelector { get; set; }
+        public Func<T, string, bool>? ItemsSelector { get; set; }
 
         /// <summary>
         /// Callback that indicates that an item has been dropped on a drop zone. Should be used to update the "status" of the data item
@@ -198,21 +66,21 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public Func<T, string, bool> CanDrop { get; set; }
+        public Func<T, string, bool>? CanDrop { get; set; }
 
         /// <summary>
         /// The CSS class(es), that is applied to drop zones that are a valid target for drag and drop transaction
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public string CanDropClass { get; set; }
+        public string? CanDropClass { get; set; }
 
         /// <summary>
         /// The CSS class(es), that is applied to drop zones that are NOT valid target for drag and drop transaction
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public string NoDropClass { get; set; }
+        public string? NoDropClass { get; set; }
 
         /// <summary>
         /// If true, drop classes CanDropClass <see cref="CanDropClass"/>  or NoDropClass <see cref="NoDropClass"/> or applied as soon, as a transaction has started
@@ -226,7 +94,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
-        public Func<T, bool> ItemIsDisabled { get; set; }
+        public Func<T, bool>? ItemIsDisabled { get; set; }
 
         /// <summary>
         /// If a drop item is disabled (determinate by <see cref="ItemIsDisabled"/>). This class is applied to the element
@@ -240,128 +108,173 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DraggingClass)]
-        public string DraggingClass { get; set; }
+        public string? DraggingClass { get; set; }
 
         /// <summary>
         /// An additional class that is applied to an drop item, when it is dragged
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DraggingClass)]
-        public string ItemDraggingClass { get; set; }
+        public string? ItemDraggingClass { get; set; }
 
-        public event EventHandler<MudDragAndDropItemTransaction<T>> TransactionStarted;
-        public event EventHandler<MudDragAndDropIndexChangedEventArgs> TransactionIndexChanged;
+        public event EventHandler<MudDragAndDropItemTransaction<T>>? TransactionStarted;
+        public event EventHandler<MudDragAndDropIndexChangedEventArgs>? TransactionIndexChanged;
 
-        public event EventHandler<MudDragAndDropTransactionFinishedEventArgs<T>> TransactionEnded;
-        public event EventHandler RefreshRequested;
+        public event EventHandler<MudDragAndDropTransactionFinishedEventArgs<T>>? TransactionEnded;
+        public event EventHandler? RefreshRequested;
 
-        public void StartTransaction(T item, string identifier, int index, Func<Task> commitCallback, Func<Task> cancelCallback)
+        public void StartTransaction(T? item, string identifier, int index, Func<Task> commitCallback, Func<Task> cancelCallback)
         {
-            _transaction = new MudDragAndDropItemTransaction<T>(item, identifier, index, commitCallback, cancelCallback);
-            TransactionStarted?.Invoke(this, _transaction);
+            var createTransaction = new MudDragAndDropItemTransaction<T>(item, identifier, index, commitCallback, cancelCallback);
+            _transaction = createTransaction;
+            TransactionStarted?.Invoke(this, createTransaction);
         }
 
-        public T GetTransactionItem() => _transaction.Item;
+        public T? GetTransactionItem()
+        {
+            if (_transaction is null)
+            {
+                return default;
+            }
 
-        public bool TransactionInProgress() => _transaction != null;
+            var capturedTransaction = _transaction;
+            return capturedTransaction.Item;
+
+        }
+
+        public bool TransactionInProgress() => _transaction is not null;
+
         public string GetTransactionOrignZoneIdentiifer() => _transaction?.SourceZoneIdentifier ?? string.Empty;
+
         public string GetTransactionCurrentZoneIdentiifer() => _transaction?.CurrentZone ?? string.Empty;
-        public bool IsTransactionOriginatedFromInside(string identifier) => _transaction.SourceZoneIdentifier == identifier;
+
+        public bool IsTransactionOriginatedFromInside(string identifier) => _transaction?.SourceZoneIdentifier == identifier;
 
         public int GetTransactionIndex() => _transaction?.Index ?? -1;
-        public bool IsItemMovedDownwards() => _transaction.Index > _transaction.SourceIndex;
+
+        public bool IsItemMovedDownwards() => _transaction?.Index > _transaction?.SourceIndex;
+
         public bool HasTransactionIndexChanged()
         {
-            if (_transaction == null)
+            if (_transaction is null)
             {
                 return false;
             }
 
-            if (_transaction.CurrentZone != _transaction.SourceZoneIdentifier)
+            var capturedTransaction = _transaction;
+            if (capturedTransaction.CurrentZone != capturedTransaction.SourceZoneIdentifier)
             {
                 return true;
             }
 
-            return _transaction.Index != _transaction.SourceIndex;
+            return capturedTransaction.Index != capturedTransaction.SourceIndex;
         }
 
         public bool IsOrign(int index, string identifier)
         {
-            if (_transaction == null)
+            if (_transaction is null)
             {
                 return false;
             }
 
-            if (identifier != _transaction.SourceZoneIdentifier)
+            var capturedTransaction = _transaction;
+            if (identifier != capturedTransaction.SourceZoneIdentifier)
             {
                 return false;
             }
 
-            return _transaction.SourceIndex == index || _transaction.SourceIndex - 1 == index;
+            return capturedTransaction.SourceIndex == index || capturedTransaction.SourceIndex - 1 == index;
         }
 
-        public async Task CommitTransaction(string dropzoneIdentifier, bool reorderIsAllowed)
+        public async Task CommitTransaction(string dropZoneIdentifier, bool reorderIsAllowed)
         {
-            await _transaction.Commit();
+            if (_transaction is null)
+            {
+                return;
+            }
+
+            //We need to capture this variable because there is race condition when the value can turn null in the middle of transaction
+            //There are multiple methods that can manipulate _transaction variable at same time
+            //https://github.com/MudBlazor/MudBlazor/issues/6551
+            var capturedTransaction = _transaction;
+            await capturedTransaction.Commit();
             var index = -1;
-            if (reorderIsAllowed == true)
+            if (reorderIsAllowed)
             {
                 index = GetTransactionIndex() + 1;
-                if (_transaction.SourceZoneIdentifier == _transaction.CurrentZone && IsItemMovedDownwards() == true)
+                if (capturedTransaction.SourceZoneIdentifier == capturedTransaction.CurrentZone && IsItemMovedDownwards())
                 {
                     index -= 1;
                 }
             }
 
-            await ItemDropped.InvokeAsync(new MudItemDropInfo<T>(_transaction.Item, dropzoneIdentifier, index));
-            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(dropzoneIdentifier, true, _transaction);
+            await ItemDropped.InvokeAsync(new MudItemDropInfo<T>(capturedTransaction.Item, dropZoneIdentifier, index));
+            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(dropZoneIdentifier, true, capturedTransaction);
             _transaction = null;
             TransactionEnded?.Invoke(this, transactionFinishedEventArgs);
         }
 
         public async Task CancelTransaction()
         {
-            await _transaction.Cancel();
-            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(_transaction);
+            if (_transaction is null)
+            {
+                return;
+            }
+
+            var capturedTransaction = _transaction;
+            await capturedTransaction.Cancel();
+            var transactionFinishedEventArgs = new MudDragAndDropTransactionFinishedEventArgs<T>(capturedTransaction);
             _transaction = null;
             TransactionEnded?.Invoke(this, transactionFinishedEventArgs);
         }
 
         public void UpdateTransactionIndex(int index)
         {
-            var changed = _transaction.UpdateIndex(index);
-            if (changed == false) { return; }
+            if (_transaction is null)
+            {
+                return;
+            }
 
-            TransactionIndexChanged?.Invoke(this, new MudDragAndDropIndexChangedEventArgs(_transaction.CurrentZone, _transaction.CurrentZone, _transaction.Index));
+            var capturedTransaction = _transaction;
+            var changed = _transaction.UpdateIndex(index);
+            if (changed)
+            {
+                TransactionIndexChanged?.Invoke(this, new MudDragAndDropIndexChangedEventArgs(capturedTransaction.CurrentZone, capturedTransaction.CurrentZone, capturedTransaction.Index));
+            }
         }
 
         internal void UpdateTransactionZone(string identifier)
         {
-            var oldValue = _transaction.CurrentZone;
-            var changed = _transaction.UpdateZone(identifier);
-            if (changed == false) { return; }
+            if (_transaction is null)
+            {
+                return;
+            }
 
-            TransactionIndexChanged?.Invoke(this, new MudDragAndDropIndexChangedEventArgs(_transaction.CurrentZone, oldValue, _transaction.Index));
+            var capturedTransaction = _transaction;
+            var oldValue = capturedTransaction.CurrentZone;
+            var changed = capturedTransaction.UpdateZone(identifier);
+            if (changed)
+            {
+                TransactionIndexChanged?.Invoke(this, new MudDragAndDropIndexChangedEventArgs(capturedTransaction.CurrentZone, oldValue, capturedTransaction.Index));
+            }
         }
 
         internal bool RegisterDropZone(MudDropZone<T> dropZone)
         {
-            return MudDropZones.TryAdd(dropZone.Identifier, dropZone);
+            return _mudDropZones.TryAdd(dropZone.Identifier, dropZone);
         }
         internal void RemoveDropZone(string identifier)
         {
-            MudDropZones.Remove(identifier);
+            _mudDropZones.Remove(identifier);
         }
-        internal MudDropZone<T> GetDropZone(string identifier)
+        internal MudDropZone<T>? GetDropZone(string identifier)
         {
-            return MudDropZones.TryGetValue(identifier, out var dropZone) ? dropZone : null;
+            return _mudDropZones.TryGetValue(identifier, out var dropZone) ? dropZone : null;
         }
 
         /// <summary>
-        /// Refreshes the dropzone and all items within. This is neded in case of adding items to the collection or changed values of items
+        /// Refreshes the drop zone and all items within. This is needed in case of adding items to the collection or changed values of items
         /// </summary>
         public void Refresh() => RefreshRequested?.Invoke(this, EventArgs.Empty);
-
-
     }
 }

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -13,15 +13,15 @@
 
     @ChildContent
 
-    @if (OnlyZone != true)
+    @if (!OnlyZone)
     {
         int index = 0;
         var transactionIndex = Container?.GetTransactionIndex() ?? -1;
         var items = GetItems();
 
-        @if (AllowReorder == true)
+        @if (AllowReorder)
         {
-            @if (items.Any() == false)
+            @if (!items.Any())
             {
                 <div class="@PlaceholderClassname"></div>
             }
@@ -54,12 +54,15 @@
                     var renderer = GetItemTemplate();
                 }
 
-                @renderer(item)
+                @if (renderer is not null)
+                {
+                    @renderer(item)
+                }
 
             </MudDynamicDropItem>
 
 
-            if (transactionIndex == indexCopy && IsOrign(indexCopy) == false)
+            if (transactionIndex == indexCopy && !IsOrigin(indexCopy))
             {
                 <div class="@PlaceholderClassname"></div>
             }

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -13,6 +12,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+#nullable enable
     public partial class MudDropZone<T> : MudComponentBase, IDisposable
     {
         private bool _containerIsInitialized = false;
@@ -21,61 +21,61 @@ namespace MudBlazor
         private bool _disposedValue = false;
         private Guid _id = Guid.NewGuid();
 
-        private Dictionary<T, int> _indicies = new();
+        private Dictionary<T, int> _indices = new();
 
-        [Inject] private IJSRuntime JsRuntime { get; set; }
+        [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
 
         [CascadingParameter]
-        protected MudDropContainer<T> Container { get; set; }
+        protected MudDropContainer<T>? Container { get; set; }
 
         /// <summary>
         /// Child content of component
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Appearance)]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// The unique identifier of this drop zone. It is used within transaction to 
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Appearance)]
-        public string Identifier { get; set; }
+        public string Identifier { get; set; } = string.Empty;
 
         /// <summary>
         /// The render fragment (template) that should be used to render the items within a drop zone. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Items)]
-        public RenderFragment<T> ItemRenderer { get; set; }
+        public RenderFragment<T>? ItemRenderer { get; set; }
 
         /// <summary>
         /// The method is used to determinate if an item can be dropped within a drop zone. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Items)]
-        public Func<T, bool> ItemsSelector { get; set; }
+        public Func<T, bool>? ItemsSelector { get; set; }
 
         /// <summary>
         /// The method is used to determinate if an item can be dropped within a drop zone. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public Func<T, bool> CanDrop { get; set; }
+        public Func<T, bool>? CanDrop { get; set; }
 
         /// <summary>
         /// The CSS class(es), that is applied to drop zones that are a valid target for drag and drop transaction. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public string CanDropClass { get; set; }
+        public string? CanDropClass { get; set; }
 
         /// <summary>
         /// The CSS class(es), that is applied to drop zones that are NOT valid target for drag and drop transaction. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DropRules)]
-        public string NoDropClass { get; set; }
+        public string? NoDropClass { get; set; }
 
         /// <summary>
         /// If true, drop classes CanDropClass <see cref="CanDropClass"/>  or NoDropClass <see cref="NoDropClass"/> or applied as soon, as a transaction has started. Overrides value provided by drop container
@@ -89,35 +89,35 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
-        public Func<T, bool> ItemIsDisabled { get; set; }
+        public Func<T, bool>? ItemIsDisabled { get; set; }
 
         /// <summary>
         /// If a drop item is disabled (determinate by <see cref="ItemIsDisabled"/>). This class is applied to the element. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
-        public string DisabledClass { get; set; }
+        public string? DisabledClass { get; set; }
 
         /// <summary>
         /// An additional class that is applied to the drop zone where a drag operation started
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DraggingClass)]
-        public string DraggingClass { get; set; }
+        public string? DraggingClass { get; set; }
 
         /// <summary>
         /// An additional class that is applied to an drop item, when it is dragged
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.DraggingClass)]
-        public string ItemDraggingClass { get; set; }
+        public string? ItemDraggingClass { get; set; }
 
         [Parameter]
         [Category(CategoryTypes.DropZone.Behavior)]
         public bool AllowReorder { get; set; }
 
         /// <summary>
-        /// If true, will only act as a dropable zone and not render any items.
+        /// If true, will only act as a droppable zone and not render any items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Behavior)]
@@ -127,30 +127,27 @@ namespace MudBlazor
 
         private int GetItemIndex(T item)
         {
-            if (_indicies.ContainsKey(item) == false)
+            if (!_indices.ContainsKey(item))
             {
-                _indicies.Add(item, _indicies.Count);
+                _indices.Add(item, _indices.Count);
             }
 
-            return _indicies[item];
+            return _indices[item];
         }
 
-        private IEnumerable<T> GetItems()
+        private T[] GetItems()
         {
-            Func<T, bool> predicate = (item) => Container.ItemsSelector(item, Identifier ?? string.Empty);
-            if (ItemsSelector != null)
-            {
-                predicate = ItemsSelector;
-            }
+            var predicate = ItemsSelector ?? (item => Container is not null && Container.ItemsSelector is not null && Container.ItemsSelector(item, Identifier));
 
-            return (Container?.Items ?? Array.Empty<T>()).Where(predicate).OrderBy(x => GetItemIndex(x)).ToArray();
+            var items = Container?.Items.Where(predicate).OrderBy(GetItemIndex).ToArray() ?? Array.Empty<T>();
+            return items;
         }
 
-        private RenderFragment<T> GetItemTemplate() => ItemRenderer ?? Container?.ItemRenderer;
+        private RenderFragment<T>? GetItemTemplate() => ItemRenderer ?? Container?.ItemRenderer;
 
-        private string GetDragginClass()
+        private string GetDraggingClass()
         {
-            if (string.IsNullOrEmpty(DraggingClass) == true)
+            if (string.IsNullOrEmpty(DraggingClass))
             {
                 return Container?.DraggingClass ?? string.Empty;
             }
@@ -160,7 +157,7 @@ namespace MudBlazor
 
         private string GetItemDraggingClass()
         {
-            if (string.IsNullOrEmpty(ItemDraggingClass) == false)
+            if (!string.IsNullOrEmpty(ItemDraggingClass))
             {
                 return ItemDraggingClass;
             }
@@ -174,7 +171,7 @@ namespace MudBlazor
         {
             var result = false;
             var predicate = ItemIsDisabled ?? Container?.ItemIsDisabled;
-            if (predicate != null)
+            if (predicate is not null)
             {
                 result = predicate(item);
             }
@@ -185,24 +182,24 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-drop-zone")
                 //.AddClass("mud-drop-zone-drag-block", Container?.TransactionInProgress() == true && Container.GetTransactionOrignZoneIdentiifer() != Identifier)
-                .AddClass(CanDropClass ?? Container?.CanDropClass, Container?.TransactionInProgress() == true && Container.GetTransactionOrignZoneIdentiifer() != Identifier && _canDrop == true && (_dragCounter > 0 || GetApplyDropClassesOnDragStarted() == true))
-                .AddClass(NoDropClass ?? Container?.NoDropClass, Container?.TransactionInProgress() == true && Container.GetTransactionOrignZoneIdentiifer() != Identifier && _canDrop == false && (_dragCounter > 0 || GetApplyDropClassesOnDragStarted() == true))
-                .AddClass(GetDragginClass(), _dragInProgress == true)
+                .AddClass(CanDropClass ?? Container?.CanDropClass, Container is not null && Container.TransactionInProgress() && Container.GetTransactionOrignZoneIdentiifer() != Identifier && _canDrop && (_dragCounter > 0 || GetApplyDropClassesOnDragStarted()))
+                .AddClass(NoDropClass ?? Container?.NoDropClass, Container is not null && Container.TransactionInProgress() && Container.GetTransactionOrignZoneIdentiifer() != Identifier && !_canDrop && (_dragCounter > 0 || GetApplyDropClassesOnDragStarted()))
+                .AddClass(GetDraggingClass(), _dragInProgress)
                 .AddClass(Class)
                 .Build();
 
         protected string PlaceholderClassname =>
             new CssBuilder("border-2 mud-border-primary border-dashed mud-chip-text mud-chip-color-primary pa-4 mud-dropitem-placeholder")
-                .AddClass("d-none", AllowReorder == false || (Container?.TransactionInProgress() == false || Container.GetTransactionCurrentZoneIdentiifer() != Identifier))
+                .AddClass("d-none", !AllowReorder || (Container?.TransactionInProgress() == false || Container?.GetTransactionCurrentZoneIdentiifer() != Identifier))
                 .Build();
 
         #endregion
 
         #region helper
 
-        private (T, bool) ItemCanBeDropped()
+        private (T?, bool) ItemCanBeDropped()
         {
-            if (Container == null || Container.TransactionInProgress() == false)
+            if (Container is null || !Container.TransactionInProgress())
             {
                 return (default(T), false);
             }
@@ -210,57 +207,66 @@ namespace MudBlazor
             var item = Container.GetTransactionItem();
 
             var result = true;
-            if (CanDrop != null)
+            if (CanDrop is not null)
             {
-                result = CanDrop(item);
+                if (item is not null)
+                {
+                    result = CanDrop(item);
+                }
             }
             else if (Container.CanDrop != null)
             {
-                result = Container.CanDrop(item, Identifier);
+                if (item is not null)
+                {
+                    result = Container.CanDrop(item, Identifier);
+                }
             }
 
             return (item, result);
         }
 
-        private bool IsOrign(int index) => Container.IsOrign(index, Identifier);
+        private bool IsOrigin(int index) => Container is not null && Container.IsOrign(index, Identifier);
 
         #endregion
 
         #region container event handling
 
-        private void Container_TransactionEnded(object sender, MudDragAndDropTransactionFinishedEventArgs<T> e)
+        private void Container_TransactionEnded(object? sender, MudDragAndDropTransactionFinishedEventArgs<T> e)
         {
             _dragCounter = 0;
 
-            if (GetApplyDropClassesOnDragStarted() == true)
+            if (GetApplyDropClassesOnDragStarted())
             {
                 _canDrop = false;
             }
 
-            if (e.Success == true)
+            if (e.Success)
             {
-                if (e.OriginatedDropzoneIdentifier == Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
+                if (e.OriginatedDropzoneIdentifier== Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
                 {
-                    _indicies.Remove(e.Item);
+                    if (e.Item is not null)
+                    {
+                        _indices.Remove(e.Item);
+                    }
                 }
 
                 if (e.OriginatedDropzoneIdentifier == Identifier || e.DestinationDropzoneIdentifier == Identifier)
                 {
-                    int index = 0;
+                    var index = 0;
 
-                    foreach (var item in _indicies.OrderBy(x => x.Value).ToArray())
+                    foreach (var item in _indices.OrderBy(x => x.Value).ToArray())
                     {
-                        _indicies[item.Key] = index++;
+                        _indices[item.Key] = index++;
                     }
                 }
             }
-            
+
             StateHasChanged();
         }
 
-        private void Container_TransactionStarted(object sender, MudDragAndDropItemTransaction<T> e)
+        private void Container_TransactionStarted(object? sender, MudDragAndDropItemTransaction<T> e)
         {
-            if (GetApplyDropClassesOnDragStarted() == true)
+            if (GetApplyDropClassesOnDragStarted())
             {
                 var dropResult = ItemCanBeDropped();
                 _canDrop = dropResult.Item2;
@@ -269,9 +275,9 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        private void Container_RefreshRequested(object sender, EventArgs e)
+        private void Container_RefreshRequested(object? sender, EventArgs e)
         {
-            _indicies.Clear();
+            _indices.Clear();
             InvokeAsync(StateHasChanged);
         }
 
@@ -286,89 +292,93 @@ namespace MudBlazor
             _dragCounter++;
 
             var (context, isValidZone) = ItemCanBeDropped();
-            if (context == null)
+            if (context is null)
             {
                 return;
             }
 
             _canDrop = isValidZone;
 
-            Container.UpdateTransactionZone(Identifier);
+            Container?.UpdateTransactionZone(Identifier);
         }
 
         private void HandleDragLeave()
         {
             _dragCounter--;
 
-            var (context, _) = ItemCanBeDropped();
-            if (context == null)
-            {
-                return;
-            }
+            _ = ItemCanBeDropped();
         }
 
         internal async Task HandleDrop()
         {
             var (context, isValidZone) = ItemCanBeDropped();
-            if (context == null)
+            if (context is null)
             {
                 return;
             }
 
             _dragCounter = 0;
 
-            if (isValidZone == false)
+            if (!isValidZone)
             {
-                await Container.CancelTransaction();
+                if (Container is not null)
+                {
+                    await Container.CancelTransaction();
+                }
+
                 return;
             }
 
-            if (AllowReorder == true)
+            if (AllowReorder)
             {
-                if (Container.HasTransactionIndexChanged() == true)
+                if (Container is not null && Container.HasTransactionIndexChanged())
                 {
                     var newIndex = Container.GetTransactionIndex() + 1;
 
-                    if (Container.IsTransactionOriginatedFromInside(this.Identifier) == true)
+                    if (Container.IsTransactionOriginatedFromInside(Identifier))
                     {
-                        var oldIndex = _indicies[context];
-
-                        if (Container.IsItemMovedDownwards() == true)
+                        if (_indices.TryGetValue(context, out var oldIndex))
                         {
-                            newIndex -= 1;
-
-                            foreach (var item in _indicies.Where(x => x.Value >= oldIndex + 1 && x.Value <= newIndex).ToArray())
+                            if (Container.IsItemMovedDownwards())
                             {
-                                _indicies[item.Key] -= 1;
-                            }
-                        }
-                        else
-                        {
-                            foreach (var item in _indicies.Where(x => x.Value >= newIndex && x.Value < oldIndex).ToArray())
-                            {
-                                _indicies[item.Key] += 1;
-                            }
-                        }
+                                newIndex -= 1;
 
-                        _indicies[context] = newIndex;
+                                foreach (var item in _indices.Where(x => x.Value >= oldIndex + 1 && x.Value <= newIndex).ToArray())
+                                {
+                                    _indices[item.Key] -= 1;
+                                }
+                            }
+                            else
+                            {
+                                foreach (var item in _indices.Where(x => x.Value >= newIndex && x.Value < oldIndex).ToArray())
+                                {
+                                    _indices[item.Key] += 1;
+                                }
+                            }
+
+                            _indices[context] = newIndex;
+                        }
                     }
                     else
                     {
-                        foreach (var item in _indicies.Where(x => x.Value >= newIndex).ToArray())
+                        foreach (var item in _indices.Where(x => x.Value >= newIndex).ToArray())
                         {
-                            _indicies[item.Key] = item.Value + 1;
+                            _indices[item.Key] = item.Value + 1;
                         }
 
-                        _indicies.Add(context, newIndex);
+                        _indices.TryAdd(context, newIndex);
                     }
                 }
             }
             else
             {
-                _indicies.Clear();
+                _indices.Clear();
             }
 
-            await Container.CommitTransaction(Identifier, AllowReorder);
+            if (Container is not null)
+            {
+                await Container.CommitTransaction(Identifier, AllowReorder);
+            }
         }
 
         private void FinishedDragOperation() => _dragInProgress = false;
@@ -380,7 +390,7 @@ namespace MudBlazor
 
         protected override void OnParametersSet()
         {
-            if (Container != null && _containerIsInitialized == false)
+            if (Container is not null && !_containerIsInitialized)
             {
                 _containerIsInitialized = true;
                 Container.TransactionStarted += Container_TransactionStarted;
@@ -393,7 +403,7 @@ namespace MudBlazor
             base.OnParametersSet();
         }
 
-        private void Container_TransactionIndexChanged(object sender, MudDragAndDropIndexChangedEventArgs e)
+        private void Container_TransactionIndexChanged(object? sender, MudDragAndDropIndexChangedEventArgs e)
         {
             if (e.ZoneIdentifier != Identifier && e.OldZoneIdentifier != Identifier) { return; }
 
@@ -402,7 +412,7 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender == true)
+            if (firstRender)
             {
                 await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudDragAndDrop.initDropZone", _id.ToString());
             }
@@ -416,7 +426,7 @@ namespace MudBlazor
             {
                 if (disposing)
                 {
-                    if (Container != null)
+                    if (Container is not null)
                     {
                         Container.TransactionStarted -= Container_TransactionStarted;
                         Container.TransactionEnded -= Container_TransactionEnded;

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
@@ -6,7 +6,7 @@
      id="@($"mud-drop-item-{_id}")"
      index="@Index"
      @attributes="UserAttributes"
-     draggable="@(Disabled == false ? "true" : "false")"
+     draggable="@(!Disabled ? "true" : "false")"
      @ondragstart="DragStarted"
      @ontouchstart="TouchStarted"
      @ontouchend="TouchEnded"
@@ -15,7 +15,7 @@
      @ondragenter="HandleDragEnter"
      @ondragleave="HandleDragLeave">
 
-    @if (HideContent == false)
+    @if (!HideContent)
     {
         @ChildContent
     }

--- a/src/MudBlazor/Components/DropZone/MudItemDropInfo.cs
+++ b/src/MudBlazor/Components/DropZone/MudItemDropInfo.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor;
+
+#nullable enable
+/// <summary>
+/// Record encapsulating data regarding a completed transaction
+/// </summary>
+/// <typeparam name="T">Type of dragged item</typeparam>
+/// <param name="Item">The dragged item during the transaction</param>
+/// <param name="DropZoneIdentifier">Identifier of the zone where the transaction started</param>
+/// <param name="IndexInZone">The index of the item within in the drop zone</param>
+public record MudItemDropInfo<T>(T? Item, string DropzoneIdentifier, int IndexInZone)
+{
+}


### PR DESCRIPTION
## Description
Fixes https://github.com/MudBlazor/MudBlazor/issues/6551 and fixes #4695, and fixes #4489
Also contributes to this https://github.com/MudBlazor/MudBlazor/issues/6535

## Important notes about PR
1.I have moved:

- MudDragAndDropIndexChangedEventArgs
- MudDragAndDropItemTransaction
- MudDragAndDropTransactionFinishedEventArgs
- MudItemDropInfo

To their own files, reasoning: the `MudDropContainer.razor.cs` was somehow way too big, it was hard to navigate and go through the code. I think it's justified considering that there are no open pull requests on this component(there is one, but it already has conflicts and needs rework).

2.There were some typo fixes, but only the comments and methods that are private. The public one will be a separate PR.

3.`private IEnumerable<T> GetItems()` was changed to `T[] GetItems()`.
It was already calling `.ToArray()` but then for some reason it was casted back to IEnumerable. The problem with this is that in places that called this method it was doing multiple enumeration which is a bad practice, it's better to keep it array since it was already converted to array by the original author of the code.

4.Coverage might drop, since there is constant check if _transaction and container is null. But those are important, especially considering that multiple methods can manipulate the _transcation value at the same time, which is why there was a problem.

## How Has This Been Tested?
Current unit tests and manual testing on the docs, tested the on this scenario too https://try.mudblazor.com/snippet/mkGHOxGtQttdZNao.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
