### PR TITLE
MudDataGrid: Allow to plug any filter type handler

### DIFF
--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("public partial class ApiDocsTests");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                var mudBlazorComponents = typeof(MudAlert).Assembly.GetTypes().OrderBy(t => t.FullName).Where(t => t.IsSubclassOf(typeof(ComponentBase)));
+                var mudBlazorComponents = typeof(MudAlert).Assembly.GetTypes().OrderBy(t => t.FullName).Where(t => t.IsSubclassOf(typeof(ComponentBase))).Where(t=> !t.IsDefined(typeof(ExcludeComponentFromApiDocsAttribute), false));
                 foreach (var type in mudBlazorComponents)
                 {
                     if (type.IsAbstract)

--- a/src/MudBlazor/Attributes/ExcludeComponentFromApiDocsAttribute.cs
+++ b/src/MudBlazor/Attributes/ExcludeComponentFromApiDocsAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor;
+
+[AttributeUsage(AttributeTargets.Class)]
+internal class ExcludeComponentFromApiDocsAttribute : Attribute
+{
+}

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -17,6 +17,10 @@ namespace MudBlazor
 
         public bool IsDateTime { get; init; }
 
+        public bool IsDateOnly { get; init; }
+
+        public bool IsTimeOnly { get; init; }
+
         public bool IsBoolean { get; init; }
 
         public bool IsGuid { get; init; }
@@ -29,6 +33,8 @@ namespace MudBlazor
                 IsNumber = TypeIdentifier.IsNumber(type),
                 IsEnum = TypeIdentifier.IsEnum(type),
                 IsDateTime = TypeIdentifier.IsDateTime(type),
+                IsDateOnly = TypeIdentifier.IsDateOnly(type),
+                IsTimeOnly = TypeIdentifier.IsTimeOnly(type),
                 IsBoolean = TypeIdentifier.IsBoolean(type),
                 IsGuid = TypeIdentifier.IsGuid(type)
             };

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace MudBlazor
 {
 #nullable enable
-    internal class Filter<T>
+    public class Filter<T>
     {
         private readonly MudDataGrid<T> _dataGrid;
         private readonly FilterDefinition<T> _filterDefinition;

--- a/src/MudBlazor/Components/DataGrid/FilterOperator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterOperator.cs
@@ -108,7 +108,7 @@ namespace MudBlazor
                     Boolean.Is,
                 };
             }
-            if (fieldType.IsDateTime)
+            if (fieldType.IsDateTime || fieldType.IsDateOnly || fieldType.IsTimeOnly)
             {
                 return new[]
                 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -1,35 +1,28 @@
 ﻿@namespace MudBlazor
-@inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudSelect T="bool?" 
+               Value="@Filter._valueBool"
+               ValueChanged="@Filter.BoolValueChanged"
+               FullWidth="true"
+               Dense="true"
+               Margin="@Margin.Dense" 
+               Class="filter-input">
+        <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+        <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
+        <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
+    </MudSelect>
+}
 
 @code {
 #nullable enable
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
 
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsBoolean;
+        return FilterDefinition.FieldType.IsBoolean;
     }
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudSelect T="bool?" 
-                    Value="@filter._valueBool"
-                    ValueChanged="@filter.BoolValueChanged"
-                    FullWidth="true"
-                    Dense="true"
-                    Margin="@Margin.Dense" 
-                    Class="filter-input">
-            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
-            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
-        </MudSelect>;
-
 }
 

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -1,0 +1,36 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsBoolean;
+    }
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudSelect T="bool?" 
+                    Value="@context.filter._valueBool"
+                    ValueChanged="@context.filter.BoolValueChanged"
+                    FullWidth="true"
+                    Dense="true"
+                    Margin="@Margin.Dense" 
+                    Class="filter-input">
+            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
+            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
+        </MudSelect>;
+
+}
+

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
-@typeparam T
-@inherits ComponentBase
-@implements IFilterType<T>
+@inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -13,16 +12,16 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsBoolean;
     }
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudSelect T="bool?" 
-                    Value="@context.filter._valueBool"
-                    ValueChanged="@context.filter.BoolValueChanged"
+                    Value="@filter._valueBool"
+                    ValueChanged="@filter.BoolValueChanged"
                     FullWidth="true"
                     Dense="true"
                     Margin="@Margin.Dense" 

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -6,8 +6,8 @@
 @if (CanBeMapped())
 {
     <MudSelect T="bool?" 
-               Value="@FilterLazy.Value._valueBool"
-               ValueChanged="@FilterLazy.Value.BoolValueChanged"
+               Value="@Filter._valueBool"
+               ValueChanged="@Filter.BoolValueChanged"
                FullWidth="true"
                Dense="true"
                Margin="@Margin.Dense" 
@@ -23,7 +23,7 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsBoolean;
+        return FilterDefinition.FieldType.IsBoolean;
     }
 }
 

