### PR TITLE
ScrollToTop: Add OnClick event

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
@@ -1,0 +1,46 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+@inject IJSRuntime JS
+
+@* https://github.com/MudBlazor/MudBlazor/issues/6517 *@
+
+<MudStack Row="true">
+    <button type="button" @onclick="ScrollBottom">Scroll bottom</button>
+    <MudText id="scroll_on_top_scroll_event_rised" Typo="Typo.subtitle1" Align="Align.Center">@scrolled</MudText>
+    <MudText id="scroll_on_top_click_event_rised" Typo="Typo.subtitle1" Align="Align.Center">@clicked</MudText>
+</MudStack>
+<div id="unique_id_scroll_section" class="ma-0" style="height:300px;overflow: auto;">
+    <MudPaper Elevation="0" Height="1500px" Class="d-flex flex-column justify-space-between py-6">
+        <MudText id="scroll_on_top_text_must_be_in_view" Typo="Typo.h3" Align="Align.Center">@text</MudText>
+        <MudText Typo="Typo.h3" Align="Align.Center">Middle text</MudText>
+        <MudText id="scroll_to_top_bottom_text" Typo="Typo.h3" Align="Align.Center">Bottom text</MudText>
+        <MudScrollToTop Selector="#unique_id_scroll_section" OnClick="@Click" OnScroll="@Scroll">
+            <MudFab Color="@Color.Primary" StartIcon="@Icons.Material.Filled.ArrowCircleUp"/>
+        </MudScrollToTop>
+    </MudPaper>
+</div>
+
+
+@code {
+    public static string __description__ = "Scroll down. MudScrollToTop element must appear. After clicking fab button view must scroll to the top and first line of text must change.";
+   
+    string text = "Scroll and click fab, this text must change afterwards.";
+    string clicked = "false";
+    string scrolled = "false";
+
+    void Click()
+    {
+        text = @"Text changed. All is OK.";
+        clicked = "true";
+    }
+
+    void Scroll()
+    {
+        scrolled = "true";
+    }
+
+    async Task ScrollBottom()
+    {
+        await JS.InvokeVoidAsync("mudScrollManager.scrollIntoView", "h3[id='scroll_to_top_bottom_text']", "smooth");
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
@@ -6,12 +6,12 @@
 
 <MudStack Row="true">
     <button type="button" @onclick="ScrollBottom">Scroll bottom</button>
-    <MudText id="scroll_on_top_scroll_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@scrolled</MudText>
-    <MudText id="scroll_on_top_click_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@clicked</MudText>
+    <MudText id="scroll_on_top_scroll_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@Scrolled</MudText>
+    <MudText id="scroll_on_top_click_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@Clicked</MudText>
 </MudStack>
 <div id="unique_id_scroll_section" class="ma-0" style="height:300px;overflow: auto;">
     <MudPaper Elevation="0" Height="1500px" Class="d-flex flex-column justify-space-between py-6">
-        <MudText id="scroll_on_top_text_must_be_in_view" Typo="Typo.h3" Align="Align.Center">@text</MudText>
+        <MudText id="scroll_on_top_text_must_be_in_view" Typo="Typo.h3" Align="Align.Center">@_text</MudText>
         <MudText Typo="Typo.h3" Align="Align.Center">Middle text</MudText>
         <MudText id="scroll_to_top_bottom_text" Typo="Typo.h3" Align="Align.Center">Bottom text</MudText>
         <MudScrollToTop Selector="#unique_id_scroll_section" OnClick="@Click" OnScroll="@Scroll">
@@ -23,20 +23,21 @@
 
 @code {
     public static string __description__ = "Scroll down. MudScrollToTop element must appear. After clicking fab button view must scroll to the top and first line of text must change.";
-   
-    string text = "Scroll and click fab, this text must change afterwards.";
-    string clicked = "false";
-    string scrolled = "false";
+       
+    public bool Clicked { get; set; } = false;
+    public bool Scrolled { get; set; } = false;
+    
+    private string _text = "Scroll and click fab, this text must change afterwards.";
 
     void Click()
     {
-        text = @"Text changed. All is OK.";
-        clicked = "true";
+        _text = @"Text changed. All is OK.";
+        Clicked = true;
     }
 
     void Scroll()
     {
-        scrolled = "true";
+        Scrolled = true;
     }
 
     async Task ScrollBottom()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
@@ -6,8 +6,8 @@
 
 <MudStack Row="true">
     <button type="button" @onclick="ScrollBottom">Scroll bottom</button>
-    <MudText id="scroll_on_top_scroll_event_rised" Typo="Typo.subtitle1" Align="Align.Center">@scrolled</MudText>
-    <MudText id="scroll_on_top_click_event_rised" Typo="Typo.subtitle1" Align="Align.Center">@clicked</MudText>
+    <MudText id="scroll_on_top_scroll_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@scrolled</MudText>
+    <MudText id="scroll_on_top_click_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@clicked</MudText>
 </MudStack>
 <div id="unique_id_scroll_section" class="ma-0" style="height:300px;overflow: auto;">
     <MudPaper Elevation="0" Height="1500px" Class="d-flex flex-column justify-space-between py-6">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
@@ -1,6 +1,6 @@
 @namespace MudBlazor.UnitTests.TestComponents
 
-@inject IJSRuntime JS
+@inject IScrollManager ScrollManager
 
 @* https://github.com/MudBlazor/MudBlazor/issues/6517 *@
 
@@ -41,6 +41,6 @@
 
     async Task ScrollBottom()
     {
-        await JS.InvokeVoidAsync("mudScrollManager.scrollIntoView", "h3[id='scroll_to_top_bottom_text']", "smooth");
+        await ScrollManager.ScrollIntoViewAsync("h3[id='scroll_to_top_bottom_text']", ScrollBehavior.Smooth);
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
@@ -1,0 +1,36 @@
+using MudBlazor.UnitTests.TestComponents;
+using Bunit;
+using NUnit.Framework;
+using FluentAssertions;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ScrollToTopTests : BunitTest
+    {
+        /// <summary>
+        /// Test scrolling and clicking on 'scroll to top' element
+        /// </summary>
+        [Test]
+        public void ScrollToTopTest()
+        {
+            var comp = Context.RenderComponent<ScrollToTopTest>();
+
+            comp.Find("h6[id='scroll_on_top_click_event_rised']").Should().NotBeNull();
+            comp.Find("h6[id='scroll_on_top_click_event_rised']").TextContent.Should().Be("false", because: "Not clicked yet");
+
+            // scrollBottomButton click check
+            comp.Find("button").Click();
+            var scrollIntoViewInvocation = Context.JSInterop.VerifyInvoke("mudScrollManager.scrollIntoView");
+            scrollIntoViewInvocation.Arguments.Count.Should().Be(2);
+
+            // checks invocation of js scroll function to ensure main functionality
+            comp.Find("span").Click();
+            var scrollToInvocation = Context.JSInterop.VerifyInvoke("mudScrollManager.scrollTo");
+            scrollToInvocation.Arguments.Count.Should().Be(4);
+
+            // checks that click on MudScrollToTop rised an event
+            comp.Find("h6[id='scroll_on_top_click_event_rised']").TextContent.Should().Be("true", because: "Clicked");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
@@ -2,6 +2,7 @@ using MudBlazor.UnitTests.TestComponents;
 using Bunit;
 using NUnit.Framework;
 using FluentAssertions;
+using System;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -16,8 +17,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<ScrollToTopTest>();
 
-            comp.Find("h6[id='scroll_on_top_click_event_raised']").Should().NotBeNull();
-            comp.Find("h6[id='scroll_on_top_click_event_raised']").TextContent.Should().Be("false", because: "Not clicked yet");
+            comp.Instance.Clicked.Should().BeFalse(because: "Not clicked yet");
 
             // scrollBottomButton click check
             comp.Find("button").Click();
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             scrollToInvocation.Arguments.Count.Should().Be(4);
 
             // checks that click on MudScrollToTop raised an event
-            comp.Find("h6[id='scroll_on_top_click_event_raised']").TextContent.Should().Be("true", because: "Clicked");
+            comp.Instance.Clicked.Should().BeTrue(because: "Clicked");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
@@ -16,8 +16,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<ScrollToTopTest>();
 
-            comp.Find("h6[id='scroll_on_top_click_event_rised']").Should().NotBeNull();
-            comp.Find("h6[id='scroll_on_top_click_event_rised']").TextContent.Should().Be("false", because: "Not clicked yet");
+            comp.Find("h6[id='scroll_on_top_click_event_raised']").Should().NotBeNull();
+            comp.Find("h6[id='scroll_on_top_click_event_raised']").TextContent.Should().Be("false", because: "Not clicked yet");
 
             // scrollBottomButton click check
             comp.Find("button").Click();
@@ -29,8 +29,8 @@ namespace MudBlazor.UnitTests.Components
             var scrollToInvocation = Context.JSInterop.VerifyInvoke("mudScrollManager.scrollTo");
             scrollToInvocation.Arguments.Count.Should().Be(4);
 
-            // checks that click on MudScrollToTop rised an event
-            comp.Find("h6[id='scroll_on_top_click_event_rised']").TextContent.Should().Be("true", because: "Clicked");
+            // checks that click on MudScrollToTop raised an event
+            comp.Find("h6[id='scroll_on_top_click_event_raised']").TextContent.Should().Be("true", because: "Clicked");
         }
     }
 }

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor
@@ -4,7 +4,7 @@
 <span class="@Classname"
       style="@Style"
       @attributes="@UserAttributes"
-      @onclick="OnElementClick">
+      @onclick="OnButtonClick">
     @ChildContent
 </span>
  

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor
@@ -4,7 +4,7 @@
 <span class="@Classname"
       style="@Style"
       @attributes="@UserAttributes"
-      @onclick="OnClick">
+      @onclick="OnElementClick">
     @ChildContent
 </span>
  

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -72,6 +73,7 @@ namespace MudBlazor
         /// Called when scroll event is fired
         /// </summary>
         [Parameter] public EventCallback<ScrollEventArgs> OnScroll { get; set; }
+        [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
         protected override void OnAfterRender(bool firstRender)
         {
@@ -118,9 +120,10 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to top when clicked
         /// </summary>
-        private void OnClick()
+        private async void OnElementClick(MouseEventArgs args)
         {
-            ScrollManager.ScrollToTopAsync(_scrollListener.Selector, ScrollBehavior);
+            await ScrollManager.ScrollToTopAsync(_scrollListener.Selector, ScrollBehavior);
+            await OnClick.InvokeAsync(args);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
@@ -118,9 +119,9 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Scrolls to top when clicked
+        /// Scrolls to top when clicked and invokes OnClick
         /// </summary>
-        private async void OnElementClick(MouseEventArgs args)
+        private async Task OnButtonClick(MouseEventArgs args)
         {
             await ScrollManager.ScrollToTopAsync(_scrollListener.Selector, ScrollBehavior);
             await OnClick.InvokeAsync(args);


### PR DESCRIPTION
## Description
Closes #6517
MudScrollToTop it is an invisible wrapper for all inner components is does not allow 'clicking' them. So i think that better way to handle clicking is to add event handler for MudScrollToTop;

### Before

https://github.com/MudBlazor/MudBlazor/assets/25841638/d702fc1d-09a1-49c9-9276-516abfab5067

### After

https://github.com/MudBlazor/MudBlazor/assets/25841638/6b5e5c00-5809-4aec-b2e6-7523f3c9bf3d


## How Has This Been Tested?
Added new unit and visual tests for MudScrollToTop component.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
