### PR TITLE
MudAutocomplete: Fix Race Condition #6475

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+<MudAutocomplete @ref="_selectAsync"
+                 T="string"
+                 ToStringFunc="x => x"
+                 ValueChanged="OnSelectAsync"
+                 SearchFunc="Search"
+                 Variant="Variant.Outlined"
+                 ResetValueOnEmptyText="true"
+                 MaxItems="null"
+                 Class="mb-3" />
+@code {
+#nullable enable
+    private MudAutocomplete<string> _selectAsync = null!;
+    private readonly IEnumerable<string> _elements = new List<string>(2)
+    {
+        "Test","Value"
+    };
+
+    private async Task OnSelectAsync(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+        await SomeTask();
+        await _selectAsync.ResetAsync();
+    }
+
+    private async Task SomeTask()
+    {
+        //await Task.Delay(5);
+    }
+
+    private Task<IEnumerable<string>> Search(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return Task.FromResult(_elements);
+        }
+
+        var items = _elements.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+        return Task.FromResult(items);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1179,5 +1179,31 @@ namespace MudBlazor.UnitTests.Components
             var selectedItem = listItems.Single(x => x.Markup.Contains(selectedItemSelector));
             selectedItem.Markup.Should().Contain(selectedItemString);
         }
+
+        /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/6475
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Reset_Value_ShouldBe_Empty()
+        {
+            var component = Context.RenderComponent<AutocompleteResetTest>();
+            var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
+
+            // get the instance
+            var autocompleteInstance = autocompleteComponent.Instance;
+
+            // click to open the popup
+            autocompleteComponent.Find(TagNames.Input).Click();
+
+            // ensure popup is open
+            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeTrue("Input has been focused and should open the popup"));
+
+            // get the matching states
+            var matchingStates = component.FindComponents<MudListItem>().ToArray();
+
+            // try clicking 'Test'
+            matchingStates.Single(s => s.Markup.Contains("Test")).Find("div.mud-list-item").Click();
+            component.WaitForAssertion(() => autocompleteInstance.Text.Should().Be(string.Empty));
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -14,7 +14,7 @@
                           Value="@Text" DisableUnderLine="@DisableUnderLine"
                           Disabled="@GetDisabledState()" ReadOnly="@GetReadOnlyState()" Error="@Error"
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
-                          Clearable="@(GetReadOnlyState() ? false : Clearable)" OnClearButtonClick="@OnClearButtonClick"
+                          Clearable="@(!GetReadOnlyState() && Clearable)" OnClearButtonClick="@OnClearButtonClick"
                           @attributes="UserAttributes"
                           TextChanged="OnTextChanged" OnBlur="OnInputBlurred"
                           OnKeyDown="@this.OnInputKeyDown"
@@ -48,18 +48,19 @@
                             @for (var index = 0; index < _items.Length; index++)
                             {
                                 var item = _items[index];
-                                bool is_selected = index == _selectedListItemIndex;
-                                bool is_disabled = !_enabledItemIndices.Contains(index);
-                                <MudListItem @key="@item" id="@GetListItemId(index)" Disabled="@(is_disabled)" OnClick="@(async() => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@(is_selected ? "mud-selected-item mud-primary-text mud-primary-hover" : "")">
+                                bool isSelected = index == _selectedListItemIndex;
+                                bool isDisabled = !_enabledItemIndices.Contains(index);
+                                var captureIndex = index;
+                                <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async() => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@(isSelected ? "mud-selected-item mud-primary-text mud-primary-hover" : "")">
                                     @if (ItemTemplate == null)
                                     {
                                         @GetItemString(item)
                                     }
-                                    else if (is_disabled && ItemDisabledTemplate != null)
+                                    else if (isDisabled && ItemDisabledTemplate != null)
                                     {
                                         @ItemDisabledTemplate(item)
                                     }
-                                    else if (is_selected)
+                                    else if (isSelected)
                                     {
                                         @if (ItemSelectedTemplate == null)
                                             @ItemTemplate(item)


### PR DESCRIPTION
## Description
Fixes: #6475

Instead of removing `_isClearer=false ` on `OnAfterRender` when it's not BSS, I decided to use a different approach. I believe this change is safer.

Additionally, I took the _liberty_ of slightly restructuring the code by moving all private fields up to where they typically belong. This makes it easier to notice them and navigate the code.
All the open PRs for MudAutocomplete are currently stale and have conflicts.

## How Has This Been Tested?
Unit test + https://try.mudblazor.com/snippet/mEGnkxbUyBZTRxbA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
