### PR TITLE
Introduce MudGlobal.UnhandledExceptionHandler for handling unawaitable task exceptions

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
@@ -1,0 +1,101 @@
+﻿using FluentAssertions;
+using MudBlazor;
+using NUnit.Framework;
+using System.Linq.Expressions;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MudBlazor.Docs.Models;
+
+namespace MudBlazor.UnitTests.Extensions
+{
+
+    [TestFixture]
+    public class TaskExtensionsTests
+    {
+        private async Task AsyncTaskExceptionGenerator(string errorMessage)
+        {
+            await Task.Delay(10);
+            throw new Exception(errorMessage);
+        }
+
+        private async ValueTask AsyncValueTaskExceptionGenerator(string errorMessage)
+        {
+            await Task.Delay(10);
+            throw new Exception(errorMessage);
+        }
+
+        private async ValueTask<TValue> AsyncValueTaskExceptionGenerator<TValue>(string errorMessage)
+        {
+            await Task.Delay(10);
+            throw new Exception(errorMessage);
+        }
+
+        [Test]
+        public async Task Task_AndForget_ShouldForwardExceptionToGlobalHandler()
+        {
+            string errorMessage = null;
+            MudBlazorGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task= AsyncTaskExceptionGenerator("Something bad is about to happen ...");
+            task.AndForget();
+            var t = Stopwatch.StartNew();
+            while (errorMessage==null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+            }
+            errorMessage.Should().Be("Something bad is about to happen ...");
+        }
+
+        [Test]
+        public async Task ValueTask_AndForget_ShouldForwardExceptionToGlobalHandler()
+        {
+            string errorMessage = null;
+            MudBlazorGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task = AsyncValueTaskExceptionGenerator("Something bad is about to happen ...");
+            task.AndForget();
+            var t = Stopwatch.StartNew();
+            while (errorMessage == null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+            }
+            errorMessage.Should().Be("Something bad is about to happen ...");
+        }
+
+        [Test]
+        public async Task ValueTask_T_AndForget_ShouldForwardExceptionToGlobalHandler()
+        {
+            string errorMessage = null;
+            MudBlazorGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task = AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...");
+            task.AndForget();
+            var t = Stopwatch.StartNew();
+            while (errorMessage == null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+            }
+            errorMessage.Should().Be("Something bad is about to happen ...");
+        }
+
+        [Test]
+        public async Task Task_AndForget_ShouldNotFailIfGlobalHandlerIsNull()
+        {
+            MudBlazorGlobal.UnhandledExceptionHandler = null;
+            var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
+            task.AndForget();
+            var t = Stopwatch.StartNew();
+            while (!(task.IsCompleted || task.IsCanceled || task.IsFaulted))
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                    Assert.Fail("The test task did not end in time, this should not happen!");
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -157,7 +157,7 @@ namespace MudBlazor
         public void Dispose()
         {
             if (!_disabled)
-                RestoreFocusAsync().AndForget(TaskOption.Safe);
+                RestoreFocusAsync().AndForget(ignoreExceptions:true);
         }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -710,7 +710,7 @@ namespace MudBlazor
             {
                 StateHasChanged();
                 await OnBlur.InvokeAsync(new FocusEventArgs());
-                _elementReference.FocusAsync().AndForget(TaskOption.Safe);
+                _elementReference.FocusAsync().AndForget(ignoreExceptions:true);
                 StateHasChanged();
             }
 
@@ -1050,7 +1050,7 @@ namespace MudBlazor
             {
                 // when the menu is open we immediately get back the focus if we lose it (i.e. because of checkboxes in multi-select)
                 // otherwise we can't receive key strokes any longer
-                _elementReference.FocusAsync().AndForget(TaskOption.Safe);
+                _elementReference.FocusAsync().AndForget(ignoreExceptions:true);
             }
             base.OnBlur.InvokeAsync(obj);
         }

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 namespace MudBlazor
 {
+    [Obsolete("This will be removed in v7.")]
     public enum TaskOption
     {
         None,
@@ -11,10 +12,13 @@ namespace MudBlazor
 
     public static class TaskExtensions
     {
+        [Obsolete("Use the bool parameter version. This will be removed in v7.")]
+        public static void AndForget(this Task task, TaskOption option) => AndForget(task);
+
         /// <summary>
-        /// Task will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// Task will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget(this Task task, TaskOption option = TaskOption.None)
+        public static async void AndForget(this Task task, bool ignoreExceptions = false)
         {
             try
             {
@@ -22,17 +26,18 @@ namespace MudBlazor
             }
             catch (Exception ex)
             {
-                if (option != TaskOption.Safe)
-                    throw;
-
-                Console.WriteLine(ex);
+                if (!ignoreExceptions)
+                    MudBlazorGlobal.UnhandledExceptionHandler?.Invoke(ex);
             }
         }
 
+        [Obsolete("Use the bool parameter version. This will be removed in v7.")]
+        public static async void AndForget(this ValueTask task, TaskOption option) => AndForget(task);
+
         /// <summary>
-        /// ValueTask will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// ValueTask will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget(this ValueTask task, TaskOption option = TaskOption.None)
+        public static async void AndForget(this ValueTask task, bool ignoreExceptions=false)
         {
             try
             {
@@ -40,17 +45,18 @@ namespace MudBlazor
             }
             catch (Exception ex)
             {
-                if (option != TaskOption.Safe)
-                    throw;
-
-                Console.WriteLine(ex);
+                if (!ignoreExceptions)
+                    MudBlazorGlobal.UnhandledExceptionHandler?.Invoke(ex);
             }
         }
 
+        [Obsolete("Use the bool parameter version. This will be removed in v7.")]
+        public static async void AndForget<T>(this ValueTask<T> task, TaskOption option) => AndForget(task, option);
+
         /// <summary>
-        /// ValueTask(bool) will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// ValueTask(bool) will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget(this ValueTask<bool> task, TaskOption option = TaskOption.None)
+        public static async void AndForget<T>(this ValueTask<T> task, bool ignoreExceptions = false)
         {
             try
             {
@@ -58,10 +64,8 @@ namespace MudBlazor
             }
             catch (Exception ex)
             {
-                if (option != TaskOption.Safe)
-                    throw;
-
-                Console.WriteLine(ex);
+                if (!ignoreExceptions)
+                    MudBlazorGlobal.UnhandledExceptionHandler?.Invoke(ex);
             }
         }
     }

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -27,6 +27,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Version>6.2.1-dev3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MudBlazor/Services/MudBlazorGlobal.cs
+++ b/src/MudBlazor/Services/MudBlazorGlobal.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MudBlazor.Extensions;
+
+namespace MudBlazor
+{
+    public static class MudBlazorGlobal
+    {
+        /// <summary>
+        /// Global unhandled exception handler for such exceptions which can not be bubbled up. Note: this is not a global catch-all.
+        /// It just allows the user to handle such exceptions which were suppressed inside MudBlazor using Task.AndForget() in places
+        /// where it is impossible to await the task. Exceptions in user code or in razor files will still crash your app if you are not carefully
+        /// handling everything with <ErrorBoundary></ErrorBoundary>.
+        /// </summary>
+        public static Action<Exception> UnhandledExceptionHandler { get; set; } = OnDefaultExceptionHandler;
+
+        /// <summary>
+        /// Note: the user can overwrite this default handler with their own implementation. The default implementation
+        /// makes sure that the unhandled exceptions don't go unnoticed
+        /// </summary>
+        private static void OnDefaultExceptionHandler(Exception ex)
+        {
+            Console.Write(ex);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR does multiple things which are connected to each other:

1)
It introduces `MudGlobal.UnhandledExceptionHandler` which writes unobserved exceptions to stdout. The user can overwrite this handler with their own implementation (i.e. forwarding to a logging framework, etc). 

2)
It changes the default behavior of `SomeAsyncMethod().AndForget()` which up until now observed the task, caught the exception but immediately rethrew it. This caused the application to crash in any case as the re-thrown exception was impossible to catch. Now the exceptions are caught and forwarded to the `MudGlobal.UnhandledExceptionHandler`. This also doesn't give you the ability to handle said exceptions but at least your application won't crash with every unhandled exception. 

Note: for those who wish their app to crash during the dev cycle they can still re-throw the exception in their own custom global exception handler like this:

`MudGlobal.UnhandledExceptionHandler = ex => throw new AggregateException("Unhandled MudBlazor exception!", ex);`

3) 
It deprecates `SomeAsyncMethod().AndForget(TaskOption.Safe)` in favor of `.AndForget(ignoreException:true)`. In some cases we really want to ignore an exception and don't forward it to the global handler. A good example for this is this line from Select: `_elementReference.FocusAsync().AndForget(ignoreExceptions:true);`. We just want to focus the component. If for any reason the _elementReference doesn't exist any more (or not yet) it shouldn't spam the user as it is truly unimportant. For any hardcore exception lovers who disagree we might add another handler for ignored exceptions should they insist on it ;)


Note: I consider this a bugfix (and not a breaking change) as an exception that is re-thrown on a task that can't be observed by the consumer of the library with try-catch blocks or ErrorBoundary is not expected behavior for a production ready application. 

## How Has This Been Tested?
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
