### PR TITLE
MudAutoComplete: Add BeforeItemsTemplate and AfterItemsTemplate

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -51,7 +51,8 @@
         <DocsPageSection>
             <SectionHeader Title="Presentation Extras">
                 <Description>
-                    You can also define a <CodeInline Tag="true">MoreItemsTemplate</CodeInline> or a <CodeInline Tag="true">NoItemsTemplate</CodeInline> for special scenarios.
+                    You can also define a <CodeInline Tag="true">MoreItemsTemplate</CodeInline>, <CodeInline Tag="true">NoItemsTemplate</CodeInline>, 
+                    <CodeInline Tag="true">BeforeItemsTemplate</CodeInline>, or <CodeInline Tag="true">AfterItemsTemplate</CodeInline>  for special scenarios.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="AutocompletePresentationExtrasExample">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -51,8 +51,10 @@
         <DocsPageSection>
             <SectionHeader Title="Presentation Extras">
                 <Description>
-                    You can also define a <CodeInline Tag="true">MoreItemsTemplate</CodeInline>, <CodeInline Tag="true">NoItemsTemplate</CodeInline>, 
-                    <CodeInline Tag="true">BeforeItemsTemplate</CodeInline>, or <CodeInline Tag="true">AfterItemsTemplate</CodeInline>  for special scenarios.
+                    You can also define a <CodeInline Tag="true">MoreItemsTemplate</CodeInline> to handle the case where the search returns more
+                    items than the list is configured to show and a <CodeInline Tag="true">NoItemsTemplate</CodeInline> that presents some default content
+                    if the search returns no results. For your own custom content that always shows at the top or the bottom of the list define the
+                    <CodeInline Tag="true">BeforeItemsTemplate</CodeInline> and the <CodeInline Tag="true">AfterItemsTemplate</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="AutocompletePresentationExtrasExample">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
@@ -24,10 +24,28 @@
             </NoItemsTemplate>
         </MudAutocomplete>
     </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="Element" Label="Periodic Table Element" @bind-Value="value3"
