### PR TITLE
MudComponentBase: Add explicit IMudStateHasChanged.StateHasChanged

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
 using Microsoft.AspNetCore.Components.Routing;
+using MudBlazor.Interfaces;
 
 namespace MudBlazor.Docs.Components
 {
@@ -138,7 +139,7 @@ namespace MudBlazor.Docs.Components
                     }
                 }
 
-                _contentNavigation.Update();
+                ((IMudStateHasChanged)_contentNavigation).StateHasChanged();
                 
                 if (_anchor != null)
                 {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogThatUpdatesItsTitle.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogThatUpdatesItsTitle.razor
@@ -1,4 +1,5 @@
-﻿<MudDialog>
+﻿@using MudBlazor.Interfaces
+<MudDialog>
     <TitleContent>
      Title: @textTest
     </TitleContent>
@@ -17,7 +18,7 @@
     string textTest;
     void Submit(){
         textTest = "Test123";
-        MudDialog.ForceRender();
+        ((IMudStateHasChanged)MudDialog).StateHasChanged();
     }
     void Cancel(){
         

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithOnBackdropClickEvent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithOnBackdropClickEvent.razor
@@ -1,4 +1,5 @@
-﻿<MudDialog OnBackdropClick="@OnBackdropClick">
+﻿@using MudBlazor.Interfaces
+<MudDialog OnBackdropClick="@OnBackdropClick">
     <TitleContent>
         Title: @textTest
     </TitleContent>
@@ -15,6 +16,6 @@
     void OnBackdropClick()
     {
         textTest = "Backdrop clicked";
-        MudDialog.ForceRender();
+        ((IMudStateHasChanged)MudDialog).StateHasChanged();
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
@@ -1,4 +1,5 @@
-﻿@namespace MudBlazor.UnitTests.TestComponents
+﻿@using MudBlazor.Interfaces
+@namespace MudBlazor.UnitTests.TestComponents
 
 <MudDialog>
     <DialogContent>
@@ -24,7 +25,7 @@
 
     private void OnTest()
     {
-        MudDialog.ForceRender();
+        ((IMudStateHasChanged)MudDialog).StateHasChanged();
         StateHasChanged();
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -63,7 +64,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<ChipLinkTest>();
             var chip = comp.FindComponent<MudChip>();
 
-            await comp.InvokeAsync(() => chip.Instance.ForceRerender());
+            await comp.InvokeAsync(() => ((IMudStateHasChanged)chip.Instance).StateHasChanged());
             await comp.InvokeAsync(() => chip.Instance.OnClickHandler(new MouseEventArgs()));
 
             comp.WaitForAssertion(() => comp.Find("#chip-click-test-expected-value").InnerHtml.Should().Be(""));

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -11,6 +11,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -2798,7 +2799,7 @@ namespace MudBlazor.UnitTests.Components
                 clickablePopover.Click();
 
                 //dataGrid.Instance._columns[0].Hide();
-                dataGrid.Instance.ExternalStateHasChanged();
+                ((IMudStateHasChanged)dataGrid.Instance).StateHasChanged();
             });
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(1);
             await comp.InvokeAsync(() =>
@@ -2823,7 +2824,7 @@ namespace MudBlazor.UnitTests.Components
                 dataGrid.FindAll(".mud-table-head th").Count.Should().Be(2);
 
                 //dataGrid.Instance._columns[0].Hide();
-                dataGrid.Instance.ExternalStateHasChanged();
+                ((IMudStateHasChanged)dataGrid.Instance).StateHasChanged();
             });
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(2);
 

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 
@@ -52,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Instance.AddSection(section1, false);
                 comp.Instance.AddSection(section2, false);
-                await comp.InvokeAsync(() => comp.Instance.Update());
+                await comp.InvokeAsync(() => ((IMudStateHasChanged)comp.Instance).StateHasChanged());
             }
 
             comp.RenderCount.Should().Be(withUpdate == true ? 3 : 2);
@@ -92,7 +93,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.AddSection(section1, false);
             comp.Instance.AddSection(section2, false);
 
-            await comp.InvokeAsync(() => comp.Instance.Update());
+            await comp.InvokeAsync(() => ((IMudStateHasChanged)comp.Instance).StateHasChanged());
 
             comp.RenderCount.Should().Be(2);
 
