### PR TITLE
PickerToolbar: Fix issue with landscape mode for non-static pickers (#5867)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PickerToolbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PickerToolbarTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components;
+
+[TestFixture]
+public class PickerToolbarTests : BunitTest
+{
+    [Test]
+    public void PickerToolbar_ShouldBeLandscape_WhenStaticAndOrientationLandscape()
+    {
+        var component = Context.RenderComponent<MudPickerToolbar>(parameters => parameters
+            .Add(p => p.PickerVariant, PickerVariant.Static)
+            .Add(p => p.Orientation, Orientation.Landscape));
+
+        var pickerToolbar = component.Instance;
+        component.FindAll(".mud-picker-toolbar-landscape").Count.Should().Be(1);
+    }
+
+    [Test]
+    [TestCase(PickerVariant.Inline)]
+    [TestCase(PickerVariant.Dialog)]
+    public void PickerToolbar_ShouldNotBeLandscape_WhenNonStaticAndOrientationLandscape(PickerVariant pickerVariant)
+    {
+        var component = Context.RenderComponent<MudPickerToolbar>(parameters => parameters
+            .Add(p => p.PickerVariant, pickerVariant)
+            .Add(p => p.Orientation, Orientation.Landscape));
+
+        var pickerToolbar = component.Instance;
+        component.FindAll(".mud-picker-toolbar-landscape").Count.Should().Be(0);
+    }
+}

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -9,7 +9,7 @@
 
     protected override RenderFragment PickerContent =>
     @<CascadingValue Value="@this" IsFixed="true">
-        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
+        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
         </MudPickerToolbar>

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
@@ -13,7 +13,7 @@
     protected string Classnames =>
     new CssBuilder("mud-picker-toolbar")
       .AddClass($"mud-theme-{Color.ToDescriptionString()}")
-      .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape)
+      .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
       .AddClass(Class)
     .Build();
 
@@ -21,6 +21,7 @@
     [Parameter] public string Style { get; set; }
     [Parameter] public bool DisableToolbar { get; set; }
     [Parameter] public Orientation Orientation { get; set; }
+    [Parameter] public PickerVariant PickerVariant { get; set; }
     [Parameter] public Color Color { get; set; }
     [Parameter] public RenderFragment ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -8,7 +8,7 @@
 
     protected override RenderFragment PickerContent=> 
     @<CascadingValue Value="@this" IsFixed="true">
-        <MudPickerToolbar Class="@ToolbarClass" Style="@Style" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
+        <MudPickerToolbar Class="@ToolbarClass" Style="@Style" DisableToolbar="@DisableToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
             <div class="mud-timepicker-hourminute mud-ltr">
                 @if (TimeEditMode == TimeEditMode.Normal)
                 {


### PR DESCRIPTION
MudPickerToolbar: Fix issue with landscape mode for non static pickers
Fixes: #5867

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Fixed the issue with #5867. The bug occurred because `MudPickerToolbar` didn't check the `PickerVariant`. 
I've decided to add `PickerVariant` as a parameter so that behavior will be the same for `MudPickerToolbar` as it is for `MudPicker`. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I've compared how pickers looked before the change and after the change if it had Landscape view and it was not Static.
Before:
![image](https://github.com/MudBlazor/MudBlazor/assets/38134495/5c4caf44-185b-423f-a69d-710f9286c675)
After:
![image](https://github.com/MudBlazor/MudBlazor/assets/38134495/d8db9026-1a37-4a30-b4b5-812b44144adf)
This change didn't affect Picker in Static state as it renders as it should:
![image](https://github.com/MudBlazor/MudBlazor/assets/38134495/22fdd3b9-690e-483f-8502-14f494674bb1)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
