### PR TITLE
MudChip, MudChipSet: Await where applicable

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -273,11 +273,11 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(1));
 
 
-            await comp.InvokeAsync(() => chipSet.Instance.OnChipDeleted((MudChip)chip.Instance.Value));
+            await comp.InvokeAsync(() => chipSet.Instance.OnChipDeletedAsync((MudChip)chip.Instance.Value));
             comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(0));
 
             await comp.InvokeAsync(() => chipSet.Instance.SelectedChip = null);
-            await comp.InvokeAsync(() => chipSet.Instance.SetSelectedValues(null));
+            await comp.InvokeAsync(() => chipSet.Instance.SetSelectedValuesAsync(null));
             comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(0));
         }
     }

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -4,17 +4,19 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudChip : MudComponentBase, IDisposable
+    public partial class MudChip : MudComponentBase, IAsyncDisposable
     {
         private bool _isSelected;
-        [Inject] public NavigationManager UriHelper { get; set; }
 
-        [Inject] public IJsApiService JsApiService { get; set; }
+        [Inject]
+        public NavigationManager UriHelper { get; set; }
+
+        [Inject]
+        public IJsApiService JsApiService { get; set; }
 
         protected string Classname =>
             new CssBuilder("mud-chip")
@@ -51,17 +53,17 @@ namespace MudBlazor
             {
                 return SelectedColor;
             }
-            else if (IsSelected && SelectedColor == Color.Inherit)
+
+            if (IsSelected && SelectedColor == Color.Inherit)
             {
                 return Color;
             }
-            else
-            {
-                return Color;
-            }
+
+            return Color;
         }
 
-        [CascadingParameter] MudChipSet ChipSet { get; set; }
+        [CascadingParameter]
+        private MudChipSet ChipSet { get; set; }
 
         /// <summary>
         /// The color of the component.
@@ -233,12 +235,14 @@ namespace MudBlazor
         /// <summary>
         /// Chip click event, if set the chip focus, hover and click effects are applied.
         /// </summary>
-        [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClick { get; set; }
 
         /// <summary>
         /// Chip delete event, if set the delete icon will be visible.
         /// </summary>
-        [Parameter] public EventCallback<MudChip> OnClose { get; set; }
+        [Parameter]
+        public EventCallback<MudChip> OnClose { get; set; }
 
         /// <summary>
         /// Set by MudChipSet
@@ -283,7 +287,7 @@ namespace MudBlazor
             }
             if (ChipSet != null)
             {
-                _ = ChipSet.OnChipClicked(this);
+                await ChipSet.OnChipClickedAsync(this);
             }
             if (Href != null)
             {
@@ -310,29 +314,38 @@ namespace MudBlazor
                 return;
             }
             await OnClose.InvokeAsync(this);
-            ChipSet?.OnChipDeleted(this);
+            if (ChipSet is not null)
+            {
+                await ChipSet.OnChipDeletedAsync(this);
+            }
+
             StateHasChanged();
         }
 
-        protected override Task OnInitializedAsync()
+        protected override async Task OnInitializedAsync()
         {
-            ChipSet?.Add(this);
-            return base.OnInitializedAsync();
+            if (ChipSet is not null)
+            {
+                await ChipSet.AddAsync(this);
+            }
+            await base.OnInitializedAsync();
         }
 
         //Exclude because we don't test to catching exception yet
         [ExcludeFromCodeCoverage]
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             try
             {
-                ChipSet?.Remove(this);
+                if (ChipSet is not null)
+                {
+                    await ChipSet.RemoveAsync(this);
+                }
             }
             catch (Exception)
             {
                 /* ignore! */
             }
         }
