### PR TITLE
Form components: Add ResetAsync / ResetValueAsync

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -30,7 +30,7 @@
         </MudPaper>
         <MudPaper Class="pa-4 mt-4">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" DisableElevation="true" OnClick="@(()=>form.Validate())">Validate</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Secondary" DisableElevation="true" OnClick="@(()=>form.Reset())" Class="mx-2">Reset</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" DisableElevation="true" OnClick="@(()=>form.ResetAsync())" Class="mx-2">Reset</MudButton>
             <MudButton Variant="Variant.Filled" DisableElevation="true" OnClick="@(()=>form.ResetValidation())">Reset Validation</MudButton>
         </MudPaper>
     </MudItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
@@ -5,7 +5,7 @@
     </MudForm>
     <div class="d-flex mt-5">
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(()=>form1.Validate())">Validate</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(()=>form1.Reset())" Class="mx-2">Reset</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(()=>form1.ResetAsync())" Class="mx-2">Reset</MudButton>
         <MudButton Variant="Variant.Filled" OnClick="@(()=>form1.ResetValidation())">Reset Validation</MudButton>
     </div>
     <div class="d-flex mt-3">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
@@ -8,7 +8,7 @@
 <span>Name: @name</span>
 <span>Age: @age</span>
 <br><br>
-<MudButton Class="reset" OnClick="@ResetForm">Reset</MudButton>
+<MudButton Class="reset" OnClick="@ResetFormAsync">Reset</MudButton>
 
 @code
 {
@@ -18,9 +18,9 @@
     private int? age;
     private DateTime? date;
 
-    void ResetForm()
+    private async Task ResetFormAsync()
     {
-        form.Reset();
+        await form.ResetAsync();
         StateHasChanged();
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/FormResetMaskTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/FormResetMaskTest.razor
@@ -8,7 +8,7 @@
 <span>Phone: @phone</span>
 <br>
 <br>
-<MudButton Class="reset" OnClick="@ResetForm">Reset</MudButton>
+<MudButton Class="reset" OnClick="@ResetFormAsync">Reset</MudButton>
 
 @code
 { 
@@ -16,9 +16,9 @@
     private MudForm form;
     private string phone;
 
-    void ResetForm()
+    protected async Task ResetFormAsync()
     {
-        form.Reset();
+        await form.ResetAsync();
         StateHasChanged();
     }
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -588,7 +587,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Reset it
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
-            await comp.InvokeAsync(() => autocomplete.Reset());
+            await comp.InvokeAsync(() => autocomplete.ResetAsync());
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");
@@ -601,7 +600,7 @@ namespace MudBlazor.UnitTests.Components
             items.First().Markup.Should().Contain("California");
 
             // Reseting it should close popover and set Text and Value to null again
-            await comp.InvokeAsync(() => autocomplete.Reset());
+            await comp.InvokeAsync(() => autocomplete.ResetAsync());
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");
@@ -935,7 +934,7 @@ namespace MudBlazor.UnitTests.Components
             // Test show
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("Loading..."));
-            
+
             // Test hide
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("Loading..."));
@@ -980,7 +979,8 @@ namespace MudBlazor.UnitTests.Components
 
             var first = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) => {
+            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            {
                 cancelToken = cancellationToken;
                 // Return task that never completes.
                 return first.Task;
@@ -995,10 +995,10 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => Assert.IsFalse(cancelToken?.IsCancellationRequested));
 
             // Arrange second call
-            
+
             var second = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) => 
+            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 return second.Task;
             }));
@@ -1068,7 +1068,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<AutocompleteStrictFalseTest>();
             var autocompletecomp = comp.FindComponents<MudAutocomplete<AutocompleteStrictFalseTest.State>>()[index];
             var autocomplete = autocompletecomp.Instance;
-            
+
             //search for and select California
             autocompletecomp.Find("input").Input("Calif");
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
@@ -1126,7 +1126,7 @@ namespace MudBlazor.UnitTests.Components
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
             var result = new List<string>();
             //create eventCallback
-            var customEvent = new EventCallbackFactory().Create<KeyboardEventArgs>("A",() => result.Add("keyevent thrown"));
+            var customEvent = new EventCallbackFactory().Create<KeyboardEventArgs>("A", () => result.Add("keyevent thrown"));
 
             //set eventCallback
             //SetCallback also possible

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -133,7 +133,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().Be(true);
 
             //reset should set touched to false
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             form.IsTouched.Should().Be(false);
 
             // clear value to null
