### PR TITLE
FileUpload: Add Disabled property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
@@ -41,6 +41,17 @@
     </ButtonTemplate>
 </MudFileUpload>
 
+<MudFileUpload T="IBrowserFile" FilesChanged="UploadFiles" Disabled>
+    <ButtonTemplate>
+        <MudButton HtmlTag="label"
+                   Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   for="@context">
+            Disabled Button
+        </MudButton>
+    </ButtonTemplate>
+</MudFileUpload>
+
 @if (files != null)
 {
     <MudText Typo="@Typo.h6">@files.Count() File@(files.Count() == 1 ? "" : "s"):</MudText>
@@ -51,7 +62,7 @@
                 @file.Name <code>@file.Size bytes</code>
             </MudListItem>
         }
-        </MudList>
+    </MudList>
 }
 
 @code

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -27,9 +27,10 @@
             <SectionHeader Title="Use any type of MudButton">
                 <Description>
                     Use a <CodeInline>MudButton</CodeInline>, a <CodeInline>MudIconButton</CodeInline> or a <CodeInline>MudFab</CodeInline> with the HtmlTag property set to "label" within the <CodeInline>ButtonTemplate</CodeInline> render fragment.
-                    Be sure to set the button's ID using the <CodeInline>&#64;context</CodeInline> parameter.
+                    Be sure to set the button's ID using the <CodeInline>&#64;context</CodeInline> parameter. <br />
+                    A <CodeInline>MudFileUpload</CodeInline> can be <CodeInline>Disabled</CodeInline> and it will Disable its child button automatically.
                 </Description>
-            </SectionHeader>
+            </SectionHeader> 
             <SectionContent DarkenBackground="true" ShowCode="false" Code="FileUploadButtonExample">
                 <FileUploadButtonExample />
             </SectionContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonsNestedDisabledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonsNestedDisabledTest.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<CascadingValue Name="ParentDisabled" Value="Disabled">
