### PR TITLE
MudDataGrid: Rename AddFilterAsync and ClearFiltersAsync (Breaking Change) 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomFilteringTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomFilteringTest.razor
@@ -27,13 +27,13 @@
 
     public bool FilterHired = false;
 
-    public void FilterHiredToggled(bool value, MudDataGrid<Model> dataGrid)
+    public async Task FilterHiredToggled(bool value, MudDataGrid<Model> dataGrid)
     {
         FilterHired = value;
 
         if (FilterHired)
         {
-            dataGrid.AddFilter(new FilterDefinition<Model>
+            await dataGrid.AddFilterAsync(new FilterDefinition<Model>
             {
                 Column = dataGrid.GetColumnByPropertyName<Model>("Hired"),
                 Operator = FilterOperator.Boolean.Is,
@@ -42,7 +42,7 @@
         }
         else
         {
-            dataGrid.ClearFilters();
+            await dataGrid.ClearFiltersAsync();
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -115,7 +115,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs()));
             //await comp.InvokeAsync(() => headerCell.Instance.GetDataType());
             await comp.InvokeAsync(() => headerCell.Instance.RemoveSortAsync());
-            await comp.InvokeAsync(() => headerCell.Instance.AddFilter());
+            await comp.InvokeAsync(() => headerCell.Instance.AddFilterAsync());
             await comp.InvokeAsync(() => headerCell.Instance.OpenFilters());
 
             await comp.InvokeAsync(() => dataGrid.Instance.SortMode = SortMode.None);
@@ -216,7 +216,7 @@ namespace MudBlazor.UnitTests.Components
             // Add a FilterDefinition to filter where the Name = "C".
             await comp.InvokeAsync(() =>
             {
-                dataGrid.Instance.AddFilter(new FilterDefinition<DataGridFilterableTest.Item>
+                return dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterableTest.Item>
                 {
                     Column = dataGrid.Instance.RenderedColumns.First(),
                     Operator = FilterOperator.String.Equal,
@@ -249,7 +249,7 @@ namespace MudBlazor.UnitTests.Components
             // Add a FilterDefinition to filter where the Name = "C".
             await comp.InvokeAsync(() =>
             {
-                dataGrid.Instance.AddFilter(new FilterDefinition<DataGridFilterableServerDataTest.Item>
+                return dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterableServerDataTest.Item>
                 {
                     Column = dataGrid.Instance.RenderedColumns.FirstOrDefault(),
                     Operator = FilterOperator.String.Equal,
@@ -2582,11 +2582,11 @@ namespace MudBlazor.UnitTests.Components
                 Value = DateTime.UtcNow.Date
             };
 
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(filterDefinition));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(filterDefinition2));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(filterDefinition3));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(filterDefinition4));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(filterDefinition5));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(filterDefinition));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(filterDefinition2));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(filterDefinition3));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(filterDefinition4));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(filterDefinition5));
             await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
 
             // check the number of filters displayed in the filters panel
@@ -2606,7 +2606,7 @@ namespace MudBlazor.UnitTests.Components
 
             // add a filter via the AddFilter method
             //await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(Guid.NewGuid(), "Status"));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter(new FilterDefinition<DataGridFiltersTest.Model>
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFiltersTest.Model>
             {
                 Column = dataGrid.Instance.RenderedColumns.FirstOrDefault(x => x.PropertyName == "Status")
             }));
@@ -3041,7 +3041,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() =>
             {
-                dataGrid.Instance.AddFilter(new FilterDefinition<DataGridColumnPopupFilteringTest.Model>
+                return dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridColumnPopupFilteringTest.Model>
                 {
                     Column = dataGrid.Instance.RenderedColumns.First(),
                     Operator = FilterOperator.String.Contains,
@@ -3647,7 +3647,7 @@ namespace MudBlazor.UnitTests.Components
             //await comp.InvokeAsync(() => headerCell.Instance.GetDataType());
             await comp.InvokeAsync(() => headerCell.Instance.RemoveSortAsync());
             dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 7);
-            await comp.InvokeAsync(() => headerCell.Instance.AddFilter());
+            await comp.InvokeAsync(() => headerCell.Instance.AddFilterAsync());
             dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 8);
             await comp.InvokeAsync(() => headerCell.Instance.OpenFilters());
             dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 9);

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -61,7 +61,7 @@ else if (Column != null && !Column.Hidden)
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" OnClick="@AddFilter"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" OnClick="@AddFilterAsync"></MudIconButton>
                     }
                 }
 
