### PR TITLE
DataGrid: Fix loading style

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -390,7 +390,6 @@
     position: relative;
 
     & .mud-table-loading-progress {
-        position: absolute;
         width: 100%;
     }
 }


### PR DESCRIPTION
Fix MudDataGrid loading style positioning problem when there is no data

I just removed a line of style, and it has been confirmed that it will only affect the Loading style of MudDataGrid and MudTable. You can check the gif below for the effect

## Description
fixes #6851

## How Has This Been Tested?
none

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![mudblazor](https://github.com/MudBlazor/MudBlazor/assets/88094578/e5299ca7-ef5b-4ed5-9fe7-4715c4ef8e2e)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