+    <MudButton>Button</MudButton>
+    <MudFab StartIcon="@Icons.Material.Filled.Abc" />
+    <MudIconButton Icon="@Icons.Material.Filled.Abc" />
+</CascadingValue>
+@code {
+    [Parameter]
+    public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadDisabledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadDisabledTest.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudFileUpload T="IBrowserFile" Disabled="Disabled">
+    <ButtonTemplate>
+        <MudButton HtmlTag="label" for="@context">Upload</MudButton>
+    </ButtonTemplate>
+</MudFileUpload>
+
+@code{
+    [Parameter]
+    public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,9 +1,12 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.Docs.Examples;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -234,6 +237,25 @@ namespace MudBlazor.UnitTests.Components
             button6Span.ClassName.Contains("mud-button-icon-size-small").Should().BeTrue();
             var button6Svg = button6Span.Children[0];
             button6Svg.ClassName.Contains("mud-icon-size-small").Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Ensures buttons inherit their disabled state
+        /// </summary>
+        [Test]
+        public void ButtonsNestedDisabledTest()
+        {
+            var comp = Context.RenderComponent<ButtonsNestedDisabledTest>();
+
+            comp.FindComponent<MudButton>().Find("button").HasAttribute("disabled").Should().BeFalse();
+            comp.FindComponent<MudFab>().Find("button").HasAttribute("disabled").Should().BeFalse();
+            comp.FindComponent<MudIconButton>().Find("button").HasAttribute("disabled").Should().BeFalse();
+
+            comp.SetParametersAndRender(parameters => parameters.Add(x => x.Disabled, true)); //buttons should be disabled when the cascading value is disabled
+
+            comp.FindComponent<MudButton>().Find("button").HasAttribute("disabled").Should().BeTrue();
+            comp.FindComponent<MudFab>().Find("button").HasAttribute("disabled").Should().BeTrue();
+            comp.FindComponent<MudIconButton>().Find("button").HasAttribute("disabled").Should().BeTrue();
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -240,5 +240,21 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.Files.Count.Should().Be(11); //if no error occurs, we have successfully uploaded more than 10 files
         }
+
+        /// <summary>
+        /// Makes sure the file upload is disabled
+        /// </summary>
+        [Test]
+        public void FileUploadDisabledTest()
+        {
+            var comp = Context.RenderComponent<FileUploadDisabledTest>();
+            comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("input").HasAttribute("disabled").Should().BeFalse();
+            comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("label").HasAttribute("disabled").Should().BeFalse();
+
+            comp.SetParametersAndRender(parameters => parameters.Add(x => x.Disabled, true)); //The input and child button should be disabled when file upload is disabled
+
+            comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("input").HasAttribute("disabled").Should().BeTrue();
+            comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("button").HasAttribute("disabled").Should().BeTrue(); //we need to test for a button as the MudButton replaces disabled labels with buttons
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -14,7 +14,8 @@ namespace MudBlazor
         /// Potential activation target for this button. This enables RenderFragments with user-defined
         /// buttons which will automatically activate the intended functionality. 
         /// </summary>
-        [CascadingParameter] protected IActivatable Activateable { get; set; }
+        [CascadingParameter] 
+        protected IActivatable Activateable { get; set; }
 
         /// <summary>
         /// The HTML element that will be rendered in the root by the component

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -63,6 +63,9 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public bool Disabled { get; set; }
+        [CascadingParameter(Name = "ParentDisabled")]
+        private bool ParentDisabled { get; set; }
+        protected bool GetDisabledState() => Disabled || ParentDisabled;
 
         /// <summary>
         /// If true, no drop-shadow will be used.
@@ -99,7 +102,7 @@ namespace MudBlazor
 
         protected virtual async Task OnClickHandler(MouseEventArgs ev)
         {
-            if (Disabled)
+            if (GetDisabledState())
                 return;
             await OnClick.InvokeAsync(ev);
             if (Command?.CanExecute(CommandParameter) ?? false)
@@ -123,7 +126,7 @@ namespace MudBlazor
         //Set the default value for HtmlTag, Link and Target 
         private void SetDefaultValues()
         {
-            if (Disabled)
+            if (GetDisabledState())
             {
                 HtmlTag = "button";
                 Href = null;

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -11,7 +11,7 @@
             href="@Href" 
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
-            disabled="@Disabled">
+            disabled="@GetDisabledState()">
     <span class="mud-button-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -12,7 +12,7 @@
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
             disabled="@GetDisabledState()"
-			title="@Title">
+            title="@Title">
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -11,7 +11,7 @@
             href="@Href"
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
-            disabled="@Disabled"
+            disabled="@GetDisabledState()"
 			title="@Title">
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
           .AddClass($"mud-fab-extended", !string.IsNullOrEmpty(Label))
           .AddClass($"mud-fab-{Color.ToDescriptionString()}")
           .AddClass($"mud-fab-size-{Size.ToDescriptionString()}")
-          .AddClass($"mud-ripple", !DisableRipple && !Disabled)
+          .AddClass($"mud-ripple", !DisableRipple && !GetDisabledState())
           .AddClass($"mud-fab-disable-elevation", DisableElevation)
           .AddClass(Class)
         .Build();

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -11,7 +11,7 @@
             href="@Href" 
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
-            disabled="@Disabled"
+            disabled="@GetDisabledState()"
 			title="@Title">
     @if (!String.IsNullOrEmpty(Icon))
     {

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -12,7 +12,7 @@
             target="@Target"
             rel="@(Target=="_blank"?"noopener":null)"
             disabled="@GetDisabledState()"
-			title="@Title">
+            title="@Title">
     @if (!String.IsNullOrEmpty(Icon))
     {
         <span class="mud-icon-button-label">

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
@@ -5,10 +5,13 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <InputFile OnChange="OnChange" id="@_id" class="@InputClass" style="@InputStyle" hidden="@(Hidden ? "" : null)" multiple="@(typeof(T) == typeof(IReadOnlyList<IBrowserFile>) ? "" : null)" accept="@Accept" @attributes="UserAttributes" />
+        <InputFile OnChange="OnChange" id="@_id" class="@InputClass" style="@InputStyle" hidden="@(Hidden ? "" : null)" multiple="@(typeof(T) == typeof(IReadOnlyList<IBrowserFile>) ? "" : null)" 
+            accept="@Accept" disabled="@(GetDisabledState())" @attributes="UserAttributes" />
         @if (ButtonTemplate != null)
         {
-            @ButtonTemplate(_id)
+            <CascadingValue Name="ParentDisabled" Value="GetDisabledState()">
+                @ButtonTemplate(_id)
+            </CascadingValue>
         }
         @if (SelectedTemplate != null)
         {

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -105,8 +105,19 @@ namespace MudBlazor
         [Category(CategoryTypes.FileUpload.Behavior)]
         public int MaximumFileCount { get; set; } = 10;
 
+        /// <summary>
+        /// Disables the FileUpload
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FileUpload.Behavior)]
+        public bool Disabled { get; set; }
+        [CascadingParameter(Name = "ParentDisabled")] private bool ParentDisabled { get; set; }
+        [CascadingParameter(Name = "ParentReadOnly")] private bool ParentReadOnly { get; set; }
+        protected bool GetDisabledState() => Disabled || ParentDisabled || ParentReadOnly;
+
         private async Task OnChange(InputFileChangeEventArgs args)
         {
+            if (GetDisabledState()) return;
             if (typeof(T) == typeof(IReadOnlyList<IBrowserFile>))
             {
                 _value = (T)args.GetMultipleFiles(MaximumFileCount);

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -49,7 +49,6 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
         public EventCallback<T> FilesChanged { get; set; }
-
         /// <summary>
         /// Called when the internal files are changed
         /// </summary>
@@ -104,7 +103,6 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
         public int MaximumFileCount { get; set; } = 10;
-
         /// <summary>
         /// Disables the FileUpload
         /// </summary>

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -109,8 +109,10 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
         public bool Disabled { get; set; }
-        [CascadingParameter(Name = "ParentDisabled")] private bool ParentDisabled { get; set; }
-        [CascadingParameter(Name = "ParentReadOnly")] private bool ParentReadOnly { get; set; }
+        [CascadingParameter(Name = "ParentDisabled")] 
+        private bool ParentDisabled { get; set; }
+        [CascadingParameter(Name = "ParentReadOnly")] 
+        private bool ParentReadOnly { get; set; }
         protected bool GetDisabledState() => Disabled || ParentDisabled || ParentReadOnly;
 
         private async Task OnChange(InputFileChangeEventArgs args)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This is the sister PR to #6511 and adds a `Disabled` property to the `MudFileUpload`.

This PR also adds a `ParentDisabled` cascading value to the `MudBaseButton`, allowing it to inherit its `Disabled` state from the `MudFileUpload` as well as the `MudForm` once #6511 is merged.

![image](https://user-images.githubusercontent.com/26885142/229179778-46601ae1-8065-4942-b3f1-79b2e7d3c4c7.png)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I have added two unit tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
