### PR TITLE
MudComponentBase: Make StateHasChanged publicly visible #6563

### DIFF
--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -16,7 +16,7 @@
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
                         <MudCheckBox Checked="@item.IsVisible" CheckedChanged="@((bool value) => item.HandleCheckboxChangeAsync())"></MudCheckBox>               
-                        <MudText Typo="Typo.body2" Inline="true">@item.Labels</MudText>
+                        <MudText Typo="Typo.body2" Class="ml-1" Inline="true">@item.Labels</MudText>
                     </div> 
                 }                 
             </div>


### PR DESCRIPTION
## Description

That you have to cast a Mud component to `(IMudStateHasChanged)` as introduced in (#6563) to be able to see the publicly available `StateHasChanged()` method is a source of confusion which will probably cause us to answer the same question over and over again. For instance, see this discussion under the original PR: https://github.com/MudBlazor/MudBlazor/pull/6563#discussion_r1186026190

I know @ScarletKuro is against this and I respect his opinion. We'll discuss the pros and cons and make a decision before merging (or not merging) this PR. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit test is coming to get it covered.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
