### PR TITLE
MudPopover: Fix flickering in delayed bss (#6345)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -90,7 +91,7 @@ namespace MudBlazor.UnitTests.Components
             handler.ShowContent.Should().BeTrue();
         }
 
-        [Test]
+        [Test(Description = "Remove in v7")]
         public void MudPopoverHandler_UpdateFragment()
         {
             RenderFragment initialRenderFragement = (tree) => { };
@@ -125,6 +126,145 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MudPopoverHandler_UpdateFragmentAsync()
+        {
+            var mock = Mock.Of<IJSRuntime>();
+
+            var updateCounter = 0;
+
+            RenderFragment initialRenderFragment = _ => { };
+
+            RenderFragment newRenderFragment = _ => { };
+
+            void Updater() => updateCounter++;
+
+            var handler = new MudPopoverHandler(initialRenderFragment, mock, Updater);
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+
+            await handler.UpdateFragmentAsync(newRenderFragment, comp.Instance, "my-extra-class", "my-extra-style:2px", true);
+
+            handler.Id.Should().NotBe(default(Guid));
+            handler.UserAttributes.Should().BeEquivalentTo(new Dictionary<string, object> { { "myprop1", "myValue1" } });
+            handler.Class.Should().Be("my-extra-class");
+            handler.Style.Should().Be("my-extra-style:2px");
+            handler.Tag.Should().Be("my tag");
+            handler.Fragment.Should().BeSameAs(newRenderFragment);
+            handler.IsConnected.Should().BeFalse();
+            handler.ShowContent.Should().BeTrue();
+
+            updateCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task MudPopoverHandler_DetachAndUpdateFragmentAsync()
+        {
+            var mock = Mock.Of<IJSRuntime>();
+
+            var updateCounter = 0;
+
+            RenderFragment initialRenderFragment = _ => { };
+
+            RenderFragment newRenderFragment = _ => { };
+
+            void Updater() => updateCounter++;
+
+            var handler = new MudPopoverHandler(initialRenderFragment, mock, Updater);
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+
+            await handler.Detach();
+            await handler.UpdateFragmentAsync(newRenderFragment, comp.Instance, "my-new-extra-class", "my-new-extra-style:2px", true);
+
+            updateCounter.Should().Be(0);
+        }
+
+        [Test]
+        public async Task MudPopoverHandler_DetachAndUpdateFragmentConcurrent_UpdateFragmentDoesNotRunInTheSameTimeAsDetach()
+        {
+            var connectTcs = new TaskCompletionSource<IJSVoidResult>();
+
+            var mock = new Mock<IJSRuntime>();
+            var handler = new MudPopoverHandler((tree) => { }, mock.Object, () => { });
+
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>())
+                .Verifiable();
+
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+                .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
+                .Verifiable();
+
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+
+            RenderFragment newRenderFragement = (tree) => { };
+            await handler.Initialize();
+
+            _ = handler.Detach();
+            var task2 = handler.UpdateFragmentAsync(newRenderFragement, comp.Instance, "my-new-extra-class", "my-new-extra-style:2px", true);
+
+            var completedTask = await Task.WhenAny(Task.Delay(50), task2);
+
+            completedTask.Should().NotBe(task2);
+
+            mock.Verify();
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public async Task MudPopoverHandler_DetachAndUpdateFragmentConcurrent_UpdateFragmentAsyncShouldRunAfterDetach()
+        {
+            var connectTcs = new TaskCompletionSource<IJSVoidResult>();
+
+            var mock = new Mock<IJSRuntime>();
+            var handler = new MudPopoverHandler(_ => { }, mock.Object, () => { });
+
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>())
+                .Verifiable();
+
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+                .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
+                .Verifiable();
+
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+
+            RenderFragment newRenderFragement = (tree) => { };
+            await handler.Initialize();
+
+            var task1 = handler.Detach();
+            var task2 = handler.UpdateFragmentAsync(newRenderFragement, comp.Instance, "my-new-extra-class", "my-new-extra-style:2px", true);
+            connectTcs.SetResult(Mock.Of<IJSVoidResult>());
+
+            await Task.WhenAll(task1, task2);
+
+            mock.Verify();
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Test(Description = "Remove in v7")]
         public void MudPopoverHandler_UpdaterInvokationTest()
         {
             RenderFragment initialRenderFragement = (tree) => { };
@@ -151,6 +291,42 @@ namespace MudBlazor.UnitTests.Components
             updateCounter.Should().Be(4);
 
             handler.UpdateFragment(newRenderFragement, comp.Instance, "my-new-extra-class", "my-new-extra-style:2px", true);
+
+            updateCounter.Should().Be(5);
+
+            handler.Class.Should().Be("my-new-extra-class");
+            handler.Style.Should().Be("my-new-extra-style:2px");
+        }
+
+        [Test]
+        public async Task MudPopoverHandler_UpdaterInvocationAsync()
+        {
+            var mock = Mock.Of<IJSRuntime>();
+
+            var updateCounter = 0;
+
+            RenderFragment initialRenderFragment = _ => { };
+
+            RenderFragment newRenderFragment = _ => { };
+
+            void Updater() => updateCounter++;
+
+            var handler = new MudPopoverHandler(initialRenderFragment, mock, Updater);
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+
+            for (int i = 0; i < 4; i++)
+            {
+               await handler.UpdateFragmentAsync(newRenderFragment, comp.Instance, "my-extra-class", "my-extra-style:2px", i % 2 == 0);
+            }
+            updateCounter.Should().Be(4);
+
+            await handler.UpdateFragmentAsync(newRenderFragment, comp.Instance, "my-new-extra-class", "my-new-extra-style:2px", true);
 
             updateCounter.Should().Be(5);
 
@@ -319,7 +495,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopoverService_Constructor_NoJsInterop()
         {
-            Assert.Throws<ArgumentNullException>(() => new MudPopoverService(null));
+            Assert.Throws<ArgumentNullException>(() => _ = new MudPopoverService(null));
         }
 
         [Test]
@@ -505,7 +681,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Verify();
         }
 
-        [Test]
+        [Test(Description = "Remove in v7")]
         public void MudPopoverService_RegisterAndUseHandler()
         {
             var service = new MudPopoverService(Mock.Of<IJSRuntime>(MockBehavior.Strict));
@@ -533,6 +709,38 @@ namespace MudBlazor.UnitTests.Components
 
             });
             handler.UpdateFragment(changedFragment, comp.Instance, "my-class", "my-style", true);
