### PR TITLE
DataGrid: Change several public methods from async void to async Task and add Async postfix (Breaking Change)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedFilteringExample.razor
@@ -22,8 +22,8 @@
                            }
                        </MudStack>
                        <MudStack Row="true">
-                            <MudButton OnClick="@(() => ClearFilter(context))">Clear</MudButton>
-                            <MudButton Color="@Color.Primary" OnClick="@(() => ApplyFilter(context))">Filter</MudButton>
+                            <MudButton OnClick="@(() => ClearFilterAsync(context))">Clear</MudButton>
+                            <MudButton Color="@Color.Primary" OnClick="@(() => ApplyFilterAsync(context))">Filter</MudButton>
                        </MudStack>
                    </MudStack>
 	            </MudPopover>
@@ -65,7 +65,7 @@
         _filterOpen = true;
     }
 
-    void SelectedChanged(bool value, Element item)
+    private void SelectedChanged(bool value, Element item)
     {
         if (value)
             _selectedItems.Add(item);
@@ -78,24 +78,24 @@
             _selectAll = false;
     }
 
-    void ClearFilter(FilterContext<Element> context)
+    private async Task ClearFilterAsync(FilterContext<Element> context)
     {
         _selectedItems = Elements.ToHashSet();
         _filterItems = Elements.ToHashSet();
         _icon = Icons.Material.Outlined.FilterAlt;
-        context.Actions.ClearFilter(_filterDefinition);
+        await context.Actions.ClearFilterAsync(_filterDefinition);
         _filterOpen = false;
     }
 
-    void ApplyFilter(FilterContext<Element> context)
+    private async Task ApplyFilterAsync(FilterContext<Element> context)
     {
         _filterItems = _selectedItems.ToHashSet();
         _icon = _filterItems.Count == Elements.Count() ? Icons.Material.Outlined.FilterAlt : Icons.Material.Filled.FilterAlt;
-        context.Actions.ApplyFilter(_filterDefinition);
+        await context.Actions.ApplyFilterAsync(_filterDefinition);
         _filterOpen = false;
     }
 
-    void SelectAll(bool value)
+    private void SelectAll(bool value)
     {
         _selectAll = value;
 

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -22,7 +22,7 @@
         <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
         <TemplateColumn Hidden="@(_isCellEditMode || _readOnly || _editTriggerRowClick)" CellClass="d-flex justify-end">
             <CellTemplate>
-                <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItem" />
+                <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
             </CellTemplate>
         </TemplateColumn>
     </Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnPopupCustomFilteringTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnPopupCustomFilteringTest.razor
@@ -10,7 +10,7 @@
             <FilterTemplate>
                 <MudStack>
                     <MudSwitch T="bool" Color="@Color.Primary" @bind-Checked="FilterHired" Label="Show Hired"></MudSwitch>
-                    <MudButton Class="align-self-end" Color="@Color.Primary" OnClick="@(() => ApplyFilter(context))">@(FilterHired ? "Filter" : "Remove Filter")</MudButton>
+                    <MudButton Class="align-self-end" Color="@Color.Primary" OnClick="@(() => ApplyFilterAsync(context))">@(FilterHired ? "Filter" : "Remove Filter")</MudButton>
                 </MudStack>
             </FilterTemplate>
         </PropertyColumn>
@@ -47,11 +47,11 @@
         }
     }
 
-    public void ApplyFilter(FilterContext<Model> context)
+    public async Task ApplyFilterAsync(FilterContext<Model> context)
     {
         if (FilterHired)
-            context.Actions.ApplyFilter(_filterDefinition);
+           await context.Actions.ApplyFilterAsync(_filterDefinition);
         else
-            context.Actions.ClearFilter(_filterDefinition);
+           await context.Actions.ClearFilterAsync(_filterDefinition);
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterRowAdvancedCustomFilteringTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterRowAdvancedCustomFilteringTest.razor
@@ -70,19 +70,18 @@
             _selectedItems.Remove(item);
     }
 
-    private void ClearFilter(FilterContext<Model> context)
+    private async Task ClearFilterAsync(FilterContext<Model> context)
     {
         _selectedItems = _items.ToHashSet();
         _filterItems = _items.ToHashSet();
-        context.Actions.ClearFilter(_filterDefinition);
+        await context.Actions.ClearFilterAsync(_filterDefinition);
         _filterOpen = false;
     }
 
