### PR TITLE
MudDialogInstance: return back public API ForceRender

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -317,6 +317,11 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        [Obsolete($"Use {nameof(StateHasChanged)}. This method will be removed in v7.")]
+        public void ForceRender() => StateHasChanged();
+
+        public new void StateHasChanged() => base.StateHasChanged();
+
         /// <summary>
         /// Cancels all dialogs in dialog provider collection.
         /// </summary>


### PR DESCRIPTION
## Description
As @mckaragoz noticed, the ForceRender was removed because of this https://github.com/MudBlazor/MudBlazor/pull/6563 PR
This was unintentional, as it's public API.
The StateHasChanged is made visible compared to the explicit implementation in the MudComponentBase.
This is due to the special need of such method for the DialogInstance.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