+            // counter doesn't change because UpdateFragment now only re-renders the updated fragment, without raising the FragmentsChanged event
+            fragmentChangedCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task MudPopoverService_RegisterAndUseHandlerAsync()
+        {
+            var service = new MudPopoverService(Mock.Of<IJSRuntime>(MockBehavior.Strict));
+
+            int fragmentChangedCounter = 0;
+
+            service.FragmentsChanged += (_, _) =>
+            {
+                fragmentChangedCounter++;
+            };
+
+            RenderFragment fragment = _ => { };
+
+            RenderFragment changedFragment = _ => { };
+
+            var handler = service.Register(fragment);
+
+            handler.Should().NotBeNull();
+            fragmentChangedCounter.Should().Be(1);
+
+            var comp = Context.RenderComponent<MudBadge>(p =>
+            {
+                p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
+                p.Add(x => x.Tag, "my tag");
+
+            });
+            await handler.UpdateFragmentAsync(changedFragment, comp.Instance, "my-class", "my-style", true);
             // counter doesn't change because UpdateFragment now only re-renders the updated fragment, without raising the FragmentsChanged event
             fragmentChangedCounter.Should().Be(1);
         }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -3,14 +3,16 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Diagnostics.CodeAnalysis;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public partial class MudPopover : MudComponentBase, IAsyncDisposable
     {
-        [Inject] public IMudPopoverService Service { get; set; }
+        private bool _afterFirstRender;
+
+        [Inject] 
+        public IMudPopoverService Service { get; set; }
 
         protected string PopoverClass =>
            new CssBuilder("mud-popover")
@@ -45,7 +47,8 @@ namespace MudBlazor
             };
         }
 
-        [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = "RightToLeft")] 
+        public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Sets the maxheight the popover can have when open.
@@ -108,7 +111,8 @@ namespace MudBlazor
         /// </summary>
         /// 
         [Obsolete("Use AnchorOrigin and TransformOrigin instead.", true)]
-        [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
+        [Parameter] 
+        public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
         /// Set the anchor point on the element of the popover.
@@ -171,9 +175,9 @@ namespace MudBlazor
             base.OnInitialized();
         }
 
-        protected override void OnParametersSet()
+        protected override async Task OnParametersSetAsync()
         {
-            base.OnParametersSet();
+            await base.OnParametersSetAsync();
 
             // henon: this change by PR #3776 caused problems on BSS (#4303)
             //// Only update the fragment if the popover is currently shown or will show
@@ -181,15 +185,20 @@ namespace MudBlazor
             //if (!_handler.ShowContent && !Open)
             //    return;
 
-            _handler.UpdateFragment(ChildContent, this, PopoverClass, PopoverStyles, Open);
+            if (_afterFirstRender)
+            {
+                await _handler.UpdateFragmentAsync(ChildContent, this, PopoverClass, PopoverStyles, Open);
+            }
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender == true)
+            if (firstRender)
             {
                 await _handler.Initialize();
                 await Service.InitializeIfNeeded();
+                await _handler.UpdateFragmentAsync(ChildContent, this, PopoverClass, PopoverStyles, Open);
+                _afterFirstRender = true;
             }
 
             await base.OnAfterRenderAsync(firstRender);


### PR DESCRIPTION
## Description
Revives this PR #6389 (conflicts + breaking change)
Fixes https://github.com/MudBlazor/MudBlazor/issues/6345
Compared to original PR this is not breaking one.
The original PR changed public API
old PR: `void UpdateFragment` -> `Task UpdateFragment`
this PR: introduce new method `Task UpdateFragmentAsync`
The `UpdateFragment` is marked as Obsolete now.
I had to copy-paste some tests that using the old method, but I think it's better to keep the unit tests for old method for now to make sure everything is backward compatible and working. There are some new tests as well (from original PR).

## How Has This Been Tested?
Unit tests, mud docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
