### PR TITLE
MudOverlay: CA2012 Use ValueTasks correctly

### DIFF
--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -8,7 +8,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-    public partial class MudOverlay : MudComponentBase, IDisposable
+    public partial class MudOverlay : MudComponentBase, IAsyncDisposable
     {
         private bool _visible;
 
@@ -85,14 +85,14 @@ namespace MudBlazor
         public string LockScrollClass { get; set; } = "scroll-locked";
 
         /// <summary>
-        /// If true applys the themes dark overlay color.
+        /// If true applies the themes dark overlay color.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]
         public bool DarkBackground { get; set; }
 
         /// <summary>
-        /// If true applys the themes light overlay color.
+        /// If true applies the themes light overlay color.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.Behavior)]
@@ -144,34 +144,33 @@ namespace MudBlazor
         }
 
         //if not visible or CSS `position:absolute`, don't lock scroll
-        protected override void OnAfterRender(bool firstTime)
+        protected override async Task OnAfterRenderAsync(bool firstTime)
         {
             if (!LockScroll || Absolute)
                 return;
 
             if (Visible)
-                BlockScroll();
+                await BlockScrollAsync();
             else
-                UnblockScroll();
-
+                await UnblockScrollAsync();
         }
 
         //locks the scroll attaching a CSS class to the specified element, in this case the body
-        private void BlockScroll()
+        private ValueTask BlockScrollAsync()
         {
-            ScrollManager.LockScrollAsync("body", LockScrollClass);
+            return ScrollManager.LockScrollAsync("body", LockScrollClass);
         }
 
         //removes the CSS class that prevented scrolling
-        private void UnblockScroll()
+        private ValueTask UnblockScrollAsync()
         {
-            ScrollManager.UnlockScrollAsync("body", LockScrollClass);
+            return ScrollManager.UnlockScrollAsync("body", LockScrollClass);
         }
 
         //When disposing the overlay, remove the class that prevented scrolling
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
-            UnblockScroll();
+            return UnblockScrollAsync();
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes [CA2012: Use ValueTasks correctly](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2012) - ValueTask instances returned from method calls should always be used, typically awaited. Not doing so often represents a functional bug, it can result in degraded performance if the target method pools objects for use with ValueTasks.

## How Has This Been Tested?
Visual that scroll is blocked and unblocked depending on the overlay visibility

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