--- a/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/BooleanFilterType.razor
@@ -5,8 +5,8 @@
 @if (CanBeMapped())
 {
     <MudSelect T="bool?" 
-               Value="@Filter._valueBool"
-               ValueChanged="@Filter.BoolValueChanged"
+               Value="@FilterLazy.Value._valueBool"
+               ValueChanged="@FilterLazy.Value.BoolValueChanged"
                FullWidth="true"
                Dense="true"
                Margin="@Margin.Dense" 
@@ -22,7 +22,7 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsBoolean;
+        return FilterDefinitionLazy.Value.FieldType.IsBoolean;
     }
 }
 

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -6,14 +6,14 @@
 {
     <MudGrid Spacing="0">
         <MudItem xs="7">
-            <MudDatePicker Date="@Filter._valueDate"
-                           DateChanged="@Filter.DateValueChanged"
+            <MudDatePicker Date="@FilterLazy.Value._valueDate"
+                           DateChanged="@FilterLazy.Value.DateValueChanged"
                            Margin="@Margin.Dense"
                            Class="filter-input-date"/>
         </MudItem>
         <MudItem xs="5">
-            <MudTimePicker Time="@Filter._valueTime"
-                           TimeChanged="@Filter.TimeValueChanged"
+            <MudTimePicker Time="@FilterLazy.Value._valueTime"
+                       TimeChanged="@FilterLazy.Value.TimeValueChanged"
                            Margin="@Margin.Dense"
                            Class="filter-input-time"/>
         </MudItem>
@@ -25,6 +25,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinitionLazy.Value.FieldType.IsDateTime && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -1,38 +1,30 @@
 ﻿@namespace MudBlazor
-inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudGrid Spacing="0">
+        <MudItem xs="7">
+            <MudDatePicker Date="@Filter._valueDate"
+                           DateChanged="@Filter.DateValueChanged"
+                           Margin="@Margin.Dense"
+                           Class="filter-input-date"/>
+        </MudItem>
+        <MudItem xs="5">
+            <MudTimePicker Time="@Filter._valueTime"
+                           TimeChanged="@Filter.TimeValueChanged"
+                           Margin="@Margin.Dense"
+                           Class="filter-input-time"/>
+        </MudItem>
+    </MudGrid>
+}
 
 @code {
 #nullable enable
 
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
-
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudGrid Spacing="0">
-            <MudItem xs="7">
-                <MudDatePicker Date="@filter._valueDate"
-                               DateChanged="@filter.DateValueChanged"
-                               Margin="@Margin.Dense"
-                               Class="filter-input-date"/>
-            </MudItem>
-            <MudItem xs="5">
-                <MudTimePicker Time="@filter._valueTime"
-                               TimeChanged="@filter.TimeValueChanged"
-                               Margin="@Margin.Dense"
-                               Class="filter-input-time"/>
-            </MudItem>
-        </MudGrid>;
-
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -7,14 +7,14 @@
 {
     <MudGrid Spacing="0">
         <MudItem xs="7">
-            <MudDatePicker Date="@FilterLazy.Value._valueDate"
-                           DateChanged="@FilterLazy.Value.DateValueChanged"
+            <MudDatePicker Date="@Filter._valueDate"
+                           DateChanged="@Filter.DateValueChanged"
                            Margin="@Margin.Dense"
                            Class="filter-input-date"/>
         </MudItem>
         <MudItem xs="5">
-            <MudTimePicker Time="@FilterLazy.Value._valueTime"
-                       TimeChanged="@FilterLazy.Value.TimeValueChanged"
+            <MudTimePicker Time="@Filter._valueTime"
+                       TimeChanged="@Filter.TimeValueChanged"
                            Margin="@Margin.Dense"
                            Class="filter-input-time"/>
         </MudItem>
@@ -26,6 +26,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsDateTime && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
-@typeparam T
-@inherits ComponentBase
-@implements IFilterType<T>
+inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -14,23 +13,23 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
     }
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudGrid Spacing="0">
             <MudItem xs="7">
-                <MudDatePicker Date="@context.filter._valueDate"
-                               DateChanged="@context.filter.DateValueChanged"
+                <MudDatePicker Date="@filter._valueDate"
+                               DateChanged="@filter.DateValueChanged"
                                Margin="@Margin.Dense"
                                Class="filter-input-date"/>
             </MudItem>
             <MudItem xs="5">
-                <MudTimePicker Time="@context.filter._valueTime"
-                               TimeChanged="@context.filter.TimeValueChanged"
+                <MudTimePicker Time="@filter._valueTime"
+                               TimeChanged="@filter.TimeValueChanged"
                                Margin="@Margin.Dense"
                                Class="filter-input-time"/>
             </MudItem>

--- a/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/DateTimeFilterType.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
+    }
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudGrid Spacing="0">
+            <MudItem xs="7">
+                <MudDatePicker Date="@context.filter._valueDate"
+                               DateChanged="@context.filter.DateValueChanged"
+                               Margin="@Margin.Dense"
+                               Class="filter-input-date"/>
+            </MudItem>
+            <MudItem xs="5">
+                <MudTimePicker Time="@context.filter._valueTime"
+                               TimeChanged="@context.filter.TimeValueChanged"
+                               Margin="@Margin.Dense"
+                               Class="filter-input-time"/>
+            </MudItem>
+        </MudGrid>;
+
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor
+@typeparam T
+@using MudBlazor.Extensions
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsEnum;
+    }
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudSelect T="Enum"
+                    Value="@context.filter._valueEnum"
+                    ValueChanged="@context.filter.EnumValueChanged"
+                    FullWidth="true"
+                    Dense="true"
+                    Margin="@Margin.Dense"
+                    Class="filter-input">
+            <MudSelectItem T="Enum"
+                           Value="@(null)"/>
+        @foreach (var item in EnumExtensions.GetSafeEnumValues(context.filterDefinition.dataType))
+            {
+                <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
+            }
+        </MudSelect>;
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -2,6 +2,7 @@
 @using MudBlazor.Extensions
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -6,15 +6,15 @@
 @if (CanBeMapped())
 {
     <MudSelect T="Enum"
-               Value="@Filter._valueEnum"
-               ValueChanged="@Filter.EnumValueChanged"
+               Value="@FilterLazy.Value._valueEnum"
+               ValueChanged="@FilterLazy.Value.EnumValueChanged"
                FullWidth="true"
                Dense="true"
                Margin="@Margin.Dense"
                Class="filter-input">
         <MudSelectItem T="Enum"
                        Value="@(null)"/>
-        @foreach (var item in EnumExtensions.GetSafeEnumValues(FilterDefinition.dataType))
+        @foreach (var item in EnumExtensions.GetSafeEnumValues(FilterDefinitionLazy.Value.dataType))
         {
             <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
         }
@@ -26,6 +26,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsEnum;
+        return FilterDefinitionLazy.Value.FieldType.IsEnum;
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -1,8 +1,7 @@
 ﻿@namespace MudBlazor
-@typeparam T
 @using MudBlazor.Extensions
-@inherits ComponentBase
-@implements IFilterType<T>
+inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -15,23 +14,23 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsEnum;
     }
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudSelect T="Enum"
-                    Value="@context.filter._valueEnum"
-                    ValueChanged="@context.filter.EnumValueChanged"
+                    Value="@filter._valueEnum"
+                    ValueChanged="@filter.EnumValueChanged"
                     FullWidth="true"
                     Dense="true"
                     Margin="@Margin.Dense"
                     Class="filter-input">
             <MudSelectItem T="Enum"
                            Value="@(null)"/>
