### PR TITLE
BreakpointService & ResizeService: KeyNotFoundException fix #3993 #3356 #3698

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
@@ -30,8 +30,8 @@
 	{
 		if (firstRender)
 		{
-			var subscriptionResult = await BreakpointListener.Subscribe((breakpoint) =>
-			{
+            var subscriptionResult = await BreakpointListener.SubscribeAsync((breakpoint) =>
+            {
 				_breakpointHistory.Add(breakpoint);
 				InvokeAsync(StateHasChanged);
 			}, new ResizeOptions
@@ -48,5 +48,5 @@
 		await base.OnAfterRenderAsync(firstRender);
 	}
 
-	public async ValueTask DisposeAsync() => await BreakpointListener.Unsubscribe(_subscriptionId);
+	public async ValueTask DisposeAsync() => await BreakpointListener.UnsubscribeAsync(_subscriptionId);
 }

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
@@ -28,24 +28,24 @@
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
-	    if (firstRender)
-	    {
-	        var subscriptionResult = await BreakpointListener.SubscribeAsync((breakpoint) =>
-	        {
-                _breakpointHistory.Add(breakpoint);
-                InvokeAsync(StateHasChanged);
-	        }, new ResizeOptions
-	        {
-	            ReportRate = 250,
-	            NotifyOnBreakpointOnly = true,
-	        });
+		if (firstRender)
+		{
+			var subscriptionResult = await BreakpointListener.SubscribeAsync((breakpoint) =>
+			{
+				_breakpointHistory.Add(breakpoint);
+				InvokeAsync(StateHasChanged);
+			}, new ResizeOptions
+			{
+				ReportRate = 250,
+				NotifyOnBreakpointOnly = true,
+			});
 
-	        _start = subscriptionResult.Breakpoint;
-	        _subscriptionId = subscriptionResult.SubscriptionId;
-	        StateHasChanged();
-	    }
+			_start = subscriptionResult.Breakpoint;
+			_subscriptionId = subscriptionResult.SubscriptionId;
+			StateHasChanged();
+		}
 
-	    await base.OnAfterRenderAsync(firstRender);
+		await base.OnAfterRenderAsync(firstRender);
 	}
 
 	public async ValueTask DisposeAsync() => await BreakpointListener.UnsubscribeAsync(_subscriptionId);

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
@@ -28,24 +28,24 @@
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
-		if (firstRender)
-		{
-            var subscriptionResult = await BreakpointListener.SubscribeAsync((breakpoint) =>
-            {
-				_breakpointHistory.Add(breakpoint);
-				InvokeAsync(StateHasChanged);
-			}, new ResizeOptions
-			{
-				ReportRate = 250,
-				NotifyOnBreakpointOnly = true,
-			});
+	    if (firstRender)
+	    {
+	        var subscriptionResult = await BreakpointListener.SubscribeAsync((breakpoint) =>
+	        {
+                _breakpointHistory.Add(breakpoint);
+                InvokeAsync(StateHasChanged);
+	        }, new ResizeOptions
+	        {
+	            ReportRate = 250,
+	            NotifyOnBreakpointOnly = true,
+	        });
 
-			_start = subscriptionResult.Breakpoint;
-			_subscriptionId = subscriptionResult.SubscriptionId;
-			StateHasChanged();
-		}
+	        _start = subscriptionResult.Breakpoint;
+	        _subscriptionId = subscriptionResult.SubscriptionId;
+	        StateHasChanged();
+	    }
 
-		await base.OnAfterRenderAsync(firstRender);
+	    await base.OnAfterRenderAsync(firstRender);
 	}
 
 	public async ValueTask DisposeAsync() => await BreakpointListener.UnsubscribeAsync(_subscriptionId);

--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
@@ -28,7 +28,7 @@
     {
         if (firstRender)
         {
-			_subscriptionId = await ResizeService.Subscribe((size) =>
+			_subscriptionId = await ResizeService.SubscribeAsync((size) =>
 			{
 				width = size.Width;
 				height = size.Height;
@@ -48,5 +48,5 @@
         await base.OnAfterRenderAsync(firstRender);
     }
 
-    public async ValueTask DisposeAsync() => await ResizeService.Unsubscribe(_subscriptionId);
+    public async ValueTask DisposeAsync() => await ResizeService.UnsubscribeAsync(_subscriptionId);
 }

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests.Components
             _breakpointListenerServiceMock = new Mock<IBreakpointService>();
 
             _breakpointListenerServiceMock
-                .Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()))
                 .ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
                 .Callback<Action<Breakpoint>>(x => _breakpointUpdateCallback = x)
                 .Verifiable();

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests.Components
         public void Content_Visible(bool mediaResult, bool invert, bool isHidden)
         {
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
             listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(mediaResult).Verifiable();
 
             Context.Services.AddSingleton(sp => listenerMock.Object);
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
             Action<Breakpoint> callback = null;
 
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()))
                 .ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
                 .Callback<Action<Breakpoint>>(x => callback = x)
                 .Verifiable();
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         public void InvertChangedAfterInitializing()
         {
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
             listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
 
             Context.Services.AddSingleton(sp => listenerMock.Object);
@@ -115,7 +115,7 @@ namespace MudBlazor.UnitTests.Components
         public void ReferenceBreakpointChangedAfterInitializing()
         {
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
             listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
             listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Xs, Breakpoint.Md)).Returns(true).Verifiable();
 
@@ -144,7 +144,7 @@ namespace MudBlazor.UnitTests.Components
             Action<Breakpoint> callback = null;
 
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()))
                 .ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
                 .Callback<Action<Breakpoint>>(x => callback = x)
                 .Verifiable();