-    private void ApplyFilter(FilterContext<Model> context)
+    private async Task ApplyFilterAsync(FilterContext<Model> context)
     {
         _filterItems = _selectedItems.ToHashSet();
-        context.Actions.ApplyFilter(_filterDefinition);
+        await context.Actions.ApplyFilterAsync(_filterDefinition);
         _filterOpen = false;
     }
-
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterRowCustomFilteringTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterRowCustomFilteringTest.razor
@@ -33,14 +33,13 @@
         Value = true
     };
 
-    private void ApplyFilter(bool value, FilterContext<Model> context)
+    private async Task ApplyFilterAsync(bool value, FilterContext<Model> context)
     {
         _filterHired = value;
 
         if (_filterHired)
-            context.Actions.ApplyFilter(_filterDefinition);
+            await context.Actions.ApplyFilterAsync(_filterDefinition);
         else
-            context.Actions.ClearFilter(_filterDefinition);
+            await context.Actions.ClearFilterAsync(_filterDefinition);
     }
-
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2988,10 +2988,10 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
 
             comp.Instance.FilterHired = true;
-            await comp.InvokeAsync(() =>
+            await comp.InvokeAsync(async () =>
             {
                 var filterContext = dataGrid.Instance.RenderedColumns[3].FilterContext;
-                comp.Instance.ApplyFilter(filterContext);
+                await comp.Instance.ApplyFilterAsync(filterContext);
             });
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(1);
@@ -3055,12 +3055,12 @@ namespace MudBlazor.UnitTests.Components
             var cell = new Cell<DataGridCellContextTest.Model>(dataGrid.Instance, column, item);
 
             cell._cellContext.IsSelected.Should().Be(false);
-            cell._cellContext.Actions.SetSelectedItem(true);
+            await cell._cellContext.Actions.SetSelectedItemAsync(true);
             cell._cellContext.IsSelected.Should().Be(true);
 
-            cell._cellContext.Actions.ToggleHierarchyVisibilityForItem();
+            await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().Contain(item);
-            cell._cellContext.Actions.ToggleHierarchyVisibilityForItem();
+            await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().NotContain(item);
         }
 

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
@@ -33,19 +34,19 @@ namespace MudBlazor
             Item = item;
             Actions = new CellActions
             {
-                SetSelectedItem = async (x) => await dataGrid.SetSelectedItemAsync(x, item),
-                StartEditingItem = async () => await dataGrid.SetEditingItemAsync(item),
-                CancelEditingItem = async () => await dataGrid.CancelEditingItemAsync(),
-                ToggleHierarchyVisibilityForItem = async () => await dataGrid.ToggleHierarchyVisibilityAsync(item),
+                SetSelectedItemAsync = x => dataGrid.SetSelectedItemAsync(x, item),
+                StartEditingItemAsync = () => dataGrid.SetEditingItemAsync(item),
+                CancelEditingItemAsync = () => dataGrid.CancelEditingItemAsync(),
+                ToggleHierarchyVisibilityForItemAsync = () => dataGrid.ToggleHierarchyVisibilityAsync(item),
             };
         }
 
         public class CellActions
         {
-            public Action<bool>? SetSelectedItem { get; internal set; }
-            public Action? StartEditingItem { get; internal set; }
-            public Action? CancelEditingItem { get; internal set; }
-            public Action? ToggleHierarchyVisibilityForItem { get; internal set; }
+            public Func<bool, Task> SetSelectedItemAsync { get; init; } = null!;
+            public Func<Task> StartEditingItemAsync { get; init; } = null!;
+            public Func<Task> CancelEditingItemAsync { get; init; } = null!;
+            public Func<Task> ToggleHierarchyVisibilityForItemAsync { get; init; } = null!;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
@@ -39,19 +40,36 @@ namespace MudBlazor
             _dataGrid = dataGrid;
             Actions = new FilterActions
             {
-                ApplyFilter = x => HeaderCell?.ApplyFilter(x),
-                ApplyFilters = x => HeaderCell?.ApplyFilters(x),
-                ClearFilter = x => HeaderCell?.ClearFilter(x),
-                ClearFilters = x => HeaderCell?.ClearFilters(x),
+                ApplyFilterAsync = x =>
+                {
+                    //Use Task.CompletedTask but later ApplyFilter should return Task
+                    HeaderCell?.ApplyFilter(x);
+                    return Task.CompletedTask;
+                },
+                ApplyFiltersAsync = x =>
+                {
+                    HeaderCell?.ApplyFilters(x);
+                    return Task.CompletedTask;
+                },
+                ClearFilterAsync = x =>
+                {
+                    HeaderCell?.ClearFilter(x);
+                    return Task.CompletedTask;
+                },
+                ClearFiltersAsync = x =>
+                {
+                    HeaderCell?.ClearFilters(x);
+                    return Task.CompletedTask;
+                },
             };
         }
 
         public class FilterActions
         {
-            public Action<FilterDefinition<T>>? ApplyFilter { get; internal set; }
-            public Action<IEnumerable<FilterDefinition<T>>>? ApplyFilters { get; internal set; }
-            public Action<FilterDefinition<T>>? ClearFilter { get; internal set; }
-            public Action<IEnumerable<FilterDefinition<T>>>? ClearFilters { get; internal set; }
+            public Func<FilterDefinition<T>, Task> ApplyFilterAsync { get; init; } = null!;
+            public Func<IEnumerable<FilterDefinition<T>>, Task> ApplyFiltersAsync { get; init; } = null!;
+            public Func<FilterDefinition<T>, Task> ClearFilterAsync { get; init; } = null!;
+            public Func<IEnumerable<FilterDefinition<T>>, Task> ClearFiltersAsync { get; init; } = null!;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
@@ -42,13 +43,13 @@ namespace MudBlazor
             _dataGrid = dataGrid;
             Actions = new FooterActions
             {
-                SetSelectAll = async (x) => await _dataGrid.SetSelectAllAsync(x),
+                SetSelectAllAsync = x => _dataGrid.SetSelectAllAsync(x),
             };
         }
 
         public class FooterActions
         {
-            public Action<bool>? SetSelectAll { get; internal set; }
+            public Func<bool, Task> SetSelectAllAsync { get; init; } = null!;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
@@ -42,14 +43,14 @@ namespace MudBlazor
             _dataGrid = dataGrid;
             Actions = new HeaderActions
             {
-                SetSelectAll = async (x) => await _dataGrid.SetSelectAllAsync(x),
+                SetSelectAllAsync = x => _dataGrid.SetSelectAllAsync(x),
             };
 
         }
 
         public class HeaderActions
         {
-            public Action<bool>? SetSelectAll { get; internal set; }
+            public Func<bool, Task> SetSelectAllAsync { get; init; } = null!;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -8,7 +8,7 @@
         <label class="ma-n3">
             <MudIconButton
             Icon="@(context.OpenHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
-            OnClick="context.Actions.ToggleHierarchyVisibilityForItem"
+            OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
             Size="@IconSize"
             Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>
         </label>

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -6,16 +6,16 @@
     <HeaderTemplate>
         @if (ShowInHeader)
         {
-            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAll" />
+            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAllAsync" />
         }
     </HeaderTemplate>
     <CellTemplate>
-        <MudCheckBox T="bool" Size="@Size" Checked="@context.IsSelected" CheckedChanged="@context.Actions.SetSelectedItem" />
+        <MudCheckBox T="bool" Size="@Size" Checked="@context.IsSelected" CheckedChanged="@context.Actions.SetSelectedItemAsync" />
     </CellTemplate>
     <FooterTemplate>
         @if (ShowInFooter)
         {
-            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAll" />
+            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAllAsync" />
         }
     </FooterTemplate>
 </TemplateColumn>


### PR DESCRIPTION
## Description
This update addresses the issue of using async **void** in lambdas, which should be avoided whenever possible.

Previously, the design was as follows:
```CSharp
SetSelectedItem = async (x) => await dataGrid.SetSelectedItemAsync(x, item),
StartEditingItem = async () => await dataGrid.SetEditingItemAsync(item),
CancelEditingItem = async () => await dataGrid.CancelEditingItemAsync(),
ToggleHierarchyVisibilityForItem = async () => await dataGrid.ToggleHierarchyVisibilityAsync(item),
```
the SetSelectedItem, StartEditingItem, and other similar methods were defined as `Actions` instead of `Func<Task>`. This update changes the signature of these methods to return a Task, eliminating the use of async void in the lambdas.

Yes, this is breaking changed, but the sooner we fix this then better.

## How Has This Been Tested?
Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