+                         SearchFunc="@Search" ToStringFunc="@(e=> e==null?null : $"{e.Name} ({e.Sign})")">
+            <BeforeItemsTemplate>
+                <MudText Color="Color.Primary" Class="px-4 py-1">Always Shows Before List</MudText>
+            </BeforeItemsTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="Element" Label="Periodic Table Element" @bind-Value="value4"
+                         SearchFunc="@Search" ToStringFunc="@(e=> e==null?null : $"{e.Name} ({e.Sign})")">
+            <AfterItemsTemplate>
+                <div class="pa-2">
+                    <MudButton Color="Color.Primary">Add Item(does nothing)</MudButton>
+                </div>
+            </AfterItemsTemplate>
+        </MudAutocomplete>
+    </MudItem>
 </MudGrid>
 
 @code {
-    private Element value1, value2;
+    private Element value1, value2, value3, value4;
 
     private async Task<IEnumerable<Element>> Search(string value)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
@@ -1,0 +1,40 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
+    <ListEndTemplate>
+        <MudText>EndList_Content</MudText>
+    </ListEndTemplate>
+</MudAutocomplete>
+
+@code {
+    public static string __description__ = "There are no items after filtering, so the no items template should render";
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value)
+    {
+    // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
+        return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
@@ -2,9 +2,9 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
-    <ListEndTemplate>
+    <AfterItemsTemplate>
         <MudText>EndList_Content</MudText>
-    </ListEndTemplate>
+    </AfterItemsTemplate>
 </MudAutocomplete>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -2,9 +2,9 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
-    <ListStartTemplate>
+    <BeforeItemsTemplate>
         <MudText>StartList_Content</MudText>
-    </ListStartTemplate>
+    </BeforeItemsTemplate>
 </MudAutocomplete>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -3,7 +3,7 @@
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
     <BeforeItemsTemplate>
-        <MudText>StartList_Content</MudText>
+        <MudText class="beforeitems-txt">StartList_Content</MudText>
     </BeforeItemsTemplate>
 </MudAutocomplete>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -1,0 +1,40 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
+    <ListStartTemplate>
+        <MudText>StartList_Content</MudText>
+    </ListStartTemplate>
+</MudAutocomplete>
+
+@code {
+    public static string __description__ = "There are no items after filtering, so the no items template should render";
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value)
+    {
+    // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
+        return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -3,7 +3,7 @@
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
     <BeforeItemsTemplate>
-        <MudText class="beforeitems-txt">StartList_Content</MudText>
+        <MudText>StartList_Content</MudText>
     </BeforeItemsTemplate>
 </MudAutocomplete>
 
@@ -32,7 +32,8 @@
 
     private async Task<IEnumerable<string>> Search1(string value)
     {
-        await Task.CompletedTask;
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
         return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -32,9 +32,7 @@
 
     private async Task<IEnumerable<string>> Search1(string value)
     {
-    // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
-
+        await Task.CompletedTask;
         return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1206,40 +1206,37 @@ namespace MudBlazor.UnitTests.Components
             component.WaitForAssertion(() => autocompleteInstance.Text.Should().Be(string.Empty));
         }
 
-        [Test]
-        public async Task Autocomplete_Should_LoadListEndWhenSet()
-        {
-            // Arrange
-            RenderFragment fragment = builder =>
-            {
-                builder.AddContent(0, "EndList_Content");
-            };
 
-            var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-
-            autocompletecomp.SetParam(x => x.ListEndTemplate, fragment);
-
-            // Test show
-            comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("EndList_Content"));
-        }
-
+        /// <summary>
+        /// ListEndTemplate should render when there are no items
+        /// </summary>
         [Test]
         public async Task Autocomplete_Should_LoadListStartWhenSet()
         {
-            // Arrange
-            RenderFragment fragment = builder =>
-            {
-                builder.AddContent(0, "StartList_Content");
-            };
+            var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
 
-            var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            autocompletecomp.SetParam(x => x.ListStartTemplate, fragment);
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+        }
 
-            // Test show
-            comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("StartList_Content"));
+        /// <summary>
+        /// ListEndTemplate should render when there are no items
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_LoadListEndWhenSet()
+        {
+            var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
+
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1215,20 +1215,13 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<AutocompleteListStartRendersTest>();
 
+
             var inputControl = comp.Find("div.mud-input-control");
             inputControl.Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            var mudTextCollection = comp.FindAll("p.mud-typography");
-            IElement beforeListTextElement = null;
-            foreach (var element in mudTextCollection)
-            {
-                if (!element.ClassList.Contains("beforeitems-txt")) continue;
-
-                beforeListTextElement = element;
-                break;
-            }
-            beforeListTextElement!.InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1219,8 +1219,16 @@ namespace MudBlazor.UnitTests.Components
             inputControl.Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+            var mudTextCollection = comp.FindAll("p.mud-typography");
+            IElement beforeListTextElement = null;
+            foreach (var element in mudTextCollection)
+            {
+                if (!element.ClassList.Contains("beforeitems-txt")) continue;
+
+                beforeListTextElement = element;
+                break;
+            }
+            beforeListTextElement!.InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1213,7 +1213,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_LoadListStartWhenSet()
         {
-            var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
+            var comp = Context.RenderComponent<AutocompleteListStartRendersTest>();
 
             var inputControl = comp.Find("div.mud-input-control");
             inputControl.Click();

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1205,5 +1205,41 @@ namespace MudBlazor.UnitTests.Components
             matchingStates.Single(s => s.Markup.Contains("Test")).Find("div.mud-list-item").Click();
             component.WaitForAssertion(() => autocompleteInstance.Text.Should().Be(string.Empty));
         }
+
+        [Test]
+        public async Task Autocomplete_Should_LoadListEndWhenSet()
+        {
+            // Arrange
+            RenderFragment fragment = builder =>
+            {
+                builder.AddContent(0, "EndList_Content");
+            };
+
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+
+            autocompletecomp.SetParam(x => x.ListEndTemplate, fragment);
+
+            // Test show
+            comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("EndList_Content"));
+        }
+
+        [Test]
+        public async Task Autocomplete_Should_LoadListStartWhenSet()
+        {
+            // Arrange
+            RenderFragment fragment = builder =>
+            {
+                builder.AddContent(0, "StartList_Content");
+            };
+
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+
+            autocompletecomp.SetParam(x => x.ListStartTemplate, fragment);
+
+            // Test show
+            comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("StartList_Content"));
+        }
     }
 }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Docs.Server", "MudBlazor.Docs.Server\MudBlazor.Docs.Server.csproj", "{90B6D51A-133A-4744-A5FE-FF398F0D6BAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Docs.Server", "MudBlazor.Docs.Server\MudBlazor.Docs.Server.csproj", "{90B6D51A-133A-4744-A5FE-FF398F0D6BAA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -87,6 +87,12 @@
                             @NoItemsTemplate
                         </div>
                     }
+                    @if (EndItemsTemplate != null)
+                    {
+                        <div class="pa-1">
+                            @EndItemsTemplate
+                        </div>
+                    }
                 </MudPopover>
             </InputContent>
         </MudInputControl>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -38,10 +38,16 @@
                 }
 
                 <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
