### PR TITLE
MudBaseInput: Make OnBlurred async

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldOnBlurErrorContenCaughtException.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldOnBlurErrorContenCaughtException.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<ErrorBoundary>
+    <ChildContent>
+        <MudTextField @bind-Value="Text" OnBlur="@HandleAsync" Variant="Variant.Outlined" 
+                      Label="Type here and blur input to show wrong exception handling"/>
+        <br/>
+    </ChildContent>
+    <ErrorContent>
+        <MudAlert Severity="Severity.Error">Oh my! We caught an error and handled it!</MudAlert>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    public string Text { get; set; } = "";
+
+    public async Task HandleAsync()
+    {
+        await Task.Delay(100);
+        throw new Exception("Something went wrong...");
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -614,7 +614,7 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParam("Value", "321");
             comp.WaitForAssertion(() => maskField.Text.Should().Be("321 ___"));
             comp.WaitForAssertion(() => maskField.Value.Should().Be("321"));
-            await comp.InvokeAsync(() => maskField.OnBlurred(new FocusEventArgs()));
+            await comp.InvokeAsync(() => maskField.OnBlurredAsync(new FocusEventArgs()));
 
             comp.SetParam("Clearable", true);
             maskField.Clearable.Should().Be(true);

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -820,7 +820,7 @@ namespace MudBlazor.UnitTests.Components
         /// ReadOnly TextFields should not validate when blurred
         /// </summary>
         [Test]
-        public async Task ReadOnlyTextFieldShouldNotValdidate()
+        public async Task ReadOnlyTextFieldShouldNotValidate()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
             .Add(p => p.ReadOnly, true)
@@ -828,6 +828,19 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Blur();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/6322
+        /// </summary>
+        [Test]
+        public async Task OnBlurErrorContentCaughtException()
+        {
+            var comp = Context.RenderComponent<TextFieldOnBlurErrorContenCaughtException>();
+            await comp.Find("input").BlurAsync(new FocusEventArgs());
+            var mudAlert = comp.FindComponent<MudAlert>();
+            var text = mudAlert.Find("div.mud-alert-message");
+            text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
         }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -267,7 +267,7 @@ namespace MudBlazor
 
         protected bool _isFocused;
 
-        protected internal virtual void OnBlurred(FocusEventArgs obj)
+        protected internal virtual async Task OnBlurredAsync(FocusEventArgs obj)
         {
             if (ReadOnly)
                 return;
@@ -276,7 +276,7 @@ namespace MudBlazor
             if (!OnlyValidateIfDirty || _isDirty)
             {
                 Touched = true;
-                BeginValidateAfter(OnBlur.InvokeAsync(obj));
+                await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -191,6 +191,25 @@ namespace MudBlazor
         /// </summary>
         protected T _value;
 
+        protected Task BeginValidationAfterAsync(Task task)
+        {
+            Func<Task> execute = async () =>
+            {
+                var value = _value;
+
+                await task;
+
+                // we validate only if the value hasn't changed while we waited for task.
+                // if it has in fact changed, another validate call will follow anyway
+                if (EqualityComparer<T>.Default.Equals(value, _value))
+                {
+                    await BeginValidateAsync();
+                }
+            };
+
+            return execute();
+        }
+
         // These are the fire-and-forget methods to launch an async validation process.
         // After each async step, we make sure the current Value of the component has not changed while
         // async code was executed to avoid race condition which could lead to incorrect validation results.
@@ -210,6 +229,23 @@ namespace MudBlazor
                 }
             };
             execute().AndForget();
+        }
+
+        protected Task BeginValidateAsync()
+        {
+            Func<Task> execute = async () =>
+            {
+                var value = _value;
+
+                await ValidateValue();
+
+                if (EqualityComparer<T>.Default.Equals(value, _value))
+                {
+                    EditFormValidate();
+                }
+            };
+
+            return execute();
         }
 
         protected void BeginValidate()

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -30,7 +30,7 @@
                 inputmode="@InputMode.ToString()"
 			    @oninput="OnInput" 
                 @onchange="OnChange" 
-                @onblur="@OnBlurred" 
+                @onblur="@OnBlurredAsync" 
                 @onkeydown="@InvokeKeyDown" 
                 @onkeypress="@InvokeKeyPress" 
                 @onkeyup="@InvokeKeyUp" 
@@ -62,7 +62,7 @@
                 placeholder="@Placeholder" 
                 disabled=@GetDisabledState()
                 readonly="@GetReadOnlyState()"
-                @onblur="@OnBlurred" 
+                @onblur="@OnBlurredAsync" 
                 inputmode="@InputMode.ToString()" 
                 pattern="@Pattern"
                 @onkeydown="@InvokeKeyDown" 
@@ -85,7 +85,7 @@
              *@
 	        <div class="@InputClassname"
                 style="@("display:"+(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"                  
-                @onblur="@OnBlurred" @ref="@_elementReference1" 
+                @onblur="@OnBlurredAsync" @ref="@_elementReference1" 
             >
                 @ChildContent
             </div>
@@ -96,7 +96,7 @@
             <div class="@InputClassname"
                  style="@("display:"+(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"  
                  tabindex="@(InputType == InputType.Hidden && ChildContent != null ? 0 : -1)" 
