### PR TITLE
MudCollapse: Add nullable annotation and Async AnimationEnd.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -23,14 +23,14 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudCollapse>(Parameter("MaxHeight", 1600));
 
             _ = comp.Instance._state = CollapseState.Exiting;
-            await comp.InvokeAsync(() => comp.Instance.AnimationEnd());
+            await comp.InvokeAsync(() => comp.Instance.AnimationEndAsync());
             comp.WaitForAssertion(() => comp.Instance._height.Should().Be(0));
 
             //MaxHeight acceptes minus value?
             _ = comp.Instance._state = CollapseState.Entering;
 #pragma warning disable BL0005
             await comp.InvokeAsync(() => comp.Instance.MaxHeight = -1);
-            await comp.InvokeAsync(() => comp.Instance.AnimationEnd());
+            await comp.InvokeAsync(() => comp.Instance.AnimationEndAsync());
             await comp.InvokeAsync(() => comp.Instance.UpdateHeight());
             comp.WaitForAssertion(() => comp.Instance._height.Should().Be(-1));
         }

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 @using System.Globalization;
 
-<div @onanimationend="EventUtil.AsNonRenderingEventHandler(AnimationEnd)" @attributes="UserAttributes" class="@Classname" style="@Stylename">
+<div @onanimationend="EventUtil.AsNonRenderingEventHandler(AnimationEndAsync)" @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <div @ref="_wrapper" class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -7,6 +7,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+#nullable enable
     public partial class MudCollapse : MudComponentBase
     {
         internal enum CollapseState
@@ -21,20 +22,20 @@ namespace MudBlazor
 
         protected string Stylename =>
             new StyleBuilder()
-            .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
-            .AddStyle("height", "auto", _state == CollapseState.Entered)
-            .AddStyle("height", _height.ToPx(), _state is CollapseState.Entering or CollapseState.Exiting)
-            .AddStyle("animation-duration", $"{CalculatedAnimationDuration.ToString("#.##", CultureInfo.InvariantCulture)}s", _state == CollapseState.Entering)
-            .AddStyle(Style)
-            .Build();
+                .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
+                .AddStyle("height", "auto", _state == CollapseState.Entered)
+                .AddStyle("height", _height.ToPx(), _state is CollapseState.Entering or CollapseState.Exiting)
+                .AddStyle("animation-duration", $"{CalculatedAnimationDuration.ToString("#.##", CultureInfo.InvariantCulture)}s", _state == CollapseState.Entering)
+                .AddStyle(Style)
+                .Build();
 
         protected string Classname =>
             new CssBuilder("mud-collapse-container")
-            .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
-            .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
-            .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
-            .AddClass(Class)
-            .Build();
+                .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
+                .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
+                .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
+                .AddClass(Class)
+                .Build();
 
         /// <summary>
         /// If true, expands the panel, otherwise collapse it. Setting this prop enables control over the panel.
@@ -67,16 +68,20 @@ namespace MudBlazor
         /// <summary>
         /// Explicitly sets the height for the Collapse element to override the css default.
         /// </summary>
-        [Parameter] public int? MaxHeight { get; set; }
+        [Parameter]
+        public int? MaxHeight { get; set; }
 
         /// <summary>
         /// Child content of component.
         /// </summary>
-        [Parameter] public RenderFragment ChildContent { get; set; }
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
 
-        [Parameter] public EventCallback OnAnimationEnd { get; set; }
+        [Parameter]
+        public EventCallback OnAnimationEnd { get; set; }
 
-        [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
+        [Parameter]
+        public EventCallback<bool> ExpandedChanged { get; set; }
 
         /// <summary>
         /// Modified Animation duration that scales with height parameter.
@@ -89,13 +94,12 @@ namespace MudBlazor
                 if (MaxHeight != null)
                 {
                     if (MaxHeight <= 200) return 0.2;
-                    else if (MaxHeight <= 600) return 0.4;
-                    else if (MaxHeight <= 1400) return 0.6;
+                    if (MaxHeight <= 600) return 0.4;
+                    if (MaxHeight <= 1400) return 0.6;
                     return 1;
                 }
                 return Math.Min(_height / 800.0, 1);
             }
-            set { }
         }
 
         internal async Task UpdateHeight()
@@ -104,12 +108,12 @@ namespace MudBlazor
             {
                 _height = (await _wrapper.MudGetBoundingClientRectAsync())?.Height ?? 0;
             }
-            catch (Exception ex) when (ex is JSDisconnectedException || ex is TaskCanceledException)
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException)
             {
                 _height = 0;
             }
 
-            if (MaxHeight != null && _height > MaxHeight)
+            if (_height > MaxHeight)
             {
                 _height = MaxHeight.Value;
             }
@@ -131,6 +135,7 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
+        [Obsolete($"Use {nameof(AnimationEndAsync)} instead. This will be removed in v7")]
         public void AnimationEnd()
         {
             if (_state == CollapseState.Entering)
@@ -144,6 +149,21 @@ namespace MudBlazor
                 StateHasChanged();
             }
             OnAnimationEnd.InvokeAsync(Expanded);
+        }
+
+        public Task AnimationEndAsync()
+        {
+            if (_state == CollapseState.Entering)
+            {
+                _state = CollapseState.Entered;
+                StateHasChanged();
+            }
+            else if (_state == CollapseState.Exiting)
+            {
+                _state = CollapseState.Exited;
+                StateHasChanged();
+            }
+            return OnAnimationEnd.InvokeAsync(Expanded);
         }
     }
 }


### PR DESCRIPTION
## Description
Part of this issue https://github.com/MudBlazor/MudBlazor/issues/6535

Also added AnimationEndAsync

## How Has This Been Tested?
No tests required.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