@@ -171,7 +171,7 @@ namespace MudBlazor.UnitTests.Components
             nestedForm.IsTouched.Should().Be(false);
 
             //reset should set touched to false
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(false);
 
@@ -212,7 +212,7 @@ namespace MudBlazor.UnitTests.Components
             nestedForm.IsTouched.Should().Be(true);
 
             //reset should set touched to false
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(false);
 
@@ -324,7 +324,7 @@ namespace MudBlazor.UnitTests.Components
             textFieldcomp.Find("input").Change("Some value");
             form.IsValid.Should().Be(true);
             // calling Reset() should reset the textField's value
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             textField.Value.Should().Be(null);
             textField.Text.Should().Be(null);
             form.IsValid.Should().Be(false); // because we did reset validation state as a side-effect.
@@ -1149,7 +1149,7 @@ namespace MudBlazor.UnitTests.Components
             textField.Value.Should().Be("asdf");
             textField.Text.Should().Be("asdf");
             // call reset directly
-            await comp.InvokeAsync(() => form.Instance.Reset());
+            await comp.InvokeAsync(() => form.Instance.ResetAsync());
             textField.Value.Should().BeNullOrEmpty();
             textField.Text.Should().BeNullOrEmpty();
             // input some text
@@ -1178,7 +1178,7 @@ namespace MudBlazor.UnitTests.Components
             numericField.Value.Should().Be(10);
             numericField.Text.Should().Be("10");
             // call reset directly
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             numericField.Value.Should().BeNull();
             numericField.Text.Should().BeNullOrEmpty();
             // input some text
@@ -1211,7 +1211,7 @@ namespace MudBlazor.UnitTests.Components
             datePicker.Date.Should().Be(testDate);
             datePicker.Text.Should().Be(testDateString);
             // call reset directly
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             datePicker.Date.Should().BeNull();
             datePicker.Text.Should().BeNullOrEmpty();
 
@@ -1248,7 +1248,7 @@ namespace MudBlazor.UnitTests.Components
             numericFieldComp.Find("input").Input("1");
             form.IsValid.Should().Be(true);
 
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             form.IsValid.Should().Be(false); // required fields
         }
 

--- a/src/MudBlazor.UnitTests/Components/MaskTests .cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests .cs
@@ -683,7 +683,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => textField.Text.Should().Be("(123) 456-7890"));
             comp.WaitForAssertion(() => textField.Value.Should().Be("(123) 456-7890"));
 
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             comp.WaitForAssertion(() => mask.Mask.ToString().Should().Be("|"));
             comp.WaitForAssertion(() => textField.Text.Should().BeNullOrEmpty());
             comp.WaitForAssertion(() => textField.Value.Should().BeNullOrEmpty());
@@ -699,7 +699,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => textField.Value.Should().Be("(123) "));
 
             //ctrl+backspace
-            await comp.InvokeAsync(() => form.Reset());
+            await comp.InvokeAsync(() => form.ResetAsync());
             await comp.InvokeAsync(() => mask.OnPaste("1234567890"));
             comp.WaitForAssertion(() => mask.Mask.ToString().Should().Be("(123) 456-7890|"));
             comp.WaitForAssertion(() => textField.Text.Should().Be("(123) 456-7890"));

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -751,7 +751,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // reset (must reset dirty state)
-            await comp.InvokeAsync(() => comp.Instance.Reset());
+            await comp.InvokeAsync(() => comp.Instance.ResetAsync());
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
 
             // user does not change input value but changes focus
@@ -790,7 +790,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // reset
-            await comp.InvokeAsync(() => comp.Instance.Reset());
+            await comp.InvokeAsync(() => comp.Instance.ResetAsync());
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
 
             // user does not change input value but changes focus

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -514,11 +515,20 @@ namespace MudBlazor
                 base.OnParametersSet();
         }
 
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         protected override void ResetValue()
         {
             SetTextAsync(null, updateValue: true).AndForget();
             this._isDirty = false;
             base.ResetValue();
+        }
+
+        protected override async Task ResetValueAsync()
+        {
+            await SetTextAsync(null, updateValue: true);
+            this._isDirty = false;
+            await base.ResetValueAsync();
         }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -530,18 +530,40 @@ namespace MudBlazor
         /// <summary>
         /// Reset the value and the validation.
         /// </summary>
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         public void Reset()
         {
             ResetValue();
             ResetValidation();
         }
 