-                 @onblur="@OnBlurred" @ref="@_elementReference1" 
+                 @onblur="@OnBlurredAsync" @ref="@_elementReference1" 
             >
                 @ChildContent
             </div>            

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -17,10 +17,10 @@
     }
 
     <input @ref="_elementReferenceStart" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" @bind-value="@TextStart" @bind-value:event="@((Immediate ? "oninput" : "onchange"))"
-           placeholder="@PlaceholderStart" disabled=@GetDisabledState() readonly="@GetReadOnlyState()" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" inputmode="@InputMode.ToString()" pattern="@Pattern" />
+           placeholder="@PlaceholderStart" disabled=@GetDisabledState() readonly="@GetReadOnlyState()" @onblur="@OnBlurredAsync" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" inputmode="@InputMode.ToString()" pattern="@Pattern" />
     <MudIcon Class="mud-range-input-separator mud-flip-x-rtl" Icon="@SeparatorIcon" Color="@Color.Default" />
     <input @ref="_elementReferenceEnd" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" @bind-value="@TextEnd" @bind-value:event="@((Immediate ? "oninput" : "onchange"))" inputmode="@InputMode.ToString()" pattern="@Pattern"
-           placeholder="@PlaceholderEnd" disabled=@GetDisabledState() readonly="@GetReadOnlyState()" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
+           placeholder="@PlaceholderEnd" disabled=@GetDisabledState() readonly="@GetReadOnlyState()" @onblur="@OnBlurredAsync" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
 
     @if (Adornment == Adornment.End)
     {

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -22,7 +22,7 @@
            placeholder="@Placeholder"
            disabled=@GetDisabledState()
            readonly="@GetReadOnlyState()"
-           @onblur="@OnBlurred"
+           @onblur="@OnBlurredAsync"
            @onfocus="OnFocused"
            @oncut="OnCut"
            @oncopy="OnCopy"
@@ -36,7 +36,7 @@
          *@
         <div class="@InputClassname"
              style="@("display:" + (InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"
-             @onblur="@OnBlurred" @ref="@_elementReference1">
+             @onblur="@OnBlurredAsync" @ref="@_elementReference1">
             @ChildContent
         </div>
     }
@@ -46,7 +46,7 @@
         <div class="@InputClassname"
              style="@("display:" + (InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"
              tabindex="@(InputType == InputType.Hidden && ChildContent != null ? 0 : -1)"
-             @onblur="@OnBlurred" @ref="@_elementReference1">
+             @onblur="@OnBlurredAsync" @ref="@_elementReference1">
             @ChildContent
         </div>
     }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -352,9 +352,9 @@ namespace MudBlazor
             _isFocused = true;
         }
 
-        protected internal override void OnBlurred(FocusEventArgs obj)
+        protected internal override async Task OnBlurredAsync(FocusEventArgs obj)
         {
-            base.OnBlurred(obj);
+            await base.OnBlurredAsync(obj);
             _isFocused = false;
         }
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -50,7 +50,7 @@
                           InputMode="@InputMode"
                           Pattern="@((Pattern ?? "[0-9]").TrimEnd('*')+"*")"
                           OnAdornmentClick="@OnAdornmentClick"
-                          OnBlur="@OnBlurred"
+                          OnBlur="@OnBlurredAsync"
                           OnKeyDown="@HandleKeydown"
                           OnKeyUp="@HandleKeyUp"
                           OnIncrement="@Increment"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -150,9 +150,9 @@ namespace MudBlazor
             return base.SetValueAsync(value, valueChanged || updateText);
         }
 
-        protected internal override async void OnBlurred(FocusEventArgs obj)
+        protected internal override async Task OnBlurredAsync(FocusEventArgs obj)
         {
-            base.OnBlurred(obj);
+            await base.OnBlurredAsync(obj);
             await UpdateValuePropertyAsync(true); //Required to set the value after a blur before the debounce period has elapsed
             await UpdateTextPropertyAsync(false); //Required to update the string formatting after a blur before the debouce period has elapsed
         }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -47,7 +47,7 @@
                               ErrorId="@ErrorId"
                               Immediate="@Immediate"
                               Margin="@Margin"
-                              OnBlur="@OnBlurred"
+                              OnBlur="@OnBlurredAsync"
                               OnKeyDown="@InvokeKeyDown"
                               OnInternalInputChanged="OnChange"
                               OnKeyPress="@InvokeKeyPress"
@@ -85,7 +85,7 @@
                              OnAdornmentClick="@OnAdornmentClick"
                              Error="@Error"
                              Immediate="@Immediate"
-                             Margin="@Margin" OnBlur="@OnBlurred"
+                             Margin="@Margin" OnBlur="@OnBlurredAsync"
                              Clearable="@Clearable"
                              OnClearButtonClick="@OnClearButtonClick"/>
                 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/6322
Wasn't catching exception since on blurr wasn't awaited (async void problem)

I believe since OnBlurred was protected **internal** it's not breaking change to change the signature

## How Has This Been Tested?
New unit test + checked visually on https://try.mudblazor.com/snippet/QOwdkmvIplIxkslV

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