@@ -173,7 +173,7 @@ namespace MudBlazor.UnitTests.Components
         public void WithinMudBreakpointProvider()
         {
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()))
                 .ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
                 .Verifiable();
 
@@ -196,7 +196,7 @@ namespace MudBlazor.UnitTests.Components
                 item.TextContent.Should().Be($"MudHidden content {i + 1}");
             }
 
-            listenerMock.Verify(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()), Times.Once());
+            listenerMock.Verify(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()), Times.Once());
             listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(8));
             listenerMock.Verify();
         }
@@ -207,7 +207,7 @@ namespace MudBlazor.UnitTests.Components
             Action<Breakpoint> callback = null;
 
             var listenerMock = new Mock<IBreakpointService>();
-            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+            listenerMock.Setup(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()))
                 .ReturnsAsync(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
                 .Callback<Action<Breakpoint>>(x => callback = x)
                 .Verifiable();
@@ -249,7 +249,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.BreakpointChangedHistory.Should().HaveCount(3).And.BeEquivalentTo(new[] { Breakpoint.Md, Breakpoint.Xs, Breakpoint.Sm });
 
-            listenerMock.Verify(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()), Times.Once());
+            listenerMock.Verify(x => x.SubscribeAsync(It.IsAny<Action<Breakpoint>>()), Times.Once());
             listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(8));
             listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Xs), Times.Exactly(16));
             listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Sm), Times.Exactly(16));

--- a/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
@@ -77,9 +77,20 @@ namespace MudBlazor.UnitTests.Mocks
 
         public async Task<Breakpoint> GetBreakpoint() => GetBreakpointInternal();
 
-        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => Task.FromResult(new BreakpointServiceSubscribeResult(Guid.NewGuid(),Breakpoint.Sm));
-        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options) => Task.FromResult(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Sm));
-        public Task<bool> Unsubscribe(Guid subscriptionId) => Task.FromResult(true);
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => SubscribeAsync(callback);
+
+        public Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback) => Task.FromResult(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Sm));
+
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options) => SubscribeAsync(callback, options);
+
+        public Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback, ResizeOptions options) => Task.FromResult(new BreakpointServiceSubscribeResult(Guid.NewGuid(), Breakpoint.Sm));
+
+        [Obsolete($"Use {nameof(UnsubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<bool> Unsubscribe(Guid subscriptionId) => UnsubscribeAsync(subscriptionId);
+
+        public Task<bool> UnsubscribeAsync(Guid subscriptionId) => Task.FromResult(true);
 
         private Breakpoint GetBreakpointInternal()
         {

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
@@ -71,9 +71,20 @@ namespace MudBlazor.UnitTests.Mocks
 
         public async Task<Breakpoint> GetBreakpoint() => GetBreakpointInternal();
 
-        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => Task.FromResult(new Guid());
-        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options) => Task.FromResult(new Guid());
-        public Task<bool> Unsubscribe(Guid subscriptionId) => Task.FromResult(true);
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => SubscribeAsync(callback);
+
+        public Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback) => Task.FromResult(new Guid());
+
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options) => SubscribeAsync(callback, options);
+
+        public Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback, ResizeOptions options) => Task.FromResult(new Guid());
+
+        [Obsolete($"Use {nameof(UnsubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<bool> Unsubscribe(Guid subscriptionId) => UnsubscribeAsync(subscriptionId);
+
+        public Task<bool> UnsubscribeAsync(Guid subscriptionId) => Task.FromResult(true);
 
         private Breakpoint GetBreakpointInternal()
         {

--- a/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
@@ -69,7 +69,7 @@ namespace MudBlazor.UnitTests.Services
         {
             SetupJsMockForSubscription(expectedOptions, setBreakpoint);
 
-            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, expectedOptions);
+            var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, expectedOptions);
 
             subscriptionResult.Should().NotBeNull();
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
@@ -141,7 +141,7 @@ namespace MudBlazor.UnitTests.Services
 
             SetupJsMockForSubscription(customResizeOptioons, true);
 
-            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+            var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
 
             subscriptionResult.Should().NotBeNull();
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
@@ -156,7 +156,7 @@ namespace MudBlazor.UnitTests.Services
             var customResizeOptioons = new ResizeOptions();
 
             SetupJsMockForSubscription(customResizeOptioons, true);
-            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, null);
+            var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
             subscriptionResult.Should().NotBeNull();
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
@@ -168,8 +168,8 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public void Subscribe_Failed_NullCallback()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null, new ResizeOptions()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null, new ResizeOptions()));
         }
 
         [Test]
@@ -189,9 +189,9 @@ namespace MudBlazor.UnitTests.Services
             };
 
             SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
-            var subscriptionId = await _service.Subscribe((Breakpoint size) => { }, null);
+            var subscriptionId = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
-            var result = await _service.Unsubscribe(subscriptionId.SubscriptionId);
+            var result = await _service.UnsubscribeAsync(subscriptionId.SubscriptionId);
 
             result.Should().BeTrue();
 
@@ -228,9 +228,9 @@ namespace MudBlazor.UnitTests.Services
                 };
 
                 SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
-                var subscritionResult = await _service.Subscribe((Breakpoint size) => { }, null);
+                var subscritionResult = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
-                var result = await _service.Unsubscribe(subscritionResult.SubscriptionId);
+                var result = await _service.UnsubscribeAsync(subscritionResult.SubscriptionId);
 
                 result.Should().BeTrue();
 
