### PR TITLE
MudTreeView: Evaluate the Disabled-Parameter for Selection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" @bind-SelectedValue="SelectedValue" Disabled="@Disabled">
+    <MudTreeViewItem Value='"content"'>
+        <MudTreeViewItem Value='"logo.png"' />
+        <MudTreeViewItem Value='"MudBlazor.svg"' />
+        <MudTreeViewItem Value='"Nuget.png"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"src"'>
+        <MudTreeViewItem Value='"MudBlazor"' />
+        <MudTreeViewItem Value='"MudBlazor.Docs"'>
+            <MudTreeViewItem Value='"wwwroot"'>
+                <MudTreeViewItem Value='"MudAppbarCorner.svg"' />
+                <MudTreeViewItem Value='"MudBlazorDocs.min.css"' />
+            </MudTreeViewItem>
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code {
+    public string SelectedValue { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -47,7 +47,7 @@ namespace MudBlazor.UnitTests.Components
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Range Picker");
         }
-        
+
         [Test]
         public void DateRangePickerLabelFor()
         {
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
             var label = comp.Find(".mud-input-label");
             label.Attributes.GetNamedItem("for")?.Value.Should().Be("dateRangeLabelTest");
         }
-        
+
         [Test]
         [Ignore("Unignore for performance measurements, not needed for code coverage")]
         public void RenderDateRangePicker_10000_Times_CheckPerformance()
@@ -549,7 +549,7 @@ namespace MudBlazor.UnitTests.Components
 
             // set a value
             await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Text = RangeConverter<DateTime>.Join(startDate.ToShortDateString(), endDate.ToShortDateString()));
-            
+
             // asert new values have been applied
             dateRangePickerInstance.DateRange.Start.Should().Be(startDate);
             dateRangePickerInstance.DateRange.End.Should().Be(endDate);
@@ -621,6 +621,21 @@ namespace MudBlazor.UnitTests.Components
                   new DateTime(DateTime.Now.Year, DateTime.Now.Month, 11)));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
+        }
+
+        [Test]
+        public void CurrentDate_ShouldBeMarked()
+        {
+            var currentDate = DateTime.Now.Date;
+            var comp = OpenPicker();
+
+            // Check that only one date is marked
+            comp.FindAll("button.mud-current").Count.Should().Be(1);
+
+            // Check that the marked date is the current date
+            comp.Find("button.mud-current").Click();
+            comp.Find("button.mud-range-start-selected").Click();
+            comp.Instance.DateRange.Should().Be(new DateRange(currentDate, currentDate));
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -9,12 +9,29 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class TreeViewTest : BunitTest
     {
+        [Test]
+        public void TreeView_ClickWhileDisabled_DoesNotChangeSelection()
+        {
+            var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), true) });
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().BeNull();
+        }
+
+        [Test]
+        public void TreeView_ClickWhileActive_DoesChangeSelection()
+        {
+            var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), false) });
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().NotBeNull();
+        }
+
         [Test]
         public void Collapsed_ClickOnArrowButton_CheckClose()
         {

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -87,6 +87,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand Command { get; set; }
 
         /// <summary>
@@ -94,6 +95,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.ClickAction)]
+        [Obsolete("This will be removed in v7.")]
         public object CommandParameter { get; set; }
 
         /// <summary>
@@ -106,10 +108,12 @@ namespace MudBlazor
             if (GetDisabledState())
                 return;
             await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
             if (Command?.CanExecute(CommandParameter) ?? false)
             {
                 Command.Execute(CommandParameter);
             }
+#pragma warning restore CS0618
             Activateable?.Activate(this, ev);
         }
 

--- a/src/MudBlazor/Base/MudBaseSelectItem.cs
+++ b/src/MudBlazor/Base/MudBaseSelectItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -47,6 +48,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.ClickAction)]
+        [Obsolete("This will be removed in v7.")]
         public object CommandParameter { get; set; }
 
         /// <summary>
@@ -54,6 +56,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand Command { get; set; }
 
         [Inject] private NavigationManager UriHelper { get; set; }
