### PR TITLE
MudTable: Avoid NoRecordsContent showing before loading data

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTest.razor
@@ -1,0 +1,38 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        @{
+            NoRecordsHasRendered = true;
+        }
+    </NoRecordsContent>
+</MudTable>
+
+@code {
+#pragma warning disable CS1998 // async without await
+    public static string __description__ = "The table should not render its NoContent fragment prior to loading server data.";
+
+    private IEnumerable<int> pagedData;
+
+    private int totalItems;
+
+    public bool NoRecordsHasRendered;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<int>> ServerReload(TableState state)
+    {
+        IEnumerable<int> data = new List<int>() { 1, 2, 3 };
+        totalItems = data.Count();
+        pagedData = data.ToArray();
+        return new TableData<int>() { TotalItems = totalItems, Items = pagedData };
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1054,6 +1054,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The table should not render its NoContent fragment prior to loading server data
+        /// </summary>
+        [Test]
+        public async Task TableServerDataLoadingTest()
+        {
+            var comp = Context.RenderComponent<TableServerDataLoadingTest>();
+            comp.Instance.NoRecordsHasRendered.Should().BeFalse();
+        }
+
+        /// <summary>
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -74,6 +74,9 @@ namespace MudBlazor
         /// </summary>
         protected override void OnInitialized()
         {
+            if (HasServerData)
+                Loading = true;
+
             if (Columns == null && RowTemplate == null && RowEditingTemplate == null)
             {
                 string[] quickcolumnslist = null;


### PR DESCRIPTION
## Description
Currently, there is a small window of time where NoRecordsContent is being shown before LoadingContent when using server data. This is due to Loading not being set to true initially when HasServerData is true. Only inside InvokeServerLoadFunc does it set Loading to true (which it still should).

## How Has This Been Tested?
Tested by putting a breakpoint in the `InvokeServerLoadFunc` method of `MudTable.razor.cs` and verifying that LoadingContent is shown.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] Mr-Technician added relevant tests.