@@ -261,7 +261,7 @@ namespace MudBlazor.UnitTests.Services
 
             for (int i = 0; i < 10; i++)
             {
-                var subscritionResult = await _service.Subscribe((Breakpoint size) => { });
+                var subscritionResult = await _service.SubscribeAsync((Breakpoint size) => { });
                 subscriptionIds.Add(subscritionResult.SubscriptionId);
             }
 
@@ -307,7 +307,7 @@ namespace MudBlazor.UnitTests.Services
                 var index = i % 4;
                 var option = options[index];
 
-                var subscritionResult = await _service.Subscribe((Breakpoint size) => { }, option);
+                var subscritionResult = await _service.SubscribeAsync((Breakpoint size) => { }, option);
                 subscriptionIds[option].Add(subscritionResult.SubscriptionId);
             }
 
@@ -332,7 +332,7 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public async Task Unsubscribe_Failed_NoActiveSubscription()
         {
-            var result = await _service.Unsubscribe(Guid.NewGuid());
+            var result = await _service.UnsubscribeAsync(Guid.NewGuid());
 
             result.Should().BeFalse();
         }
@@ -343,9 +343,9 @@ namespace MudBlazor.UnitTests.Services
             var customResizeOptioons = new ResizeOptions();
 
             SetupJsMockForSubscription(customResizeOptioons, true);
-            var subscriptionId = await _service.Subscribe((Breakpoint size) => { }, null);
+            var subscriptionId = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
-            var result = await _service.Unsubscribe(Guid.NewGuid());
+            var result = await _service.UnsubscribeAsync(Guid.NewGuid());
 
             result.Should().BeFalse();
         }
@@ -389,7 +389,7 @@ namespace MudBlazor.UnitTests.Services
                 var index = i % 4;
                 var option = options[index];
 
-                await _service.Subscribe((Breakpoint size) => { }, option);
+                await _service.SubscribeAsync((Breakpoint size) => { }, option);
             }
 
             Func<IEnumerable<Guid>, bool> idChecker = (ids) =>
@@ -424,7 +424,7 @@ namespace MudBlazor.UnitTests.Services
             public async Task Subscribe(BreakpointService service,
                 ResizeOptions options)
             {
-                var result = await service.Subscribe((x) => ActualSize = x, options);
+                var result = await service.SubscribeAsync((x) => ActualSize = x, options);
                 SubscriptionId = result.SubscriptionId;
             }
         }
@@ -497,13 +497,13 @@ namespace MudBlazor.UnitTests.Services
             var customResizeOptioons = new ResizeOptions();
 
             SetupJsMockForSubscription(customResizeOptioons, true);
-            var firstSubscribeResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+            var firstSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
 
             firstSubscribeResult.Breakpoint.Should().Be(Breakpoint.Md);
 
             _service.RaiseOnResized(new BrowserWindowSize { }, Breakpoint.Xl, Guid.NewGuid());
 
-            var secondSubscribeResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+            var secondSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
             secondSubscribeResult.Breakpoint.Should().Be(Breakpoint.Xl);
 
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());

--- a/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
@@ -80,7 +80,7 @@ namespace MudBlazor.UnitTests.Services
         {
             SetupJsMockForSubscription(expectedOptions);
 
-            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+            var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { });
 
             subscriptionId.Should().NotBe(Guid.Empty);
 
@@ -118,7 +118,7 @@ namespace MudBlazor.UnitTests.Services
 
             SetupJsMockForSubscription(customResizeOptioons);
 
-            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, customResizeOptioons);
+            var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, customResizeOptioons);
 
             subscriptionId.Should().NotBe(Guid.Empty);
             _jsruntimeMock.Verify();
@@ -130,7 +130,7 @@ namespace MudBlazor.UnitTests.Services
             var customResizeOptioons = new ResizeOptions();
 
             SetupJsMockForSubscription(customResizeOptioons);
-            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+            var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, null);
 
             subscriptionId.Should().NotBe(Guid.Empty);
             _jsruntimeMock.Verify();
@@ -139,8 +139,8 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public void Subscribe_Failed_NullCallback()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null, new ResizeOptions()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null!));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null!, new ResizeOptions()));
 
         }
 
@@ -161,9 +161,9 @@ namespace MudBlazor.UnitTests.Services
             };
 
             SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
-            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+            var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, null);
 
-            var result = await _service.Unsubscribe(subscriptionId);
+            var result = await _service.UnsubscribeAsync(subscriptionId);
 
             result.Should().BeTrue();
 
@@ -199,9 +199,9 @@ namespace MudBlazor.UnitTests.Services
                 };
 
                 SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
-                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+                var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, null);
 
-                var result = await _service.Unsubscribe(subscriptionId);
+                var result = await _service.UnsubscribeAsync(subscriptionId);
 
                 result.Should().BeTrue();
 
@@ -232,7 +232,7 @@ namespace MudBlazor.UnitTests.Services
 
             for (int i = 0; i < 10; i++)
             {
-                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+                var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { });
                 subscriptionIds.Add(subscriptionId);
             }
 
@@ -278,7 +278,7 @@ namespace MudBlazor.UnitTests.Services
                 var index = i % 4;
                 var option = options[index];
 
-                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, option);
+                var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, option);
                 subscriptionIds[option].Add(subscriptionId);
             }
 
