### PR TITLE
MudTable: Fix discrepency with initial RowsPerPage in TablePager

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePageSizeOptionsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePageSizeOptionsTest.razor
@@ -1,0 +1,58 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable @ref="filteredTable" Items="states" Filter="new Func<string, bool>(FilterFunc)">
+     <ToolBarContent>
+        <MudText>Filtered Item Count: @FilteredItemCount</MudText>
+        <MudSpacer />
+        <MudTextField id="searchString" @bind-Value="searchString" Placeholder="Search"></MudTextField>
+    </ToolBarContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate> 
+    <PagerContent>
+        <MudTablePager PageSizeOptions="new int[] {8, 16, 32}" />
+    </PagerContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "paging for different PageSizeOptions than the default 10";
+
+    private string searchString;
+
+    private MudTable<string> filteredTable;
+
+    private string FilteredItemCount
+    {
+        get
+        {
+            return filteredTable.GetFilteredItemsCount().ToString();
+        }
+    }
+
+    private bool FilterFunc(string state)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+            return true;
+        if (state.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        return false;
+    }
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -328,6 +328,19 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// page size option initial value test. Initial value should not be 10 since PageSizeOption is set to be new int[]{8, 16, 32}
+        /// </summary>
+        [Test]
+        public async Task TablePageSizeOptions()
+        {
+            var comp = Context.RenderComponent<TablePageSizeOptionsTest>();
+            // print the generated html      
+            // select elements needed for the test
+            var pager = comp.FindComponent<MudSelect<int>>().Instance;
+            pager.Value.Should().Be(8);
+        }
+
+        /// <summary>
         /// page size select tests
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
         internal bool IsEditing => _editingItem != null;
 
         private int _currentPage = 0;
-        private int? _rowsPerPage;
+        internal int? _rowsPerPage;
         private bool _isFirstRendered = false;
 
         protected string Classname =>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
@@ -125,6 +126,8 @@ namespace MudBlazor
             {
                 Context.HasPager = true;
                 Context.PagerStateHasChanged = StateHasChanged;
+                var size = Table._rowsPerPage ?? PageSizeOptions.FirstOrDefault();
+                SetRowsPerPage(size);
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Fix discrepency with initial RowsPerPage (default to 10) in TablePager between the RowsPerPage value and the content of PageSizeOptions. On initialization, if there is no value set to RowsPerPage, it will be updated to be the first value of PageSizeOptions array

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #4580

Reproduced how it is done with DataGrid by adding a check in the OnInitialized method of MudTablePager. 
1- Made int? _rowsPerPage internal so we can access it from the pager
2- Check if value of RowsPerPage was set by testing nullability on _rowsPerPage
2- If null, change its value to be the first from PageSizeOptions array

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Made a unit Test that validates that Pager RowsPerPage value is no longer the default 10, but the first from my test component (8 in this case)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
