### PR TITLE
Add "void ISnackbar.RemoveByKey(string)" API

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRemoveByKeyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRemoveByKeyExample.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@inject ISnackbar Snackbar
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@Show">
+    Open Snackbar
+</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@Hide">
+    Hide Snackbar
+</MudButton>
+
+@code {
+    private const string Key = "Same";
+    void Show()
+    {
+        var config = (SnackbarOptions options) =>
+        {
+            options.VisibleStateDuration = int.MaxValue;
+            options.DuplicatesBehavior = SnackbarDuplicatesBehavior.Allow;
+        };
+
+        Snackbar.Add($"Now click hide snackbar. Key: {Key}", Severity.Normal, config, Key);
+        Snackbar.Add($"Now click hide snackbar. Key: {Key}", Severity.Normal, config, Key);
+    }
+
+    void Hide()
+    {
+        Snackbar.RemoveByKey(Key);
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
@@ -170,13 +170,23 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Programmatically remove">
+            <SectionHeader Title="Programmatically remove"/>
+            <SectionHeader>
                 <Description>
                     Using the injected ISnackbar, you can use the <CodeInline>.Remove</CodeInline> method to remove a Snackbar programmatically.
                 </Description>
             </SectionHeader>
             <SectionContent Code="SnackbarRemoveExample" ShowCode="false">
-                <SnackbarRemoveExample />
+                <SnackbarRemoveExample/>
+            </SectionContent>
+            <SectionHeader>
+                <Description>
+                    Alternatively, you can use the <CodeInline>.RemoveByKey</CodeInline> method to remove the Snackbars by key programmatically.
+                    It will remove all the Snackbars with the specified key, including those that are not displayed due to <CodeInline>MaxDisplayedSnackbars</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="SnackbarRemoveByKeyExample" ShowCode="false">
+                <SnackbarRemoveByKeyExample/>
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -183,6 +183,27 @@ namespace MudBlazor
             OnSnackbarsUpdated?.Invoke();
         }
 
+        public void RemoveByKey(string key)
+        {
+            SnackBarLock.EnterWriteLock();
+            try
+            {
+                var snackbars = SnackBarList.Where(snackbar => snackbar.SnackbarMessage.Key == key).ToArray();
+                foreach (var snackbar in snackbars)
+                {
+                    snackbar.OnClose -= Remove;
+                    snackbar.Dispose();
+                    SnackBarList.Remove(snackbar);
+                }
+            }
+            finally
+            {
+                SnackBarLock.ExitWriteLock();
+            }
+
+            OnSnackbarsUpdated?.Invoke();
+        }
+
         private bool ResolvePreventDuplicates(SnackbarOptions options)
         {
             return options.DuplicatesBehavior == SnackbarDuplicatesBehavior.Prevent

--- a/src/MudBlazor/Interfaces/ISnackbar.cs
+++ b/src/MudBlazor/Interfaces/ISnackbar.cs
@@ -25,5 +25,7 @@ namespace MudBlazor
         void Clear();
 
         void Remove(Snackbar snackbar);
+
+        void RemoveByKey(string key);
     }
 }


### PR DESCRIPTION
## Description
We can only remove the Snackbar by reference now, and only `ShownSnackbars` is public. It will meet difficulty when to remove a Snackbar. Add `ISnackbar.RemoveByKey` to extend the flexibility.
Resolves https://github.com/MudBlazor/MudBlazor/issues/6857

## How Has This Been Tested?
Visually tested in added documentation. Since the Remove method is not tested, I think this is not needed as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
