### PR TITLE
Docs: Fix typo in toggle example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Mud/Introduction.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Introduction.razor
@@ -16,7 +16,7 @@
             <SectionHeader Title="First step: MudBlazor as a component library ">
                 <Description>
                     <MudText>What was missing was an easy-to-use yet visually compelling component library. Providing developers with a comfortable way to produce awesome-looking UIs for their customers out of the box would make working with Blazor an even more enjoyable task. With other core principles, this idea resulted in MudBlazor: An material design inspired Blazor Component library. </MudText>
-                    <MudText>What a component library does is offload everyday UI tasks from the developer. For instance, a Blazor developer wants to display certain information within a "tabbed" view. No problem: we can offer <code>MudTab</code>. Does a developer need a button that remembers the click state? Take the <code>MudToogleButton</code>, and there are fewer things you need to worry about.</MudText>
+                    <MudText>What a component library does is offload everyday UI tasks from the developer. For instance, a Blazor developer wants to display certain information within a "tabbed" view. No problem: we can offer <code>MudTab</code>. Does a developer need a button that remembers the click state? Take the <code>MudToggleIconButton</code>, and there are fewer things you need to worry about.</MudText>
                     <MudText>We are happy and proud to see people around the globe and various industries using MudBlazor to make their development faster, more reliable, and create a better experience for their users. </MudText>
                 </Description>
             </SectionHeader>


### PR DESCRIPTION
## Description
Typo in `Toogle`. Also adding the missing `Icon` in the component name.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
