### PR TITLE
Docs/include sub components

### DIFF
--- a/src/MudBlazor.Docs/Components/ApiHref.razor
+++ b/src/MudBlazor.Docs/Components/ApiHref.razor
@@ -1,0 +1,10 @@
+﻿<MudLink Href="@ApiLink.GetApiLinkFor(Type)">
+    <CodeInline>@($"<{DocStrings.GetSaveTypename(Type)}>")</CodeInline>
+</MudLink>
+
+    @code {
+
+    [Parameter, EditorRequired]
+    public Type Type { get; set; }
+
+}

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -15,9 +15,9 @@
 
         @{
             // save as lists to speed up displaying the page
-            var properties = getProperties().ToList();
-            var methods = getMethods().ToList();
-            var eventCallbacks = getEventCallbacks().ToList();
+            var properties = GetProperties().ToList();
+            var methods = GetMethods().ToList();
+            var eventCallbacks = GetEventCallbacks().ToList();
             var mudBlazorTypes = GetReferencedMudBlazorTypes().ToList();
         }
 
@@ -180,7 +180,7 @@
     };
     [Parameter] public Type Type { get; set; }
 
-    private IEnumerable<ApiProperty> getEventCallbacks()
+    private IEnumerable<ApiProperty> GetEventCallbacks()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 
@@ -201,7 +201,7 @@
         }
     }
 
-    private IEnumerable<ApiMethod> getMethods()
+    private IEnumerable<ApiMethod> GetMethods()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 
@@ -224,7 +224,7 @@
         }
     }
 
-    private IEnumerable<ApiProperty> getProperties()
+    private IEnumerable<ApiProperty> GetProperties()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 

--- a/src/MudBlazor.Docs/Components/DocsClass.razor
+++ b/src/MudBlazor.Docs/Components/DocsClass.razor
@@ -15,9 +15,9 @@
 
         @{
             // save as lists to speed up displaying the page
-            var properties = getProperties().ToList();
-            var methods = getMethods().ToList();
-            var eventCallbacks = getEventCallbacks().ToList();
+            var properties = GetProperties().ToList();
+            var methods = GetMethods().ToList();
+            var eventCallbacks = GetEventCallbacks().ToList();
             var mudBlazorTypes = GetReferencedMudBlazorTypes().ToList();
         }
 
@@ -180,7 +180,7 @@
     };
     [Parameter] public Type Type { get; set; }
 
-    private IEnumerable<ApiProperty> getEventCallbacks()
+    private IEnumerable<ApiProperty> GetEventCallbacks()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 
@@ -201,7 +201,7 @@
         }
     }
 
-    private IEnumerable<ApiMethod> getMethods()
+    private IEnumerable<ApiMethod> GetMethods()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 
@@ -224,7 +224,7 @@
         }
     }
 
-    private IEnumerable<ApiProperty> getProperties()
+    private IEnumerable<ApiProperty> GetProperties()
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 

--- a/src/MudBlazor.Docs/Components/DocsClass.razor
+++ b/src/MudBlazor.Docs/Components/DocsClass.razor
@@ -10,7 +10,7 @@
 
 
 <DocsPage>
