### PR TITLE
Date/DateRange/Time-picker and Select trigger required validation when clearing input or touched

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormWithDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormWithDatePickerTest.razor
@@ -1,0 +1,32 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.ComponentModel.DataAnnotations;
+
+<EditForm Model="@model">
+    <DataAnnotationsValidator />
+    <MudDatePicker @bind-Date="model.Date" For="@(() => model.Date)" Editable="@EnableEditable" />
+    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled">Submit</MudButton>
+</EditForm>
+
+<MudButton OnClick="ToggleEditable">Toggle editable? @EnableEditable</MudButton>
+@code {
+    public static string __description__ = "Form should validate date picker's date.";
+
+    private readonly Test model = new Test();
+
+    private class Test
+    {
+        [Required]
+        public DateTime? Date { get; set; }
+    }
+
+    [Parameter]
+    public bool EnableEditable { get; set; }
+
+    public async Task ModifyDate(DateTime? date)
+    {
+        model.Date = date;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void ToggleEditable() => EnableEditable = !EnableEditable;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormWithTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormWithTimePickerTest.razor
@@ -1,0 +1,32 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.ComponentModel.DataAnnotations;
+
+<EditForm Model="@model">
+    <DataAnnotationsValidator />
+    <MudTimePicker Required="true" @bind-Time="@model.Time" For="@(() => model.Time)" Editable="@EnableEditable" />
+    <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled">Submit</MudButton>
+</EditForm>
+
+<MudButton OnClick="ToggleEditable">Toggle editable? @EnableEditable</MudButton>
+@code {
+    public static string __description__ = "Form should validate date picker's date.";
+
+    private readonly Test model = new Test();
+
+    private class Test
+    {
+        [Required]
+        public TimeSpan? Time{ get; set; }
+    }
+
+    [Parameter]
+    public bool EnableEditable { get; set; }
+
+    public async Task ModifyTime(TimeSpan? time)
+    {
+        model.Time = time;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void ToggleEditable() => EnableEditable = !EnableEditable;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredControlTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredControlTest.razor
@@ -4,16 +4,17 @@
     <MudCard>
         <MudCardContent>
             <MudForm>
-                <MudTextField T="string" Label="TextField" Required="Required" />
-                <MudTextField T="string" Label="TextFieldMask" Mask="@(new DateMask(" yyyy-MM-dd"))" Required="Required" />
-                <MudSelect T="string" Label="Select string" Required="Required"></MudSelect>
-                <MudDatePicker Label="DatePicker" Required="Required" Editable="false" />
-                <MudDateRangePicker Label="DateRangePicker" Required="Required" Editable="false" />
-                <MudTimePicker Label="TimePicker" Required="Required" Editable="false"  />
+                <MudTextField T="string" Label="TextField" Required="Required" ReadOnly="ReadOnly" />
+                <MudTextField T="string" Label="TextFieldMask" Mask="@(new DateMask(" yyyy-MM-dd"))" Required="Required" ReadOnly="ReadOnly" />
+                <MudSelect T="string" Label="Select string" Required="Required" ReadOnly="ReadOnly"></MudSelect>
+                <MudDatePicker Label="DatePicker" Required="Required" Editable="false" ReadOnly="ReadOnly" />
+                <MudDateRangePicker Label="DateRangePicker" Required="Required" Editable="false" ReadOnly="ReadOnly" />
+                <MudTimePicker Label="TimePicker" Required="Required" Editable="false" ReadOnly="ReadOnly" />
             </MudForm>
         </MudCardContent>
         <MudCardActions>
             <MudCheckBox @bind-Checked="Required">Comp Required</MudCheckBox>
+            <MudCheckBox @bind-Checked="ReadOnly">Comp ReadOnly</MudCheckBox>
         </MudCardActions>
     </MudCard>
 </div>
@@ -22,4 +23,7 @@
     public static string __description__ = "All components should respect required parameter when touched";
     [Parameter]
     public bool Required { get; set; }
+
+    [Parameter]
+    public bool ReadOnly { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredControlTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredControlTest.razor
@@ -1,0 +1,25 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<div style="max-width: 400px;">
+    <MudCard>
+        <MudCardContent>
+            <MudForm>
+                <MudTextField T="string" Label="TextField" Required="Required" />
+                <MudTextField T="string" Label="TextFieldMask" Mask="@(new DateMask(" yyyy-MM-dd"))" Required="Required" />
+                <MudSelect T="string" Label="Select string" Required="Required"></MudSelect>
+                <MudDatePicker Label="DatePicker" Required="Required" Editable="false" />
+                <MudDateRangePicker Label="DateRangePicker" Required="Required" Editable="false" />
+                <MudTimePicker Label="TimePicker" Required="Required" Editable="false"  />
+            </MudForm>
+        </MudCardContent>
+        <MudCardActions>
+            <MudCheckBox @bind-Checked="Required">Comp Required</MudCheckBox>
+        </MudCardActions>
+    </MudCard>
+</div>
+@code
+{
+    public static string __description__ = "All components should respect required parameter when touched";
+    [Parameter]
+    public bool Required { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDatePickerTest.razor
@@ -1,13 +1,19 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
-    <MudDatePicker Required="true" @bind-Date="Date">
+    <MudDatePicker Required="true" @bind-Date="Date" Editable="@EnableEditable">
     </MudDatePicker>
 </MudForm>
 
+<MudButton OnClick="ToggleEditable">Toggle editable? @EnableEditable</MudButton>
 @code {
     public static string __description__ = "Form should validate date picker's date.";
 
     [Parameter]
     public DateTime? Date { get; set; }
+
+    [Parameter]
+    public bool EnableEditable { get; set; }
+
+    private void ToggleEditable() => EnableEditable = !EnableEditable;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDateRangePickerTest.razor
@@ -3,13 +3,20 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudForm ValidationDelay="0">
-    <MudDateRangePicker Required="true" @bind-DateRange="DateRange">
+    <MudDateRangePicker Required="true" @bind-DateRange="DateRange" Editable="@EnableEditable">
     </MudDateRangePicker>
 </MudForm>
+
+<MudButton OnClick="ToggleEditable">Toggle editable? @EnableEditable</MudButton>
 
 @code {
     public static string __description__ = "Form should validate date range picker's date range.";
 
     [Parameter]
     public DateRange? DateRange { get; set; }
+
+    [Parameter]
+    public bool EnableEditable { get; set; }
+
+    private void ToggleEditable() => EnableEditable = !EnableEditable;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
@@ -3,13 +3,20 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudForm ValidationDelay="0">
-    <MudTimePicker Required="true" @bind-Time="Time">
+    <MudTimePicker Required="true" @bind-Time="Time" Editable="@EnableEditable">
     </MudTimePicker>
 </MudForm>
+
+<MudButton OnClick="ToggleEditable">Toggle editable? @EnableEditable</MudButton>
 
 @code {
     public static string __description__ = "Form should validate time picker's value.";
 
     [Parameter]
     public TimeSpan? Time { get; set; }
+
+    [Parameter]
+    public bool EnableEditable { get; set; }
+
+    private void ToggleEditable() => EnableEditable = !EnableEditable;
 }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Bunit;
 using Bunit.Extensions.WaitForHelpers;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.Docs.Examples;
@@ -1460,6 +1461,67 @@ namespace MudBlazor.UnitTests.Components
             textComps[1].Instance.Validation.Should().BeNull(); //Validation is not set
             dateComps[0].Instance.Validation.Should().NotBeNull(); //Validation is set
             dateComps[1].Instance.Validation.Should().BeNull(); //Validation is not set
+        }
+
+        /// <summary>
+        /// Ensures that Required option is respected when control touched.
+        /// (RadioGroup, ColorPicker (never null), Switch (never null), Autocomplete, NumericField(never null) and FileUpload controls not included)
+        /// </summary>
+        [Test]
+        public async Task FormRequiredComponentTest()
+        {
+            var comp = Context.RenderComponent<FormRequiredControlTest>(c => c
+                .Add(x => x.Required, false));
+
+            var textField = comp.FindComponents<MudTextField<string>>()[0];
+            var maskedTextField = comp.FindComponents<MudTextField<string>>()[1];
+            var select = comp.FindComponent<MudSelect<string>>();
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            var dateRangePicker = comp.FindComponent<MudDateRangePicker>();
+            var timePicker = comp.FindComponent<MudTimePicker>();
+
+            // comp required = false
+            using (new AssertionScope())
+            {
+                textField.Instance.Error.Should().BeFalse();
+                textField.Instance.ErrorText.Should().BeNullOrEmpty();
+                maskedTextField.Instance.Error.Should().BeFalse();
+                maskedTextField.Instance.ErrorText.Should().BeNullOrEmpty();
+                select.Instance.Error.Should().BeFalse();
+                select.Instance.ErrorText.Should().BeNullOrEmpty();
+                datePicker.Instance.Error.Should().BeFalse();
+                datePicker.Instance.ErrorText.Should().BeNullOrEmpty();
+                dateRangePicker.Instance.Error.Should().BeFalse();
+                dateRangePicker.Instance.ErrorText.Should().BeNullOrEmpty();
+                timePicker.Instance.Error.Should().BeFalse();
+                timePicker.Instance.ErrorText.Should().BeNullOrEmpty();
+            }
+
+            // comp required = true
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.Required, true));
+            // trigger touched
+            textField.Find("input").Blur();
+            maskedTextField.Find("input").Blur();
+            select.Find("input").Blur();
+            datePicker.Find("input").Blur();
+            dateRangePicker.FindAll("input")[0].Blur();
+            timePicker.Find("input").Blur();
+
+            using (new AssertionScope())
+            {
+                textField.Instance.Error.Should().BeTrue();
+                textField.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                maskedTextField.Instance.Error.Should().BeTrue();
+                maskedTextField.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                select.Instance.Error.Should().BeTrue();
+                select.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                datePicker.Instance.Error.Should().BeTrue();
+                datePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                dateRangePicker.Instance.Error.Should().BeTrue();
+                dateRangePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                timePicker.Instance.Error.Should().BeTrue();
+                timePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
+            }
         }
 
         /// <summaryReadonly

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1467,11 +1467,13 @@ namespace MudBlazor.UnitTests.Components
         /// Ensures that Required option is respected when control touched.
         /// (RadioGroup, ColorPicker (never null), Switch (never null), Autocomplete, NumericField(never null) and FileUpload controls not included)
         /// </summary>
-        [Test]
-        public async Task FormRequiredComponentTest()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task FormRequiredComponentTest(bool isReadOnly)
         {
             var comp = Context.RenderComponent<FormRequiredControlTest>(c => c
-                .Add(x => x.Required, false));
+                .Add(x => x.Required, false)
+                .Add(x => x.ReadOnly, isReadOnly));
 
             var textField = comp.FindComponents<MudTextField<string>>()[0];
             var maskedTextField = comp.FindComponents<MudTextField<string>>()[1];
@@ -1507,20 +1509,22 @@ namespace MudBlazor.UnitTests.Components
             dateRangePicker.FindAll("input")[0].Blur();
             timePicker.Find("input").Blur();
 
+            bool expectedError = isReadOnly ? false : true;
+            var expectedErrorText = isReadOnly ? null : "Required";
             using (new AssertionScope())
             {
-                textField.Instance.Error.Should().BeTrue();
-                textField.Instance.ErrorText.Should().BeEquivalentTo("Required");
-                maskedTextField.Instance.Error.Should().BeTrue();
-                maskedTextField.Instance.ErrorText.Should().BeEquivalentTo("Required");
-                select.Instance.Error.Should().BeTrue();
-                select.Instance.ErrorText.Should().BeEquivalentTo("Required");
-                datePicker.Instance.Error.Should().BeTrue();
-                datePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
-                dateRangePicker.Instance.Error.Should().BeTrue();
-                dateRangePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
-                timePicker.Instance.Error.Should().BeTrue();
-                timePicker.Instance.ErrorText.Should().BeEquivalentTo("Required");
+                textField.Instance.Error.Should().Be(expectedError);
+                textField.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
+                maskedTextField.Instance.Error.Should().Be(expectedError);
+                maskedTextField.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
+                select.Instance.Error.Should().Be(expectedError);
+                select.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
+                datePicker.Instance.Error.Should().Be(expectedError);
+                datePicker.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
+                dateRangePicker.Instance.Error.Should().Be(expectedError);
+                dateRangePicker.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
+                timePicker.Instance.Error.Should().Be(expectedError);
+                timePicker.Instance.ErrorText.Should().BeEquivalentTo(expectedErrorText);
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -565,10 +565,13 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// DatePicker should be validated like every other form component
         /// </summary>
-        [Test]
-        public async Task FormWithDatePickerTest()
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        [TestCase(false /* input event only relevant when editable */, true)]
+        public async Task FormWithDatePickerTest(bool useSetParamForClear, bool editable)
         {
-            var comp = Context.RenderComponent<FormWithDatePickerTest>();
+            var comp = Context.RenderComponent<FormWithDatePickerTest>(c => c
+                .Add(d => d.EnableEditable, editable));
             var form = comp.FindComponent<MudForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             var datepicker = comp.FindComponent<MudDatePicker>().Instance;
@@ -583,7 +586,14 @@ namespace MudBlazor.UnitTests.Components
             datepicker.Error.Should().BeFalse();
             datepicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            comp.SetParam(x => x.Date, null);
+            if (useSetParamForClear)
+            {
+                comp.SetParam(x => x.Date, null);
+            }
+            else
+            {
+                dateComp.Find("input").Input("");
+            }
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
@@ -620,10 +630,13 @@ namespace MudBlazor.UnitTests.Components
         /// DateRangePicker should be validated like every other form component when the dateRange
         /// is changed via inputs
         /// </summary>
-        [Test]
-        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs()
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs(bool useSetParamForClear, bool editable)
         {
-            var comp = Context.RenderComponent<FormWithDateRangePickerTest>();
+            var comp = Context.RenderComponent<FormWithDateRangePickerTest>(c => c
+                .Add(d => d.EnableEditable, editable));
             var form = comp.FindComponent<MudForm>().Instance;
             var dateRangeComp = comp.FindComponent<MudDateRangePicker>();
             var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
@@ -641,7 +654,15 @@ namespace MudBlazor.UnitTests.Components
             dateRangePicker.Error.Should().BeFalse();
             dateRangePicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            comp.SetParam(x => x.DateRange, null);
+            if (useSetParamForClear)
+            {
+                comp.SetParam(x => x.DateRange, null);
+            }
+            else
+            {
+                await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[0].Change(""));
+                await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[1].Change(""));
+            }
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
@@ -687,10 +708,13 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// TimePicker should be validated like every other form component
         /// </summary>
-        [Test]
-        public async Task FormWithTimePickerTest()
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        [TestCase(false /* input event only relevant when editable */, true)]
+        public async Task FormWithTimePickerTest(bool useSetParamForClear, bool editable)
         {
-            var comp = Context.RenderComponent<FormWithTimePickerTest>();
+            var comp = Context.RenderComponent<FormWithTimePickerTest>(c => c
+                .Add(d => d.EnableEditable, editable));
             var form = comp.FindComponent<MudForm>().Instance;
             var timePickerComp = comp.FindComponent<MudTimePicker>();
             var timePicker = comp.FindComponent<MudTimePicker>().Instance;
@@ -705,7 +729,14 @@ namespace MudBlazor.UnitTests.Components
             timePicker.Error.Should().BeFalse();
             timePicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            comp.SetParam(x => x.Time, null);
+            if (useSetParamForClear)
+            {
+                comp.SetParam(x => x.Time, null);
+            }
+            else
+            {
+                timePickerComp.Find("input").Input("");
+            }
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -568,7 +568,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, false)]
         [TestCase(true, true)]
         [TestCase(false /* input event only relevant when editable */, true)]
-        public async Task FormWithDatePickerTest(bool useSetParamForClear, bool editable)
+        public async Task FormWithDatePickerTest(bool clearUsingParameter, bool editable)
         {
             var comp = Context.RenderComponent<FormWithDatePickerTest>(c => c
                 .Add(d => d.EnableEditable, editable));
@@ -586,7 +586,7 @@ namespace MudBlazor.UnitTests.Components
             datepicker.Error.Should().BeFalse();
             datepicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            if (useSetParamForClear)
+            if (clearUsingParameter)
             {
                 comp.SetParam(x => x.Date, null);
             }
@@ -633,7 +633,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]
-        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs(bool useSetParamForClear, bool editable)
+        public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs(bool clearUsingParameter, bool editable)
         {
             var comp = Context.RenderComponent<FormWithDateRangePickerTest>(c => c
                 .Add(d => d.EnableEditable, editable));
@@ -654,7 +654,7 @@ namespace MudBlazor.UnitTests.Components
             dateRangePicker.Error.Should().BeFalse();
             dateRangePicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            if (useSetParamForClear)
+            if (clearUsingParameter)
             {
                 comp.SetParam(x => x.DateRange, null);
             }
@@ -711,7 +711,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, false)]
         [TestCase(true, true)]
         [TestCase(false /* input event only relevant when editable */, true)]
-        public async Task FormWithTimePickerTest(bool useSetParamForClear, bool editable)
+        public async Task FormWithTimePickerTest(bool clearUsingParameter, bool editable)
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>(c => c
                 .Add(d => d.EnableEditable, editable));
@@ -729,7 +729,7 @@ namespace MudBlazor.UnitTests.Components
             timePicker.Error.Should().BeFalse();
             timePicker.ErrorText.Should().BeNullOrEmpty();
             // clear selection
-            if (useSetParamForClear)
+            if (clearUsingParameter)
             {
                 comp.SetParam(x => x.Time, null);
             }
@@ -906,6 +906,72 @@ namespace MudBlazor.UnitTests.Components
             {
                 vc.Should().NotBeNull();
             }
+        }
+
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        [TestCase(false /* input event only relevant when editable */, true)]
+        public async Task EditForm_WithDatePicker_Validation_Required(bool clearModel, bool editable)
+        {
+            var comp = Context.RenderComponent<EditFormWithDatePickerTest>(c => c
+                .Add(d => d.EnableEditable, editable));
+            var form = comp.FindComponent<EditForm>().Instance;
+            var dateComp = comp.FindComponent<MudDatePicker>();
+            var datepicker = comp.FindComponent<MudDatePicker>().Instance;
+            // check initial state: should have error because datepicker is required
+            comp.Find("form").Submit();
+            datepicker.Error.Should().BeTrue();
+            datepicker.ErrorText.Should().NotBeEmpty();
+            // input a date
+            dateComp.Find("input").Change(new DateTime(2001, 01, 31).ToShortDateString());
+            comp.Find("form").Submit();
+            datepicker.Error.Should().BeFalse();
+            datepicker.ErrorText.Should().BeNullOrEmpty();
+            // clear selection
+            if (clearModel)
+            {
+                await comp.Instance.ModifyDate(null);
+            }
+            else
+            {
+                dateComp.Find("input").Input("");
+            }
+            comp.Find("form").Submit();
+            datepicker.Error.Should().BeTrue();
+            datepicker.ErrorText.Should().NotBeEmpty();
+        }
+
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        [TestCase(false /* input event only relevant when editable */, true)]
+        public async Task EditForm_WithTimePicker_Validation_Required(bool clearModel, bool editable)
+        {
+            var comp = Context.RenderComponent<EditFormWithTimePickerTest>(c => c
+                .Add(d => d.EnableEditable, editable));
+            var form = comp.FindComponent<EditForm>().Instance;
+            var timeComp = comp.FindComponent<MudTimePicker>();
+            var timepicker = comp.FindComponent<MudTimePicker>().Instance;
+            // check initial state: should have error because datepicker is required
+            comp.Find("form").Submit();
+            timepicker.Error.Should().BeTrue();
+            timepicker.ErrorText.Should().NotBeEmpty();
+            // input a date
+            timeComp.Find("input").Change("06:00");
+            comp.Find("form").Submit();
+            timepicker.Error.Should().BeFalse();
+            timepicker.ErrorText.Should().BeNullOrEmpty();
+            // clear selection
+            if (clearModel)
+            {
+                await comp.Instance.ModifyTime(null);
+            }
+            else
+            {
+                timeComp.Find("input").Input("");
+            }
+            comp.Find("form").Submit();
+            timepicker.Error.Should().BeTrue();
+            timepicker.ErrorText.Should().NotBeEmpty();
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Bunit;
+using Bunit.Extensions.WaitForHelpers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -908,68 +909,36 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
-        [TestCase(true, false)]
-        [TestCase(true, true)]
-        [TestCase(false /* input event only relevant when editable */, true)]
-        public async Task EditForm_WithDatePicker_Validation_Required(bool clearModel, bool editable)
+        [Test]
+        public async Task EditForm_WithDatePicker_Validation_Required()
         {
             var comp = Context.RenderComponent<EditFormWithDatePickerTest>(c => c
-                .Add(d => d.EnableEditable, editable));
+                .Add(d => d.EnableEditable, true));
             var form = comp.FindComponent<EditForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             var datepicker = comp.FindComponent<MudDatePicker>().Instance;
-            // check initial state: should have error because datepicker is required
-            comp.Find("form").Submit();
-            datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().NotBeEmpty();
-            // input a date
-            dateComp.Find("input").Change(new DateTime(2001, 01, 31).ToShortDateString());
-            comp.Find("form").Submit();
+            //// check initial state: should not have error because datepicker not touched
             datepicker.Error.Should().BeFalse();
             datepicker.ErrorText.Should().BeNullOrEmpty();
-            // clear selection
-            if (clearModel)
-            {
-                await comp.Instance.ModifyDate(null);
-            }
-            else
-            {
-                dateComp.Find("input").Input("");
-            }
-            comp.Find("form").Submit();
+            // blur input to trigger touched
+             comp.Find("input").Blur();
             datepicker.Error.Should().BeTrue();
             datepicker.ErrorText.Should().NotBeEmpty();
         }
 
-        [TestCase(true, false)]
-        [TestCase(true, true)]
-        [TestCase(false /* input event only relevant when editable */, true)]
-        public async Task EditForm_WithTimePicker_Validation_Required(bool clearModel, bool editable)
+        [Test]
+        public async Task EditForm_WithTimePicker_Validation_Required()
         {
             var comp = Context.RenderComponent<EditFormWithTimePickerTest>(c => c
-                .Add(d => d.EnableEditable, editable));
+                .Add(d => d.EnableEditable, true));
             var form = comp.FindComponent<EditForm>().Instance;
             var timeComp = comp.FindComponent<MudTimePicker>();
             var timepicker = comp.FindComponent<MudTimePicker>().Instance;
-            // check initial state: should have error because datepicker is required
-            comp.Find("form").Submit();
-            timepicker.Error.Should().BeTrue();
-            timepicker.ErrorText.Should().NotBeEmpty();
-            // input a date
-            timeComp.Find("input").Change("06:00");
-            comp.Find("form").Submit();
+            // check initial state: should not have error because timepicker is not touched
             timepicker.Error.Should().BeFalse();
             timepicker.ErrorText.Should().BeNullOrEmpty();
-            // clear selection
-            if (clearModel)
-            {
-                await comp.Instance.ModifyTime(null);
-            }
-            else
-            {
-                timeComp.Find("input").Input("");
-            }
-            comp.Find("form").Submit();
+            // blur input to trigger touched
+            comp.Find("input").Blur();
             timepicker.Error.Should().BeTrue();
             timepicker.ErrorText.Should().NotBeEmpty();
         }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -17,12 +17,6 @@ namespace MudBlazor
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
         /// <summary>
-        /// If true, the input element is used in context of a <see cref="MudPicker{T}"/> component 
-        /// and will enable validation even if <see cref="MudFormComponent{T, U}.SubscribeToParentForm"/> is false.
-        /// </summary>
-        internal bool IsInputForPicker { get; set; }
-
-        /// <summary>
         /// If true, the input element will be disabled.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -17,6 +17,13 @@ namespace MudBlazor
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
         /// <summary>
+        /// If true, the <see cref="OnBlurredAsync(FocusEventArgs)"/> ignores <see cref="ReadOnly"/> flag to trigger validation/onblur.
+        /// Use case for setting this to true is for component that wrap some input component (inherit <see cref="MudBaseInput{T}"/>), example <see cref="MudPicker{T}"/>.
+        /// to notify the outer component of the <see cref="OnBlur"/> event.
+        /// </summary>
+        internal bool OverrideReadOnlyOnBlur { get; set; }
+
+        /// <summary>
         /// If true, the input element will be disabled.
         /// </summary>
         [Parameter]
@@ -270,7 +277,7 @@ namespace MudBlazor
 
         protected internal virtual async Task OnBlurredAsync(FocusEventArgs obj)
         {
-            if (ReadOnly)
+            if (ReadOnly && !OverrideReadOnlyOnBlur)
                 return;
             _isFocused = false;
 
@@ -280,7 +287,7 @@ namespace MudBlazor
                 await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
             }
         }
-
+        
         /// <summary>
         /// Fired on the KeyDown event.
         /// </summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -17,6 +17,12 @@ namespace MudBlazor
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
         /// <summary>
+        /// If true, the input element is used in context of a <see cref="MudPicker{T}"/> component 
+        /// and will enable validation even if <see cref="MudFormComponent{T, U}.SubscribeToParentForm"/> is false.
+        /// </summary>
+        internal bool IsInputForPicker { get; set; }
+
+        /// <summary>
         /// If true, the input element will be disabled.
         /// </summary>
         [Parameter]
@@ -442,7 +448,7 @@ namespace MudBlazor
 
         protected override Task ValidateValue()
         {
-            if (SubscribeToParentForm)
+            if (SubscribeToParentForm || IsInputForPicker)
                 return base.ValidateValue();
 
             return Task.CompletedTask;

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -448,7 +448,7 @@ namespace MudBlazor
 
         protected override Task ValidateValue()
         {
-            if (SubscribeToParentForm || IsInputForPicker)
+            if (SubscribeToParentForm)
                 return base.ValidateValue();
 
             return Task.CompletedTask;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -12,6 +12,7 @@
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
+                                   OnBlur="@OnInternalInputBlurred"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"/>
                </InputContent>
            </MudInputControl>;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -164,6 +165,24 @@ namespace MudBlazor
         private DateRange ParseDateRangeValue(string start, string end)
         {
             return DateRange.TryParse(start, end, Converter, out var dateRange) ? dateRange : null;
+        }
+
+        protected override async Task OnInternalInputBlurred(FocusEventArgs args)
+        {
+            Touched = _rangeInput?.Touched ?? Touched;
+            await BeginValidateAsync();
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (firstRender)
+            {
+                if (_rangeInput is not null)
+                {
+                    _rangeInput.OverrideReadOnlyOnBlur = true;
+                }
+            }
+            base.OnAfterRender(firstRender);
         }
 
         protected override void OnPickerClosed()

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -169,8 +169,11 @@ namespace MudBlazor
 
         protected override async Task OnInternalInputBlurred(FocusEventArgs args)
         {
-            Touched = _rangeInput?.Touched ?? Touched;
-            await BeginValidateAsync();
+            if (!ReadOnly)
+            {
+                Touched = _rangeInput?.Touched ?? Touched;
+                await BeginValidateAsync();
+            }
         }
 
         protected override void OnAfterRender(bool firstRender)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
 
         protected Task OnInput(ChangeEventArgs args)
         {
-            if (!Immediate)
+            if (!Immediate && IsInputForPicker && !string.IsNullOrEmpty(args?.Value as string))
                 return Task.CompletedTask;
             _isFocused = true;
             return SetTextAsync(args?.Value as string);

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
 
         protected Task OnInput(ChangeEventArgs args)
         {
-            if (!Immediate && IsInputForPicker && !string.IsNullOrEmpty(args?.Value as string))
+            if (!Immediate && !string.IsNullOrEmpty(args?.Value as string))
                 return Task.CompletedTask;
             _isFocused = true;
             return SetTextAsync(args?.Value as string);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -35,6 +35,7 @@
              Error="@Error" 
              ErrorText="@ErrorText"
              Clearable="@(GetReadOnlyState() ? false : Clearable)"
+             OnBlur="@OnInternalInputBlurred"
              OnClearButtonClick="@(() => Clear())"
              @onclick="@(() => { if (!Editable) ToggleState(); })" 
              @onkeydown="HandleKeyDown" 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -541,8 +541,11 @@ namespace MudBlazor
 
         protected virtual async Task OnInternalInputBlurred(FocusEventArgs args)
         {
-            Touched = _inputReference?.Touched ?? Touched;
-            await BeginValidateAsync();
+            if (!ReadOnly)
+            {
+                Touched = _inputReference?.Touched ?? Touched;
+                await BeginValidateAsync();
+            }
         }
 
         protected internal virtual void HandleKeyDown(KeyboardEventArgs obj)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -482,6 +482,10 @@ namespace MudBlazor
             if (firstRender == true)
             {
                 await EnsureKeyInterceptor();
+                if (_inputReference is not null)
+                {
+                    _inputReference.IsInputForPicker = true;
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -482,10 +482,6 @@ namespace MudBlazor
             if (firstRender == true)
             {
                 await EnsureKeyInterceptor();
-                if (_inputReference is not null)
-                {
-                    _inputReference.IsInputForPicker = true;
-                }
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -539,6 +539,11 @@ namespace MudBlazor
             PickerClosed.InvokeAsync(this);
         }
 
+        protected virtual async Task OnInternalInputBlurred(FocusEventArgs args)
+        {
+            await BeginValidateAsync();
+        }
+
         protected internal virtual void HandleKeyDown(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -482,6 +482,10 @@ namespace MudBlazor
             if (firstRender == true)
             {
                 await EnsureKeyInterceptor();
+                if (_inputReference is not null)
+                {
+                    _inputReference.OverrideReadOnlyOnBlur = true;
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -537,6 +541,7 @@ namespace MudBlazor
 
         protected virtual async Task OnInternalInputBlurred(FocusEventArgs args)
         {
+            Touched = _inputReference?.Touched ?? Touched;
             await BeginValidateAsync();
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1057,8 +1057,13 @@ namespace MudBlazor
                 // otherwise we can't receive key strokes any longer
                 _elementReference.FocusAsync().AndForget(ignoreExceptions:true);
             }
-            Touched = _elementReference.Touched;
-            await BeginValidateAsync();
+            
+            if (!ReadOnly)
+            {
+                Touched = _elementReference.Touched;
+                await BeginValidateAsync();
+            }
+
             await OnBlur.InvokeAsync(obj);
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -741,6 +741,11 @@ namespace MudBlazor
         {
             if (firstRender)
             {
+                if (_elementReference is not null)
+                {
+                    _elementReference.OverrideReadOnlyOnBlur = true;
+                }
+
                 _keyInterceptor = KeyInterceptorFactory.Create();
 
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
@@ -1044,7 +1049,7 @@ namespace MudBlazor
             _shadowLookup.Remove(item.Value);
         }
 
-        internal void OnLostFocus(FocusEventArgs obj)
+        internal async Task OnLostFocus(FocusEventArgs obj)
         {
             if (_isOpen)
             {
@@ -1052,7 +1057,9 @@ namespace MudBlazor
                 // otherwise we can't receive key strokes any longer
                 _elementReference.FocusAsync().AndForget(ignoreExceptions:true);
             }
-            base.OnBlur.InvokeAsync(obj);
+            Touched = _elementReference.Touched;
+            await BeginValidateAsync();
+            await OnBlur.InvokeAsync(obj);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -166,6 +166,24 @@ namespace MudBlazor
         {
             await SetTextAsync(s);
         }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (firstRender == true)
+            {
+                if (InputReference is not null)
+                {
+                    InputReference.OverrideReadOnlyOnBlur = true;
+                }
+
+                if (_maskReference is not null)
+                {
+                    _maskReference.OverrideReadOnlyOnBlur = true;
+                }
+            }
+
+            base.OnAfterRender(firstRender);
+        }
     }
 
     [Obsolete("MudTextFieldString is no longer available.", true)]

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -171,14 +171,17 @@ namespace MudBlazor
         {
             if (firstRender == true)
             {
-                if (InputReference is not null)
+                if (OverrideReadOnlyOnBlur)
                 {
-                    InputReference.OverrideReadOnlyOnBlur = true;
-                }
+                    if (InputReference is not null)
+                    {
+                        InputReference.OverrideReadOnlyOnBlur = true;
+                    }
 
-                if (_maskReference is not null)
-                {
-                    _maskReference.OverrideReadOnlyOnBlur = true;
+                    if (_maskReference is not null)
+                    {
+                        _maskReference.OverrideReadOnlyOnBlur = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Trigger required validation for DatePicker, TimePicker, DateRangePicker and Select when control is touched and empty (behavior of MudTextField).
This pull request provides one possible solution/workaround to enable same behavior by trigger the SetTextAsync in MudInput.OnInput when text is cleared and hook up OnBlur event from the inner input (TextField, Input, RangeInput) used to trigger validation in the component, handles both EditForm and required.

Fixes #4475, #4571.

## How Has This Been Tested?
Unit tests added/updated (FormTests).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
