### PR TITLE
MudButtonGroup: Add nullable annotation.

### DIFF
--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
@@ -6,6 +6,5 @@
 </MudElement>
 
 @{
-    if(!UserAttributes.ContainsKey("role"))
-       UserAttributes.Add("role", "group");
+    UserAttributes.TryAdd("role", "group");
 }

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -1,26 +1,26 @@
 ﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+#nullable enable
     public partial class MudButtonGroup : MudComponentBase
     {
         protected string Classname =>
-        new CssBuilder("mud-button-group-root")
-          .AddClass($"mud-button-group-override-styles", OverrideStyles)
-          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}")
-          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
-          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
-          .AddClass($"mud-button-group-vertical", VerticalAlign)
-          .AddClass($"mud-button-group-horizontal", !VerticalAlign)
-          .AddClass($"mud-button-group-disable-elevation", DisableElevation)
-          .AddClass($"mud-button-group-rtl", RightToLeft)
-          .AddClass(Class)
-        .Build();
+            new CssBuilder("mud-button-group-root")
+                .AddClass($"mud-button-group-override-styles", OverrideStyles)
+                .AddClass($"mud-button-group-{Variant.ToDescriptionString()}")
+                .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
+                .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
+                .AddClass("mud-button-group-vertical", VerticalAlign)
+                .AddClass("mud-button-group-horizontal", !VerticalAlign)
+                .AddClass("mud-button-group-disable-elevation", DisableElevation)
+                .AddClass("mud-button-group-rtl", RightToLeft)
+                .AddClass(Class)
+                .Build();
 
-
-        [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = "RightToLeft")]
+        public bool RightToLeft { get; set; }
 
         /// <summary>
         /// If true, the button group will override the styles of the individual buttons.
@@ -34,7 +34,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Behavior)]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// If true, the button group will be displayed vertically.


### PR DESCRIPTION
## Description
Part of this issue https://github.com/MudBlazor/MudBlazor/issues/6535

Used re-sharpers new analyze for reducing the number of lookups in collections 
from
```C#
if(!UserAttributes.ContainsKey("role")) 
  UserAttributes.Add("role", "group");
```
to
```C#
UserAttributes.TryAdd("role", "group");
```

Furthermore, we agreed to apply a code style change when applicable: new line after attribute. Also, fix the indentation for CssBuilder.

## How Has This Been Tested?
No tests required in case of MudButtonGroup

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change, improve null diagnostic warnings)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