+        /// <summary>
+        /// Reset the value and the validation.
+        /// </summary>
+        public async Task ResetAsync()
+        {
+            await ResetValueAsync();
+            ResetValidation();
+        }
+
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         protected virtual void ResetValue()
         {
             /* to be overridden */
             _value = default;
             Touched = false;
             StateHasChanged();
+        }
+
+        protected virtual Task ResetValueAsync()
+        {
+            /* to be overridden */
+            _value = default;
+            Touched = false;
+            StateHasChanged();
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -13,7 +13,8 @@ namespace MudBlazor
 {
     public partial class MudAutocomplete<T> : MudBaseInput<T>, IDisposable
     {
-        [Inject] IScrollManager ScrollManager { get; set; }
+        [Inject]
+        private IScrollManager ScrollManager { get; set; }
 
         private bool _dense;
 
@@ -314,7 +315,8 @@ namespace MudBlazor
         /// <summary>
         /// An event triggered when the state of IsOpen has changed
         /// </summary>
-        [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
+        [Parameter]
+        public EventCallback<bool> IsOpenChanged { get; set; }
 
         /// <summary>
         /// If true, the currently selected item from the drop-down (if it is open) is selected.
@@ -333,7 +335,8 @@ namespace MudBlazor
         /// <summary>
         /// Button click event for clear button. Called after text and value has been cleared.
         /// </summary>
-        [Parameter] public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         private string CurrentIcon => !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
 
@@ -388,7 +391,7 @@ namespace MudBlazor
             else
             {
                 _timer?.Dispose();
-                RestoreScrollPosition();
+                await RestoreScrollPositionAsync();
                 await CoerceTextToValue();
                 IsOpen = false;
                 StateHasChanged();
@@ -545,11 +548,11 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        protected override async void ResetValue()
-        {
-            await Clear();
-        }
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
+        protected override async void ResetValue() => await Clear();
 
+        protected override Task ResetValueAsync() => Clear();
 
         private string GetItemString(T item)
         {
@@ -637,7 +640,7 @@ namespace MudBlazor
                 case "Backspace":
                     if (args.CtrlKey == true && args.ShiftKey == true)
                     {
-                        Reset();
+                        await ResetAsync();
                     }
                     break;
             }
@@ -657,7 +660,6 @@ namespace MudBlazor
         /// We need a random id for the year items in the year list so we can scroll to the item safely in every DatePicker.
         /// </summary>
         private readonly string _componentId = Guid.NewGuid().ToString();
-
 
         /// <summary>
         /// Scroll to a specific item index in the Autocomplete list of items.
@@ -681,10 +683,10 @@ namespace MudBlazor
         }
 
         //This restores the scroll position after closing the menu and element being 0
-        private void RestoreScrollPosition()
+        private ValueTask RestoreScrollPositionAsync()
         {
-            if (_selectedListItemIndex != 0) return;
-            ScrollManager.ScrollToListItemAsync(GetListItemId(0));
+            if (_selectedListItemIndex != 0) return ValueTask.CompletedTask;
+            return ScrollManager.ScrollToListItemAsync(GetListItemId(0));
         }
 
         private string GetListItemId(in int index)
@@ -805,6 +807,5 @@ namespace MudBlazor
         {
             await SelectOption(item);
         }
-
     }
 }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -267,6 +267,7 @@ namespace MudBlazor
         /// <summary>
         /// Reset all form controls and reset their validation state.
         /// </summary>
+        [Obsolete($"Use {nameof(ResetAsync)} instead. This will ve removed in v7")]
         public void Reset()
         {
             foreach (var control in _formControls.ToArray())
@@ -277,6 +278,24 @@ namespace MudBlazor
             foreach (var form in ChildForms)
             {
                 form.Reset();
+            }
+
+            EvaluateForm(debounce: false);
+        }
+
+        /// <summary>
+        /// Reset all form controls and reset their validation state.
+        /// </summary>
+        public async Task ResetAsync()
+        {
+            foreach (var control in _formControls.ToArray())
+            {
+                await control.ResetAsync();
+            }
+
+            foreach (var form in ChildForms)
+            {
+                await form.ResetAsync();
             }
 
             EvaluateForm(debounce: false);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -392,10 +392,21 @@ namespace MudBlazor
             }
         }
 
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         protected override void ResetValue()
         {
             _inputReference?.Reset();
             base.ResetValue();
+        }
+
+        protected override async Task ResetValueAsync()
+        {
+            if (_inputReference is not null)
+            {
+                await _inputReference.ResetAsync();
+            }
+            await base.ResetValueAsync();
         }
 
         protected internal MudTextField<string> _inputReference;

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -2,7 +2,7 @@
 @typeparam T
 @inherits MudComponentBase
 
-<label class="@Classname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDown">
+<label class="@Classname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync">
     <span tabindex="0" class="@ButtonClassname">
         <span class="mud-radio-button">
             <input tabindex="-1" @attributes="UserAttributes" aria-checked="@(Checked.ToString().ToLower())" aria-disabled="@(IsDisabled.ToString().ToLower())" role="radio" type="radio" class="mud-radio-input" name="@MudRadioGroup?.Name" disabled="@IsDisabled" @onclick="OnClick" />

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -172,6 +172,7 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
+        [Obsolete($"Use {nameof(HandleKeyDownAsync)} instead. This method will be removed in v7")]
         protected internal void HandleKeyDown(KeyboardEventArgs obj)
         {
             if (IsDisabled || (MudRadioGroup?.GetReadOnlyState() ?? false))
@@ -185,6 +186,27 @@ namespace MudBlazor
                     break;
                 case "Backspace":
                     MudRadioGroup.Reset();
+                    break;
+            }
+        }
+
+        protected internal async Task HandleKeyDownAsync(KeyboardEventArgs keyboardEventArgs)
+        {
+            if (IsDisabled || (MudRadioGroup?.GetReadOnlyState() ?? false))
+                return;
+            switch (keyboardEventArgs.Key)
+            {
+                case "Enter":
+                case "NumpadEnter":
+                case " ":
+                    Select();
+                    break;
+                case "Backspace":
+                    if (MudRadioGroup is not null)
+                    {
+                        await MudRadioGroup.ResetAsync();
+                    }
+
                     break;
             }
         }

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -141,6 +142,8 @@ namespace MudBlazor
                 _selectedRadio = null;
         }
 
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         protected override void ResetValue()
         {
             if (_selectedRadio != null)
@@ -150,6 +153,17 @@ namespace MudBlazor
             }
 
             base.ResetValue();