@@ -303,7 +303,7 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public async Task Unsubscribe_Failed_NoActiveSubscription()
         {
-            var result = await _service.Unsubscribe(Guid.NewGuid());
+            var result = await _service.UnsubscribeAsync(Guid.NewGuid());
 
             result.Should().BeFalse();
 
@@ -315,9 +315,9 @@ namespace MudBlazor.UnitTests.Services
             var customResizeOptioons = new ResizeOptions();
 
             SetupJsMockForSubscription(customResizeOptioons);
-            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+            var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { }, null);
 
-            var result = await _service.Unsubscribe(Guid.NewGuid());
+            var result = await _service.UnsubscribeAsync(Guid.NewGuid());
 
             result.Should().BeFalse();
         }
@@ -362,7 +362,7 @@ namespace MudBlazor.UnitTests.Services
                 var index = i % 4;
                 var option = options[index];
 
-                await _service.Subscribe((BrowserWindowSize size) => { }, option);
+                await _service.SubscribeAsync((BrowserWindowSize size) => { }, option);
             }
 
             Func<IEnumerable<Guid>, bool> idChecker = (ids) =>
@@ -398,7 +398,7 @@ namespace MudBlazor.UnitTests.Services
             public async Task Subscribe(ResizeService service,
                 ResizeOptions options)
             {
-                SubscriptionId = await service.Subscribe((x) => ActualSize = x, options);
+                SubscriptionId = await service.SubscribeAsync((x) => ActualSize = x, options);
             }
         }
 
@@ -488,7 +488,7 @@ namespace MudBlazor.UnitTests.Services
 
             for (int i = 0; i < 40; i++)
             {
-                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+                var subscriptionId = await _service.SubscribeAsync((BrowserWindowSize size) => { });
                 subscriptionIds.Add(subscriptionId);
             }
 
@@ -503,7 +503,7 @@ namespace MudBlazor.UnitTests.Services
                 var temp = i;
                 var task = Task.Run(async () =>
                 {
-                    _ = await _service.Unsubscribe(subscriptionIds.ElementAt(temp));
+                    _ = await _service.UnsubscribeAsync(subscriptionIds.ElementAt(temp));
                 });
 
                 tasksToExecute[i] = task;

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
 
             if (firstRender == true)
             {
-                var attachResult = await Service.Subscribe(SetBreakpointCallback);
+                var attachResult = await Service.SubscribeAsync(SetBreakpointCallback);
                 _breakPointListenerSubscriptionId = attachResult.SubscriptionId;
                 Breakpoint = attachResult.Breakpoint;
                 await OnBreakpointChanged.InvokeAsync(Breakpoint);
@@ -50,6 +50,6 @@ namespace MudBlazor
             }).AndForget();
         }
 
-        public async ValueTask DisposeAsync() => await Service.Unsubscribe(_breakPointListenerSubscriptionId);
+        public async ValueTask DisposeAsync() => await Service.UnsubscribeAsync(_breakPointListenerSubscriptionId);
     }
 }

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -266,7 +266,7 @@ namespace MudBlazor
             if (firstRender)
             {
                 await UpdateHeight();
-                var result = await Breakpointistener.Subscribe(UpdateBreakpointState);
+                var result = await Breakpointistener.SubscribeAsync(UpdateBreakpointState);
                 var currentBreakpoint = result.Breakpoint;
 
                 _breakpointListenerSubscriptionId = result.SubscriptionId;
@@ -305,7 +305,7 @@ namespace MudBlazor
 
                     if (_breakpointListenerSubscriptionId != default)
                     {
-                        Breakpointistener.Unsubscribe(_breakpointListenerSubscriptionId).AndForget();
+                        Breakpointistener.UnsubscribeAsync(_breakpointListenerSubscriptionId).AndForget();
                     }
                 }
             }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -97,7 +97,7 @@ namespace MudBlazor
             {
                 if (CurrentBreakpointFromProvider == Breakpoint.None)
                 {
-                    var attachResult = await BreakpointService.Subscribe((x) =>
+                    var attachResult = await BreakpointService.SubscribeAsync((x) =>
                     {
                         Update(x);
                         InvokeAsync(StateHasChanged);
@@ -115,6 +115,6 @@ namespace MudBlazor
             }
         }
 
-        public async ValueTask DisposeAsync() => await BreakpointService.Unsubscribe(_breakpointServiceSubscriptionId);
+        public async ValueTask DisposeAsync() => await BreakpointService.UnsubscribeAsync(_breakpointServiceSubscriptionId);
     }
 }

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -6,23 +6,21 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
 namespace MudBlazor.Services
 {
-
+#nullable enable
     public class BreakpointService :
         ResizeBasedService<BreakpointService, BreakpointServiceSubscriptionInfo, Breakpoint, ResizeOptions>,
         IBreakpointService
     {
         private readonly IJSRuntime _jsRuntime;
         private readonly ResizeOptions _options;
-        private IBrowserWindowSizeProvider _browserWindowSizeProvider;
-        private BrowserWindowSize _windowSize;
+        private readonly IBrowserWindowSizeProvider _browserWindowSizeProvider;
+        private BrowserWindowSize? _windowSize;
         private Breakpoint _breakpoint = Breakpoint.None;
 
         /// <summary>
@@ -32,12 +30,12 @@ namespace MudBlazor.Services
         /// <param name="browserWindowSizeProvider"></param>
         /// <param name="options"></param>
         [DynamicDependency(nameof(RaiseOnResized))]
-        public BreakpointService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions> options = null)
+        public BreakpointService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions>? options = null)
             : base(jsRuntime)
         {
-            this._options = options?.Value ?? new ResizeOptions();
-            this._jsRuntime = jsRuntime;
-            this._browserWindowSizeProvider = browserWindowSizeProvider;
+            _options = options?.Value ?? new ResizeOptions();
+            _jsRuntime = jsRuntime;
+            _browserWindowSizeProvider = browserWindowSizeProvider;
         }
 
         /// <summary>
@@ -52,10 +50,15 @@ namespace MudBlazor.Services
             _windowSize = browserWindowSize;
             _breakpoint = breakpoint;
 
-            if (Listeners.ContainsKey(optionId) == false) { return; }
+            if (!Listeners.ContainsKey(optionId))
+            {
+                return;
+            }
 
-            var listenerInfo = Listeners[optionId];
-            listenerInfo.InvokeCallbacks(breakpoint);
+            if (Listeners.TryGetValue(optionId, out var listenerInfo))
+            {
+                listenerInfo.InvokeCallbacks(breakpoint);
+            }
         }
 
         /// <summary>
