### PR TITLE
MudTabs: Fix XSS in Text (#5478)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1086,8 +1086,8 @@ namespace MudBlazor.UnitTests.Components
             panels.Should().HaveCount(2);
 
             // index 0 : html text "Hello <span>World</span>!"
-            panels[0].InnerHtml.Contains("Hello <span>World</span>!").Should().BeTrue();
-            panels[0].TextContent.Contains("Hello World!").Should().BeTrue();
+            panels[0].InnerHtml.Should().Be("Hello &lt;span&gt;World&lt;/span&gt;!");
+            panels[0].TextContent.Should().Be("Hello <span>World</span>!");
 
             // index 1 : simple text without html "Hello World!"
             panels[1].InnerHtml.Contains("Hello World!").Should().BeTrue();

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -26,7 +26,8 @@ else
 
 
     /// <summary>
-    /// Text will be displayed in the TabPanel as TabTitle.
+    /// Text will be displayed in the TabPanel as TabTitle. Text is no longer rendered
+    /// as a MarkupString, so use the TabContent RenderFragment instead for HTML content.
     /// </summary>
     [Parameter] 
     [Category(CategoryTypes.Tabs.Behavior)]

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -87,7 +87,7 @@
             }
             else if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
             {
-                @((MarkupString)panel.Text)
+                @panel.Text
             }
             else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
             {
@@ -96,7 +96,7 @@
             else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
             {
                 <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                @((MarkupString)panel.Text)
+                @panel.Text
             }
             @if (panel.BadgeData != null || panel.BadgeDot)
             {


### PR DESCRIPTION
## Description

`MudTabs` presents a cross-site scripting (XSS) vulnerability when it renders the `Text` property of `MudTabPanel` as a `MarkupString`. Various fixes were discussed in PR #5551. The apparent consensus was to remove `MarkupString` support for `Text` and use `RenderFragment` for more complex tab titles, but that PR has stalled.

Since the existing `TabContent` of `MudTabPanel` already provides the `RenderFragment` option, the only change here is to stop rendering `Text` as a `MarkupString`. This is a breaking change for anyone using markup tab titles via `Text`, but the XML comments have been updated to direct consumers to use `TabContent` instead. I did not think it was appropriate to decorate `Text` with `Obsolete` since it is not being removed.

Fixes #5478

## How Has This Been Tested?

- Relevant unit tests were updated
- Entire unit test suite ran and passed
- Used https://try.mudblazor.com/snippet/GuGHkoPLKDcXwxRw to verify current behaviors
- Visually verified XSS is handled safely in updated version

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
