### PR TITLE
MudDataGrid: Filter for Nullable DateTime not working(#6521)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2557,7 +2557,7 @@ namespace MudBlazor.UnitTests.Components
             filterDefinition3.Column.dataType.Should().Be(typeof(Severity?));
             await comp.InvokeAsync(() => internalFilter.NumberValueChanged(35));
             filterDefinition3.Value.Should().Be(35);
-            internalFilter.IsEnum.Should().Be(true);
+            filterDefinition3.FiledType.IsEnum.Should().Be(true);
             // test internal filter class for bool data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, filterDefinition4, null);
             filterDefinition4.Column.dataType.Should().Be(typeof(bool?));

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2557,7 +2557,7 @@ namespace MudBlazor.UnitTests.Components
             filterDefinition3.Column.dataType.Should().Be(typeof(Severity?));
             await comp.InvokeAsync(() => internalFilter.NumberValueChanged(35));
             filterDefinition3.Value.Should().Be(35);
-            filterDefinition3.FiledType.IsEnum.Should().Be(true);
+            filterDefinition3.FieldType.IsEnum.Should().Be(true);
             // test internal filter class for bool data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, filterDefinition4, null);
             filterDefinition4.Column.dataType.Should().Be(typeof(bool?));

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -9,17 +9,17 @@ namespace MudBlazor
 #nullable enable
     public class FieldType
     {
-        public bool IsString { get; set; }
+        public bool IsString { get; init; }
 
-        public bool IsNumber { get; set; }
+        public bool IsNumber { get; init; }
 
-        public bool IsEnum { get; set; }
+        public bool IsEnum { get; init; }
 
-        public bool IsDateTime { get; set; }
+        public bool IsDateTime { get; init; }
 
-        public bool IsBoolean { get; set; }
+        public bool IsBoolean { get; init; }
 
-        public bool IsGuid { get; set; }
+        public bool IsGuid { get; init; }
 
         public static FieldType Identify(Type? type)
         {

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -21,10 +21,6 @@ namespace MudBlazor
         internal DateTime? _valueDate;
         internal TimeSpan? _valueTime;
 
-        internal bool IsNumber => TypeIdentifier.IsNumber(_filterDefinition.dataType);
-
-        internal bool IsEnum => TypeIdentifier.IsEnum(_filterDefinition.dataType);
-
         internal Column<T>? FilterColumn =>
             _column ?? (_dataGrid.RenderedColumns?.FirstOrDefault(c => c.PropertyName == _filterDefinition.Column?.PropertyName));
 
@@ -34,7 +30,7 @@ namespace MudBlazor
             _filterDefinition = filterDefinition;
             _column = column;
 
-            var fieldType = FieldType.Identify(_filterDefinition.dataType);
+            var fieldType = _filterDefinition.FiledType;
 
             if (fieldType.IsString)
                 _valueString = _filterDefinition.Value?.ToString();

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
             _filterDefinition = filterDefinition;
             _column = column;
 
-            var fieldType = _filterDefinition.FiledType;
+            var fieldType = _filterDefinition.FieldType;
 
             if (fieldType.IsString)
                 _valueString = _filterDefinition.Value?.ToString();

--- a/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
@@ -25,6 +25,8 @@ namespace MudBlazor
         public object? Value { get; set; }
         public Func<T, bool>? FilterFunction { get; set; }
 
+        public FieldType FiledType => FieldType.Identify(Column?.PropertyType);
+
         internal Type dataType
         {
             get
@@ -66,7 +68,7 @@ namespace MudBlazor
 
         public Expression<Func<T, bool>> GenerateFilterExpression()
         {
-            var fieldType = FieldType.Identify(dataType);
+            var fieldType = FiledType;
 
             if (PropertyExpression is null)
             {

--- a/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterDefinition.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
         public object? Value { get; set; }
         public Func<T, bool>? FilterFunction { get; set; }
 
-        public FieldType FiledType => FieldType.Identify(Column?.PropertyType);
+        public FieldType FieldType => FieldType.Identify(Column?.PropertyType);
 
         internal Type dataType
         {
@@ -68,7 +68,7 @@ namespace MudBlazor
 
         public Expression<Func<T, bool>> GenerateFilterExpression()
         {
-            var fieldType = FiledType;
+            var fieldType = FieldType;
 
             if (PropertyExpression is null)
             {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -388,7 +388,7 @@
             @{
                 var filter = new Filter<T>(this, filterDefinition, column);
             }
-            @if (column == null)
+            @if (column is null)
             {
                 <MudItem xs="1" Class="d-flex">
                     <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilter" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -412,17 +412,17 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="4">
-                    @if (filterDefinition.FiledType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    @if (filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
                                       Immediate="true" Class="filter-input"/>
                     }
-                    else if (filterDefinition.FiledType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    else if (filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
                                          Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                     }
-                    else if (filterDefinition.FiledType.IsEnum)
+                    else if (filterDefinition.FieldType.IsEnum)
                     {
                         <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-input">
@@ -433,7 +433,7 @@
                             }
                         </MudSelect>
                     }
-                    else if (filterDefinition.FiledType.IsBoolean)
+                    else if (filterDefinition.FieldType.IsBoolean)
                     {
                         <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-input">
@@ -442,7 +442,7 @@
                             <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
                         </MudSelect>
                     }
-                    else if (filterDefinition.FiledType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    else if (filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudGrid Spacing="0">
                             <MudItem xs="7">
@@ -453,7 +453,7 @@
                             </MudItem>
                         </MudGrid>
                     }
-                    else if (filterDefinition.FiledType.IsGuid)
+                    else if (filterDefinition.FieldType.IsGuid)
                     {
                         <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
                                       Immediate="true" Class="filter-input"/>
@@ -472,17 +472,17 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12">
-                    @if (filterDefinition.FiledType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    @if (filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
                                       Immediate="true" Class="filter-input"/>
                     }
-                    else if (filterDefinition.FiledType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    else if (filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
                                          Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                     }
-                    else if (filterDefinition.FiledType.IsEnum)
+                    else if (filterDefinition.FieldType.IsEnum)
                     {
                         <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-input">
@@ -493,7 +493,7 @@
                             }
                         </MudSelect>
                     }
-                    else if (filterDefinition.FiledType.IsBoolean)
+                    else if (filterDefinition.FieldType.IsBoolean)
                     {
                         <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-input">
@@ -502,7 +502,7 @@
                             <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
                         </MudSelect>
                     }
-                    else if (filterDefinition.FiledType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    else if (filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudGrid Spacing="0">
                             <MudItem xs="7">
@@ -513,7 +513,7 @@
                             </MudItem>
                         </MudGrid>
                     }
-                    else if (filterDefinition.FiledType.IsGuid)
+                    else if (filterDefinition.FieldType.IsGuid)
                     {
                         <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
                                       Immediate="true" Class="filter-input"/>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -283,243 +283,242 @@
 </CascadingValue>
 
 @code {
-    internal RenderFragment ToolbarMenu(MudDataGrid<T> __this)
-    {
-        return
-    @<text>
-        <MudMenu Icon="@Icons.Material.Outlined.Settings" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true">
-            <MudMenuItem OnClick="@__this.ShowColumnsPanel">Columns</MudMenuItem>
-            @if (__this.Groupable)
-            {
-                <MudMenuItem OnClick="@__this.ExpandAllGroups">Expand All Groups</MudMenuItem>
-                <MudMenuItem OnClick="@__this.CollapseAllGroups">Collapse All Groups</MudMenuItem>
-            }
-            @if (__this.ServerData != null)
-            {
-                <MudMenuItem OnClick="@__this.InvokeServerLoadFunc">Refresh Data</MudMenuItem>
-            }
-        </MudMenu>
-    </text>;
-    }
 
-    internal RenderFragment FooterCells(IEnumerable<T> currentItems)
-    {
-        return
-    @<text>
-        @if (currentItems != null)
-        {
-            foreach (var column in RenderedColumns)
-            {
-                if (!column.Hidden)
+    internal RenderFragment ToolbarMenu(MudDataGrid<T> dataGrid) =>
+        @<text>
+            <MudMenu Icon="@Icons.Material.Outlined.Settings" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true">
+            <MudMenuItem OnClick="@dataGrid.ShowColumnsPanel">Columns</MudMenuItem>
+                @if (dataGrid.Groupable)
                 {
-                    if (column.AggregateDefinition != null || column.FooterTemplate != null || hasFooter)
+                    <MudMenuItem OnClick="@dataGrid.ExpandAllGroups">Expand All Groups</MudMenuItem>
+                    <MudMenuItem OnClick="@dataGrid.CollapseAllGroups">Collapse All Groups</MudMenuItem>
+                }
+                @if (dataGrid.ServerData is not null)
+                {
+                    <MudMenuItem OnClick="@dataGrid.InvokeServerLoadFunc">Refresh Data</MudMenuItem>
+                }
+            </MudMenu>
+         </text>;
+
+    internal RenderFragment FooterCells(IEnumerable<T> currentItems) =>
+        @<text>
+            @if (currentItems is not null)
+            {
+                foreach (var column in RenderedColumns)
+                {
+                    if (!column.Hidden)
                     {
-                        <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
+                        if (column.AggregateDefinition is not null || column.FooterTemplate is not null || hasFooter)
+                        {
+                            <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
+                        }
                     }
                 }
             }
-        }
-    </text>;
-    }
+         </text>;
+    
 
-    internal RenderFragment Cell(Column<T> column, T item)
-    {
-        return
-    @<text>
-        @{
-            var cell = new Cell<T>(this, column, item);
-        }
-        <td data-label="@column.Title" class="@cell.computedClass" style="@cell.computedStyle">
-            @if (column.IsEditable && !ReadOnly && EditMode == DataGridEditMode.Cell)
-            {
-                if (column.EditTemplate != null)
+    internal RenderFragment Cell(Column<T> column, T item) =>
+        @<text>
+            @{
+                var cell = new Cell<T>(this, column, item);
+            }
+            <td data-label="@column.Title" class="@cell.computedClass" style="@cell.computedStyle">
+                @if (column.IsEditable && !ReadOnly && EditMode == DataGridEditMode.Cell)
                 {
-                    @column.EditTemplate(cell._cellContext)
+                    if (column.EditTemplate is not null)
+                    {
+                        @column.EditTemplate(cell._cellContext)
+                    }
+                    else
+                    {
+                        if (column.PropertyType == typeof(string))
+                        {
+                            <MudTextField T="string"
+                                          Value="@cell._valueString"
+                                          ValueChanged="@cell.StringValueChangedAsync"
+                                          Margin="@Margin.Dense" Style="margin-top:0"
+                                          Required="true"
+                                          Variant="@Variant.Text" />
+                        }
+                        else if (column.isNumber)
+                        {
+                            <MudNumericField T="double?"
+                                             Value="@cell._valueNumber"
+                                             ValueChanged="@cell.NumberValueChangedAsync"
+                                             Margin="@Margin.Dense" Style="margin-top:0"
+                                             Required="true" Variant="@Variant.Text" Culture="@column.Culture" />
+                        }
+                    }
                 }
                 else
                 {
-                    if (column.PropertyType == typeof(string))
+                    if (column.CellTemplate is not null)
                     {
-                        <MudTextField T="string" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense" Style="margin-top:0"
-                      Required="true" Variant="@Variant.Text" />
+                        @column.CellTemplate(cell._cellContext)
                     }
-                    else if (column.isNumber)
+                    else if (column.Culture is not null && column.isNumber)
                     {
-                        <MudNumericField T="double?" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense" Style="margin-top:0"
-                         Required="true" Variant="@Variant.Text" Culture="@column.Culture" />
+                        if (column.ContentFormat is not null)
+                        {
+                            @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
+                        }
+                        else
+                        {
+                            @cell._valueNumber?.ToString(column.Culture)
+                        }
+                    }
+                    else
+                    {
+                        if (column.ContentFormat is not null)
+                        {
+                            @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
+                        }
+                        else
+                        {
+                            @cell.ComputedValue
+                        }
                     }
                 }
+            </td>
+         </text>;
+
+    internal RenderFragment Filter(FilterDefinition<T> filterDefinition, Column<T> column) =>
+        @<text>
+            @{
+                var filter = new Filter<T>(this, filterDefinition, column);
+            }
+            @if (column == null)
+            {
+                <MudItem xs="1" Class="d-flex">
+                    <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilter" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
+                </MudItem>
+                <MudItem xs="4">
+                    <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="Column" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-field">
+                        @foreach (var renderColumn in RenderedColumns ?? Enumerable.Empty<Column<T>>())
+                        {
+                            <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="3">
+                    <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-operator">
+                        @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(filterDefinition.dataType))
+                        {
+                            <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="4">
+                    @if (filterDefinition.FiledType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    {
+                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
+                                      Immediate="true" Class="filter-input"/>
+                    }
+                    else if (filterDefinition.FiledType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    {
+                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
+                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
+                    }
+                    else if (filterDefinition.FiledType.IsEnum)
+                    {
+                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-input">
+                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
+                            @foreach (var item in EnumExtensions.GetSafeEnumValues(filterDefinition.dataType))
+                            {
+                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                    else if (filterDefinition.FiledType.IsBoolean)
+                    {
+                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-input">
+                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+                            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
+                            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
+                        </MudSelect>
+                    }
+                    else if (filterDefinition.FiledType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    {
+                        <MudGrid Spacing="0">
+                            <MudItem xs="7">
+                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
+                            </MudItem>
+                            <MudItem xs="5">
+                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
+                            </MudItem>
+                        </MudGrid>
+                    }
+                    else if (filterDefinition.FiledType.IsGuid)
+                    {
+                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
+                                      Immediate="true" Class="filter-input"/>
+                    }
+                </MudItem>
             }
             else
             {
-                if (column.CellTemplate != null)
-                {
-                    @column.CellTemplate(cell._cellContext)
-                }
-                else if (column.Culture != null && column.isNumber)
-                {
-                    if (column.ContentFormat != null)
+                <MudItem xs="12">
+                    <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-operator">
+                        @foreach (var o in FilterOperator.GetOperatorByDataType(filterDefinition.dataType))
+                        {
+                            <MudSelectItem Value="@o">@o</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12">
+                    @if (filterDefinition.FiledType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
-                        @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
+                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
+                                      Immediate="true" Class="filter-input"/>
                     }
-                    else
-                        @cell._valueNumber?.ToString(column.Culture)
-                }
-                else
-                {
-                    if (column.ContentFormat != null)
+                    else if (filterDefinition.FiledType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
-                        @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
+                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
+                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                     }
-                    else
-                        @cell.ComputedValue
-                }
+                    else if (filterDefinition.FiledType.IsEnum)
+                    {
+                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-input">
+                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
+                            @foreach (var item in Enum.GetValues(filterDefinition.dataType))
+                            {
+                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                    else if (filterDefinition.FiledType.IsBoolean)
+                    {
+                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-input">
+                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+                            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
+                            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
+                        </MudSelect>
+                    }
+                    else if (filterDefinition.FiledType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    {
+                        <MudGrid Spacing="0">
+                            <MudItem xs="7">
+                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
+                            </MudItem>
+                            <MudItem xs="5">
+                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
+                            </MudItem>
+                        </MudGrid>
+                    }
+                    else if (filterDefinition.FiledType.IsGuid)
+                    {
+                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
+                                      Immediate="true" Class="filter-input"/>
+                    }
+                </MudItem>
             }
-        </td>
-    </text>
-    ;
-    }
-
-    internal RenderFragment Filter(FilterDefinition<T> f, Column<T> column)
-    {
-        return
-    @<text>
-        @{
-            var filter = new Filter<T>(this, f, column);
-        }
-        @if (column == null)
-        {
-            <MudItem xs="1" Class="d-flex">
-                <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilter" Size="@Size.Small" Style="align-self:flex-end"></MudIconButton>
-            </MudItem>
-            <MudItem xs="4">
-                <MudSelect T="Column<T>" Value="@f.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="Column" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-field">
-                    @foreach (var column in RenderedColumns ?? Enumerable.Empty<Column<T>>())
-                    {
-                        <MudSelectItem T="Column<T>" Value="@column">@column.Title</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudItem>
-            <MudItem xs="3">
-                <MudSelect @bind-Value="f.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-operator">
-                    @foreach (var o in FilterOperator.GetOperatorByDataType(f.dataType))
-                {
-                    <MudSelectItem Value="@o">@o</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-            <MudItem xs="4">
-                @if (f.dataType == typeof(string) && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                      Immediate="true" Class="filter-input" />
-                }
-                else if (filter.IsNumber && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
-                }
-                else if (filter.IsEnum)
-                {
-                    <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-input">
-                        <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                        @foreach (var item in EnumExtensions.GetSafeEnumValues(f.dataType))
-                        {
-                            <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
-                        }
-                    </MudSelect>
-                }
-                else if (f.dataType == typeof(bool))
-                {
-                    <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-input">
-                        <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                        <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
-                        <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
-                    </MudSelect>
-                }
-                else if (f.dataType == typeof(DateTime) && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudGrid Spacing="0">
-                        <MudItem xs="7">
-                            <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
-                        </MudItem>
-                        <MudItem xs="5">
-                            <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
-                        </MudItem>
-                    </MudGrid>
-                }
-                else if (f.dataType == typeof(Guid))
-                {
-                    <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                      Immediate="true" Class="filter-input" />
-                }
-            </MudItem>
-        }
-        else
-        {
-            <MudItem xs="12">
-                <MudSelect @bind-Value="f.Operator" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-operator">
-                    @foreach (var o in FilterOperator.GetOperatorByDataType(f.dataType))
-                {
-                    <MudSelectItem Value="@o">@o</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-            <MudItem xs="12">
-                @if (f.dataType == typeof(string) && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
-                      Immediate="true" Class="filter-input" />
-                }
-                else if (filter.IsNumber && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
-                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
-                }
-                else if (filter.IsEnum)
-                {
-                    <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-input">
-                        <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                        @foreach (var item in Enum.GetValues(f.dataType))
-                        {
-                            <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
-                        }
-                    </MudSelect>
-                }
-                else if (f.dataType == typeof(bool))
-                {
-                    <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                   Class="filter-input">
-                        <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                        <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
-                        <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
-                    </MudSelect>
-                }
-                else if (f.dataType == typeof(DateTime) && !(f.Operator ?? "").EndsWith("empty"))
-                {
-                    <MudGrid Spacing="0">
-                        <MudItem xs="7">
-                            <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
-                        </MudItem>
-                        <MudItem xs="5">
-                            <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
-                        </MudItem>
-                    </MudGrid>
-                }
-                else if (f.dataType == typeof(Guid))
-                {
-                    <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                      Immediate="true" Class="filter-input" />
-                }
-            </MudItem>
-        }
-    </text>
-    ;
-    }
+         </text>;
 }


### PR DESCRIPTION
## Description
Fixes #6521.

In the previous implementation, the code was checking for `f.dataType == typeof(DateTime)` in the razor file, which caused issues with filters not working correctly. The problem was that it did not account for nullable DateTime types.

To fix this, I added a new public property called `FieldType` to the `FilterDefinition` class, which checks for nullable types. The `FieldType` type already has all the necessary tests and works as expected. The updated code now uses `f.FieldType.IsDateTime` instead of `f.dataType == typeof(DateTime)`. Additionally, I updated all the rest type checks to use `FieldType` instead.

I had to redo all the RenderFragments in `MudDataGrid.razor` due to compatibility issues with Visual Studio 2022. The file was not editable and caused a lot of problems, but everything is parsing smoothly now.

## How Has This Been Tested?
Docs, reproduction snippet 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