-                    @if(ProgressIndicatorInPopoverTemplate != null && IsLoading)
+                    @if (ListStartTemplate != null)
+                    {
+                        <div class="pa-1">
+                            @ListStartTemplate
+                        </div>
+                    }
+                    @if (ProgressIndicatorInPopoverTemplate != null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate
-                    } 
+                    }
                     else if (_items != null && _items.Length != 0)
                     {
                         <MudList Class="@ListClass" Clickable="true" Dense="@Dense">
@@ -51,7 +57,7 @@
                                 bool isSelected = index == _selectedListItemIndex;
                                 bool isDisabled = !_enabledItemIndices.Contains(index);
                                 var captureIndex = index;
-                                <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async() => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@(isSelected ? "mud-selected-item mud-primary-text mud-primary-hover" : "")">
+                                <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async () => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@(isSelected ? "mud-selected-item mud-primary-text mud-primary-hover" : "")">
                                     @if (ItemTemplate == null)
                                     {
                                         @GetItemString(item)
@@ -87,10 +93,10 @@
                             @NoItemsTemplate
                         </div>
                     }
-                    @if (EndItemsTemplate != null)
+                    @if (ListEndTemplate != null)
                     {
                         <div class="pa-1">
-                            @EndItemsTemplate
+                            @ListEndTemplate
                         </div>
                     }
                 </MudPopover>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -44,7 +44,7 @@
                     }
                     else if (_items != null && _items.Length != 0)
                     {
-                        @if (BeforeItemsTemplate != null && IsLoading is false)
+                        @if (BeforeItemsTemplate != null)
                         {
                             <div class="pa-1">
                                 @BeforeItemsTemplate
@@ -89,7 +89,7 @@
                     }
                     else if (NoItemsTemplate != null)
                     {
-                        @if (BeforeItemsTemplate != null && IsLoading is false)
+                        @if (BeforeItemsTemplate != null)
                         {
                             <div class="pa-1">
                                 @BeforeItemsTemplate
@@ -97,6 +97,12 @@
                         }
                         <div class="pa-1">
                             @NoItemsTemplate
+                        </div>
+                    }
+                    else if (BeforeItemsTemplate != null && IsLoading is false)
+                    {
+                        <div class="pa-1">
+                            @BeforeItemsTemplate
                         </div>
                     }
                     @if (AfterItemsTemplate != null && IsLoading is false)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -38,18 +38,18 @@
                 }
 
                 <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