@@ -162,7 +163,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.AddSection(section2, false);
             comp.Instance.AddSection(section3, false);
 
-            comp.InvokeAsync(() => comp.Instance.Update());
+            comp.InvokeAsync(() => ((IMudStateHasChanged)comp.Instance).StateHasChanged());
 
             for (var i = 0; i < 3; i++)
             {
@@ -204,7 +205,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.AddSection(section2, false);
             comp.Instance.AddSection(section3, false);
 
-            await comp.InvokeAsync(() => comp.Instance.Update());
+            await comp.InvokeAsync(() => ((IMudStateHasChanged)comp.Instance).StateHasChanged());
 
             //active second section
             await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent(section2.Id));

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor.Interfaces;
 
 namespace MudBlazor
 {
-    public abstract class MudComponentBase : ComponentBase
+    public abstract class MudComponentBase : ComponentBase, IMudStateHasChanged
     {
         [Inject]
         private ILoggerFactory LoggerFactory { get; set; }
@@ -45,5 +46,8 @@ namespace MudBlazor
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>
         public string FieldId => (UserAttributes?.ContainsKey("id") == true ? UserAttributes["id"].ToString() : $"mudinput-{Guid.NewGuid()}");
+
+        /// <inheritdoc />
+        void IMudStateHasChanged.StateHasChanged() => StateHasChanged();
     }
 }

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -100,10 +100,5 @@ namespace MudBlazor
         {
             AvatarGroup?.RemoveAvatar(this);
         }
-
-        internal void ForceRedraw()
-        {
-            StateHasChanged();
-        }
     }
 }

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -165,9 +166,9 @@ namespace MudBlazor
 
             if (_childrenNeedUpdates == true)
             {
-                foreach (var avatar in _avatars)
+                foreach (IMudStateHasChanged avatar in _avatars)
                 {
-                    avatar.ForceRedraw();
+                    avatar.StateHasChanged();
                 }
 
                 _childrenNeedUpdates = false;

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -320,8 +320,6 @@ namespace MudBlazor
             return base.OnInitializedAsync();
         }
 
-        internal void ForceRerender() => StateHasChanged();
-
         //Exclude because we don't test to catching exception yet
         [ExcludeFromCodeCoverage]
         public void Dispose()

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -57,8 +58,8 @@ namespace MudBlazor
                     return;
                 _filter = value;
                 StateHasChanged();
-                foreach (var chip in _chips)
-                    chip.ForceRerender();
+                foreach (IMudStateHasChanged chip in _chips)
+                    chip.StateHasChanged();
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -376,7 +377,7 @@ namespace MudBlazor
         {
             Hidden = !Hidden;
             await HiddenChanged.InvokeAsync(Hidden);
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
         }
 
 

--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
 
 namespace MudBlazor
 {
@@ -63,7 +64,7 @@ namespace MudBlazor
             _mouseUpSubscriptionId = await _eventListener.SubscribeGlobal<MouseEventArgs>(EventMouseUp, 0, OnApplicationMouseUp);
 
             _dataGrid.IsResizing = true;
-            _dataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)_dataGrid).StateHasChanged();
             return true;
         }
 
@@ -77,7 +78,7 @@ namespace MudBlazor
             var requiresUpdate = _mouseMoveSubscriptionId != default || _mouseUpSubscriptionId != default;
 
             _dataGrid.IsResizing = false;
-            _dataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)_dataGrid).StateHasChanged();
             await UnsubscribeApplicationEvents();
 
             if (requiresUpdate)

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -189,7 +190,7 @@ namespace MudBlazor
                 DataGrid.FilterDefinitions.Add(filterDefinition);
 
             DataGrid.GroupItems();
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
         }
 
         private void ClearFilter()

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -344,21 +345,21 @@ namespace MudBlazor
         internal void ApplyFilter()
         {
             DataGrid.FilterDefinitions.Add(Column.FilterContext.FilterDefinition);
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
             _filtersMenuVisible = false;
         }
 
         internal void ApplyFilter(FilterDefinition<T> filterDefinition)
         {
             DataGrid.FilterDefinitions.Add(filterDefinition);
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
             _filtersMenuVisible = false;
         }
 
         internal void ApplyFilters(IEnumerable<FilterDefinition<T>> filterDefinitions)
         {
             DataGrid.FilterDefinitions.AddRange(filterDefinitions);
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
             _filtersMenuVisible = false;
         }
 