+        }
+
+        protected override Task ResetValueAsync()
+        {
+            if (_selectedRadio != null)
+            {
+                _selectedRadio.SetChecked(false);
+                _selectedRadio = null;
+            }
+
+            return base.ResetValueAsync();
         }
 
         private static T GetOptionOrDefault(MudRadio<T> radio)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -71,6 +72,8 @@ namespace MudBlazor
                 return _maskReference.SelectRangeAsync(pos1, pos2);
         }
 
+        [Obsolete($"Use {nameof(ResetValueAsync)} instead. This will be removed in v7")]
+        [ExcludeFromCodeCoverage]
         protected override void ResetValue()
         {
             if (_mask == null)
@@ -78,6 +81,15 @@ namespace MudBlazor
             else
                 _maskReference.Reset();
             base.ResetValue();
+        }
+
+        protected override async Task ResetValueAsync()
+        {
+            if (_mask == null)
+                await InputReference.ResetAsync();
+            else
+                await _maskReference.ResetAsync();
+            await base.ResetValueAsync();
         }
 
         /// <summary>
@@ -133,9 +145,10 @@ namespace MudBlazor
             {
                 var textValue = Converter.Set(value);
                 _mask.SetText(textValue);
-                textValue=Mask.GetCleanText();
+                textValue = Mask.GetCleanText();
                 value = Converter.Get(textValue);
             }
+
             return base.SetValueAsync(value, updateText);
         }
 

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace MudBlazor.Interfaces
@@ -13,7 +15,10 @@ namespace MudBlazor.Interfaces
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }
         public Task Validate();
+        [Obsolete($"Use {nameof(ResetAsync)} instead. This will b removed in v7")]
+        [ExcludeFromCodeCoverage]
         public void Reset();
+        public Task ResetAsync();
         public void ResetValidation();
         public void StateHasChanged();
     }


### PR DESCRIPTION
## Description

I introduced a new API
1. Introduced `ResetValueAsync` to replace `ResetValue` since some components, such as `MudAutocomplete`, require async methods. Previously, `MudAutocomplete` was using async void, which is not considered good practice.
2. Created `ResetAsync` to replace `Reset`. 

I believe it would be beneficial if `MudFormComponent` provided virtual async APIs, even if the `MudFormComponent` itself doesn't need to call task/value task methods. In these cases, it's best to return `Task.CompletedTask` instead. This is because components that inherit `MudFormComponent` and override methods may need to await certain methods. For instance, `MudBaseInput` -> `ResetValue` serves as a good example.

## How Has This Been Tested?
Current unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
