### PR TITLE
MudTreeView: Don't accept clicks and selection changes for Disabled items

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" @bind-SelectedValue="SelectedValue" Disabled="@Disabled">
+    <MudTreeViewItem Value='"content"'>
+        <MudTreeViewItem Value='"logo.png"' />
+        <MudTreeViewItem Value='"MudBlazor.svg"' />
+        <MudTreeViewItem Value='"Nuget.png"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"src"'>
+        <MudTreeViewItem Value='"MudBlazor"' />
+        <MudTreeViewItem Value='"MudBlazor.Docs"'>
+            <MudTreeViewItem Value='"wwwroot"'>
+                <MudTreeViewItem Value='"MudAppbarCorner.svg"' />
+                <MudTreeViewItem Value='"MudBlazorDocs.min.css"' />
+            </MudTreeViewItem>
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code {
+    public string SelectedValue { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -22,6 +22,9 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), true) });
             comp.Find("div.mud-treeview-item-content").Click();
             comp.Instance.SelectedValue.Should().BeNull();
+
+            comp.Find("div.mud-treeview-item-content").DoubleClick();
+            comp.Instance.SelectedValue.Should().BeNull();
         }
 
         [Test]
@@ -29,6 +32,13 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), false) });
             comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().NotBeNull();
+
+            // To reset
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().BeNull();
+
+            comp.Find("div.mud-treeview-item-content").DoubleClick();
             comp.Instance.SelectedValue.Should().NotBeNull();
         }
 

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -9,12 +9,29 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class TreeViewTest : BunitTest
     {
+        [Test]
+        public void TreeView_ClickWhileDisabled_DoesNotChangeSelection()
+        {
+            var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), true) });
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().BeNull();
+        }
+
+        [Test]
+        public void TreeView_ClickWhileActive_DoesChangeSelection()
+        {
+            var comp = Context.RenderComponent<DisabledTreeViewTest>(new ComponentParameter[] { Parameter(nameof(MudTreeView<string>.Disabled), false) });
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.SelectedValue.Should().NotBeNull();
+        }
+
         [Test]
         public void Collapsed_ClickOnArrowButton_CheckClose()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -332,7 +332,7 @@ namespace MudBlazor
 
         protected async Task OnItemClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -344,18 +344,21 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            await OnClick.InvokeAsync(ev);
-#pragma warning disable CS0618
-            if (Command?.CanExecute(Value) ?? false)
+            if (!Disabled)
             {
-                Command.Execute(Value);
-            }
+                await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
+                if (Command?.CanExecute(Value) ?? false)
+                {
+                    Command.Execute(Value);
+                }
 #pragma warning restore CS0618
+            }
         }
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)
         {
-            if (MudTreeRoot?.IsSelectable ?? false)
+            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -367,11 +370,16 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            await OnDoubleClick.InvokeAsync(ev);
+            if (!Disabled)
+            {
+                await OnDoubleClick.InvokeAsync(ev);
+            }
         }
+
         protected internal async Task OnItemExpanded(bool expanded)
         {
-            if (Expanded != expanded) {
+            if (Expanded != expanded)
+            {
                 Expanded = expanded;
                 await TryInvokeServerLoadFunc();
                 await ExpandedChanged.InvokeAsync(expanded);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -332,7 +332,12 @@ namespace MudBlazor
 
         protected async Task OnItemClicked(MouseEventArgs ev)
         {
-            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
+            if (Disabled)
+            {
+                return;
+            }
+
+            if (MudTreeRoot?.IsSelectable ?? false)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -344,21 +349,23 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            if (!Disabled)
-            {
-                await OnClick.InvokeAsync(ev);
+            await OnClick.InvokeAsync(ev);
 #pragma warning disable CS0618
-                if (Command?.CanExecute(Value) ?? false)
-                {
-                    Command.Execute(Value);
-                }
-#pragma warning restore CS0618
+            if (Command?.CanExecute(Value) ?? false)
+            {
+                Command.Execute(Value);
             }
+#pragma warning restore CS0618
         }
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)
         {
-            if ((MudTreeRoot?.IsSelectable ?? false) && !Disabled)
+            if (Disabled)
+            {
+                return;
+            }
+
+            if (MudTreeRoot?.IsSelectable ?? false)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
@@ -370,10 +377,7 @@ namespace MudBlazor
                 await ExpandedChanged.InvokeAsync(Expanded);
             }
 
-            if (!Disabled)
-            {
-                await OnDoubleClick.InvokeAsync(ev);
-            }
+            await OnDoubleClick.InvokeAsync(ev);
         }
 
         protected internal async Task OnItemExpanded(bool expanded)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -332,6 +332,13 @@ namespace MudBlazor
 
         protected async Task OnItemClicked(MouseEventArgs ev)
         {
+            if (HasChild && (MudTreeRoot?.ExpandOnClick ?? false))
+            {
+                Expanded = !Expanded;
+                await TryInvokeServerLoadFunc();
+                await ExpandedChanged.InvokeAsync(Expanded);
+            }
+
             if (Disabled)
             {
                 return;
@@ -340,13 +347,6 @@ namespace MudBlazor
             if (MudTreeRoot?.IsSelectable ?? false)
             {
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
-            }
-
-            if (HasChild && (MudTreeRoot?.ExpandOnClick ?? false))
-            {
-                Expanded = !Expanded;
-                await TryInvokeServerLoadFunc();
-                await ExpandedChanged.InvokeAsync(Expanded);
             }
 
             await OnClick.InvokeAsync(ev);
@@ -360,6 +360,13 @@ namespace MudBlazor
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)
         {
+            if (HasChild && (MudTreeRoot?.ExpandOnDoubleClick ?? false))
+            {
+                Expanded = !Expanded;
+                await TryInvokeServerLoadFunc();
+                await ExpandedChanged.InvokeAsync(Expanded);
+            }
+
             if (Disabled)
             {
                 return;
@@ -370,20 +377,12 @@ namespace MudBlazor
                 await MudTreeRoot.UpdateSelected(this, !_isSelected);
             }
 
-            if (HasChild && (MudTreeRoot?.ExpandOnDoubleClick ?? false))
-            {
-                Expanded = !Expanded;
-                await TryInvokeServerLoadFunc();
-                await ExpandedChanged.InvokeAsync(Expanded);
-            }
-
             await OnDoubleClick.InvokeAsync(ev);
         }
 
         protected internal async Task OnItemExpanded(bool expanded)
         {
-            if (Expanded != expanded)
-            {
+            if (Expanded != expanded) {
                 Expanded = expanded;
                 await TryInvokeServerLoadFunc();
                 await ExpandedChanged.InvokeAsync(expanded);


### PR DESCRIPTION
This is an update of [PR 6774](https://github.com/MudBlazor/MudBlazor/pull/6774) because I messed up something on the rebase. Will do better next time...

## Description
So far the "Disabled"-Parameter on the MudTreeView only disables the checkboxes in the Multiselection-Treeview.
I adapted the same behaviour for the "Single-Selection"-Treeview, so that the selected value no longer changes, when `Disabled = true`.
Fixes #6746 

## How Has This Been Tested?
Two new BUnit tests.
One that checks if the SelectedValue is set when `Disabled = false`, one that checks if the SelectedValue stays unchanged when `Disabled = true`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
