### PR TITLE
Remove Parameter attribute from non-component SnackbarOptions class

### DIFF
--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -36,27 +36,27 @@ namespace MudBlazor
         /// <summary>
         /// Custom normal icon.
         /// </summary>
-        [Parameter] public string NormalIcon { get; set; } = Icons.Material.Outlined.EventNote;
+        public string NormalIcon { get; set; } = Icons.Material.Outlined.EventNote;
 
         /// <summary>
         /// Custom info icon.
         /// </summary>
-        [Parameter] public string InfoIcon { get; set; } = Icons.Material.Outlined.Info;
+        public string InfoIcon { get; set; } = Icons.Material.Outlined.Info;
 
         /// <summary>
         /// Custom success icon.
         /// </summary>
-        [Parameter] public string SuccessIcon { get; set; } = Icons.Custom.Uncategorized.AlertSuccess;
+        public string SuccessIcon { get; set; } = Icons.Custom.Uncategorized.AlertSuccess;
 
         /// <summary>
         /// Custom warning icon.
         /// </summary>
-        [Parameter] public string WarningIcon { get; set; } = Icons.Material.Outlined.ReportProblem;
+        public string WarningIcon { get; set; } = Icons.Material.Outlined.ReportProblem;
 
         /// <summary>
         /// Custom error icon.
         /// </summary>
-        [Parameter] public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
+        public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
 
         public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {


### PR DESCRIPTION
## Description
Fixes #6800 by removing the `[Parameter]` attribute from `SnackbarOptions` class which isn't even a component, hence usage of that property attribute isn't allowed here in the first place.

## How Has This Been Tested?
No tests added, but run locally where it worked flawlessly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
