### PR TITLE
Docs: Example for nested MudMenu

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudMenu Label="Open Menu" Variant="Variant.Filled" Color="Color.Primary" AnchorOrigin="Origin.CenterCenter" TransformOrigin="Origin.TopLeft" Dense>
+    <MudMenuItem>
+        <MudMenu ActivationEvent="MouseEvent.MouseOver" AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopLeft" Dense>
+            <ActivatorContent>
+                <MudMenuItem> Item 1 </MudMenuItem>
+            </ActivatorContent>
+
+            <ChildContent>
+                <MudMenuItem> Item 1.1 </MudMenuItem>
+                <MudMenuItem> Item 1.2 </MudMenuItem>
+            </ChildContent>
+        </MudMenu>
+    </MudMenuItem>
+
+    <MudMenuItem>
+        <MudMenu ActivationEvent="MouseEvent.MouseOver" AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopLeft" Dense>
+            <ActivatorContent>
+                <MudMenuItem>Item 2</MudMenuItem>
+            </ActivatorContent>
+
+            <ChildContent>
+                <MudMenuItem> Item 2.1 </MudMenuItem>
+                <MudMenuItem> Item 2.2 </MudMenuItem>
+            </ChildContent>
+        </MudMenu>
+    </MudMenuItem>
+</MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -109,6 +109,17 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Nested Menu">
+                <Description>
+                    Multiple menus can be nested. With the <CodeInline>ActivationEvent="MouseEvent.MouseOver"</CodeInline> property, a <CodeInline>MudMenu</CodeInline> component can be used inside of a <CodeInline>MudMenuItem</CodeInline> component to create a simple nested menu.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="MenuWithNestingExample" ShowCode="true">
+                <MenuWithNestingExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>
 


### PR DESCRIPTION
## Description
Since I couldn't figure out how to create a nested menu with multiple submenus, until someone in the discussions helped me with an example, I thought it might be a good idea, to include an example in the official documentation.
resolves #4810

## How Has This Been Tested?
No tests since it is documentation only

## Types of changes
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
