### PR TITLE
MudToolBar: Allow longer content

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -327,6 +327,7 @@
     padding-right: 2px;
     padding-inline-end: 2px;
     padding-inline-start: unset;
+    flex-wrap: nowrap;
 
     & .mud-tablepager-left {
         flex-direction: row !important;

--- a/src/MudBlazor/Styles/components/_toolbar.scss
+++ b/src/MudBlazor/Styles/components/_toolbar.scss
@@ -4,7 +4,8 @@
     display: flex;
     position: relative;
     align-items: center;
-    height: 56px;
+    min-height: 56px;
+    flex-wrap: wrap;
 }
 
 .mud-toolbar-gutters {
@@ -14,13 +15,13 @@
 
 @media (min-width:$breakpoint-xs) and (orientation: landscape) {
     .mud-toolbar {
-        height: 48px;
+        min-height: 48px;
     }
 }
 
 @media (min-width:$breakpoint-sm) {
     .mud-toolbar {
-        height: 64px;
+        min-height: 64px;
     }
 
     .mud-toolbar-gutters {
@@ -30,5 +31,5 @@
 }
 
 .mud-toolbar-dense {
-    height: 48px;
+    min-height: 48px;
 }


### PR DESCRIPTION
## Description
On smaller screens, or if you put a lot of content in the toolbar (including the ToolBarContent of a Table component), then certain items are no longer visible.

Before:
![image](https://user-images.githubusercontent.com/1436449/236616005-bfa5512f-1354-48c7-9b14-c38adb113557.png)

After:
![image](https://user-images.githubusercontent.com/1436449/236616039-559748d7-bbf9-42cc-9a11-fe8b4b6d5b0a.png)


## How Has This Been Tested?
Tests were done visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