-                    @if (BeforeItemsTemplate != null)
-                    {
-                        <div class="pa-1">
-                            @BeforeItemsTemplate
-                        </div>
-                    }
                     @if (ProgressIndicatorInPopoverTemplate != null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate
                     }
                     else if (_items != null && _items.Length != 0)
                     {
+                        @if (BeforeItemsTemplate != null && IsLoading is false)
+                        {
+                            <div class="pa-1">
+                                @BeforeItemsTemplate
+                            </div>
+                        }
                         <MudList Class="@ListClass" Clickable="true" Dense="@Dense">
                             @for (var index = 0; index < _items.Length; index++)
                             {
@@ -89,11 +89,17 @@
                     }
                     else if (NoItemsTemplate != null)
                     {
+                        @if (BeforeItemsTemplate != null && IsLoading is false)
+                        {
+                            <div class="pa-1">
+                                @BeforeItemsTemplate
+                            </div>
+                        }
                         <div class="pa-1">
                             @NoItemsTemplate
                         </div>
                     }
-                    @if (AfterItemsTemplate != null)
+                    @if (AfterItemsTemplate != null && IsLoading is false)
                     {
                         <div class="pa-1">
                             @AfterItemsTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -38,10 +38,10 @@
                 }
 
                 <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
-                    @if (ListStartTemplate != null)
+                    @if (BeforeItemsTemplate != null)
                     {
                         <div class="pa-1">
-                            @ListStartTemplate
+                            @BeforeItemsTemplate
                         </div>
                     }
                     @if (ProgressIndicatorInPopoverTemplate != null && IsLoading)
@@ -93,10 +93,10 @@
                             @NoItemsTemplate
                         </div>
                     }
-                    @if (ListEndTemplate != null)
+                    @if (AfterItemsTemplate != null)
                     {
                         <div class="pa-1">
-                            @ListEndTemplate
+                            @AfterItemsTemplate
                         </div>
                     }
                 </MudPopover>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -265,14 +265,14 @@ namespace MudBlazor
 
 
         /// <summary>
-        /// Optional presentation template for when you need to section to always show at the start in the drop down
+        /// Optional presentation template that is always shown at the top of the list
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public RenderFragment BeforeItemsTemplate { get; set; }
 
         /// <summary>
-        /// Optional presentation template for when you need to section to always show at the end in the drop down
+        /// Optional presentation template that is always shown at the bottom of the list
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -263,12 +263,20 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public RenderFragment NoItemsTemplate { get; set; }
 
+
         /// <summary>
-        /// Optional presentation template for when you need to section to always show in the drop down
+        /// Optional presentation template for when you need to section to always show at the start in the drop down
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public RenderFragment EndItemsTemplate { get; set; }
+        public RenderFragment ListStartTemplate { get; set; }
+
+        /// <summary>
+        /// Optional presentation template for when you need to section to always show at the end in the drop down
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment ListEndTemplate { get; set; }
 
         /// <summary>
         /// Optional template for progress indicator

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -269,14 +269,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public RenderFragment ListStartTemplate { get; set; }
+        public RenderFragment BeforeItemsTemplate { get; set; }
 
         /// <summary>
         /// Optional presentation template for when you need to section to always show at the end in the drop down
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public RenderFragment ListEndTemplate { get; set; }
+        public RenderFragment AfterItemsTemplate { get; set; }
 
         /// <summary>
         /// Optional template for progress indicator

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -264,6 +264,13 @@ namespace MudBlazor
         public RenderFragment NoItemsTemplate { get; set; }
 
         /// <summary>
+        /// Optional presentation template for when you need to section to always show in the drop down
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public RenderFragment EndItemsTemplate { get; set; }
+
+        /// <summary>
         /// Optional template for progress indicator
         /// </summary>
         [Parameter]


### PR DESCRIPTION
## Description
This adds an additional render fragment for use cases when you want to always show something at the end of the pop up. An example of this is adding a button at the end to add additional items to the list no matter how many items there are in the list.

![image](https://user-images.githubusercontent.com/31353783/234706374-178183c5-0b11-406a-85d0-c0ec38feee65.png)


## How Has This Been Tested?
No new test are required. All that was added is a render fragment.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
