### PR TITLE
MudTimePicker: Fix duplicate hour event in minute mode #6523

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.TimePicker;
 using NUnit.Framework;
@@ -631,7 +632,7 @@ namespace MudBlazor.UnitTests.Components
             // Select 16 hours
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
             picker.TimeIntermediate.Value.Hours.Should().Be(16);
-
+            
             // Select 30 minutes
             comp.FindAll("div.mud-minute")[30].Click();
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);
@@ -649,7 +650,6 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => timePicker.Instance.Clear());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
             await comp.InvokeAsync(() => timePicker.Instance.Close(false));
-
             // Change the value of autoclose
             timePicker.Instance.AutoClose = true;
 
@@ -829,6 +829,41 @@ namespace MudBlazor.UnitTests.Components
             timePicker.ReadOnly = true;
             await comp.InvokeAsync(() => timePicker.Submit());
 
+        }
+
+        [Test]
+        public async Task CheckCallOneTimeChanged()
+        {
+            // Get access to the timepicker of the instance
+            var comp = Context.RenderComponent<SimpleTimePickerTest>();
+            var picker = comp.FindComponent<MudTimePicker>().Instance;
+            comp.WaitForAssertion(() => picker.Time.Should().Be(null));
+            // Open the timepicker
+            await comp.InvokeAsync(() => picker.Open());
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+
+            var count = 0;
+            picker.TimeChanged = new EventCallbackFactory().Create<TimeSpan?>(this, v =>
+            {
+                count++;
+            });
+
+            // Select 16 hours
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click(new MouseEventArgs()));
+            picker.TimeIntermediate.Value.Hours.Should().Be(16);
+
+            // Select 30 minutes
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new MouseEventArgs()));
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
+
+            Assert.AreEqual(0, count);
+            // Click outside of the timepicker
+            await comp.InvokeAsync(() => comp.Find("div.mud-overlay").Click());
+
+            // Check that the time have been changed
+            comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
+
+            Assert.AreEqual(1, count);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -856,14 +856,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new MouseEventArgs()));
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);
 
-            Assert.AreEqual(0, count);
+            Assert.AreEqual(1, count);
             // Click outside of the timepicker
             await comp.InvokeAsync(() => comp.Find("div.mud-overlay").Click());
 
             // Check that the time have been changed
             comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
 
-            Assert.AreEqual(1, count);
         }
     }
 }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -499,11 +499,15 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private void OnMouseClickMinute(int value)
+        private async Task OnMouseClickMinute(int value)
         {
             _timeSet.Minute = value;
             UpdateTime();
-            SubmitAndClose();
+            if (PickerVariant != PickerVariant.Static)
+            {
+                await Task.Delay(ClosingDelay);
+                Close(false);
+            }
         }
 
         protected async void SubmitAndClose()

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -472,7 +472,11 @@ namespace MudBlazor
                     h = value + 12;
             }
             _timeSet.Hour = h;
-            UpdateTime();
+
+            if(_currentView == OpenTo.Hours)
+            {
+                UpdateTime();
+            }
 
             if (TimeEditMode == TimeEditMode.Normal)
             {
@@ -499,15 +503,11 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private async Task OnMouseClickMinute(int value)
+        private void OnMouseClickMinute(int value)
         {
             _timeSet.Minute = value;
             UpdateTime();
-            if (PickerVariant != PickerVariant.Static)
-            {
-                await Task.Delay(ClosingDelay);
-                Close(false);
-            }
+            SubmitAndClose();
         }
 
         protected async void SubmitAndClose()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixed a bug that problem with hour event being called even in minute mode

This PR fixes #6523

## How Has This Been Tested?
I have updated all Unit Tests to work with MudTimepicker so they pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
