### PR TITLE
MudMenu: Introduce OnClickHandlerAsync to fix #6645

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuErrorContenCaughtException.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuErrorContenCaughtException.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<ErrorBoundary>
+    <ChildContent>
+        <MudPopoverProvider></MudPopoverProvider>
+        <MudMenu Label="Open Menu">
+            <ChildContent>
+                <MudMenuItem @onclick="@HandleClickAsync">Throw error</MudMenuItem>
+            </ChildContent>
+        </MudMenu>
+        <br/>
+    </ChildContent>
+    <ErrorContent>
+        <MudAlert Severity="Severity.Error">Oh my! We caught an error and handled it!</MudAlert>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    public async Task HandleClickAsync()
+    {
+        await Task.Delay(100);
+        throw new Exception("Something went wrong...");
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -217,5 +217,21 @@ namespace MudBlazor.UnitTests.Components
             svg.ClassList.Should().Contain("mud-icon-size-large");
             svg.ClassList.Should().Contain("mud-secondary-text");
         }
+
+        /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/6645
+        /// </summary>
+        [Test]
+        public async Task OnClickErrorContentCaughtException()
+        {
+            var comp = Context.RenderComponent<MenuErrorContenCaughtException>();
+            await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs());
+            comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
+            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync(new MouseEventArgs());
+            var mudAlert = comp.FindComponent<MudAlert>();
+            var text = mudAlert.Find("div.mud-alert-message");
+            text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+        }
     }
 }

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -79,7 +79,7 @@ namespace MudBlazor
             {
                 if (_selectedItem == value)
                     return;
-                _ = SetSelectedValueAsync(_selectedItem?.Value, force: true);
+                SetSelectedValueAsync(_selectedItem?.Value, force: true).AndForget();
             }
         }
 
@@ -99,7 +99,7 @@ namespace MudBlazor
             get => _selectedValue;
             set
             {
-                _ = SetSelectedValueAsync(value, force: true);
+                SetSelectedValueAsync(value, force: true).AndForget();
             }
         }
 

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
@@ -78,7 +79,7 @@ namespace MudBlazor
             {
                 if (_selectedItem == value)
                     return;
-                SetSelectedValue(_selectedItem?.Value, force: true);
+                _ = SetSelectedValueAsync(_selectedItem?.Value, force: true);
             }
         }
 
@@ -98,7 +99,7 @@ namespace MudBlazor
             get => _selectedValue;
             set
             {
-                SetSelectedValue(value, force: true);
+                _ = SetSelectedValueAsync(value, force: true);
             }
         }
 
@@ -133,14 +134,14 @@ namespace MudBlazor
         private MudListItem _selectedItem;
         private object _selectedValue;
 
-        internal void Register(MudListItem item)
+        internal async Task RegisterAsync(MudListItem item)
         {
             _items.Add(item);
             if (CanSelect && SelectedValue!=null && object.Equals(item.Value, SelectedValue))
             {
                 item.SetSelected(true);
                 _selectedItem = item;
-                SelectedItemChanged.InvokeAsync(item);
+                await SelectedItemChanged.InvokeAsync(item);
             }
         }
 
@@ -159,30 +160,34 @@ namespace MudBlazor
             _childLists.Remove(child);
         }
 
-        internal void SetSelectedValue(object value, bool force = false)
+        internal async Task SetSelectedValueAsync(object value, bool force = false)
         {
             if ((!CanSelect || !Clickable) && !force)
                 return;
             if (object.Equals(_selectedValue, value))
                 return;
             _selectedValue = value;
-            SelectedValueChanged.InvokeAsync(value).AndForget();
+            await SelectedValueChanged.InvokeAsync(value);
             _selectedItem = null; // <-- for now, we'll see which item matches the value below
             foreach (var listItem in _items.ToArray())
             {
-                var isSelected = value!=null && object.Equals(value, listItem.Value);
+                var isSelected = value != null && object.Equals(value, listItem.Value);
                 listItem.SetSelected(isSelected);
                 if (isSelected)
                     _selectedItem = listItem;
             }
             foreach (var childList in _childLists.ToArray())
             {
-                childList.SetSelectedValue(value);
+                await childList.SetSelectedValueAsync(value);
                 if (childList.SelectedItem != null)
                     _selectedItem= childList.SelectedItem;
             }
-            SelectedItemChanged.InvokeAsync(_selectedItem).AndForget();
-            ParentList?.SetSelectedValue(value);
+
+            await SelectedItemChanged.InvokeAsync(_selectedItem);
+            if (ParentList is not null)
+            {
+                await ParentList.SetSelectedValueAsync(value);
+            }
         }
 
         internal bool CanSelect { get; private set; }
@@ -192,6 +197,5 @@ namespace MudBlazor
             ParametersChanged = null;
             ParentList?.Unregister(this);
         }
-
     }
 }

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div tabindex="0" @attributes="UserAttributes" class="@Classname" @onclick="OnClickHandler" @onclick:stopPropagation="true" style="@Style">
+<div tabindex="0" @attributes="UserAttributes" class="@Classname" @onclick="OnClickHandlerAsync" @onclick:stopPropagation="true" style="@Style">
     @if (!string.IsNullOrWhiteSpace(Avatar))
     {
         <div class="mud-list-item-avatar">

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -126,7 +126,7 @@ namespace MudBlazor
         /// If true, instead of positioning the menu at the left upper corner, position at the exact cursor location.
         /// This makes sense for larger activators
         /// </summary>
-        [Obsolete("Use PositionAtCursor instead.",true)]
+        [Obsolete("Use PositionAtCursor instead.", true)]
         [Parameter]
         public bool PositionAtCurser
         {

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -27,10 +27,10 @@ namespace MudBlazor
         /// <summary>
         /// If set to a URL, clicking the button will open the referenced document. Use Target to specify where
         /// </summary>
-        [Parameter] 
-        [Category(CategoryTypes.Menu.ClickAction)] 
-        public string Href { get; set; }        
-        
+        [Parameter]
+        [Category(CategoryTypes.Menu.ClickAction)]
+        public string Href { get; set; }
+
         /// <summary>
         /// Icon to be used for this menu entry
         /// </summary>


### PR DESCRIPTION
## Description
Resolved issue #6645 by introducing a new API, `OnClickHandlerAsync`, which properly awaits `OnClick.InvokeAsync` to show exceptions.
There are still some concerns with `SelectedItem` and `SelectedValue` as they call methods that should be awaited. We should avoid overriding the Parameters getter and setters and look for an alternative solution. 
Additionally, to catch the `MudMenuItem` exception, it's necessary to have the `MudPopoverProvider` inside the `ErrorBoundary` since the `MudPopoverProvider` renders the list popover which is a significant disadvantage.

## How Has This Been Tested?
new unit test + visual check on https://try.mudblazor.com/snippet/GOwnkebdRgyviedF

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