@@ -64,7 +67,7 @@ namespace MudBlazor.Services
         /// <param name="mediaQuery"></param>
         /// <returns>Returns true if matched.</returns>
         public async ValueTask<bool> MatchMedia(string mediaQuery) =>
-            await _jsRuntime.InvokeAsync<bool>($"mudResizeListener.matchMedia", mediaQuery);
+            await _jsRuntime.InvokeAsync<bool>("mudResizeListener.matchMedia", mediaQuery);
 
         public static Dictionary<Breakpoint, int> DefaultBreakpointDefinitions { get; set; } = new Dictionary<Breakpoint, int>()
         {
@@ -84,14 +87,13 @@ namespace MudBlazor.Services
                 return Breakpoint.Xs;
             if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
-            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Lg])
+            if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
-            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Md])
+            if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Md])
                 return Breakpoint.Md;
-            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Sm])
+            if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Sm])
                 return Breakpoint.Sm;
-            else
-                return Breakpoint.Xs;
+            return Breakpoint.Xs;
         }
 
         public async Task<bool> IsMediaSize(Breakpoint breakpoint)
@@ -107,14 +109,10 @@ namespace MudBlazor.Services
 
         public bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference)
         {
-            if (breakpoint == Breakpoint.None)
-                return false;
-
-            if (breakpoint == Breakpoint.Always)
-                return true;
-
             return breakpoint switch
             {
+                Breakpoint.None => false,
+                Breakpoint.Always => true,
                 Breakpoint.Xs => reference == Breakpoint.Xs,
                 Breakpoint.Sm => reference == Breakpoint.Sm,
                 Breakpoint.Md => reference == Breakpoint.Md,
@@ -128,13 +126,13 @@ namespace MudBlazor.Services
                 Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
                 Breakpoint.MdAndUp => reference >= Breakpoint.Md,
                 Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
-                _ => false,
+                _ => false
             };
         }
 
-        public async Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => await Subscribe(callback, _options);
+        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => Subscribe(callback, _options);
 
-        public async Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options)
+        public async Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions? options)
         {
             if (callback is null)
             {
@@ -147,52 +145,53 @@ namespace MudBlazor.Services
                 options.BreakpointDefinitions = DefaultBreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
             }
 
-            if (DotNetRef == null)
-            {
-                DotNetRef = DotNetObjectReference.Create(this);
-            }
-
+            DotNetRef ??= DotNetObjectReference.Create(this);
 
             try
             {
                 await Semaphore.WaitAsync();
 
-                var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
+                //We capture both key and value, because someone might unsubscribe at meantime
+                //This way we do not need to check if key exist
+                var existingOptionKeyValuePair = Listeners.FirstOrDefault(x => x.Value.Option == options);
 
-                if (existingOptionId == default)
+                //better way than existingOptionKeyValuePair.Equals(default) to avoid boxing
+                //we use ValueTuple to compare if KeyValuePair struct is default
+                if ((existingOptionKeyValuePair.Key, existingOptionKeyValuePair.Value) == default)
                 {
-                    var subscriptionInfo = new BreakpointServiceSubscriptionInfo(options);
-                    var subscriptionId = subscriptionInfo.AddSubscription(callback);
-                    var listenerId = Guid.NewGuid();
-
-                    Listeners.Add(listenerId, subscriptionInfo);
-
-                    var interopResult = await JsRuntime.InvokeVoidAsyncWithErrorHandling
-                        ("mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
-                    
-                    if (interopResult == true)
-                    {
-                        if (_breakpoint == Breakpoint.None)
-                        {
-                            _breakpoint = await GetBreakpoint();
-
-                        }
-                    }
-
-                    return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
+                    return await CreateSubscription(callback, options);
                 }
-                else
-                {
-                    var entry = Listeners[existingOptionId];
-                    var subscriptionId = entry.AddSubscription(callback);
 
-                    return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
-                }
+                var subscriptionId = existingOptionKeyValuePair.Value.AddSubscription(callback);
+                return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
             }
             finally
             {
                 Semaphore.Release();
             }
+        }
+
+        private async Task<BreakpointServiceSubscribeResult> CreateSubscription(Action<Breakpoint> callback, ResizeOptions options)
+        {
+            var subscriptionInfo = new BreakpointServiceSubscriptionInfo(options);
+            var subscriptionId = subscriptionInfo.AddSubscription(callback);
+            var listenerId = Guid.NewGuid();
+
+            Listeners.TryAdd(listenerId, subscriptionInfo);
+
+            var interopResult = await JsRuntime.InvokeVoidAsyncWithErrorHandling
+                ("mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
+
+            if (interopResult)
+            {
+                if (_breakpoint == Breakpoint.None)
+                {
+                    _breakpoint = await GetBreakpoint();
+
+                }
+            }
+
+            return new BreakpointServiceSubscribeResult(subscriptionId, _breakpoint);
         }
     }
 
@@ -229,17 +228,17 @@ namespace MudBlazor.Services
         /// <summary>
         /// Subscribe to size changes of the browser window with default options
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
         Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback);
 
         /// <summary>
         /// Subscribe to size changes of the browser window using the provided options
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <param name="options">The options used to subscribe to changes</param>
         /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