@@ -378,7 +379,7 @@ namespace MudBlazor
         internal void ClearFilters(IEnumerable<FilterDefinition<T>> filterDefinitions)
         {
             DataGrid.FilterDefinitions.RemoveAll(x => filterDefinitions.Any(y => y.Id == x.Id));
-            DataGrid.ExternalStateHasChanged();
+            ((IMudStateHasChanged)DataGrid).StateHasChanged();
             _filtersMenuVisible = false;
         }
 
@@ -392,7 +393,7 @@ namespace MudBlazor
             if (Column != null)
             {
                 await Column.HideAsync();
-                DataGrid.ExternalStateHasChanged();
+                ((IMudStateHasChanged)DataGrid).StateHasChanged();
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1221,11 +1221,6 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        internal void ExternalStateHasChanged()
-        {
-            StateHasChanged();
-        }
-
         public void GroupItems(bool noStateChange = false)
         {          
             if (GroupedColumn == null)

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -171,20 +172,12 @@ namespace MudBlazor
                 else if (_reference != null)
                 {
                     if (IsVisible)
-                        (_reference.Dialog as MudDialog)?.ForceUpdate(); // forward render update to instance
+                        (_reference.Dialog as IMudStateHasChanged)?.StateHasChanged(); // forward render update to instance
                     else
                         Close(); // if we still have reference but it's not visible call Close
                 }
             }
             base.OnAfterRender(firstRender);
-        }
-
-        /// <summary>
-        /// Used for forwarding state changes from inlined dialog to its instance
-        /// </summary>
-        internal void ForceUpdate()
-        {
-            StateHasChanged();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -317,11 +317,6 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void ForceRender()
-        {
-            StateHasChanged();
-        }
-
         /// <summary>
         /// Cancels all dialogs in dialog provider collection.
         /// </summary>

--- a/src/MudBlazor/Components/Popover/MudPopoverService.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverService.cs
@@ -76,7 +76,7 @@ namespace MudBlazor
             Fragment = fragment;
             SetComponentBaseParameters(componentBase, @class, @style, showContent);
             // this basically calls StateHasChanged on the Popover
-            ElementReference?.ForceRender();
+            ElementReference?.StateHasChanged();
             _updater?.Invoke(); // <-- this doesn't do anything anymore except making unit tests happy 
         }
 

--- a/src/MudBlazor/Components/Render/MudRender.razor
+++ b/src/MudBlazor/Components/Render/MudRender.razor
@@ -1,4 +1,6 @@
-﻿@namespace MudBlazor
+﻿@using MudBlazor.Interfaces;
+@namespace MudBlazor
+@implements IMudStateHasChanged
 
 @* MudRender is a container component that only renders its content, so it really doesn't do anything other than giving you the ability to force a re-render of its content
     This is especially useful if you don't want to render the whole tree for some reason. All you need to force a renderupdate of its content is to call ForceRender() on an 
@@ -18,8 +20,15 @@
     /// <summary>
     /// Re-render the content
     /// </summary>
+    [Obsolete($"Use {nameof(StateHasChanged)} instead. This method will be removed in v7.")]
     public void ForceRender()
     {
         StateHasChanged();
+    }
+
+    /// <inheritdoc />
+    public new void StateHasChanged()
+    {
+        base.StateHasChanged();
     }
 }

--- a/src/MudBlazor/Interfaces/IMudStateHasChanged.cs
+++ b/src/MudBlazor/Interfaces/IMudStateHasChanged.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Interfaces;
+
+#nullable enable
+public interface IMudStateHasChanged
+{
+    /// <summary>
+    /// Notifies the component that its state has changed. When applicable, this will
+    /// cause the component to be re-rendered.
+    /// </summary>
+    void StateHasChanged();
+}


### PR DESCRIPTION
## Description
We had an internal discussion about this in discord.
This adds `IMudStateHasChanged`  interface with method `StateHasChanged`.
The interface is added to the `MudComponentBase` and implemented it explicitly!
This means that in order to use `StateHasChanged` you need to cast to the `IMudStateHasChanged` interface.
I still think it should be this way. It shows a clear intention, if it was that cheap and safe then Microsoft wouldn't do a breaking change by removing the public visibility for `StateHasChanged`.
In the end, if the user will need to call  `StateHasChanged` for our components, he is free to use the interface as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
