### PR TITLE
Docs: Toggle MudMini menu icon when menu is open

### DIFF
--- a/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
@@ -42,7 +42,7 @@
     </div>
     <div class="@ContentClassNames">
         <MudToolBar DisableGutters="true" Class="mud-text-secondary">
-            <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@Icons.Material.Rounded.MenuOpen" Color="Color.Inherit"/>
+            <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@GetIcon()" Color="Color.Inherit"/>
             <MudIconButton Icon="@Icons.Material.Outlined.Search" Color="Color.Inherit"/>
             <MudSpacer/>
             <MudIconButton Class="mud-text-secondary" Icon="@Icons.Material.Outlined.Notifications"/>
@@ -313,6 +313,8 @@
             overlayVisible = false;
         }
     }
+
+    private string GetIcon() => miniDrawerOpen ? Icons.Material.Rounded.MenuOpen : Icons.Material.Rounded.Menu;
 
     protected string MiniDrawerClassNames =>
         new CssBuilder("mini-drawer py-8 flex-grow-0 flex-shrink-0")


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Currently, the OpenMenu icon is always used regardless of if the MudMini menu is open or closed. This PR modifies the menu to use the standard Menu icon when closed and the existing icon when open.

Open:
<img width="365" alt="Screenshot 2023-05-12 at 1 19 48 PM" src="https://github.com/MudBlazor/MudBlazor/assets/26885142/ba5aae95-c4b4-49ae-ac3f-531c7f05c17f">

Closed:
<img width="309" alt="Screenshot 2023-05-12 at 1 21 35 PM" src="https://github.com/MudBlazor/MudBlazor/assets/26885142/229c82a8-e09c-479e-a6ed-5ccc6add0679">

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

This PR was authored, committed, and merged from the Amtrak California Zephyr train. :)