-        Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options);
+        Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions? options);
 
         /// <summary>
         /// Used for cancel the subscription to the resize event.

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -50,11 +50,6 @@ namespace MudBlazor.Services
             _windowSize = browserWindowSize;
             _breakpoint = breakpoint;
 
-            if (!Listeners.ContainsKey(optionId))
-            {
-                return;
-            }
-
             if (Listeners.TryGetValue(optionId, out var listenerInfo))
             {
                 listenerInfo.InvokeCallbacks(breakpoint);
@@ -152,14 +147,14 @@ namespace MudBlazor.Services
                 await Semaphore.WaitAsync();
 
                 //We capture both key and value, because someone might unsubscribe at meantime
-                //This way we do not need to check if key exist
+                //This way we do not need to check if key exist and do look up the dictionary again later
                 var existingOptionKeyValuePair = Listeners.FirstOrDefault(x => x.Value.Option == options);
 
                 //better way than existingOptionKeyValuePair.Equals(default) to avoid boxing
                 //we use ValueTuple to compare if KeyValuePair struct is default
                 if ((existingOptionKeyValuePair.Key, existingOptionKeyValuePair.Value) == default)
                 {
-                    return await CreateSubscription(callback, options);
+                    return await CreateSubscriptionAsync(callback, options);
                 }
 
                 var subscriptionId = existingOptionKeyValuePair.Value.AddSubscription(callback);
@@ -171,7 +166,7 @@ namespace MudBlazor.Services
             }
         }
 
-        private async Task<BreakpointServiceSubscribeResult> CreateSubscription(Action<Breakpoint> callback, ResizeOptions options)
+        private async Task<BreakpointServiceSubscribeResult> CreateSubscriptionAsync(Action<Breakpoint> callback, ResizeOptions options)
         {
             var subscriptionInfo = new BreakpointServiceSubscriptionInfo(options);
             var subscriptionId = subscriptionInfo.AddSubscription(callback);

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -73,6 +73,7 @@ namespace MudBlazor.Services
             [Breakpoint.Xs] = 0,
         };
 
+        /// <inheritdoc />
         public async Task<Breakpoint> GetBreakpoint()
         {
             // note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
@@ -91,6 +92,7 @@ namespace MudBlazor.Services
             return Breakpoint.Xs;
         }
 
+        /// <inheritdoc />
         public async Task<bool> IsMediaSize(Breakpoint breakpoint)
         {
             if (breakpoint == Breakpoint.None)
@@ -102,6 +104,7 @@ namespace MudBlazor.Services
             return IsMediaSize(breakpoint, await GetBreakpoint());
         }
 
+        /// <inheritdoc />
         public bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference)
         {
             return breakpoint switch
@@ -125,9 +128,19 @@ namespace MudBlazor.Services
             };
         }
 
-        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => Subscribe(callback, _options);
+        /// <inheritdoc />
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback) => SubscribeAsync(callback, _options);
 
-        public async Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions? options)
+        /// <inheritdoc />
+        public Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback) => SubscribeAsync(callback, _options);
+
+        /// <inheritdoc />
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions? options) => SubscribeAsync(callback, options);
+
+        /// <inheritdoc />
+        public async Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback, ResizeOptions? options)
         {
             if (callback is null)
             {
@@ -225,7 +238,15 @@ namespace MudBlazor.Services
         /// </summary>
         /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
         Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window with default options
+        /// </summary>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback);
 
         /// <summary>
         /// Subscribe to size changes of the browser window using the provided options
@@ -233,13 +254,30 @@ namespace MudBlazor.Services
         /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <param name="options">The options used to subscribe to changes</param>
         /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
         Task<BreakpointServiceSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions? options);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window using the provided options
+        /// </summary>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="options">The options used to subscribe to changes</param>
+        /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        Task<BreakpointServiceSubscribeResult> SubscribeAsync(Action<Breakpoint> callback, ResizeOptions? options);
 
         /// <summary>
         /// Used for cancel the subscription to the resize event.
         /// </summary>
         /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
         /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        [Obsolete($"Use {nameof(UnsubscribeAsync)} instead. This will be removed in v7.")]
         Task<bool> Unsubscribe(Guid subscriptionId);
+
+        /// <summary>
+        /// Used for cancel the subscription to the resize event.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
+        /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        Task<bool> UnsubscribeAsync(Guid subscriptionId);
     }
 }

--- a/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
@@ -30,7 +30,10 @@ namespace MudBlazor.Services
             JsRuntime = jsRuntime;
         }
 