@@ -72,10 +75,12 @@ namespace MudBlazor
             else
             {
                 await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
                     Command.Execute(CommandParameter);
                 }
+#pragma warning restore CS0618
             }
         }
     }

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -223,6 +223,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chip.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand Command { get; set; }
 
         /// <summary>
@@ -230,6 +231,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chip.ClickAction)]
+        [Obsolete("This will be removed in v7.")]
         public object CommandParameter { get; set; }
 
         /// <summary>
@@ -300,10 +302,12 @@ namespace MudBlazor
             else
             {
                 await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
                     Command.Execute(CommandParameter);
                 }
+#pragma warning restore CS0618
             }
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -186,6 +186,7 @@ namespace MudBlazor
                 return b
                     .AddClass("mud-range")
                     .AddClass("mud-range-between")
+                    .AddClass($"mud-current mud-{Color.ToDescriptionString()}-text mud-button-outlined mud-button-outlined-{Color.ToDescriptionString()}", day == DateTime.Today)
                     .Build();
             }
 
@@ -216,18 +217,17 @@ namespace MudBlazor
             }
             else if (_firstDate != null && day > _firstDate)
             {
-                return b.AddClass("mud-range")
-                    .AddClass("mud-range-selection", _secondDate == null)
+                return b.AddClass("mud-range", _secondDate == null && day != DateTime.Today)
+                    .AddClass("mud-range-selection")
                     .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate != null)
+                    .AddClass($"mud-current mud-{Color.ToDescriptionString()}-text mud-button-outlined mud-button-outlined-{Color.ToDescriptionString()}", day == DateTime.Today)
                     .Build();
             }
 
             if (day == DateTime.Today)
             {
                 return b.AddClass("mud-current")
-                    .AddClass("mud-range", _firstDate != null && day > _firstDate)
-                    .AddClass("mud-range-selection", _firstDate != null && day > _firstDate)
-                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate != null && day > _firstDate)
+                    .AddClass($"mud-button-outlined mud-button-outlined-{Color.ToDescriptionString()}")
                     .AddClass($"mud-{Color.ToDescriptionString()}-text")
                     .Build();
             }

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -191,6 +191,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand Command { get; set; }
 
         /// <summary>
@@ -247,10 +248,12 @@ namespace MudBlazor
                         await MudList.SetSelectedValueAsync(Value);
                     }
                     await OnClick.InvokeAsync(eventArgs);
+#pragma warning disable CS0618
                     if (Command?.CanExecute(CommandParameter) ?? false)
                     {
                         Command.Execute(CommandParameter);
                     }
+#pragma warning restore CS0618
                 }
             }
             else

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -52,8 +52,16 @@ namespace MudBlazor
 
         [Parameter] [Category(CategoryTypes.Menu.ClickAction)] public string Target { get; set; }
         [Parameter] [Category(CategoryTypes.Menu.ClickAction)] public bool ForceLoad { get; set; }
-        [Parameter] [Category(CategoryTypes.Menu.ClickAction)] public ICommand Command { get; set; }
-        [Parameter] [Category(CategoryTypes.Menu.ClickAction)] public object CommandParameter { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.Menu.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
+        public ICommand Command { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.Menu.ClickAction)]
+        [Obsolete("This will be removed in v7.")]
+        public object CommandParameter { get; set; }
 
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
         [Parameter] public EventCallback<TouchEventArgs> OnTouch { get; set; }
@@ -74,10 +82,12 @@ namespace MudBlazor
             else
             {
                 await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
                     Command.Execute(CommandParameter);
                 }
+#pragma warning restore CS0618
             }
         }
 
@@ -97,10 +107,12 @@ namespace MudBlazor
             else
             {
                 await OnTouch.InvokeAsync(ev);
+#pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
                     Command.Execute(CommandParameter);
                 }
+#pragma warning restore CS0618
             }
         }
     }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -117,6 +117,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.ClickAction)]
