### PR TITLE
MudDataDrid: Validation errors now prevent changes being committed (#6748)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormValidationErrorsPreventUpdateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormValidationErrorsPreventUpdateTest.razor
@@ -1,0 +1,57 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+@using System.Text.RegularExpressions;
+
+<MudDialogProvider />
+
+<MudDataGrid Items="this.Items" ReadOnly="false" EditMode="DataGridEditMode.Form" EditTrigger="DataGridEditTrigger.Manual">
+    <Columns>
+        <PropertyColumn Property="x => x.FirstName" />
+        <PropertyColumn Property="x => x.LastName" />
+        <PropertyColumn Property="x => x.Email">
+            <EditTemplate>
+                <MudTextField @bind-Value="context.Item.Email" Required Validation="(string s) => this.ValidateEmail(s)" Variant="Variant.Outlined" Label="Email"/>
+            </EditTemplate>
+        </PropertyColumn>
+        <TemplateColumn>
+            <CellTemplate>
+                <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
+            </CellTemplate>
+        </TemplateColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public class Model
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+
+    public List<Model> Items = new()
+    {
+        new() { FirstName = "Augusta", LastName = "Homenick", Email = "Augusta_Homenick26@mud.com" },
+        new() { FirstName = "Kiel", LastName = "Bogisich", Email = "Kiel.Bogisich@mud.com" },
+        new() { FirstName = "Brigitte", LastName = "Breitenberg", Email = "Brigitte27@mud.com" },
+        new() { FirstName = "Kamren", LastName = "McKenzie", Email = "Kamren64@mud.com" },
+        new() { FirstName = "Pansy", LastName = "West", Email = "Pansy82@mud.com" },
+    };
+
+    public string ValidateEmail(string email)
+    {
+        if (string.IsNullOrEmpty(email))
+            return null;
+
+        // really basic e-mail match (anything@anything.anything):
+        //  - anything other than '@' and white space
+        //  - single '@'
+        //  - anything other than '.' and white space
+        //  - single '.'
+        //  - anything other than white space
+        if (!Regex.IsMatch(email, @"^[^@\s]+@[^\.\s]+\.[^\s]+$"))
+            return "This is not a valid e-mail address";
+
+        return null;
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -256,7 +256,7 @@
     <CascadingValue Value="true" IsFixed Name="IsNested">
         <MudDialog Options="EditDialogOptions" @bind-IsVisible="isEditFormOpen">
             <DialogContent>
-                <MudForm FieldChanged="FormFieldChanged">
+                <MudForm @ref="_editForm" FieldChanged="FormFieldChanged">
                     @foreach (var column in RenderedColumns)
                     {
                         var cell = new Cell<T>(this, column, _editingItem);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -28,6 +28,7 @@ namespace MudBlazor
         private bool _columnsPanelVisible = false;
         private IEnumerable<T> _items;
         private T _selectedItem;
+        private MudForm _editForm;
         internal Dictionary<object, bool> _groupExpansionsDict = new Dictionary<object, bool>();
         private List<GroupDefinition<T>> _currentPageGroups = new List<GroupDefinition<T>>();
         private List<GroupDefinition<T>> _allGroups = new List<GroupDefinition<T>>();
@@ -1074,7 +1075,11 @@ namespace MudBlazor
         /// <returns></returns>
         internal async Task CommitItemChangesAsync()
         {
-            // Here, we need to validate at the cellular level...
+            await _editForm.Validate();
+            if (!_editForm.IsValid)
+            {
+                return;
+            }
 
             if (editingSourceItem != null)
             {


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/6748
When editing data with `MudDataGrid` with `EditMode=DataGridEditMode.Form` validation failures for the forms input fields would not prevent the selected item from being updated nor the dialog from being closed, essentially allowing you to submit invalid data.

I have simply added a `@ref` to the `MudForm` which can be used to check the validity of the data in `MudDataGrid.CommitItemChangesAsync()` before updating the property values and closing the dialog, leaving the validation message visible to the user to act on:

```
internal async Task CommitItemChangesAsync()
{
    // this is the new bit:
    await _editForm.Validate();
    if (!_editForm.IsValid)
        return;

    if (editingSourceItem != null)
    {
        foreach (var property in _properties)
        {
            if (property.CanWrite)
                property.SetValue(editingSourceItem, property.GetValue(_editingItem));
        }

        await CommittedItemChanges.InvokeAsync(editingSourceItem);
        ClearEditingItem();
        isEditFormOpen = false;
    }
}
```

## How Has This Been Tested?
I have created a new unit test (`DataGridTests.DataGridFormValidationErrorsPreventUpdateTest()`) verifies that the properties are not updated and the dialog stays open in the event of invalid data. I have also confirmed that my changes work as intended manually by running the docs projects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
