### PR TITLE
DataGrid: Fix PropertyColumn cannot set property's properties

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditTest.razor
@@ -4,16 +4,20 @@
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.EmployeeInfo.Position" />
+        <PropertyColumn Property="x => x.EmployeeInfo.YearsEmployed" />
     </Columns>
 </MudDataGrid>
 
 @code {
     private IEnumerable<Model> _items = new List<Model>()
     {
-        new Model("John", 45), 
-        new Model("Johanna", 23), 
-        new Model("Steve", 32)
+        new Model("John", 45, new("CPA", 23)),
+        new Model("Johanna", 23, new("Product Manager", 1)),
+        new Model("Steve", 32, new("Developer", 9))
     };
 
-    public record Model(string Name, int Age);
+    public record Model(string Name, int Age, ChildModel EmployeeInfo);
+
+    public record ChildModel(string Position, int YearsEmployed);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditWithNullableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditWithNullableTest.razor
@@ -4,17 +4,20 @@
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.EmployeeInfo.Position" />
+        <PropertyColumn Property="x => x.EmployeeInfo.YearsEmployed" />
     </Columns>
 </MudDataGrid>
 
 @code {
     private IEnumerable<Model> _items = new List<Model>()
     {
-        new Model("John", 45), 
-        new Model("Johanna", 23), 
-        new Model("Steve", null)
+        new Model("John", 45, new("CPA", 23)),
+        new Model("Johanna", 23, new("Product Manager", null)),
+        new Model("Steve", null, new("Developer", 9))
     };
 
-    public record Model(string Name, int? Age);
+    public record Model(string Name, int? Age, ChildModel EmployeeInfo);
 
+    public record ChildModel(string Position, int? YearsEmployed);
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -369,19 +369,33 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
             dataGrid.FindAll("td input")[1].GetAttribute("value").Trim().Should().Be("45");
-            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("CPA");
             dataGrid.FindAll("td input")[3].GetAttribute("value").Trim().Should().Be("23");
-            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("Steve");
-            dataGrid.FindAll("td input")[5].GetAttribute("value").Trim().Should().Be("32");
+            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td input")[5].GetAttribute("value").Trim().Should().Be("23");
+            dataGrid.FindAll("td input")[6].GetAttribute("value").Trim().Should().Be("Product Manager");
+            dataGrid.FindAll("td input")[7].GetAttribute("value").Trim().Should().Be("1");
+            dataGrid.FindAll("td input")[8].GetAttribute("value").Trim().Should().Be("Steve");
+            dataGrid.FindAll("td input")[9].GetAttribute("value").Trim().Should().Be("32");
+            dataGrid.FindAll("td input")[10].GetAttribute("value").Trim().Should().Be("Developer");
+            dataGrid.FindAll("td input")[11].GetAttribute("value").Trim().Should().Be("9");
             dataGrid.FindAll(".mud-table-body tr td input")[0].Change("Jonathan");
             dataGrid.FindAll(".mud-table-body tr td input")[1].Change(52d);
+            dataGrid.FindAll(".mud-table-body tr td input")[2].Change("HR");
+            dataGrid.FindAll(".mud-table-body tr td input")[3].Change(21);
             dataGrid.FindAll(".mud-table-body tr td input")[0].GetAttribute("value").Trim().Should().Be("Jonathan");
             dataGrid.FindAll(".mud-table-body tr td input")[1].GetAttribute("value").Trim().Should().Be("52");
+            dataGrid.FindAll(".mud-table-body tr td input")[2].GetAttribute("value").Trim().Should().Be("HR");
+            dataGrid.FindAll(".mud-table-body tr td input")[3].GetAttribute("value").Trim().Should().Be("21");
 
             var name = dataGrid.Instance.Items.First().Name;
             var age = dataGrid.Instance.Items.First().Age;
+            var position = dataGrid.Instance.Items.First().EmployeeInfo.Position;
+            var yearsEmployed = dataGrid.Instance.Items.First().EmployeeInfo.YearsEmployed;
             name.Should().Be("Jonathan");
             age.Should().Be(52);
+            position.Should().Be("HR");
+            yearsEmployed.Should().Be(21);
         }
 
         [Test]
@@ -392,19 +406,33 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
             dataGrid.FindAll("td input")[1].GetAttribute("value").Trim().Should().Be("45");
-            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("CPA");
             dataGrid.FindAll("td input")[3].GetAttribute("value").Trim().Should().Be("23");
-            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("Steve");
-            Assert.IsNull(dataGrid.FindAll("td input")[5].GetAttribute("value"));
+            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td input")[5].GetAttribute("value").Trim().Should().Be("23");
+            dataGrid.FindAll("td input")[6].GetAttribute("value").Trim().Should().Be("Product Manager");
+            dataGrid.FindAll("td input")[8].GetAttribute("value").Trim().Should().Be("Steve");
+            dataGrid.FindAll("td input")[10].GetAttribute("value").Trim().Should().Be("Developer");
+            dataGrid.FindAll("td input")[11].GetAttribute("value").Trim().Should().Be("9");
+            Assert.IsNull(dataGrid.FindAll("td input")[7].GetAttribute("value"));
+            Assert.IsNull(dataGrid.FindAll("td input")[9].GetAttribute("value"));
             dataGrid.FindAll(".mud-table-body tr td input")[0].Change("Jonathan");
             dataGrid.FindAll(".mud-table-body tr td input")[1].Change(52);
+            dataGrid.FindAll(".mud-table-body tr td input")[6].Change("HR");
+            dataGrid.FindAll(".mud-table-body tr td input")[7].Change(1);
             dataGrid.FindAll(".mud-table-body tr td input")[0].GetAttribute("value").Trim().Should().Be("Jonathan");
             dataGrid.FindAll(".mud-table-body tr td input")[1].GetAttribute("value").Trim().Should().Be("52");
+            dataGrid.FindAll(".mud-table-body tr td input")[6].GetAttribute("value").Trim().Should().Be("HR");
+            dataGrid.FindAll(".mud-table-body tr td input")[7].GetAttribute("value").Trim().Should().Be("1");
 
             var name = dataGrid.Instance.Items.First().Name;
             var age = dataGrid.Instance.Items.First().Age;
+            var position = dataGrid.Instance.Items.Skip(1).First().EmployeeInfo.Position;
+            var yearsEmployed = dataGrid.Instance.Items.Skip(1).First().EmployeeInfo.YearsEmployed;
             name.Should().Be("Jonathan");
             age.Should().Be(52);
+            position.Should().Be("HR");
+            yearsEmployed.Should().Be(1);
         }
 
         [Test]


### PR DESCRIPTION
When using PropertyColumn like this `<PropertyColumn Property="x => x.EmployeeInfo.Position" />`, editing `Position` will throw an exception

ps: I'm sorry this is my third pull request for this bug, I'm not very skilled at this 🤣

## Description
fixes #6804, #6788

## How Has This Been Tested?
unit (updated existing one)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