-        @foreach (var item in EnumExtensions.GetSafeEnumValues(context.filterDefinition.dataType))
+        @foreach (var item in EnumExtensions.GetSafeEnumValues(filterDefinition.dataType))
             {
                 <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
             }

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -7,15 +7,15 @@
 @if (CanBeMapped())
 {
     <MudSelect T="Enum"
-               Value="@FilterLazy.Value._valueEnum"
-               ValueChanged="@FilterLazy.Value.EnumValueChanged"
+               Value="@Filter._valueEnum"
+               ValueChanged="@Filter.EnumValueChanged"
                FullWidth="true"
                Dense="true"
                Margin="@Margin.Dense"
                Class="filter-input">
         <MudSelectItem T="Enum"
                        Value="@(null)"/>
-        @foreach (var item in EnumExtensions.GetSafeEnumValues(FilterDefinitionLazy.Value.dataType))
+        @foreach (var item in EnumExtensions.GetSafeEnumValues(FilterDefinition.dataType))
         {
             <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
         }
@@ -27,6 +27,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsEnum;
+        return FilterDefinition.FieldType.IsEnum;
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/EnumFilterType.razor
@@ -1,38 +1,31 @@
 ﻿@namespace MudBlazor
 @using MudBlazor.Extensions
-inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudSelect T="Enum"
+               Value="@Filter._valueEnum"
+               ValueChanged="@Filter.EnumValueChanged"
+               FullWidth="true"
+               Dense="true"
+               Margin="@Margin.Dense"
+               Class="filter-input">
+        <MudSelectItem T="Enum"
+                       Value="@(null)"/>
+        @foreach (var item in EnumExtensions.GetSafeEnumValues(FilterDefinition.dataType))
+        {
+            <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
+        }
+    </MudSelect>
+}
 
 @code {
 #nullable enable
 
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
-
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsEnum;
+        return FilterDefinition.FieldType.IsEnum;
     }
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudSelect T="Enum"
-                    Value="@filter._valueEnum"
-                    ValueChanged="@filter.EnumValueChanged"
-                    FullWidth="true"
-                    Dense="true"
-                    Margin="@Margin.Dense"
-                    Class="filter-input">
-            <MudSelectItem T="Enum"
-                           Value="@(null)"/>
-        @foreach (var item in EnumExtensions.GetSafeEnumValues(filterDefinition.dataType))
-            {
-                <MudSelectItem T="Enum" Value="@(item)">@item</MudSelectItem>
-            }
-        </MudSelect>;
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+public class FilterTypeBase
+{
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
@@ -2,8 +2,37 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Microsoft.AspNetCore.Components;
+
 namespace MudBlazor;
 
-public class FilterTypeBase
+#nullable enable
+public abstract class FilterTypeBase<T> : ComponentBase
 {
+    [CascadingParameter(Name = "Filter")] 
+    private Filter<T> FilterInternal { get; set; } = null!;
+
+    [CascadingParameter(Name = "FilterDefinition")]
+    private FilterDefinition<T> FilterDefinitionInternal { get; set; } = null!;
+
+    protected Filter<T> Filter
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(FilterInternal);
+            return FilterInternal;
+        }
+    }
+
+    protected FilterDefinition<T> FilterDefinition
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
+            return FilterDefinitionInternal;
+        }
+    }
+
+    public abstract bool CanBeMapped();
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
@@ -16,23 +16,27 @@ public abstract class FilterTypeBase<T> : ComponentBase
     [CascadingParameter(Name = "FilterDefinition")]
     private FilterDefinition<T> FilterDefinitionInternal { get; set; } = null!;
 
-    protected Filter<T> Filter
+    protected FilterTypeBase()
     {
-        get
-        {
-            ArgumentNullException.ThrowIfNull(FilterInternal);
-            return FilterInternal;
-        }
+        FilterLazy = new Lazy<Filter<T>>(GetFilter);
+        FilterDefinitionLazy = new Lazy<FilterDefinition<T>>(GetFilterDefinition);
     }
 
-    protected FilterDefinition<T> FilterDefinition
-    {
-        get
-        {
-            ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
-            return FilterDefinitionInternal;
-        }
-    }
+    protected Lazy<Filter<T>> FilterLazy { get; }
+
+    protected Lazy<FilterDefinition<T>> FilterDefinitionLazy { get; }
 
     public abstract bool CanBeMapped();
+
+    private Filter<T> GetFilter()
+    {
+        ArgumentNullException.ThrowIfNull(FilterInternal);
+        return FilterInternal;
+    }
+
+    private FilterDefinition<T> GetFilterDefinition()
+    {
+        ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
+        return FilterDefinitionInternal;
+    }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
@@ -30,13 +30,13 @@ public abstract class FilterTypeBase<T> : ComponentBase
 
     private Filter<T> GetFilter()
     {
-        ArgumentNullException.ThrowIfNull(FilterInternal);
+        //ArgumentNullException.ThrowIfNull(FilterInternal);
         return FilterInternal;
     }
 
     private FilterDefinition<T> GetFilterDefinition()
     {
-        ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
+        //ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
         return FilterDefinitionInternal;
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeBase.cs
@@ -16,27 +16,24 @@ public abstract class FilterTypeBase<T> : ComponentBase
     [CascadingParameter(Name = "FilterDefinition")]
     private FilterDefinition<T> FilterDefinitionInternal { get; set; } = null!;
 
-    protected FilterTypeBase()
+
+    protected Filter<T> Filter
     {
-        FilterLazy = new Lazy<Filter<T>>(GetFilter);
-        FilterDefinitionLazy = new Lazy<FilterDefinition<T>>(GetFilterDefinition);
+        get
+        {
+            ArgumentNullException.ThrowIfNull(FilterInternal);
+            return FilterInternal;
+        }
     }
 
-    protected Lazy<Filter<T>> FilterLazy { get; }
-
-    protected Lazy<FilterDefinition<T>> FilterDefinitionLazy { get; }
+    protected FilterDefinition<T> FilterDefinition
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
+            return FilterDefinitionInternal;
+        }
+    }
 
     public abstract bool CanBeMapped();