-        public async Task<bool> Unsubscribe(Guid subscriptionId)
+        [Obsolete($"Use {nameof(UnsubscribeAsync)} instead. This will be removed in v7")]
+        public Task<bool> Unsubscribe(Guid subscriptionId) => UnsubscribeAsync(subscriptionId);
+
+        public async Task<bool> UnsubscribeAsync(Guid subscriptionId)
         {
             if (DotNetRef is null)
             {

--- a/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
@@ -63,7 +63,7 @@ namespace MudBlazor.Services
 
             if (BreakpointDefinitions is null)
                 return other.BreakpointDefinitions is null;
-            if (other.BreakpointDefinitions is null) 
+            if (other.BreakpointDefinitions is null)
                 return false;
             if (BreakpointDefinitions.Count != other.BreakpointDefinitions.Count)
                 return false;

--- a/src/MudBlazor/Services/ResizeListener/ResizeService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeService.cs
@@ -32,9 +32,7 @@ namespace MudBlazor.Services
             _browserWindowSizeProvider = browserWindowSizeProvider;
         }
 
-        /// <summary>
-        /// Get the current BrowserWindowSize, this includes the Height and Width of the document.
-        /// </summary>
+        /// <inheritdoc />
         public ValueTask<BrowserWindowSize> GetBrowserWindowSize() =>
             _browserWindowSizeProvider.GetBrowserWindowSize();
 
@@ -53,20 +51,19 @@ namespace MudBlazor.Services
             }
         }
 
-        /// <summary>
-        /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
-        /// </summary>
-        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
-        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
-        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => await Subscribe(callback, _options);
+        /// <inheritdoc />
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => SubscribeAsync(callback, _options);
 
-        /// <summary>
-        /// Subscribe to size changes of the browser window using the provided options
-        /// </summary>
-        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
-        /// <param name="options"></param>
-        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
-        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions? options)
+        /// <inheritdoc />
+        public Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback) => SubscribeAsync(callback, _options);
+
+        /// <inheritdoc />
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions? options) => SubscribeAsync(callback, options);
+
+        /// <inheritdoc />
+        public async Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback, ResizeOptions? options)
         {
             if (callback is null)
             {
@@ -119,7 +116,15 @@ namespace MudBlazor.Services
         /// </summary>
         /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
         Task<Guid> Subscribe(Action<BrowserWindowSize> callback);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
+        /// </summary>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback);
 
         /// <summary>
         /// Subscribe to size changes of the browser window using the provided options
@@ -127,13 +132,30 @@ namespace MudBlazor.Services
         /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <param name="options">The options used to subscribe to changes</param>
         /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        [Obsolete($"Use {nameof(SubscribeAsync)} instead. This will be removed in v7.")]
         Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions? options);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window using the provided options
+        /// </summary>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="options">The options used to subscribe to changes</param>
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        Task<Guid> SubscribeAsync(Action<BrowserWindowSize> callback, ResizeOptions? options);
 
         /// <summary>
         /// Used for cancel the subscription to the resize event.
         /// </summary>
         /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
         /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        [Obsolete($"Use {nameof(UnsubscribeAsync)} instead. This will be removed in v7.")]
         Task<bool> Unsubscribe(Guid subscriptionId);
+
+        /// <summary>
+        /// Used for cancel the subscription to the resize event.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
+        /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        Task<bool> UnsubscribeAsync(Guid subscriptionId);
     }
 }

--- a/src/MudBlazor/Services/ResizeListener/ResizeService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +7,7 @@ using Microsoft.JSInterop;
 
 namespace MudBlazor.Services
 {
+#nullable enable
     /// <summary>
     /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
     /// </summary>
@@ -25,11 +25,11 @@ namespace MudBlazor.Services
         /// <param name="browserWindowSizeProvider"></param>
         /// <param name="options"></param>
         [DynamicDependency(nameof(RaiseOnResized))]
-        public ResizeService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions> options = null) :
+        public ResizeService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions>? options = null) :
             base(jsRuntime)
         {
-            this._options = options?.Value ?? new ResizeOptions();
-            this._browserWindowSizeProvider = browserWindowSizeProvider;
+            _options = options?.Value ?? new ResizeOptions();
+            _browserWindowSizeProvider = browserWindowSizeProvider;
         }
 
         /// <summary>
@@ -47,26 +47,31 @@ namespace MudBlazor.Services
         [JSInvokable]
         public void RaiseOnResized(BrowserWindowSize browserWindowSize, Breakpoint _, Guid optionId)
         {
-            if (Listeners.ContainsKey(optionId) == false) { return; }
+            if (!Listeners.ContainsKey(optionId))
+            {
+                return;
+            }
 
-            var listenerInfo = Listeners[optionId];
-            listenerInfo.InvokeCallbacks(browserWindowSize);
+            if (Listeners.TryGetValue(optionId, out var listenerInfo))
+            {
+                listenerInfo.InvokeCallbacks(browserWindowSize);
+            }
         }
 
         /// <summary>
         /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