-
     }
 }

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -10,11 +10,10 @@ namespace MudBlazor
 {
     public partial class MudChipSet : MudComponentBase, IDisposable
     {
-
         protected string Classname =>
-        new CssBuilder("mud-chipset")
-          .AddClass(Class)
-        .Build();
+            new CssBuilder("mud-chipset")
+                .AddClass(Class)
+                .Build();
 
         /// <summary>
         /// Child content of component.
@@ -77,7 +76,7 @@ namespace MudBlazor
         [Category(CategoryTypes.ChipSet.Behavior)]
         public MudChip SelectedChip
         {
-            get { return _chips.OfType<MudChip>().FirstOrDefault(x => x.IsSelected); }
+            get { return _chips.FirstOrDefault(x => x.IsSelected); }
             set
             {
                 if (value == null)
@@ -111,7 +110,7 @@ namespace MudBlazor
         [Category(CategoryTypes.ChipSet.Behavior)]
         public MudChip[] SelectedChips
         {
-            get { return _chips.OfType<MudChip>().Where(x => x.IsSelected).ToArray(); }
+            get { return _chips.Where(x => x.IsSelected).ToArray(); }
             set
             {
                 if (value == null || value.Length == 0)
@@ -180,22 +179,23 @@ namespace MudBlazor
             set
             {
                 if (value == null)
-                    SetSelectedValues(new object[0]);
+                    SetSelectedValuesAsync(Array.Empty<object>());
                 else
-                    SetSelectedValues(value.ToArray()).AndForget();
+                    SetSelectedValuesAsync(value.ToArray()).AndForget();
             }
         }
 
         /// <summary>
         /// Called whenever the selection changed
         /// </summary>
-        [Parameter] public EventCallback<ICollection<object>> SelectedValuesChanged { get; set; }
+        [Parameter]
+        public EventCallback<ICollection<object>> SelectedValuesChanged { get; set; }
 
-        internal Task SetSelectedValues(object[] values)
+        internal Task SetSelectedValuesAsync(object[] values)
         {
             HashSet<object> newValues = null;
             if (values == null)
-                values = new object[0];
+                values = Array.Empty<object>();
             if (MultiSelection)
                 newValues = new HashSet<object>(values, _comparer);
             else
@@ -222,25 +222,26 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<MudChip> OnClose { get; set; }
 
-        internal Task Add(MudChip chip)
+        internal Task AddAsync(MudChip chip)
         {
             _chips.Add(chip);
             if (_selectedValues.Contains(chip.Value))
                 chip.IsSelected = true;
-            return CheckDefault(chip);
+            return CheckDefaultAsync(chip);
         }
 
-        internal void Remove(MudChip chip)
+        internal Task RemoveAsync(MudChip chip)
         {
             _chips.Remove(chip);
             if (chip.IsSelected)
             {
                 _selectedValues.Remove(chip.Value);
-                NotifySelection().AndForget();
+                return NotifySelection();
             }
+            return Task.CompletedTask;
         }
 
-        private async Task CheckDefault(MudChip chip)
+        private async Task CheckDefaultAsync(MudChip chip)
         {
             if (!MultiSelection)
                 return;
@@ -264,7 +265,7 @@ namespace MudBlazor
         private HashSet<MudChip> _chips = new();
         private bool _filter;
 
-        internal Task OnChipClicked(MudChip chip)
+        internal Task OnChipClickedAsync(MudChip chip)
         {
             var wasSelected = chip.IsSelected;
             if (MultiSelection)
@@ -305,20 +306,27 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        [Obsolete($"Use {nameof(OnChipDeletedAsync)} instead. This will be removed in v7.")]
         public void OnChipDeleted(MudChip chip)
         {
-            Remove(chip);
+            RemoveAsync(chip).AndForget();
             OnClose.InvokeAsync(chip);
         }
 
-        protected override async void OnAfterRender(bool firstRender)
+        public async Task OnChipDeletedAsync(MudChip chip)
         {
-            if (firstRender)
-                await SelectDefaultChips();
-            base.OnAfterRender(firstRender);
+            await RemoveAsync(chip);
+            await OnClose.InvokeAsync(chip);
         }
 
-        private async Task SelectDefaultChips()
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+                await SelectDefaultChipsAsync();
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        private async Task SelectDefaultChipsAsync()
         {
             if (!MultiSelection)
             {

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -213,7 +213,7 @@ namespace MudBlazor
                 var isSelected = _selectedValues.Contains(chip.Value);
                 chip.IsSelected = isSelected;
             }
-            return NotifySelection();
+            return NotifySelectionAsync();
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace MudBlazor
             if (chip.IsSelected)
             {
                 _selectedValues.Remove(chip.Value);
-                return NotifySelection();
+                return NotifySelectionAsync();
             }
             return Task.CompletedTask;
         }
@@ -258,7 +258,7 @@ namespace MudBlazor
                     _selectedValues.Add(chip.Value);
                 else
                     _selectedValues.Remove(chip.Value);
-                await NotifySelection();
+                await NotifySelectionAsync();
             }
         }
 
@@ -282,7 +282,7 @@ namespace MudBlazor
                     chip.IsSelected = !wasSelected;
             }
             UpdateSelectedValues();
-            return NotifySelection();
+            return NotifySelectionAsync();
         }
 
         private void UpdateSelectedValues()
@@ -292,7 +292,7 @@ namespace MudBlazor
 
         private object[] _lastSelectedValues = null;
 
-        private async Task NotifySelection()
+        private async Task NotifySelectionAsync()
         {
             if (_disposed)
                 return;
@@ -340,7 +340,7 @@ namespace MudBlazor
                 if (anySelected)
                 {
                     UpdateSelectedValues();
-                    await NotifySelection();
+                    await NotifySelectionAsync();
                 }
             }
         }


### PR DESCRIPTION
## Description
Improve by awaiting Task.
1. ChipSet used `async void OnAfterRender` instead of `Task OnAfterRenderAsyn`.
2. Chipset OnInitializedAsync didn't await `Add` tho `Add` is `Task`, I added Async suffix as it was not obvious.
3. Remove should be Task same as Add was since it's calling `NotifySelection` which is async.

Misc: 
1. replaced `object[0]` to `Array.Empty` since `new object[0]` creates a new array instance every time it is called while the other one doesn't.
2. Removed `OfType<MudChip>()` - `_chips` is already type of MudChip and no cast is required, it also redundant since it's never null.

## How Has This Been Tested?
Visual only

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
