### PR TITLE
MudTable: Add methods to expand or collapse all groups

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
@@ -19,7 +19,8 @@
           GroupBy="@_groupDefinition"
           GroupHeaderStyle="background-color:var(--mud-palette-background-grey)"
           GroupFooterClass="mb-4"
-          Dense="true">
+          Dense="true"
+          @ref="_tableRef">
     <ColGroup>
         <col style="width: 60px;" />
         <col />
@@ -36,7 +37,7 @@
         <MudTh>Molar mass</MudTh>
     </HeaderContent>
     <GroupHeaderTemplate>
-        <MudTh Class="mud-table-cell-custom-group" colspan="5">@($"{context.GroupName}: {context.Key}")</MudTh>
+        <MudTh Class="mud-table-cell-custom-group" colspan="5">@($"{context.GroupName}: {context.Key}") </MudTh>
     </GroupHeaderTemplate>
     <RowTemplate>
         <MudTd DataLabel="Nr">@context.Number</MudTd>
@@ -50,15 +51,20 @@
     </GroupFooterTemplate>
 </MudTable>
 
-@code { 
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mt-3" OnClick="@((args) => _tableRef?.ToggleExpandGroups(expand: true))">Expand all groups</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="mt-3 ml-3" OnClick="@((args) => _tableRef?.ToggleExpandGroups(expand: false))">Collapse all groups</MudButton>
+
+@code {
+    private MudTable<Element> _tableRef;
+
     private TableGroupDefinition<Element> _groupDefinition = new()
-    {
-        GroupName = "Group",
-        Indentation = false,
-        Expandable = true,
-        IsInitiallyExpanded = false,
-        Selector = (e) => e.Group
-    };
+        {
+            GroupName = "Group",
+            Indentation = false,
+            Expandable = true,
+            IsInitiallyExpanded = false,
+            Selector = (e) => e.Group
+        };
 
     private IEnumerable<Element> Elements = new List<Element>();
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicGroupingInitiallyCollapsedExample.razor
@@ -51,8 +51,8 @@
     </GroupFooterTemplate>
 </MudTable>
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mt-3" OnClick="@((args) => _tableRef?.ToggleExpandGroups(expand: true))">Expand all groups</MudButton>
-<MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="mt-3 ml-3" OnClick="@((args) => _tableRef?.ToggleExpandGroups(expand: false))">Collapse all groups</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mt-3" OnClick="@((args) => _tableRef?.ExpandAllGroups())">Expand all groups</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="mt-3 ml-3" OnClick="@((args) => _tableRef?.CollapseAllGroups())">Collapse all groups</MudButton>
 
 @code {
     private MudTable<Element> _tableRef;

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -219,7 +219,7 @@
             <SectionHeader Title="Grouping (Basic) - Initially collapsed">
                 <Description>
                     Displays items in a grouped way, but the groups are all collapsed as default. <br />
-                    Groups can be expanded or collapsed all at once with the <CodeInline>ToggleExpandGroups(bool expand)</CodeInline>.
+                    Groups can be expanded or collapsed all at once by calling <CodeInline>ExpandAllGroups()</CodeInline> or <CodeInline>CollapseAllGroups()</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableBasicGroupingInitiallyCollapsedExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -218,7 +218,8 @@
         <DocsPageSection>
             <SectionHeader Title="Grouping (Basic) - Initially collapsed">
                 <Description>
-                    Displays items in a grouped way, but the groups are all collapsed as default.
+                    Displays items in a grouped way, but the groups are all collapsed as default. <br />
+                    Groups can be expanded or collapsed all at once with the <CodeInline>ToggleExpandGroups(bool expand)</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableBasicGroupingInitiallyCollapsedExample" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1782,7 +1782,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ToggleExpandAllGroupsTest()
+        public void ExpandAndCollapsAllGroupsTest()
         {
             var comp = Context.RenderComponent<TableGroupingTest>();
             var table = comp.Instance.tableInstance;
@@ -1794,12 +1794,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").ToArray().Length.Should().Be(5); // 1 table header + 4 group headers
 
             // Expand all groups
-            table.ToggleExpandGroups(true);
+            table.ExpandAllGroups();
             comp.Render();
             comp.FindAll("tr").ToArray().Length.Should().Be(18); // 1 table header + 4 group headers + 9 item rows + 4 group footers
 
             // Collapse all groups
-            table.ToggleExpandGroups(false);
+            table.CollapseAllGroups();
             comp.Render();
             comp.FindAll("tr").ToArray().Length.Should().Be(5); // 1 table header + 4 group headers
         }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1781,11 +1781,34 @@ namespace MudBlazor.UnitTests.Components
             tr.Length.Should().Be(5); // 1 table header + 4 group headers
         }
 
+        [Test]
+        public void ToggleExpandAllGroupsTest()
+        {
+            var comp = Context.RenderComponent<TableGroupingTest>();
+            var table = comp.Instance.tableInstance;
+            table.GroupBy = new TableGroupDefinition<TableGroupingTest.RacingCar>(rc => rc.Category, null) { GroupName = "Category", IsInitiallyExpanded = false, Expandable = true };
+            comp.Render();
+
+            // Header only since we have IsInitiallyExpanded = false
+            table.Context.GroupRows.Count.Should().Be(4);
+            comp.FindAll("tr").ToArray().Length.Should().Be(5); // 1 table header + 4 group headers
+
+            // Expand all groups
+            table.ToggleExpandGroups(true);
+            comp.Render();
+            comp.FindAll("tr").ToArray().Length.Should().Be(18); // 1 table header + 4 group headers + 9 item rows + 4 group footers
+
+            // Collapse all groups
+            table.ToggleExpandGroups(false);
+            comp.Render();
+            comp.FindAll("tr").ToArray().Length.Should().Be(5); // 1 table header + 4 group headers
+        }
+
         /// <summary>
         /// Tests the correct output when filter does not return any matching elements
         /// </summary>
         /// <returns>The awaitable <see cref="Task"/></returns>
-        [Test]
+
         public async Task TablePagerInfoTextTest()
         {
             // create the component

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1808,7 +1808,7 @@ namespace MudBlazor.UnitTests.Components
         /// Tests the correct output when filter does not return any matching elements
         /// </summary>
         /// <returns>The awaitable <see cref="Task"/></returns>
-
+        [Test]
         public async Task TablePagerInfoTextTest()
         {
             // create the component

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -595,10 +595,7 @@ namespace MudBlazor
             if (_groupBy is not null)
             {
                 _groupBy.IsInitiallyExpanded = expand;
-
-                // The set encapsulates a method, it needs to be called twice for it to function correctly.
-                _groupBy.Expandable = false;
-                _groupBy.Expandable = true;
+                Context?.GroupRows.Where(gr => gr.GroupDefinition == _groupBy).ToList().ForEach(gr => gr.IsExpanded = _groupBy.IsInitiallyExpanded);
             }
         }
 

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -590,6 +590,18 @@ namespace MudBlazor
                 SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
+        public void ToggleExpandGroups(bool expand)
+        {
+            if (_groupBy is not null)
+            {
+                _groupBy.IsInitiallyExpanded = expand;
+
+                // The set encapsulates a method, it needs to be called twice for it to function correctly.
+                _groupBy.Expandable = false;
+                _groupBy.Expandable = true;
+            }
+        }
+
         private string ClearFilterCache()
         {
             _currentRenderFilteredItemsCached = false; 

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -590,7 +590,17 @@ namespace MudBlazor
                 SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
-        public void ToggleExpandGroups(bool expand)
+        public void ExpandAllGroups()
+        {
+            ToggleExpandGroups(expand: true);
+        }
+
+        public void CollapseAllGroups()
+        {
+            ToggleExpandGroups(expand: false);
+        }
+
+        private void ToggleExpandGroups(bool expand)
         {
             if (_groupBy is not null)
             {

--- a/src/MudBlazor/Components/Table/TableGroupDefinition.cs
+++ b/src/MudBlazor/Components/Table/TableGroupDefinition.cs
@@ -74,7 +74,7 @@ namespace MudBlazor
 
         private bool _expandable = false;
         /// <summary>
-        /// Gets or Sets is group header can Expand and Collapse its children.
+        /// Gets or Sets if group header can Expand and Collapse its children.
         /// </summary>
         public bool Expandable
         {


### PR DESCRIPTION
## Description
I added a method to the MudTable to expand or collapse all groups inside of the table. I decided to use a the "ToogleExpandGroups"-Name over creating two dedicated methods for expanding and collapsing, since the code would be 99% identical.
I also added two buttons for expanding and collapsing to the existing "Grouping (Basic) - Initially collapsed" Example from the MudTable documentation. Since it is pretty straight forward, I dont think that an additional example is needed.
Resolves #5318

## How Has This Been Tested?
New test in the Testproject.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![MudTable](https://user-images.githubusercontent.com/41902900/236627525-dccdab52-88bc-4675-bf1b-222b0ec2655c.gif)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