@@ -71,7 +71,7 @@ else if (Column != null && !Column.Hidden)
                         <MudMenuItem Disabled="@(_initialDirection == SortDirection.None)" OnClick="@RemoveSortAsync">Unsort</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {
-                            <MudMenuItem OnClick="@AddFilter">Filter</MudMenuItem>
+                            <MudMenuItem OnClick="@AddFilterAsync">Filter</MudMenuItem>
                         }
                         @if (hideable)
                         {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -324,11 +324,11 @@ namespace MudBlazor
             MarkAsUnsorted();
         }
 
-        internal void AddFilter()
+        internal async Task AddFilterAsync()
         {
             if (DataGrid.FilterMode == DataGridFilterMode.Simple && Column != null)
             {
-                DataGrid.AddFilter(Column.FilterContext.FilterDefinition.Clone());
+                await DataGrid.AddFilterAsync(Column.FilterContext.FilterDefinition.Clone());
             }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
                 _filtersMenuVisible = true;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -68,9 +68,9 @@
                                     <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">Add Filter</MudButton>
                                     @if (ServerData != null)
                                     {
-                                        <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFilters" Color="@Color.Primary">Apply</MudButton>
+                                        <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFiltersAsync" Color="@Color.Primary">Apply</MudButton>
                                     }
-                                    <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFilters" Color="@Color.Primary">Clear</MudButton>
+                                    <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFiltersAsync" Color="@Color.Primary">Clear</MudButton>
                                 }
                                 else
                                 {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -855,23 +855,23 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        internal void ApplyFilters()
+        internal Task ApplyFiltersAsync()
         {
             _filtersMenuVisible = false;
-            InvokeServerLoadFunc().AndForget();
+            return InvokeServerLoadFunc();
         }
 
-        public void ClearFilters()
+        public Task ClearFiltersAsync()
         {
             FilterDefinitions.Clear();
-            InvokeServerLoadFunc().AndForget();
+            return InvokeServerLoadFunc();
         }
 
-        public void AddFilter(FilterDefinition<T> definition)
+        public async Task AddFilterAsync(FilterDefinition<T> definition)
         {
             FilterDefinitions.Add(definition);
             _filtersMenuVisible = true;
-            InvokeServerLoadFunc().AndForget();
+            await InvokeServerLoadFunc();
             if (ServerData is null) StateHasChanged();
         }
 
@@ -899,7 +899,7 @@ namespace MudBlazor
             var items = ServerData != null
                     ? ServerItems
                     : Items;
-                    
+
             if (value)
                 Selection = new HashSet<T>(items);
             else
@@ -1232,7 +1232,7 @@ namespace MudBlazor
         }
 
         public void GroupItems(bool noStateChange = false)
-        {          
+        {
             if (GroupedColumn == null)
             {
                 _currentPageGroups = new List<GroupDefinition<T>>();
@@ -1243,7 +1243,7 @@ namespace MudBlazor
             }
 
             var currentPageGroupings = CurrentPageItems.GroupBy(GroupedColumn.groupBy);
-            
+
             // Maybe group Items to keep groups expanded after clearing a filter?
             var allGroupings = FilteredItems.GroupBy(GroupedColumn.groupBy);
 


### PR DESCRIPTION
## Description
This PR #6627 introduced `AndForget()` calls in the public API, which we consider to be risky. As a result, we have decided to modify the public API and replace the AndForget() calls with async versions that will use await. Furthermore, since DataGrid generally has an async nature, this change makes sense.

## How Has This Been Tested?
Unit test + docs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