+        [Obsolete($"This will be removed in v7.")]
         public object? CommandParameter { get; set; }
 
         /// <summary>
@@ -124,6 +125,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Overlay.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand? Command { get; set; }
 
         /// <summary>
@@ -137,10 +139,12 @@ namespace MudBlazor
             if (AutoClose)
                 Visible = false;
             await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
             if (Command?.CanExecute(CommandParameter) ?? false)
             {
                 Command.Execute(CommandParameter);
             }
+#pragma warning restore CS0618
         }
 
         //if not visible or CSS `position:absolute`, don't lock scroll

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -315,6 +315,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
+        [Obsolete($"Use {nameof(OnCommitEditClick)} instead. This will be removed in v7.")]
         public ICommand CommitEditCommand { get; set; }
 
         /// <summary>
@@ -322,6 +323,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
+        [Obsolete("This will be removed in v7.")]
         public object CommitEditCommandParameter { get; set; }
 
         /// <summary>
@@ -515,6 +517,7 @@ namespace MudBlazor
         internal async Task OnCommitEditHandler(MouseEventArgs ev, object item)
         {
             await OnCommitEditClick.InvokeAsync(ev);
+#pragma warning disable CS0618
             if (CommitEditCommand?.CanExecute(CommitEditCommandParameter) ?? false)
             {
                 var parameter = CommitEditCommandParameter;
@@ -522,6 +525,7 @@ namespace MudBlazor
                     parameter = item;
                 CommitEditCommand.Execute(parameter);
             }
+#pragma warning restore CS0618
         }
 
         internal Task OnPreviewEditHandler(object item)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -163,6 +164,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
         public ICommand Command { get; set; }
 
         /// <summary>
@@ -343,10 +345,12 @@ namespace MudBlazor
             }
 
             await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
             if (Command?.CanExecute(Value) ?? false)
             {
                 Command.Execute(Value);
             }
+#pragma warning restore CS0618
         }
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -330,7 +330,7 @@ namespace MudBlazor
 
         protected async Task OnItemClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -342,16 +342,19 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            await OnClick.InvokeAsync(ev);
-            if (Command?.CanExecute(Value) ?? false)
+            if (!Disabled)
             {
-                Command.Execute(Value);
+                await OnClick.InvokeAsync(ev);
+                if (Command?.CanExecute(Value) ?? false)
+                {
+                    Command.Execute(Value);
+                }
             }
         }
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -363,11 +366,16 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            await OnDoubleClick.InvokeAsync(ev);
+            if (!Disabled)
+            {
+                await OnDoubleClick.InvokeAsync(ev);
+            }
         }
+
         protected internal async Task OnItemExpanded(bool expanded)
         {
-            if (Expanded != expanded) {
+            if (Expanded != expanded)
+            {
                 Expanded = expanded;
                 await TryInvokeServerLoadFunc();
                 await ExpandedChanged.InvokeAsync(expanded);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -332,7 +332,7 @@ namespace MudBlazor
 
         protected async Task OnItemClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -355,7 +355,7 @@ namespace MudBlazor
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -367,11 +367,16 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            await OnDoubleClick.InvokeAsync(ev);
+            if (!Disabled)
+            {
+                await OnDoubleClick.InvokeAsync(ev);
+            }
         }
+
         protected internal async Task OnItemExpanded(bool expanded)
         {
-            if (Expanded != expanded) {
+            if (Expanded != expanded)
+            {
                 Expanded = expanded;
                 await TryInvokeServerLoadFunc();
                 await ExpandedChanged.InvokeAsync(expanded);


### PR DESCRIPTION
## Description
So far the "Disabled"-Parameter on the MudTreeView only disables the checkboxes in the Multiselection-Treeview.
I adapted the same behaviour for the "Single-Selection"-Treeview, so that the selected value no longer changes, when `Disabled = true`. 
Fixes #6746

## How Has This Been Tested?
Two new BUnit tests.
One that checks if the SelectedValue is set when `Disabled = false`, one that checks if the SelectedValue stays unchanged when `Disabled = true`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