-
-    private Filter<T> GetFilter()
-    {
-        //ArgumentNullException.ThrowIfNull(FilterInternal);
-        return FilterInternal;
-    }
-
-    private FilterDefinition<T> GetFilterDefinition()
-    {
-        //ArgumentNullException.ThrowIfNull(FilterDefinitionInternal);
-        return FilterDefinitionInternal;
-    }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
@@ -17,20 +17,10 @@ public class FilterTypeMapper
         typeof(EnumFilterType<>),
         typeof(GuidFilterType<>),
         typeof(NumberFilterType<>),
-        typeof(StringFilterType<>),
+        typeof(StringFilterType<>)
     };
 
-    //public IReadOnlyList<IFilterType> Filters => new List<IFilterType>()
-    //{
-    //    new BooleanFilterType(),
-    //    new DateTimeFilterType(),
-    //    new EnumFilterType(),
-    //    new GuidFilterType(),
-    //    new NumberFilterType(),
-    //    new StringFilterType()
-    //};
-
-    public IEnumerable<Type> Create<T>()
+    public virtual IEnumerable<Type> Create<T>()
     {
         foreach (var filterType in _filterTypes)
         {
@@ -39,11 +29,17 @@ public class FilterTypeMapper
         }
     }
 
-    //public void AddFilterType(IFilterType filterType) => _filters.Add(filterType);
+    public void AddFilterType<T>() where T : FilterTypeBase<T>
+    {
+        _filterTypes.Add(typeof(T).GetGenericTypeDefinition());
+    }
 
-    //public void RemoveFilterType(IFilterType filterType) => _filters.Remove(filterType);
+    public void RemoveFilterType<T>() where T : FilterTypeBase<T>
+    {
+        _filterTypes.Remove(typeof(T).GetGenericTypeDefinition());
+    }
 
