### PR TITLE
MudHighlighter: Add nullable annotation.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,6 +1,5 @@
 ﻿
 using System.Collections.Generic;
-using System.Linq;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
@@ -18,7 +17,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextParameterTest()
         {
             var highlightedText = "item";
-            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex).ToArray();
+            var result = GetFragments(TEXT, highlightedText, null, out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item))");
@@ -68,7 +67,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldUseUntilNextBoundaryTest()
         {
             var highlightedText = "it";
-            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, false, true).ToArray();
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, false, true).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:it.*?\\b))");
@@ -78,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldBeCaseSensitiveTest()
         {
             var highlightedText = "It";
-            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, true, false).ToArray();
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:It))");
@@ -89,7 +88,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //regex characters are properly escaped in GetFragments
             var highlightedText = ".";
-            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, true, false).ToArray();
+            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:\\.))");

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.Collections.Generic;
+using System.Linq;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
@@ -17,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSplitUsingHighlightedTextParameterTest()
         {
             var highlightedText = "item";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex).ToArray();
+            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item))");
@@ -67,7 +68,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldUseUntilNextBoundaryTest()
         {
             var highlightedText = "it";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, false, true).ToArray();
+            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, false, true).ToArray();
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:it.*?\\b))");
@@ -77,7 +78,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldBeCaseSensitiveTest()
         {
             var highlightedText = "It";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
+            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:It))");
@@ -88,7 +89,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //regex characters are properly escaped in GetFragments
             var highlightedText = ".";
-            var result = GetFragments(TEXT, highlightedText, null, out var regex, true, false).ToArray();
+            var result = GetFragments(TEXT, highlightedText, Enumerable.Empty<string>(), out var regex, true, false).ToArray();
             result.Should().HaveCount(1);
             result.Should().BeEquivalentTo(new List<string> { TEXT });
             regex.Should().Be("((?:\\.))");

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -4,36 +4,38 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using static MudBlazor.Components.Highlighter.Splitter;
 
 namespace MudBlazor;
 
+#nullable enable
 public partial class MudHighlighter : MudComponentBase
 {
     private Memory<string> _fragments;
-    private string _regex;
+    private string? _regex;
 
     /// <summary>
     /// The whole text in which a fragment will be highlighted
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Highlighter.Behavior)]
-    public string Text { get; set; }
+    public string? Text { get; set; }
 
     /// <summary>
     /// The fragment of text to be highlighted
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Highlighter.Behavior)]
-    public string HighlightedText { get; set; }
+    public string? HighlightedText { get; set; }
 
     /// <summary>
     /// The fragments of text to be highlighted
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Highlighter.Behavior)]
-    public IEnumerable<string> HighlightedTexts { get; set; }
+    public IEnumerable<string> HighlightedTexts { get; set; } = Enumerable.Empty<string>();
 
     /// <summary>
     /// Whether or not the highlighted text is case sensitive

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -6,11 +6,12 @@ using System.Threading;
 
 namespace MudBlazor.Components.Highlighter
 {
+#nullable enable
     public static class Splitter
     {
         private const string NextBoundary = ".*?\\b";
 
-        private static StringBuilder s_stringBuilderCached;
+        private static StringBuilder? s_stringBuilderCached;
 
         /// <summary>
         /// Splits the text into fragments, according to the
@@ -23,8 +24,8 @@ namespace MudBlazor.Components.Highlighter
         /// <param name="caseSensitive">Whether it's case sensitive or not</param>
         /// <param name="untilNextBoundary">If true, splits until the next regex boundary</param>
         /// <returns></returns>
-        public static Memory<string> GetFragments(string text,
-                                                       string highlightedText,
+        public static Memory<string> GetFragments(string? text,
+                                                       string? highlightedText,
                                                        IEnumerable<string> highlightedTexts,
                                                        out string regex,
                                                        bool caseSensitive = false,
@@ -32,7 +33,7 @@ namespace MudBlazor.Components.Highlighter
         {
             if (string.IsNullOrEmpty(text))
             {
-                regex = "";
+                regex = string.Empty;
                 return Memory<string>.Empty;
             }
 
@@ -48,21 +49,18 @@ namespace MudBlazor.Components.Highlighter
                 AppendPattern(highlightedText);
             }
 
-            if (highlightedTexts is not null)
+            foreach (var substring in highlightedTexts)
             {
-                foreach (var substring in highlightedTexts)
+                if (string.IsNullOrEmpty(substring))
+                    continue;
+
+                //split pattern if we already added an string to search.
+                if (hasAtLeastOnePattern)
                 {
-                    if (string.IsNullOrEmpty(substring))
-                        continue;
-
-                    //split pattern if we already added an string to search.
-                    if (hasAtLeastOnePattern)
-                    {
-                        builder.Append(")|(?:");
-                    }
-
-                    AppendPattern(substring);
+                    builder.Append(")|(?:");
                 }
+
+                AppendPattern(substring);
             }
 
             if (hasAtLeastOnePattern)
@@ -76,8 +74,8 @@ namespace MudBlazor.Components.Highlighter
                 s_stringBuilderCached = builder;
 
                 //all patterns were empty or null.
-                regex = "";
-                return new string[] { text };
+                regex = string.Empty;
+                return new[] { text };
             }
 
             regex = builder.ToString();

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.Components.Highlighter
         /// <returns></returns>
         public static Memory<string> GetFragments(string? text,
                                                        string? highlightedText,
-                                                       IEnumerable<string> highlightedTexts,
+                                                       IEnumerable<string>? highlightedTexts,
                                                        out string regex,
                                                        bool caseSensitive = false,
                                                        bool untilNextBoundary = false)
@@ -49,18 +49,21 @@ namespace MudBlazor.Components.Highlighter
                 AppendPattern(highlightedText);
             }
 
-            foreach (var substring in highlightedTexts)
+            if (highlightedTexts is not null)
             {
-                if (string.IsNullOrEmpty(substring))
-                    continue;
-
-                //split pattern if we already added an string to search.
-                if (hasAtLeastOnePattern)
+                foreach (var substring in highlightedTexts)
                 {
-                    builder.Append(")|(?:");
-                }
+                    if (string.IsNullOrEmpty(substring))
+                        continue;
 
-                AppendPattern(substring);
+                    //split pattern if we already added an string to search.
+                    if (hasAtLeastOnePattern)
+                    {
+                        builder.Append(")|(?:");
+                    }
+
+                    AppendPattern(substring);
+                }
             }
 
             if (hasAtLeastOnePattern)


### PR DESCRIPTION
## Description
Part of this issue https://github.com/MudBlazor/MudBlazor/issues/6535

I changed `HighlightedTexts` to have empty collection instead of null.
It's known that returning null instead of empty collection is considered a bad practice. Framework Design Guidelines: Conventions, Idioms, and Patterns for Reuseable .NET Libraries: "DO NOT return null values from collection properties or from methods returning collections. Return an empty collection or an empty array instead."

## How Has This Been Tested?
No tests required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change, improve null diagnostic warnings)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
