### PR TITLE
Optimization: Replace .Count() > 0 with .Any()

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -20,7 +20,7 @@
            var eventCallbacks = getEventCallbacks().ToList();
         }
 
-        @if (properties.Count() > 0)
+        @if (properties.Any())
         {
             <DocsPageSection>
                 <SectionHeader Title="Properties" />
@@ -85,7 +85,7 @@
             </DocsPageSection>
         }
 
-        @if (eventCallbacks.Count() > 0)
+        @if (eventCallbacks.Any())
         {
             <DocsPageSection>
                 <SectionHeader Title="EventCallbacks" />
@@ -106,7 +106,7 @@
             </DocsPageSection>
         }
 
-        @if (methods.Count() > 0)
+        @if (methods.Any())
         {
             <DocsPageSection>
                 <SectionHeader Title="Methods" />

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -20,7 +20,7 @@
            var eventCallbacks = getEventCallbacks().ToList();
         }
 
-        @if (properties.Any())
+        @if (properties.Count > 0)
         {
             <DocsPageSection>
                 <SectionHeader Title="Properties" />

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1080,7 +1080,7 @@ namespace MudBlazor
         protected override bool HasValue(T value)
         {
             if (MultiSelection)
-                return SelectedValues?.Count() > 0;
+                return SelectedValues?.Any() ?? false;
             else
                 return base.HasValue(value);
         }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -67,7 +67,7 @@
                     @if (Loading)
                     {
                         <tr>
-                            <td colspan="1000" class="@(CurrentPageItems.Count() > 0 || LoadingContent != null ? "mud-table-loading" : "")">
+                            <td colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent != null ? "mud-table-loading" : "")">
                                 <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                             </td>
                         </tr>
@@ -84,7 +84,7 @@
                     }
                     else
                     {
-                        @if (CurrentPageItems != null && CurrentPageItems.Count() > 0)
+                        @if (CurrentPageItems != null && CurrentPageItems.Any())
                         {
                             var rowIndex = 0;
                             <MudVirtualize IsEnabled="@Virtualize" OverscanCount="@OverscanCount" Items="@CurrentPageItems?.ToList()" Context="item">
@@ -131,7 +131,7 @@
                             </MudVirtualize>
                         }
                     }
-                    @if(!(CurrentPageItems != null && CurrentPageItems.Count() > 0)
+                    @if(!(CurrentPageItems != null && CurrentPageItems.Any())
                         && (Loading ? LoadingContent != null : NoRecordsContent != null)
                     )
                     {


### PR DESCRIPTION
## Description
Using Any() is faster than .Count() > 0 because, depending on the underlying type, the latter has to calculate the total count and only then can it return true, whereas the Any() method can stop as soon as there is at least one item.

## How Has This Been Tested?
By building the solution and running all tests. This PR isn't a fundamental change of the code, simply a change of calculation. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