-    <DocsPageHeader ComponentLink="@ApiLink.GetComponentLinkFor(Type)" Title="@($"{Type.GetTypeDisplayName()} API")" />
+    <DocsPageHeader ComponentLink="@ApiLink.GetClassLinkFor(Type)" Title="@($"{TypeNameHelper.GetTypeDisplayName(Type, includeGenericParameterNames: true)} Class")" />
     <DocsPageContent>
 
         @{
@@ -99,7 +99,7 @@
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Type">@context.Type.GetTypeDisplayName()</MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type">@TypeNameHelper.GetTypeDisplayName(context.Type, includeGenericParameterNames: true)</MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                         </RowTemplate>
                     </MudTable>
@@ -126,14 +126,14 @@
                             {
                                 foreach (var parameterInfo in context.Parameters)
                                 {
-                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.GetTypeDisplayName()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
+                                        <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{TypeNameHelper.GetTypeDisplayName(parameterInfo.ParameterType, includeGenericParameterNames: true)} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
                                 }
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Return">
                             @if (@context.Return != null && context.Return.ParameterType.GetTypeDisplayName() != "void")
                             {
-                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.GetTypeDisplayName()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
+                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{TypeNameHelper.GetTypeDisplayName(context.Return.ParameterType, includeGenericParameterNames: true)}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>
@@ -228,7 +228,7 @@
     {
         string saveTypename = DocStrings.GetSaveTypename(Type);
 
-        foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>()
+        foreach (var info in Type.GetProperties()
                                  .OrderBy(x => _propertiesGrouping switch {
                                      Grouping.Categories => x.GetCustomAttribute<CategoryAttribute>()?.Order ?? int.MaxValue - 1,
                                      Grouping.Inheritance => -NumberOfAncestorClasses(BaseDefinitionClass(x)),
@@ -260,7 +260,7 @@
         && !x.Namespace.StartsWith("MudBlazor.Docs", StringComparison.OrdinalIgnoreCase) && !x.IsEnum && x != Type && !x.IsInterface && !Type.IsSubclassOf(x) && !x.IsGenericParameter).Distinct();
     }
 
-  
+    
 
     private string AnalyseMethodDocumentation(string documentation, string occurrence, string parameter = "")
     {

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor
@@ -53,8 +53,8 @@ else
                     @foreach (var childType in _component.ChildTypes)
                     {
                         <li>
-                            <MudLink Href="@($"api/{childType.Name.Replace("`1", "").ToLowerInvariant().Replace("mud","")}")" Class="ms-1">
-                                - <CodeInline>@($"<{childType.Name.Replace("`1", "")}>")</CodeInline>
+                            <MudLink Href="@(ApiLink.GetApiLinkFor(childType))" Class="ms-1">
+                                - <CodeInline>@($"<{new string(childType.Name.TakeWhile(c => c != '`').ToArray())}>")</CodeInline>
                             </MudLink>
                         </li>
                     }
@@ -99,12 +99,14 @@ else
     private string _componentPage;
     private bool _isApiPage;
     private string _apiLink;
+    private bool _isClassPage;
     private string _componentTypeName;
 
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
         _isApiPage = NavigationManager.Uri.ToString().Contains("/api/");
+        _isClassPage = NavigationManager.Uri.ToString().Contains("/class/");
         _componentName = NavigationManager.Uri.ToString().Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
         _componentType = ApiLink.GetTypeFromComponentLink(_componentName);
         _component = MenuService.GetComponent(_componentType);

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -17,7 +17,7 @@
 }
 else
 {
-    @Type.GetTypeDisplayName()
+    @TypeNameHelper.GetTypeDisplayName(Type, fullName: false ,includeGenericParameterNames: true)
 }
 
 @code {

--- a/src/MudBlazor.Docs/Extensions/RecursiveExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/RecursiveExtension.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudBlazor.Docs.Extensions
+{
+    public static class RecursiveExtension
+    {
+        public static IEnumerable<T> Recursive<T>(this T parent, Func<T, IEnumerable<T>> selector)
+        {
+            yield return parent;
+
+            foreach (var child in selector(parent))
+            {
+                foreach (var recursiveChild in Recursive(child, selector))
+                    yield return recursiveChild;
+            }
+        }
+
+        public static IEnumerable<T> Recursive<T>(this T parent, Func<T, T> selector)
+        {
+            yield return parent;
+
+            var next = selector(parent);
+            foreach (var child in Recursive(next, selector))
+            {
+                yield return child;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Extensions/TypeNameHelper.cs
+++ b/src/MudBlazor.Docs/Extensions/TypeNameHelper.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace MudBlazor.Docs.Extensions
@@ -221,6 +223,32 @@ namespace MudBlazor.Docs.Extensions
             public bool FullName { get; }
 
             public bool IncludeGenericParameterNames { get; }
+        }
+
+        /// <summary>
+        /// caching a Dyctionary of IList types for faster browsing
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static readonly Dictionary<Type, Type> CachedActualType = new Dictionary<Type, Type>();
+        // Get Internal type of IList.
+        // When the type is not a list then it will return the same type.
+        // if type is List<T> it will return the type of T
+        public static Type GetActualType(this Type type)
+        {
+            if (CachedActualType.ContainsKey(type))
+                return CachedActualType[type];
+
+            if (type.GetTypeInfo().IsArray)
+                CachedActualType.Add(type, type.GetElementType());
+            else if (type.GenericTypeArguments.Any())
+                CachedActualType.Add(type, type.GenericTypeArguments.First());// this is almost always find the right type of an IList but if it fail then do the below. dont really remember why this fail sometimes.
+            else if (type.FullName?.Contains("List`1") ?? false)
+                CachedActualType.Add(type, type.GetRuntimeProperty("Item").PropertyType);
+            else
+                CachedActualType.Add(type, type);
+
+            return CachedActualType[type];
         }
     }
 }

--- a/src/MudBlazor.Docs/Models/ApiLink.cs
+++ b/src/MudBlazor.Docs/Models/ApiLink.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts;
+using System.Reflection;
 
 namespace MudBlazor.Docs.Models
 {
     public static class ApiLink
     {
+        public static string GetClassLinkFor(Type type)
+        {
+            return $"class/{new string(type.Name.TakeWhile(c => c != '`').ToArray()).ToLowerInvariant()}"; //.ToString().Replace("MudBlazor.", "") 
+        }
         public static string GetApiLinkFor(Type type)
         {
             return $"api/{GetComponentName(type)}";
@@ -54,12 +60,11 @@ namespace MudBlazor.Docs.Models
 
             return null;
         }
-
         private static string GetComponentName(Type type)
         {
             if (!s_specialCaseComponents.TryGetValue(type, out var component))
             {
-                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray())
+                component = new string(type.ToString().Replace("MudBlazor.Mud", "").Replace("MudBlazor.", "").TakeWhile(c => c != '`').ToArray())
                     .ToLowerInvariant();
             }
 
@@ -79,11 +84,53 @@ namespace MudBlazor.Docs.Models
                 [typeof(Line)] = "linechart",
                 [typeof(Pie)] = "piechart",
                 [typeof(MudChip)] = "chips",
-                [typeof(ChartOptions)] = "options"
+                [typeof(ChartOptions)] = "options",
+                [typeof(TemplateColumn<T>)] = "datagridtemplatecolumn",
+                [typeof(PropertyColumn<T,TProperty>)] = "datagridpropertycolumn",
+                [typeof(SelectColumn<T>)] = "datagridselectcolumn",
             };
 
         // this is the inversion of above lookup
         private static Dictionary<string, Type> s_inverseSpecialCase =
             s_specialCaseComponents.ToDictionary(pair => pair.Value, pair => pair.Key);
+
+        /// <summary>
+        /// Converts a lowercase Class name from an URL into the C# Type name.
+        /// Examples: 
+        ///   table --> <see cref="MudTable{T}"/>
+        ///   button  <see cref="MudButton"/>
+        ///   appbar  <see cref="MudAppBar"/>
+        /// </summary>
+        public static Type GetTypeFromClassLink(string className)
+        {
+            if (className.Contains('#') == true)
+            {
+                className = className.Substring(0, className.IndexOf('#'));
+            }
+
+            if (string.IsNullOrEmpty(className))
+                return null;
+            if (s_inverseSpecialCase.TryGetValue(className, out var type))
+                return type;
+
+
+            var assembly = typeof(MudComponentBase).Assembly;
+            foreach (var x in assembly.GetTypes())
+            {
+                if (new string(x.Name.ToLowerInvariant().TakeWhile(c => c != '`').ToArray()) == $"{className}".ToLowerInvariant())
+                {
+                    if (x.Name.Contains('`'))
+                    {
+                        return x.GetGenericTypeDefinition();//.MakeGenericType(x.GetGenericArguments());// GenericTypeParameters);
+                    }
+                    else if (x.Name.ToLowerInvariant() == $"{className}".ToLowerInvariant())
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.Docs.Models
             return (string)field.GetValue(null);
         }
 
-        public static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").TrimEnd('_');
+        public static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.]", "_").Replace("<T>", "").Replace("<T, TProperty>", "").TrimEnd('_');
 
         private static string GetSaveMethodIdentifier(MethodInfo method) => Regex.Replace(method.ToString().Replace("MudBlazor.Docs.Models.T", "T"), "[^A-Za-z0-9_]", "_");  // method signature
     }

--- a/src/MudBlazor.Docs/Models/TProperty.cs
+++ b/src/MudBlazor.Docs/Models/TProperty.cs
@@ -1,0 +1,4 @@
+﻿namespace MudBlazor.Docs.Models
+{
+    public class TProperty { }
+}

--- a/src/MudBlazor.Docs/Pages/Class/Class.razor
+++ b/src/MudBlazor.Docs/Pages/Class/Class.razor
@@ -1,0 +1,25 @@
+﻿@page "/class/{className}"
+@using MudBlazor.Docs.Extensions
+
+
+@if (ComponentType == null)
+{
+    <MudProgressCircular Indeterminate="true"></MudProgressCircular>
+}
+else
+{
+    <DocsClass Type="@ComponentType"></DocsClass>
+}
+
+
+@code {
+    [Parameter] public string className { get; set; }
+
+    public Type ComponentType { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        ComponentType = ApiLink.GetTypeFromClassLink(className);
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -36,6 +36,41 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="PropertyColum with CellTemplate">
+                <Description>
+                    You can use <CodeInline>&lt;CellTemplate></CodeInline> to change how a property is displayed or to make it a component to which you can assign methods to their <CodeInline>EventCallback</CodeInline> Properties
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="DataGridPropertyColumnBasicCellTemplateExample" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridPropertyColumnBasicCellTemplateExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Advanced CellTemplate usage">
+                <Description>
+                    In this example, we will explore how we can use <ApiHref Type="typeof(MudDataGrid<T>)"/> to display data that is both driven by columns and rows.
+                    <br><br>
+                    Let's say you want to display stocks from different stores that do not have exactly the same product lists. (e.g. one of them is selling scented fir while the others not)
+                    Since the product list they offer may change at any time or whenever a store manager decides to add items, a single class object with a property for each possible item
+                    is not feasible and would require refactoring every time a new product hits the shelves. So you just decide to have each store send their product list.         
+                    <br><br>
+                    We define <CodeInline>Items</CodeInline> to be a list of distinct products gathered from product lists we recieved from each store.
+                    The first <CodeInline>Column</CodeInline> represents this list we defined and will act as our RowHeader. From there, we know that the <CodeInline>context</CodeInline> 
+                    object from <CodeInline>CellTemplate</CodeInline> will correspond to our previously defined RowHeader value.
+                    <br><br>
+                    Then, we can add one column per store and leverage <CodeInline>CellTemplate</CodeInline> <CodeInline>context</CodeInline> object to find relevant stock quanties
+                    that correspond to products from the RowHeader <CodeInline>Column</CodeInline>.
+                    <br><br>
+                    Since store columns are defined with <CodeInline>TemplateColumn</CodeInline>, Sorting and filtering is not infered.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="DataGridAdvancedCellTemplateExample" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridAdvancedCellTemplateExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Advanced Data Grid">
                 <Description>
                     In a more advanced scenario, the data grid offers sorting, filtering, pagination and selection. There are two ways to filter the data 

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedCellTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedCellTemplateExample.razor
@@ -1,0 +1,74 @@
+﻿@using System.Linq
+@namespace MudBlazor.Docs.Examples
+
+<MudDataGrid T="string" Items="Products">
+    <Columns>
+        <PropertyColumn Property="x => x" Title="Store Products" />
+        @foreach(var store in Stores)
+        {
+            <TemplateColumn Title="@store.Key" Filterable="false" Sortable="false">
+                <CellTemplate>
+                    @{
+                        if (!store.Value.TryGetValue(context.Item, out string value))
+                        {
+                            value = "";
+                        }
+                    }
+                    <MudText>@value</MudText>
+                </CellTemplate>
+            </TemplateColumn>
+        }
+    </Columns>
+</MudDataGrid>
+
+@code {
+
+    IEnumerable<string> Products = Enumerable.Empty<string>();
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Products = Stores.SelectMany(x => x.Value.Keys).Distinct();
+    }
+
+    Dictionary<string, Dictionary<string, string>> Stores = new()
+    {
+        { "Store1",  new Dictionary<string, string>()
+            {
+                {"Brakes", "43"},
+                {"Motor Oil", "12"},
+                {"Tires", "19"},
+                {"Batteries", "98"},
+                {"Engine Coolant", "46"}
+            } 
+        },
+        { "Store2",  new Dictionary<string, string>()
+            {
+                {"Brakes", "94"},
+                {"Motor Oil", "3"},
+                {"Tires", "63"},
+                {"Batteries", "27"},
+                {"Engine Coolant", "89"},
+                {"Windshield Wipers", "23"}
+            }
+        },
+        { "Store3",  new Dictionary<string, string>()
+            {
+                {"Motor Oil", "890"},
+                {"Tires", "347"},
+                {"Batteries", "872"},
+                {"Engine Coolant", "121"},
+                {"Windshield Wipers", "863"},
+                {"Scented fir", "4659"}
+            }
+        },
+        { "Store4",  new Dictionary<string, string>()
+            {
+                {"Motor Oil", "6432"},
+                {"Tires", "876"},
+                {"Batteries", "24"}
+            }
+        },
+
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridPropertyColumnBasicCellTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridPropertyColumnBasicCellTemplateExample.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.Docs.Examples
+@inject ISnackbar Snackbar
+
+<MudDataGrid T="DataModel" Items="Models">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Checked">
+            <CellTemplate>
+                <MudCheckBox Checked="context.Item.Checked" CheckedChanged="@((bool e) => Change(context.Item, e))" />
+            </CellTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+
+    public class DataModel
+    {
+        public bool Checked { get; set; }
+        public string Name { get; set; }
+    }
+
+    List<DataModel> Models = new()
+    {
+        new DataModel(){Checked = false, Name = "Item 1"},
+        new DataModel(){Checked = false, Name = "Item 2"}
+    };
+
+    void Change(DataModel dataModel, bool value)
+    {
+        Snackbar.Add($"This is {dataModel.Name} ! and it changed from {dataModel.Checked.ToString()} to {value.ToString()}");
+        dataModel.Checked = value;
+    }
+
+}

--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -112,7 +112,7 @@ public class LayoutService
 
     public DocsBasePage GetDocsBasePage(string uri)
     {
-        if (uri.Contains("/docs/") || uri.Contains("/api/") || uri.Contains("/components/") ||
+        if (uri.Contains("/docs/") || uri.Contains("/api/") || uri.Contains("/components/") || uri.Contains("/class/") ||
             uri.Contains("/features/") || uri.Contains("/customization/") || uri.Contains("/utilities/"))
         {
             return DocsBasePage.Docs;

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using MudBlazor.Charts;
+using MudBlazor.Docs.Extensions;
 using MudBlazor.Docs.Models;
 
 namespace MudBlazor.Docs.Services
@@ -59,8 +60,8 @@ namespace MudBlazor.Docs.Services
             .AddItem("Paper", typeof(MudPaper))
             .AddItem("Rating", typeof(MudRating), typeof(MudRatingItem))
             .AddItem("Skeleton", typeof(MudSkeleton))
-            .AddItem("Table", typeof(MudTable<T>))
-            .AddItem("Data Grid", typeof(MudDataGrid<T>))
+            .AddItem("Table", typeof(MudTable<T>), typeof(MudTh), typeof(MudTHeadRow), typeof(MudTFootRow), typeof(MudTd), typeof(MudTableSortLabel<T>), typeof(MudTablePager))
+            .AddItem("Data Grid", typeof(MudDataGrid<T>), typeof(PropertyColumn<T,TProperty>), typeof(TemplateColumn<T>), typeof(SelectColumn<T>), typeof(MudDataGridPager<T>))
             .AddItem("Simple Table", typeof(MudSimpleTable))
             .AddItem("Tooltip", typeof(MudTooltip))
             .AddItem("Typography", typeof(MudText))

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -1,4 +1,12 @@
-﻿// Copyright (c) MudBlazor 2021
+﻿/// <summary>
+/// MudBlazor is a component framework for Blazor applications that implements Google's Material Design.
+/// This is the base implementation of a column in a MudBlazor DataGrid.
+/// </summary>
+/// <typeparam name="T">Type of the data to be displayed in the column.</typeparam>
+/// <remarks>
+/// For more information about MudBlazor see: <a href="https://mudblazor.com/">https://mudblazor.com/</a>
+/// </remarks>
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,17 +22,31 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// Base implementation of a column in a MudBlazor DataGrid.
+    /// </summary>
+    /// <typeparam name="T">Type of the data to be displayed in the column.</typeparam>
     public abstract partial class Column<T> : MudComponentBase
     {
         private static readonly RenderFragment<CellContext<T>> EmptyChildContent = _ => builder => { };
 
         internal readonly Guid uid = Guid.NewGuid();
 
+        /// <summary>
+        /// Cascading parameter representing the parent MudDataGrid of this column.
+        /// </summary>
         [CascadingParameter] public MudDataGrid<T> DataGrid { get; set; }
 
         //[CascadingParameter(Name = "HeaderCell")] public HeaderCell<T> HeaderCell { get; set; }
 
+        /// <summary>
+        /// The value of the data in this column.
+        /// </summary>
         [Parameter] public T Value { get; set; }
+
+        /// <summary>
+        /// EventCallback that is invoked when the value of the column changes.
+        /// </summary>
         [Parameter] public EventCallback<T> ValueChanged { get; set; }
 
         //[Parameter] public bool Visible { get; set; } = true;
@@ -35,30 +57,72 @@ namespace MudBlazor
         //[Parameter] public string Field { get; set; }
 
         //[Parameter] public Type FieldType { get; set; }
+        
+        /// <summary>
+        /// Specifies the title of the column. Othwerwise will take the nameof(Property)
+        /// </summary>
         [Parameter] public string Title { get; set; }
+        /// <summary>
+        /// Whether to hide the column on small screens.
+        /// </summary>
         [Parameter] public bool HideSmall { get; set; }
+        /// <summary>
+        /// The number of columns to span in the footer of the DataGrid.
+        /// </summary>
+        /// <value>Default = 1</value>
         [Parameter] public int FooterColSpan { get; set; } = 1;
+        /// <summary>
+        /// The number of columns to span in the header of the DataGrid.
+        /// </summary>
+        /// <value>Default = 1</value>
         [Parameter] public int HeaderColSpan { get; set; } = 1;
+        /// <summary>
+        /// The template used to render the header of this column.
+        /// </summary>
         [Parameter] public RenderFragment<HeaderContext<T>> HeaderTemplate { get; set; }
+        /// <summary>
+        /// The template used to render the body cells of this column.
+        /// </summary>
         [Parameter] public RenderFragment<CellContext<T>> CellTemplate { get; set; }
+        /// <summary>
+        /// The template used to render the footer of this column.
+        /// </summary>
         [Parameter] public RenderFragment<FooterContext<T>> FooterTemplate { get; set; }
+        /// <summary>
+        /// The template used to render the group summary row for this column.
+        /// </summary>
         [Parameter] public RenderFragment<GroupDefinition<T>> GroupTemplate { get; set; }
+        /// <summary>
+        /// A function that specifies how to group the rows in the data grid by the values in this column.
+        /// </summary>
         [Parameter] public Func<T, object> GroupBy { get; set; }
 
         #region HeaderCell Properties
-
+        /// <summary>
+        /// The CSS class that is applied to the header cell.
+        /// </summary>
         [Parameter] public string HeaderClass { get; set; }
+        /// <summary>
+        /// A function that returns the CSS class that is applied to the header cell.
+        /// </summary>
         [Parameter] public Func<T, string> HeaderClassFunc { get; set; }
+        /// <summary>
+        /// The inline style that is applied to the header cell.
+        /// </summary>
         [Parameter] public string HeaderStyle { get; set; }
+        /// <summary>
+        /// A function that returns the inline style that is applied to the header cell.
+        /// </summary>
         [Parameter] public Func<T, string> HeaderStyleFunc { get; set; }
 
         /// <summary>
         /// Determines whether this columns data can be sorted. This overrides the Sortable parameter on the DataGrid.
         /// </summary>
         [Parameter] public bool? Sortable { get; set; }
-
+        /// <summary>
+        ///  Determines whether the column can be resized.
+        /// </summary>
         [Parameter] public bool? Resizable { get; set; }
-
         /// <summary>
         /// If set this will override the DragDropColumnReordering parameter of MudDataGrid which applies to all columns.
         /// Set true to enable reordering for this column. Set false to disable it. 
@@ -68,29 +132,39 @@ namespace MudBlazor
         /// Determines whether this columns data can be filtered. This overrides the Filterable parameter on the DataGrid.
         /// </summary>
         [Parameter] public bool? Filterable { get; set; }
-
+        /// <summary>
+        /// Indicates whether to show the filter icon in the header cell.
+        /// </summary>
         [Parameter] public bool? ShowFilterIcon { get; set; }
-
         /// <summary>
         /// Determines whether this column can be hidden. This overrides the Hideable parameter on the DataGrid.
         /// </summary>
         [Parameter] public bool? Hideable { get; set; }
-
+        /// <summary>
+        /// Indicates whether the column is currently hidden.
+        /// </summary>
         [Parameter] public bool Hidden { get; set; }
+        /// <summary>
+        /// EventCallback that is invoked when the value of the Hidden property changes.
+        /// </summary>
         [Parameter] public EventCallback<bool> HiddenChanged { get; set; }
-
         /// <summary>
         /// Determines whether to show or hide column options. This overrides the ShowColumnOptions parameter on the DataGrid.
         /// </summary>
         [Parameter] public bool? ShowColumnOptions { get; set; }
-
+        /// <summary>
+        /// An IComparer object that is used to compare the values in the column for sorting.
+        /// </summary>
+        /// <value>If none is supplied, default comparer for object will be used</value>
         [Parameter]
         public IComparer<object> Comparer
         {
             get => _comparer;
             set => _comparer = value;
         }
-
+        /// <summary>
+        /// Function that specifies how to sort the rows in the data grid by the values in this column.
+        /// </summary>
         [Parameter]
         public Func<T, object> SortBy
         {
@@ -103,28 +177,39 @@ namespace MudBlazor
                 _sortBy = value;
             }
         }
+        /// <summary>
+        /// The initial sort direction for the column.
+        /// </summary>
+        /// <value>Default = SortDirection.None</value>
         [Parameter] public SortDirection InitialDirection { get; set; } = SortDirection.None;
+        /// <summary>
+        /// The icon that is displayed in the header cell to indicate the sort direction.
+        /// </summary>
+        /// <value>Default = Icons.Material.Filled.ArrowUpward</value>
         [Parameter] public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
-
         /// <summary>
         /// Specifies whether the column can be grouped.
         /// </summary>
         [Parameter] public bool? Groupable { get; set; }
-
         /// <summary>
         /// Specifies whether the column is grouped.
         /// </summary>
         [Parameter] public bool Grouping { get; set; }
-
         /// <summary>
-        /// Specifies whether the column is sticky.
+        /// Specifies whether the column is sticky to the left of the Datagrid.
         /// </summary>
         [Parameter] public bool StickyLeft { get; set; }
-
+        /// <summary>
+        /// Specifies whether the column is sticky to the right of the Datagrid.
+        /// </summary>
         [Parameter] public bool StickyRight { get; set; }
-
+        /// <summary>
+        /// Specifies the template for the filter input field.
+        /// </summary>
         [Parameter] public RenderFragment<FilterContext<T>> FilterTemplate { get; set; }
-
+        /// <summary>
+        /// A string that can be used to identify the column in the Datagrid.
+        /// </summary>
         public string Identifier { get; set; }
         
 
@@ -145,23 +230,59 @@ namespace MudBlazor
         #endregion
 
         #region Cell Properties
-
+        /// <summary>
+        /// The CSS class that is applied to the body cells.
+        /// </summary>
         [Parameter] public string CellClass { get; set; }
+        /// <summary>
+        /// A function that returns the CSS class that is applied to the body cells.
+        /// </summary>
         [Parameter] public Func<T, string> CellClassFunc { get; set; }
+        /// <summary>
+        /// The inline style that is applied to the body cells.
+        /// </summary>
         [Parameter] public string CellStyle { get; set; }
+        /// <summary>
+        /// A function that returns the inline style that is applied to the body cells.
+        /// </summary>
         [Parameter] public Func<T, string> CellStyleFunc { get; set; }
+
+        /// <summary>
+        /// Specifies whether the cell content may be edited. When true, Edit template (when provided) will be rendered instead of CellTemplate.
+        /// </summary>
+        /// <value>Default = true</value>
         [Parameter] public bool IsEditable { get; set; } = true;
+        /// <summary>
+        /// The template used to render the editable body cells of this column. Usefull when it is desired to render cells differently between editable and not.
+        /// </summary>
         [Parameter] public RenderFragment<CellContext<T>> EditTemplate { get; set; }
 
         #endregion
 
         #region FooterCell Properties
-
+        /// <summary>
+        /// The CSS class that is applied to the footer cell of this Datagrid Column.
+        /// </summary>
         [Parameter] public string FooterClass { get; set; }
+        /// <summary>
+        /// A function that returns the CSS class that is applied to the footer cell of this Datagrid Column.
+        /// </summary>
         [Parameter] public Func<T, string> FooterClassFunc { get; set; }
+        /// <summary>
+        /// The inline style that is applied to the footer cell of this Datagrid Column.
+        /// </summary>
         [Parameter] public string FooterStyle { get; set; }
+        /// <summary>
+        /// A function that returns the inline style that is applied to the footer cell of this Datagrid Column.
+        /// </summary>
         [Parameter] public Func<T, string> FooterStyleFunc { get; set; }
+   
         [Parameter] public bool EnableFooterSelection { get; set; }
+
+        /// <summary>
+        /// Aggregation class to define an aggregation method that will display in the footer. Define AggregateType for built-in
+        /// aggregation (Avg, Count, Custom, Max, Min and Sum). Custom allows you to define your own method.
+        /// </summary>
         [Parameter] public AggregateDefinition<T> AggregateDefinition { get; set; }
 
         #endregion
@@ -223,7 +344,6 @@ namespace MudBlazor
                         return typeof(object);
                     }
                 }
-
                 return dataType;
             }
         }
@@ -264,6 +384,9 @@ namespace MudBlazor
         private FilterContext<T> filterContext;
         internal FooterContext<T> footerContext;
 
+        /// <summary>
+        /// Get the FilterContext of the DataGrid Column
+        /// </summary>
         public FilterContext<T> FilterContext
         {
             get
@@ -375,19 +498,28 @@ namespace MudBlazor
         {
             grouping = false;
         }
-
+        /// <summary>
+        /// Async method to hide the column
+        /// </summary>
+        /// <returns></returns>
         public async Task HideAsync()
         {
             Hidden = true;
             await HiddenChanged.InvokeAsync(Hidden);
         }
-
+        /// <summary>
+        /// Async method to show the column
+        /// </summary>
+        /// <returns></returns>
         public async Task ShowAsync()
         {
             Hidden = false;
             await HiddenChanged.InvokeAsync(Hidden);
         }
-
+        /// <summary>
+        /// Async method to toggle the column visible state
+        /// </summary>
+        /// <returns></returns>
         public async Task ToggleAsync()
         {
             Hidden = !Hidden;

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -15,10 +15,16 @@ namespace MudBlazor
     /// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
     public partial class PropertyColumn<T, TProperty> : Column<T>
     {
+        /// <summary>
+        /// Specifies the lambda expression that selects a specific property of an instance of type T used for this column
+        /// </summary>
         [Parameter]
         [EditorRequired]
         public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
 
+        /// <summary>
+        /// Format string passed to TProperty.ToString(string, culture) method.
+        /// </summary>
         [Parameter] public string? Format { get; set; }
 
         private Expression<Func<T, TProperty>>? _lastAssignedProperty;

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
@@ -8,8 +8,17 @@ namespace MudBlazor
 {
     public partial class SelectColumn<T>
     {
+        /// <summary>
+        /// Specifies wheter theres a select all box in the datagrid header
+        /// </summary>
         [Parameter] public bool ShowInHeader { get; set; } = true;
+        /// <summary>
+        /// Specifies wheter theres a select all box in the datagrid footer
+        /// </summary>
         [Parameter] public bool ShowInFooter { get; set; } = true;
+        /// <summary>
+        /// Specifies the size parameter for the MudCheckBox used in the column
+        /// </summary>
         [Parameter] public Size Size { get; set; } = Size.Medium;
     }
 }

--- a/src/MudBlazor/Components/Table/TableGroupData.cs
+++ b/src/MudBlazor/Components/Table/TableGroupData.cs
@@ -6,8 +6,19 @@ using System.Collections.Generic;
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// Represents a group of data items in a table, along with a grouping key and a name for the group.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the grouping key.</typeparam>
+    /// <typeparam name="TElement">The type of the items in the group.</typeparam>
     public class TableGroupData<TKey, TElement>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableGroupData{TKey,TElement}"/> class with the specified group name, grouping key, and items.
+        /// </summary>
+        /// <param name="groupName">The name of the group.</param>
+        /// <param name="key">The grouping key.</param>
+        /// <param name="items">The items in the group.</param>
         public TableGroupData(string groupName, TKey key, IEnumerable<TElement> items)
         {
             GroupName = groupName;
@@ -15,8 +26,17 @@ namespace MudBlazor
             Items = items;
         }
 
+        /// <summary>
+        /// Gets the name of the group.
+        /// </summary>
         public string GroupName { get; }
+        /// <summary>
+        /// Gets the grouping key.
+        /// </summary>
         public TKey Key { get; }
+        /// <summary>
+        /// Gets the items in the group.
+        /// </summary>
         public IEnumerable<TElement> Items { get; }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This one is more complex, so I split it in different commits so each one can be analysed and understood

1. **Added Summary description to some DataGrid sub components**
This one is self explanatory. If the result is satisfactory, I will go ahead and try to expand this to other component that yet lacks description.

![image](https://user-images.githubusercontent.com/29356866/236637143-6c3a69af-6d30-4b74-beb2-feeaeb9fe460.png)


2. **Fix to the Doc page header that display the list of API link.**
Changed it so it displays correctly PropertyColumn that was displaying PropertyColumn`2 (I guess because it contains two generic type reference ?). Also changed the href to use the APILink specialCaseComponent that will help differentiate MudTemplateColumn (From MudTable) from TemplateColumn (from DataGrid).

3. **Added TProperty class**
Was required so the code compile when referencing to PropertyColumn<T, TProperty>.

4. ~~**Fix a displaying bug in DocString when fetching summary Description**~~
~~The code was including newlines from summary tags. they are now replace with whitespace so we do not introduce random newline into the doc description section.~~
EDIT: This was not a bug. It helps with long description such as Validation

5. **Added SubComponent in reference to DataGrid**
For now, PropertyColumn, TemplateColumn, SelectColumn and Pager components are added as API Reference to the Datagrid Docs

![image](https://user-images.githubusercontent.com/29356866/236637111-d6aef044-8be5-43a4-b87d-da413b724caa.png)

6. **Added CellTemplate example**
Often times, when helping people on Discord about how to use DataGrid, it involves CellTemplate and how to leverage that in order to get the full potential out of DataGrid. This is a basic example of how you can use EventCallBack from a component into the cell that will expose both the item from Items and the property from which the EventCallback was invoked.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
All these changes target the Documentation project only. the changes into MudBlazor Components are only for the summary descriptions. I don't know of a method to test this other than navigating the documentations and validating that nothing's broken

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
