### PR TITLE
MudSwitch: LabelPosition.Start uses row-reverse instead of RTL

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
@@ -2,7 +2,7 @@
 
 <MudSwitch @bind-Checked="@Label_Switch1" Label="Info" Color="Color.Info" />
 <MudSwitch @bind-Checked="@Label_Switch2" Label="Success" Color="Color.Success" />
-<MudSwitch @bind-Checked="@Label_Switch3" Label="Warning !" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
+<MudSwitch @bind-Checked="@Label_Switch3" Label="Warning!" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start" />
 
 @code{

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
@@ -2,7 +2,7 @@
 
 <MudSwitch @bind-Checked="@Label_Switch1" Label="Info" Color="Color.Info" />
 <MudSwitch @bind-Checked="@Label_Switch2" Label="Success" Color="Color.Success" />
-<MudSwitch @bind-Checked="@Label_Switch3" Label="Warning" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
+<MudSwitch @bind-Checked="@Label_Switch3" Label="Warning !" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start" />
 
 @code{

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -86,9 +86,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<SwitchWithLabelExample>();
             var switches = comp.FindAll("label.mud-switch");
-
-            switches[0].ClassList.Should().Contain("mud-ltr"); // 1st switch: (default) LabelPosition.End
-            switches[2].ClassList.Should().Contain("mud-rtl"); // 3rd switch: LabelPosition.Start
+    
+            switches[0].ClassList.Should().NotContain("flex-row-reverse"); // 1st switch: (default) LabelPosition.End
+            switches[2].ClassList.Should().Contain("flex-row-reverse"); // 3rd switch: LabelPosition.Start
         }
 
         [Test]

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
         new CssBuilder("mud-switch")
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())
-            .AddClass(LabelPosition == LabelPosition.End ? "mud-ltr" : "mud-rtl", true)
+            .AddClass(LabelPosition == LabelPosition.End ? "" : "flex-row-reverse", true)
         .Build();
 
         protected string SwitchLabelClassname =>


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
dir: rtl is used to switch the label position which also sets the label with a RTL direction. Question marks and exclamation marks are character that are Bidirectionnal. They are neutral as they exists in both RTL and LTR language.

When setting a switch label position to LabelPositin.Start, english text is rendered in LTR, but a neutral character is rendered in RTL. The result is a switch rendered like so: 

![image](https://user-images.githubusercontent.com/29356866/231529981-07445204-0771-45b9-b4fe-ccc843963d5f.png)

You can find more info about that phenomenon here: https://www.w3.org/International/articles/inline-bidi-markup/

RTL should be used only for text that uses a RTL language. When used for layout manipulation, you would need to change every component inside back to LTR. 

I changed the use of rtl for flex-direction: row-reverse. We get the same effect, without having to deal with exclamation mark going to the start of the text block.

![image](https://user-images.githubusercontent.com/29356866/231530911-ea36f13b-141d-4d2a-a333-ba686a462e92.png)
  
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested visually, this change only a class applied to the label
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
