### PR TITLE
MudAppBar: Bottom=true should render <footer> instead of <header>

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -26,5 +26,46 @@ namespace MudBlazor.UnitTests.Components
                 .Contain("test-class");
         }
 
+        /// <summary>
+        /// AppBar with <c>Bottom</c> not set.
+        /// </summary>
+        [Test]
+        public void AppBarWithBottomUnset()
+        {
+            var bar = Context.RenderComponent<MudAppBar>();
+            bar.Markup
+               .Should()
+               .StartWith("<header")
+               .And
+               .Contain("mud-appbar-fixed-top");
+        }
+
+        /// <summary>
+        /// AppBar with <c>Bottom</c> set to <see langword="false" />.
+        /// </summary>
+        [Test]
+        public void AppBarWithBottomSetFalse()
+        {
+            var bar = Context.RenderComponent<MudAppBar>(Parameter(nameof(MudAppBar.Bottom), false));
+            bar.Markup
+               .Should()
+               .StartWith("<header")
+               .And
+               .Contain("mud-appbar-fixed-top");
+        }
+
+        /// <summary>
+        /// AppBar with <c>Bottom</c> set to <see langword="true" />.
+        /// </summary>
+        [Test]
+        public void AppBarWithBottomSetTrue()
+        {
+            var bar = Context.RenderComponent<MudAppBar>(Parameter(nameof(MudAppBar.Bottom), true));
+            bar.Markup
+               .Should()
+               .StartWith("<footer")
+               .And
+               .Contain("mud-appbar-fixed-bottom");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2023
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -1,10 +1,18 @@
-﻿@namespace MudBlazor
+@namespace MudBlazor
 @inherits MudComponentBase
-
+@if (Bottom)
+{
+<footer @attributes="UserAttributes" class="@Classname" style="@Style">
+    <MudToolBar Dense="@Dense" DisableGutters="@DisableGutters" Class="@ToolBarClassname">
+        @ChildContent
+    </MudToolBar>
+</footer>
+}
+else
+{
 <header @attributes="UserAttributes" class="@Classname" style="@Style">
     <MudToolBar Dense="@Dense" DisableGutters="@DisableGutters" Class="@ToolBarClassname">
         @ChildContent
     </MudToolBar>
 </header>
-
-
+}


### PR DESCRIPTION
## Description
Checks for `Bottom="true"` & if so, outputs `<footer>` instead of `<header>` as the resulting HTML tag.
Fixes #6644 in accordance with the [HTML specification](https://html.spec.whatwg.org/multipage/sections.html#the-footer-element)

## How Has This Been Tested?
Added unit tests to cover all 3 scenarios: `Bottom="false"`, `Bottom="true"` & `Bottom` not set.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