-        /// <returns>The subscription id. This id is needed for unscribe </returns>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
         public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => await Subscribe(callback, _options);
 
         /// <summary>
         /// Subscribe to size changes of the browser window using the provided options
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <param name="options"></param>
-        /// <returns>The subscription id. This id is needed for unscribe</returns>
-        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options)
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions? options)
         {
             if (callback is null)
             {
@@ -75,32 +80,34 @@ namespace MudBlazor.Services
 
             options ??= _options;
 
-            if (DotNetRef == null)
+            DotNetRef ??= DotNetObjectReference.Create(this);
+
+            //We capture both key and value, because someone might unsubscribe at meantime
+            //This way we do not need to check if key exist
+            var existingOptionKeyValuePair = Listeners.FirstOrDefault(x => x.Value.Option == options);
+
+            //better way than existingOptionKeyValuePair.Equals(default) to avoid boxing
+            //we use ValueTuple to compare if KeyValuePair struct is default
+            if ((existingOptionKeyValuePair.Key, existingOptionKeyValuePair.Value) == default)
             {
-                DotNetRef = DotNetObjectReference.Create(this);
+                return await CreateSubscription(callback, options);
             }
 
-            var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
+            var subscriptionId = existingOptionKeyValuePair.Value.AddSubscription(callback);
+            return subscriptionId;
+        }
 
-            if (existingOptionId == default)
-            {
-                var subscriptionInfo = new ResizeServiceSubscriptionInfo(options);
-                var subscriptionId = subscriptionInfo.AddSubscription(callback);
-                var listenerId = Guid.NewGuid();
+        private async Task<Guid> CreateSubscription(Action<BrowserWindowSize> callback, ResizeOptions options)
+        {
+            var subscriptionInfo = new ResizeServiceSubscriptionInfo(options);
+            var subscriptionId = subscriptionInfo.AddSubscription(callback);
+            var listenerId = Guid.NewGuid();
 
-                Listeners.Add(listenerId, subscriptionInfo);
+            Listeners.TryAdd(listenerId, subscriptionInfo);
 
-                await JsRuntime.InvokeVoidAsyncWithErrorHandling($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
+            await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
 
-                return subscriptionId;
-            }
-            else
-            {
-                var entry = Listeners[existingOptionId];
-                var subscriptionId = entry.AddSubscription(callback);
-
-                return subscriptionId;
-            }
+            return subscriptionId;
         }
     }
 
@@ -115,17 +122,17 @@ namespace MudBlazor.Services
         /// <summary>
         /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
-        /// <returns>The subscription id. This id is needed for unscribe </returns>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
         Task<Guid> Subscribe(Action<BrowserWindowSize> callback);
 
         /// <summary>
         /// Subscribe to size changes of the browser window using the provided options
         /// </summary>
-        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="callback">The method (callback) that is invoke as soon as the size of the window has changed</param>
         /// <param name="options">The options used to subscribe to changes</param>
-        /// <returns>The subscription id. This id is needed for unscribe</returns>
-        Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options);
+        /// <returns>The subscription id. This id is needed for unsubscribe</returns>
+        Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions? options);
 
         /// <summary>
         /// Used for cancel the subscription to the resize event.

--- a/src/MudBlazor/Services/ResizeListener/ResizeService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeService.cs
@@ -47,11 +47,6 @@ namespace MudBlazor.Services
         [JSInvokable]
         public void RaiseOnResized(BrowserWindowSize browserWindowSize, Breakpoint _, Guid optionId)
         {
-            if (!Listeners.ContainsKey(optionId))
-            {
-                return;
-            }
-
             if (Listeners.TryGetValue(optionId, out var listenerInfo))
             {
                 listenerInfo.InvokeCallbacks(browserWindowSize);
@@ -83,21 +78,21 @@ namespace MudBlazor.Services
             DotNetRef ??= DotNetObjectReference.Create(this);
 
             //We capture both key and value, because someone might unsubscribe at meantime
-            //This way we do not need to check if key exist
+            //This way we do not need to check if key exist and do look up the dictionary again later
             var existingOptionKeyValuePair = Listeners.FirstOrDefault(x => x.Value.Option == options);
 
             //better way than existingOptionKeyValuePair.Equals(default) to avoid boxing
             //we use ValueTuple to compare if KeyValuePair struct is default
             if ((existingOptionKeyValuePair.Key, existingOptionKeyValuePair.Value) == default)
             {
-                return await CreateSubscription(callback, options);
+                return await CreateSubscriptionAsync(callback, options);
             }
 
             var subscriptionId = existingOptionKeyValuePair.Value.AddSubscription(callback);
             return subscriptionId;
         }
 
-        private async Task<Guid> CreateSubscription(Action<BrowserWindowSize> callback, ResizeOptions options)
+        private async Task<Guid> CreateSubscriptionAsync(Action<BrowserWindowSize> callback, ResizeOptions options)
         {
             var subscriptionInfo = new ResizeServiceSubscriptionInfo(options);
             var subscriptionId = subscriptionInfo.AddSubscription(callback);

--- a/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 namespace MudBlazor.Services
 {
+#nullable enable
     public class SubscriptionInfo<TAction,TOption>
     {
         private readonly Dictionary<Guid, Action<TAction>> _subscriptions;
@@ -21,7 +22,7 @@ namespace MudBlazor.Services
         public Guid AddSubscription(Action<TAction> action)
         {
             var id = Guid.NewGuid();
-            _subscriptions.Add(id, action);
+            _subscriptions.TryAdd(id, action);
 
             return id;
         }
@@ -30,7 +31,10 @@ namespace MudBlazor.Services
 
         public bool RemoveSubscription(Guid listenerId)
         {
-            _subscriptions.Remove(listenerId);
+            if (_subscriptions.ContainsKey(listenerId))
+            {
+                _subscriptions.Remove(listenerId);
+            }
             return _subscriptions.Count == 0;
         }
 


### PR DESCRIPTION
## Description
Fixes #3356
Fixes #3698
Fixes #3993

Problematic line was this:
```Csharp
var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
//...
var entry = Listeners[existingOptionId];
```
The issue with this code is that it captures the key and then later extracts the value, which could have already been removed from the dictionary.
it could be counteracted differently like this
```Csharp
if (Listener.TryGetValue(...))
{
    //...
}
else
{
    return await CreateSubscription(callback, options);
}
```
But I think my solution is better by getting both the key and the value at the same time, without having to look up the dictionary again later.

I also protected the rest places with dictionary with TryAdd and checking if value exist before removing.

There was already some partial nullable enabled, I made it for whole file to eliminate other weak spots.

## How Has This Been Tested?
No tests. Unfortunately, no reproductions in issues so just the docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
