### PR TITLE
MudFormComponent: Deprecate BeginValidate in favor of Async version

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -377,7 +377,7 @@ namespace MudBlazor
                 if (updateText)
                     await UpdateTextPropertyAsync(false);
                 await ValueChanged.InvokeAsync(Value);
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(Value);
             }
         }

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -71,7 +71,7 @@ namespace MudBlazor
             {
                 Checked = value;
                 await CheckedChanged.InvokeAsync(value);
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(Checked);
             }
         }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -213,6 +213,7 @@ namespace MudBlazor
         // These are the fire-and-forget methods to launch an async validation process.
         // After each async step, we make sure the current Value of the component has not changed while
         // async code was executed to avoid race condition which could lead to incorrect validation results.
+        [Obsolete($"Use {nameof(BeginValidationAfterAsync)} instead, this will be removed in v7")]
         protected void BeginValidateAfter(Task task)
         {
             Func<Task> execute = async () =>
@@ -248,6 +249,7 @@ namespace MudBlazor
             return execute();
         }
 
+        [Obsolete($"Use {nameof(BeginValidateAsync)} instead, this will be removed in v7")]
         protected void BeginValidate()
         {
             Func<Task> execute = async () =>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -360,7 +360,7 @@ namespace MudBlazor
                 await SetTextAsync(optionText, false);
             _timer?.Dispose();
             IsOpen = false;
-            BeginValidate();
+            await BeginValidateAsync();
             if (!_isCleared)
                 _elementReference?.SetText(optionText);
             _elementReference?.FocusAsync().AndForget();

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
                     await SetTextAsync(Converter.Set(_value), false);
                 }
                 await DateChanged.InvokeAsync(_value);
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(_value);
             }
         }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -77,7 +77,7 @@ namespace MudBlazor
                 }
 
                 await DateRangeChanged.InvokeAsync(_dateRange);
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(_value);
             }
         }

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -129,7 +129,7 @@ namespace MudBlazor
             else return;
 
             await FilesChanged.InvokeAsync(_value);
-            BeginValidate();
+            await BeginValidateAsync();
             FieldChanged(_value);
             if (!Error || !SuppressOnChangeWhenInvalid) //only trigger FilesChanged if validation passes or SuppressOnChangeWhenInvalid is false
                 await OnFilesChanged.InvokeAsync(args);

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -93,7 +93,7 @@ namespace MudBlazor
 
                 await SelectedOptionChanged.InvokeAsync(_value);
 
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(_value);
             }
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -588,7 +588,7 @@ namespace MudBlazor
                 }
 
                 UpdateSelectAllChecked();
-                BeginValidate();
+                await BeginValidateAsync();
             }
             else
             {
@@ -803,7 +803,7 @@ namespace MudBlazor
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedValues.Clear();
-            BeginValidate();
+            await BeginValidateAsync();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(_selectedValues);
             await OnClearButtonClick.InvokeAsync(e);
@@ -985,7 +985,7 @@ namespace MudBlazor
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedValues.Clear();
-            BeginValidate();
+            await BeginValidateAsync();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(_selectedValues);
         }
@@ -1024,7 +1024,7 @@ namespace MudBlazor
             }
             UpdateSelectAllChecked();
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
-            BeginValidate();
+            await BeginValidateAsync();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
                 SetValueAsync((T)(object)Text, updateText: false).AndForget();

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -161,7 +161,7 @@ namespace MudBlazor
                     await SetTextAsync(Converter.Set(_value), false);
                 UpdateTimeSetFromTime();
                 await TimeChanged.InvokeAsync(_value);
-                BeginValidate();
+                await BeginValidateAsync();
                 FieldChanged(_value);
             }
         }


### PR DESCRIPTION
## Description
This PR #6633 introduced `BeginValidateAsync` and `BeginValidateAfterAsync`.
It makes sense to deprecate the old ones, because they are dangerous.
All methods that used them were async which is great and everything is awaited properly now.

## How Has This Been Tested?
Unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
