### PR TITLE
MudToolBar: Add example and test for new WrapContent

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToolBar/Examples/ToolBarWrapContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToolBar/Examples/ToolBarWrapContentExample.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Elevation="25" MaxWidth="250px">
+    <MudToolBar WrapContent="true">
+        <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Class="mr-5" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Add" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Edit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Remove" Color="Color.Inherit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Settings" Color="Color.Inherit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Notifications" />
+        <MudIconButton Icon="@Icons.Material.Outlined.PushPin" />
+        <MudIconButton Icon="@Icons.Material.Outlined.PeopleAlt" />
+        <MudIconButton Icon="@Icons.Material.Outlined.MoreVert" Color="Color.Inherit" />
+    </MudToolBar>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/ToolBar/ToolBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToolBar/ToolBarPage.razor
@@ -12,6 +12,14 @@
                 <ToolBarExample />
             </SectionContent>
         </DocsPageSection>
-
+        
+        <DocsPageSection>
+            <SectionHeader Title="ToolBar Wrap Content Example">
+                <Description>The <CodeInline>MudToolBar</CodeInline> component provides a flexible and versatile layout for organizing content. By setting the <CodeInline>WrapContent</CodeInline> property to true, the ToolBar is granted the ability to wrap its content based on the available space. This means that if the content within the ToolBar exceeds the width of the container, it will automatically wrap onto the next line to ensure optimal display and prevent overflow. Enabling <CodeInline>WrapContent</CodeInline> offers a responsive behavior, allowing the ToolBar to adapt dynamically to different screen sizes and ensure that all content remains visible and accessible to the user.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="ToolBarWrapContentExample" Block="true">
+                <ToolBarWrapContentExample />
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ToolBar/ToolBarWrapContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ToolBar/ToolBarWrapContentTest.razor
@@ -1,0 +1,13 @@
+﻿<MudPaper Elevation="25" MaxWidth="250px">
+    <MudToolBar WrapContent="true">
+        <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Class="mr-5" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Add" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Edit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Remove" Color="Color.Inherit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Settings" Color="Color.Inherit" />
+        <MudIconButton Icon="@Icons.Material.Outlined.Notifications" />
+        <MudIconButton Icon="@Icons.Material.Outlined.PushPin" />
+        <MudIconButton Icon="@Icons.Material.Outlined.PeopleAlt" />
+        <MudIconButton Icon="@Icons.Material.Outlined.MoreVert" Color="Color.Inherit" />
+    </MudToolBar>
+</MudPaper>

--- a/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents.ToolBar;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ToolBarTests : BunitTest
+    {
+        [Test]
+        public void ToolBarWrapContentTest()
+        {
+            var component = Context.RenderComponent<ToolBarWrapContentTest>();
+            var mudToolBar = component.Find(".mud-toolbar");
+
+            mudToolBar.ClassList.Should().Contain("mud-toolbar-wrap-content");
+        }
+    }
+}

--- a/src/MudBlazor/Components/ToolBar/MudToolBar.razor
+++ b/src/MudBlazor/Components/ToolBar/MudToolBar.razor
@@ -10,38 +10,38 @@
 @code {
 
     protected string Classname =>
-    new CssBuilder("mud-toolbar")
-      .AddClass($"mud-toolbar-dense", Dense)
-      .AddClass($"mud-toolbar-gutters", !DisableGutters)
-      .AddClass($"mud-toolbar-wrap-content", WrapContent)
-      .AddClass(Class)
-    .Build();
+        new CssBuilder("mud-toolbar")
+            .AddClass("mud-toolbar-dense", Dense)
+            .AddClass("mud-toolbar-gutters", !DisableGutters)
+            .AddClass("mud-toolbar-wrap-content", WrapContent)
+            .AddClass(Class)
+            .Build();
 
     /// <summary>
     /// If true, compact padding will be used.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.ToolBar.Appearance)]
     public bool Dense { get; set; }
 
     /// <summary>
     /// If true, disables gutter padding.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.ToolBar.Appearance)]
     public bool DisableGutters { get; set; }
 
     /// <summary>
     /// Child content of component.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.ToolBar.Behavior)]
     public RenderFragment ChildContent { get; set; }
     
     /// <summary>
     /// If true, ToolBar is allowed to wrap.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.ToolBar.Behavior)]
     public bool WrapContent { get; set; }
 }


### PR DESCRIPTION
## Description
This commit serves as a follow-up to the PR https://github.com/MudBlazor/MudBlazor/pull/6869.
It introduces an example and test cases to showcase the functionality of the newly added `WrapContent` feature.

Instead of extending the existing example with a `WrapContent` toggle, which would require additional explanations about resizing the browser to see the difference with the `WrapContent` enabled, I opted to create a separate example. This approach allows users to immediately observe the outcome.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