-    //public void RemoveAll() => _filters.Clear();
+    public void RemoveAll() => _filterTypes.Clear();
 
     public static FilterTypeMapper Default = new();
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace MudBlazor;
+
+#nullable enable
+public class FilterTypeMapper<T>
+{
+    private readonly List<IFilterType<T>> _filters = new()
+    {
+        new BooleanFilterType<T>(),
+        new DateTimeFilterType<T>(),
+        new EnumFilterType<T>(),
+        new GuidFilterType<T>(),
+        new NumberFilterType<T>(),
+        new StringFilterType<T>()
+    };
+
+    public IReadOnlyList<IFilterType<T>> Filters => _filters;
+
+    public void AddFilterType(IFilterType<T> filterType) => _filters.Add(filterType);
+
+    public void RemoveFilterType(IFilterType<T> filterType) => _filters.Remove(filterType);
+
+    public void RemoveAll() => _filters.Clear();
+
+    public static FilterTypeMapper<T> Default = new();
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
@@ -7,25 +7,25 @@ using System.Collections.Generic;
 namespace MudBlazor;
 
 #nullable enable
-public class FilterTypeMapper<T>
+public class FilterTypeMapper
 {
-    private readonly List<IFilterType<T>> _filters = new()
+    private readonly List<IFilterType> _filters = new()
     {
-        new BooleanFilterType<T>(),
-        new DateTimeFilterType<T>(),
-        new EnumFilterType<T>(),
-        new GuidFilterType<T>(),
-        new NumberFilterType<T>(),
-        new StringFilterType<T>()
+        new BooleanFilterType(),
+        new DateTimeFilterType(),
+        new EnumFilterType(),
+        new GuidFilterType(),
+        new NumberFilterType(),
+        new StringFilterType()
     };
 
-    public IReadOnlyList<IFilterType<T>> Filters => _filters;
+    public IReadOnlyList<IFilterType> Filters => _filters;
 
-    public void AddFilterType(IFilterType<T> filterType) => _filters.Add(filterType);
+    public void AddFilterType(IFilterType filterType) => _filters.Add(filterType);
 
-    public void RemoveFilterType(IFilterType<T> filterType) => _filters.Remove(filterType);
+    public void RemoveFilterType(IFilterType filterType) => _filters.Remove(filterType);
 
     public void RemoveAll() => _filters.Clear();
 
-    public static FilterTypeMapper<T> Default = new();
+    public static FilterTypeMapper Default = new();
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/FilterTypeMapper.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace MudBlazor;
@@ -9,23 +10,40 @@ namespace MudBlazor;
 #nullable enable
 public class FilterTypeMapper
 {
-    private readonly List<IFilterType> _filters = new()
+    private readonly List<Type> _filterTypes = new()
     {
-        new BooleanFilterType(),
-        new DateTimeFilterType(),
-        new EnumFilterType(),
-        new GuidFilterType(),
-        new NumberFilterType(),
-        new StringFilterType()
+        typeof(BooleanFilterType<>),
+        typeof(DateTimeFilterType<>),
+        typeof(EnumFilterType<>),
+        typeof(GuidFilterType<>),
+        typeof(NumberFilterType<>),
+        typeof(StringFilterType<>),
     };
 
-    public IReadOnlyList<IFilterType> Filters => _filters;
+    //public IReadOnlyList<IFilterType> Filters => new List<IFilterType>()
+    //{
+    //    new BooleanFilterType(),
+    //    new DateTimeFilterType(),
+    //    new EnumFilterType(),
+    //    new GuidFilterType(),
+    //    new NumberFilterType(),
+    //    new StringFilterType()
+    //};
 
-    public void AddFilterType(IFilterType filterType) => _filters.Add(filterType);
+    public IEnumerable<Type> Create<T>()
+    {
+        foreach (var filterType in _filterTypes)
+        {
+            var genericType = filterType.MakeGenericType(typeof(T));
+            yield return genericType;
+        }
+    }
 
-    public void RemoveFilterType(IFilterType filterType) => _filters.Remove(filterType);
+    //public void AddFilterType(IFilterType filterType) => _filters.Add(filterType);
 
-    public void RemoveAll() => _filters.Clear();
+    //public void RemoveFilterType(IFilterType filterType) => _filters.Remove(filterType);
+
+    //public void RemoveAll() => _filters.Clear();
 
     public static FilterTypeMapper Default = new();
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -1,33 +1,25 @@
 ﻿@namespace MudBlazor
-inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudTextField T="string"
+                  Value="@Filter._valueString"
+                  ValueChanged="@Filter.StringValueChanged"
+                  FullWidth="true"
+                  Label="Value"
+                  Placeholder="Filter value"
+                  Margin="@Margin.Dense"
+                  Immediate="true"
+                  Class="filter-input"/>
+}
 
 @code {
 #nullable enable
 
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
-
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudTextField T="string"
-                       Value="@filter._valueString"
-                       ValueChanged="@filter.StringValueChanged"
-                       FullWidth="true"
-                       Label="Value"
-                       Placeholder="Filter value"
-                       Margin="@Margin.Dense"
-                       Immediate="true"
-                       Class="filter-input"/>;
-
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -5,8 +5,8 @@
 @if (CanBeMapped())
 {
     <MudTextField T="string"
-                  Value="@Filter._valueString"
-                  ValueChanged="@Filter.StringValueChanged"
+                  Value="@FilterLazy.Value._valueString"
+                  ValueChanged="@FilterLazy.Value.StringValueChanged"
                   FullWidth="true"
                   Label="Value"
                   Placeholder="Filter value"
@@ -20,6 +20,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinitionLazy.Value.FieldType.IsDateTime && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -6,8 +6,8 @@
 @if (CanBeMapped())
 {
     <MudTextField T="string"
-                  Value="@FilterLazy.Value._valueString"
-                  ValueChanged="@FilterLazy.Value.StringValueChanged"
+                  Value="@Filter._valueString"
+                  ValueChanged="@Filter.StringValueChanged"
                   FullWidth="true"
                   Label="Value"
                   Placeholder="Filter value"
@@ -21,6 +21,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsDateTime && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsDateTime && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
-@typeparam T
-@inherits ComponentBase
-@implements IFilterType<T>
+inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -14,16 +13,16 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
     }
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudTextField T="string"
-                       Value="@context.filter._valueString"
-                       ValueChanged="@context.filter.StringValueChanged"
+                       Value="@filter._valueString"
+                       ValueChanged="@filter.StringValueChanged"
                        FullWidth="true"
                        Label="Value"
                        Placeholder="Filter value"

--- a/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/GuidFilterType.razor
@@ -1,0 +1,34 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty");
+    }
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudTextField T="string"
+                       Value="@context.filter._valueString"
+                       ValueChanged="@context.filter.StringValueChanged"
+                       FullWidth="true"
+                       Label="Value"
+                       Placeholder="Filter value"
+                       Margin="@Margin.Dense"
+                       Immediate="true"
+                       Class="filter-input"/>;
+
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
@@ -11,13 +11,4 @@ namespace MudBlazor;
 /// </summary>
 public interface IFilterType
 {
-    /// <summary>
-    /// TODO: document
-    /// </summary>
-    bool CanBeMapped<T>(FilterDefinition<T> filterDefinition);
-
-    /// <summary>
-    /// TODO: document
-    /// </summary>
-    RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter);
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor;
+
+/// <summary>
+/// TODO: document
+/// </summary>
+public interface IFilterType<T>
+{
+    /// <summary>
+    /// TODO: document
+    /// </summary>
+    bool CanBeMapped(FilterDefinition<T> filterDefinition);
+
+    /// <summary>
+    /// TODO: document
+    /// </summary>
+    RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment { get; }
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterType/IFilterType.cs
@@ -9,15 +9,15 @@ namespace MudBlazor;
 /// <summary>
 /// TODO: document
 /// </summary>
-public interface IFilterType<T>
+public interface IFilterType
 {
     /// <summary>
     /// TODO: document
     /// </summary>
-    bool CanBeMapped(FilterDefinition<T> filterDefinition);
+    bool CanBeMapped<T>(FilterDefinition<T> filterDefinition);
 
     /// <summary>
     /// TODO: document
     /// </summary>
-    RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment { get; }
+    RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter);
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -5,15 +5,15 @@
 @if (CanBeMapped())
 {
     <MudNumericField T="double?"
-                     Value="@Filter._valueNumber"
-                     ValueChanged="@Filter.NumberValueChanged"
+                 Value="@FilterLazy.Value._valueNumber"
+                 ValueChanged="@FilterLazy.Value.NumberValueChanged"
                      FullWidth="true"
                      Label="Value"
                      Placeholder="Filter value"
                      Margin="@Margin.Dense"
                      Immediate="true"
                      Class="filter-input"
-                     Culture="@Filter.FilterColumn?.Culture"/>
+                     Culture="@FilterLazy.Value.FilterColumn?.Culture"/>
 }
 
 @code {
@@ -21,6 +21,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsNumber && !(FilterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinitionLazy.Value.FieldType.IsNumber && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
-@typeparam T
-@inherits ComponentBase
-@implements IFilterType<T>
+inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -14,22 +13,22 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty");
     }
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudNumericField T="double?"
-                          Value="@context.filter._valueNumber"
-                          ValueChanged="@context.filter.NumberValueChanged"
+                          Value="@filter._valueNumber"
+                          ValueChanged="@filter.NumberValueChanged"
                           FullWidth="true"
                           Label="Value"
                           Placeholder="Filter value"
                           Margin="@Margin.Dense"
                           Immediate="true"
                           Class="filter-input"
-                          Culture="@context.filter.FilterColumn?.Culture"/>;
+                          Culture="@filter.FilterColumn?.Culture"/>;
 
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -1,34 +1,26 @@
 ﻿@namespace MudBlazor
-inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudNumericField T="double?"
+                     Value="@Filter._valueNumber"
+                     ValueChanged="@Filter.NumberValueChanged"
+                     FullWidth="true"
+                     Label="Value"
+                     Placeholder="Filter value"
+                     Margin="@Margin.Dense"
+                     Immediate="true"
+                     Class="filter-input"
+                     Culture="@Filter.FilterColumn?.Culture"/>
+}
 
 @code {
 #nullable enable
 
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
-
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsNumber && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudNumericField T="double?"
-                          Value="@filter._valueNumber"
-                          ValueChanged="@filter.NumberValueChanged"
-                          FullWidth="true"
-                          Label="Value"
-                          Placeholder="Filter value"
-                          Margin="@Margin.Dense"
-                          Immediate="true"
-                          Class="filter-input"
-                          Culture="@filter.FilterColumn?.Culture"/>;
-
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty");
+    }
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudNumericField T="double?"
+                          Value="@context.filter._valueNumber"
+                          ValueChanged="@context.filter.NumberValueChanged"
+                          FullWidth="true"
+                          Label="Value"
+                          Placeholder="Filter value"
+                          Margin="@Margin.Dense"
+                          Immediate="true"
+                          Class="filter-input"
+                          Culture="@context.filter.FilterColumn?.Culture"/>;
+
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/NumberFilterType.razor
@@ -6,15 +6,15 @@
 @if (CanBeMapped())
 {
     <MudNumericField T="double?"
-                 Value="@FilterLazy.Value._valueNumber"
-                 ValueChanged="@FilterLazy.Value.NumberValueChanged"
+                 Value="@Filter._valueNumber"
+                 ValueChanged="@Filter.NumberValueChanged"
                      FullWidth="true"
                      Label="Value"
                      Placeholder="Filter value"
                      Margin="@Margin.Dense"
                      Immediate="true"
                      Class="filter-input"
-                     Culture="@FilterLazy.Value.FilterColumn?.Culture"/>
+                     Culture="@Filter.FilterColumn?.Culture"/>
 }
 
 @code {
@@ -22,6 +22,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsNumber && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsNumber && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @typeparam T
 @inherits FilterTypeBase<T>
+@attribute [ExcludeComponentFromApiDocs]
 
 @if (CanBeMapped())
 {

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits ComponentBase
+@implements IFilterType<T>
+
+@Render
+
+@code {
+#nullable enable
+
+    /// <summary>
+    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
+    /// </summary>
+    public RenderFragment Render => base.BuildRenderTree;
+
+    /// <inheritdoc />
+    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    {
+        return filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty");
+    }
+
+
+    /// <inheritdoc />
+    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+        @<MudTextField T="string"
+                       Value="@context.filter._valueString"
+                       ValueChanged="@context.filter.StringValueChanged"
+                       FullWidth="true"
+                       Label="Value"
+                       Placeholder="Filter value"
+                       Margin="@Margin.Dense"
+                       Immediate="true"
+                       Class="filter-input"/>;
+
+}

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -5,8 +5,8 @@
 @if (CanBeMapped())
 {
     <MudTextField T="string"
-                  Value="@Filter._valueString"
-                  ValueChanged="@Filter.StringValueChanged"
+                  Value="@FilterLazy.Value._valueString"
+                  ValueChanged="@FilterLazy.Value.StringValueChanged"
                   FullWidth="true"
                   Label="Value"
                   Placeholder="Filter value"
@@ -20,6 +20,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinition.FieldType.IsString && !(FilterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinitionLazy.Value.FieldType.IsString && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -1,34 +1,25 @@
 ﻿@namespace MudBlazor
-inherits MudComponentBase
-@implements IFilterType
+@typeparam T
+@inherits FilterTypeBase<T>
 
-@Render
+@if (CanBeMapped())
+{
+    <MudTextField T="string"
+                  Value="@Filter._valueString"
+                  ValueChanged="@Filter.StringValueChanged"
+                  FullWidth="true"
+                  Label="Value"
+                  Placeholder="Filter value"
+                  Margin="@Margin.Dense"
+                  Immediate="true"
+                  Class="filter-input"/>
+}
 
 @code {
 #nullable enable
 
-    /// <summary>
-    /// Renders the component to the supplied <see cref="BuildRenderTree"/>.
-    /// </summary>
-    public RenderFragment Render => base.BuildRenderTree;
-
-    /// <inheritdoc />
-    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
+    public override bool CanBeMapped()
     {
-        return filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsString && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
-
-
-    /// <inheritdoc />
-    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
-        @<MudTextField T="string"
-                       Value="@filter._valueString"
-                       ValueChanged="@filter.StringValueChanged"
-                       FullWidth="true"
-                       Label="Value"
-                       Placeholder="Filter value"
-                       Margin="@Margin.Dense"
-                       Immediate="true"
-                       Class="filter-input"/>;
-
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -6,8 +6,8 @@
 @if (CanBeMapped())
 {
     <MudTextField T="string"
-                  Value="@FilterLazy.Value._valueString"
-                  ValueChanged="@FilterLazy.Value.StringValueChanged"
+                  Value="@Filter._valueString"
+                  ValueChanged="@Filter.StringValueChanged"
                   FullWidth="true"
                   Label="Value"
                   Placeholder="Filter value"
@@ -21,6 +21,6 @@
 
     public override bool CanBeMapped()
     {
-        return FilterDefinitionLazy.Value.FieldType.IsString && !(FilterDefinitionLazy.Value.Operator ?? "").EndsWith("empty");
+        return FilterDefinition.FieldType.IsString && !(FilterDefinition.Operator ?? "").EndsWith("empty");
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterType/StringFilterType.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
-@typeparam T
-@inherits ComponentBase
-@implements IFilterType<T>
+inherits MudComponentBase
+@implements IFilterType
 
 @Render
 
@@ -14,17 +13,17 @@
     public RenderFragment Render => base.BuildRenderTree;
 
     /// <inheritdoc />
-    public bool CanBeMapped(FilterDefinition<T> filterDefinition)
+    public bool CanBeMapped<T>(FilterDefinition<T> filterDefinition)
     {
         return filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty");
     }
 
 
     /// <inheritdoc />
-    public RenderFragment<(FilterDefinition<T> filterDefinition, Filter<T> filter)> RenderFilterFragment => context =>
+    public RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter) =>
         @<MudTextField T="string"
-                       Value="@context.filter._valueString"
-                       ValueChanged="@context.filter.StringValueChanged"
+                       Value="@filter._valueString"
+                       ValueChanged="@filter.StringValueChanged"
                        FullWidth="true"
                        Label="Value"
                        Placeholder="Filter value"

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -413,8 +413,8 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="4">
-                    <CascadingValue Name="Filter" Value="filter" IsFixed="true">
-                        <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
+                    <CascadingValue Name="Filter" Value="filter">
+                        <CascadingValue Name="FilterDefinition" Value="filterDefinition">
                             @foreach (var filterType in FilterTypeMapper.Create<T>())
                             {
                                 <DynamicComponent Type="@filterType" />
@@ -435,8 +435,8 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12">
-                    <CascadingValue Name="Filter" Value="filter" IsFixed="true">
-                        <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
+                    <CascadingValue Name="Filter" Value="filter">
+                        <CascadingValue Name="FilterDefinition" Value="filterDefinition">
                             @foreach (var filterType in FilterTypeMapper.Create<T>())
                             {
                                 <DynamicComponent Type="@filterType"/>
@@ -445,57 +445,5 @@
                     </CascadingValue>
                 </MudItem>
             }
-            </text>
-    ;
-
-
-
-    private void RenderFilters(RenderTreeBuilder __builder)
-    {
-        foreach (var filterDefinition in FilterDefinitions)
-        {
-            RenderFilter(__builder, filterDefinition);
-        }
-    }
-
-    private RenderFragment Hack => __builder =>
-    {
-        __builder.OpenComponent<StringFilterType<T>>(0);
-        __builder.CloseComponent();
-    };
-
-    private void RenderFilter(RenderTreeBuilder __builder, FilterDefinition<T> filterDefinition)
-    {
-        var filter = new Filter<T>(this, filterDefinition, null);
-
-        <MudItem xs="1" Class="d-flex">
-            <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilter" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
-        </MudItem>
-        <MudItem xs="4">
-            <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="Column" Dense="true" Margin="@Margin.Dense"
-               Class="filter-field">
-                @foreach (var renderColumn in RenderedColumns ?? Enumerable.Empty<Column<T>>())
-                {
-                    <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="3">
-            <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
-               Class="filter-operator">
-                @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(filterDefinition.dataType))
-                {
-                    <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="4">
-            <CascadingValue Name="Filter" Value="filter" IsFixed="true">
-                <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
-                    <DynamicComponent Type="@typeof(StringFilterType<T>)" />
-                </CascadingValue>
-            </CascadingValue>
-        </MudItem>
-
-    }
+            </text>;
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -412,51 +412,12 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="4">
-                    @if (filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    @foreach (var filterType in FilterTypeMapper.Filters)
                     {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
-                    }
-                    else if (filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
-                    }
-                    else if (filterDefinition.FieldType.IsEnum)
-                    {
-                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                            @foreach (var item in EnumExtensions.GetSafeEnumValues(filterDefinition.dataType))
-                            {
-                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
-                            }
-                        </MudSelect>
-                    }
-                    else if (filterDefinition.FieldType.IsBoolean)
-                    {
-                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
-                        </MudSelect>
-                    }
-                    else if (filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudGrid Spacing="0">
-                            <MudItem xs="7">
-                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
-                            </MudItem>
-                            <MudItem xs="5">
-                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
-                            </MudItem>
-                        </MudGrid>
-                    }
-                    else if (filterDefinition.FieldType.IsGuid)
-                    {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
+                        if (filterType.CanBeMapped(filterDefinition))
+                        {
+                            @filterType.RenderFilterFragment((filterDefinition, filter));
+                        }
                     }
                 </MudItem>
             }
@@ -472,51 +433,13 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12">
-                    @if (filterDefinition.FieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                    @foreach (var filterType in FilterTypeMapper.Filters)
                     {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
+                        if (filterType.CanBeMapped(filterDefinition))
+                        {
+                        @filterType.RenderFilterFragment((filterDefinition, filter))
+                        ;
                     }
-                    else if (filterDefinition.FieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="Filter value" Margin="@Margin.Dense"
-                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
-                    }
-                    else if (filterDefinition.FieldType.IsEnum)
-                    {
-                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                            @foreach (var item in Enum.GetValues(filterDefinition.dataType))
-                            {
-                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
-                            }
-                        </MudSelect>
-                    }
-                    else if (filterDefinition.FieldType.IsBoolean)
-                    {
-                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(true)">true</MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(false)">false</MudSelectItem>
-                        </MudSelect>
-                    }
-                    else if (filterDefinition.FieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudGrid Spacing="0">
-                            <MudItem xs="7">
-                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
-                            </MudItem>
-                            <MudItem xs="5">
-                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
-                            </MudItem>
-                        </MudGrid>
-                    }
-                    else if (filterDefinition.FieldType.IsGuid)
-                    {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="Value" Placeholder="Filter value" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
                     }
                 </MudItem>
             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -413,13 +413,14 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="4">
-                    @foreach (var filterType in FilterTypeMapper.Filters)
-                    {
-                        if (filterType.CanBeMapped(filterDefinition))
-                        {
-                            @filterType.RenderFilterFragment(filterDefinition, filter)
-                        }
-                    }
+                    <CascadingValue Name="Filter" Value="filter" IsFixed="true">
+                        <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
+                            @foreach (var filterType in FilterTypeMapper.Create<T>())
+                            {
+                                <DynamicComponent Type="@filterType" />
+                            }
+                        </CascadingValue>
+                    </CascadingValue>
                 </MudItem>
             }
             else
@@ -434,14 +435,67 @@
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12">
-                    @foreach (var filterType in FilterTypeMapper.Filters)
-                    {
-                        if (filterType.CanBeMapped(filterDefinition))
-                        {
-                            @filterType.RenderFilterFragment(filterDefinition, filter)
-                        }
-                    }
+                    <CascadingValue Name="Filter" Value="filter" IsFixed="true">
+                        <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
+                            @foreach (var filterType in FilterTypeMapper.Create<T>())
+                            {
+                                <DynamicComponent Type="@filterType"/>
+                            }
+                        </CascadingValue>
+                    </CascadingValue>
                 </MudItem>
             }
-         </text>;
+            </text>
+    ;
+
+
+
+    private void RenderFilters(RenderTreeBuilder __builder)
+    {
+        foreach (var filterDefinition in FilterDefinitions)
+        {
+            RenderFilter(__builder, filterDefinition);
+        }
+    }
+
+    private RenderFragment Hack => __builder =>
+    {
+        __builder.OpenComponent<StringFilterType<T>>(0);
+        __builder.CloseComponent();
+    };
+
+    private void RenderFilter(RenderTreeBuilder __builder, FilterDefinition<T> filterDefinition)
+    {
+        var filter = new Filter<T>(this, filterDefinition, null);
+
+        <MudItem xs="1" Class="d-flex">
+            <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilter" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
+        </MudItem>
+        <MudItem xs="4">
+            <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="Column" Dense="true" Margin="@Margin.Dense"
+               Class="filter-field">
+                @foreach (var renderColumn in RenderedColumns ?? Enumerable.Empty<Column<T>>())
+                {
+                    <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="3">
+            <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
+               Class="filter-operator">
+                @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(filterDefinition.dataType))
+                {
+                    <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="4">
+            <CascadingValue Name="Filter" Value="filter" IsFixed="true">
+                <CascadingValue Name="FilterDefinition" Value="filterDefinition" IsFixed="true">
+                    <DynamicComponent Type="@typeof(StringFilterType<T>)" />
+                </CascadingValue>
+            </CascadingValue>
+        </MudItem>
+
+    }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -3,6 +3,7 @@
 @typeparam T
 @using MudBlazor.Utilities
 @using MudBlazor.Extensions
+@using Microsoft.AspNetCore.Components.Rendering
 
 @{
     _currentRenderFilteredItemsCache = null;
@@ -416,7 +417,7 @@
                     {
                         if (filterType.CanBeMapped(filterDefinition))
                         {
-                            @filterType.RenderFilterFragment((filterDefinition, filter));
+                            @filterType.RenderFilterFragment(filterDefinition, filter)
                         }
                     }
                 </MudItem>
@@ -437,9 +438,8 @@
                     {
                         if (filterType.CanBeMapped(filterDefinition))
                         {
-                        @filterType.RenderFilterFragment((filterDefinition, filter))
-                        ;
-                    }
+                            @filterType.RenderFilterFragment(filterDefinition, filter)
+                        }
                     }
                 </MudItem>
             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -628,7 +628,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool ShowMenuIcon { get; set; } = false;
 
-        [Parameter] public FilterTypeMapper FilterTypeMapper { get; set; } = FilterTypeMapper.Default;
+        [Parameter] public FilterTypeMapper FilterTypeMapper { get; set; } = new();
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -628,6 +628,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool ShowMenuIcon { get; set; } = false;
 
+        [Parameter] public FilterTypeMapper<T> FilterTypeMapper { get; set; } = FilterTypeMapper<T>.Default;
+
         #endregion
 
         #region Properties

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -628,7 +628,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool ShowMenuIcon { get; set; } = false;
 
-        [Parameter] public FilterTypeMapper<T> FilterTypeMapper { get; set; } = FilterTypeMapper<T>.Default;
+        [Parameter] public FilterTypeMapper FilterTypeMapper { get; set; } = FilterTypeMapper.Default;
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
+++ b/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
@@ -79,6 +79,30 @@ namespace MudBlazor
             return underlyingType is not null && underlyingType == typeof(DateTime);
         }
 
+        public static bool IsDateOnly(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(DateOnly))
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is not null && underlyingType == typeof(DateOnly);
+        }
+
+        public static bool IsTimeOnly(Type? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type == typeof(TimeOnly))
+                return true;
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType is not null && underlyingType == typeof(TimeOnly);
+        }
+
         public static bool IsBoolean(Type? type)
         {
             if (type is null)

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -105,6 +105,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="MudBlazor.UnitTests" />
+    <InternalsVisibleTo Include="MudBlazor.Docs.Compiler" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
This is an early prototype for an idea that can be found here: https://github.com/MudBlazor/MudBlazor/pull/6049#issuecomment-1502039705. Essentially, it allows to wire up any type to the filter. For example, if there is a lack of support for `TimeOnly`, one can implement their own `FilterTypeBase` and add the corresponding UI part to handle it.

Initially, I had a simple idea:
```CSharp
public interface ITypeFilter
{
	bool CanBeMapped { get; }
	RenderFragment RenderFilterFragment<T>(FilterDefinition<T> filterDefinition, Filter<T> filter);
}
```

However, I encountered the issue of an external render fragment interfering with the render lifecycle and throwing an error: `System.InvalidOperationException: 'The render handle is not yet assigned.' `

I attempted three prototypes before settling on the current implementation, which uses `DynamicComponent` and ensures that the render lifecycle works correctly. My previous prototypes required "hacks" that probably wouldn't be accepted, which is why I decided to go with the current solution.

## How Has This Been Tested?
Unit test + new unit tests(incoming)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
