### PR TITLE
MudColorPicker: Fix/Enable color picker form validation (#6841)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithColorPickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithColorPickerTest.razor
@@ -1,0 +1,16 @@
+﻿@using MudBlazor.Utilities
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudForm ValidationDelay="0">
+    <MudColorPicker Required="true" @bind-Value="ColorValue">
+    </MudColorPicker>
+</MudForm>
+
+@code {
+    public static string __description__ = "Form should validate color picker's value.";
+
+    [Parameter]
+    public MudColor? ColorValue { get; set; } = new("#000000");
+}

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -68,7 +68,7 @@
                                 @if (!DisablePreview)
                                 {
                                     <div class="mud-picker-color-dot mud-picker-color-dot-current mud-ripple" @onclick="ToggleCollection">
-                                        <div class="mud-picker-color-fill" style="@($"background: {_color.ToString(MudColorOutputFormats.RGBA)};")"></div>
+                                        <div class="mud-picker-color-fill" style="@($"background: {_value.ToString(MudColorOutputFormats.RGBA)};")"></div>
                                     </div>
                                 }
                                 @if (!DisableSliders && !_collectionOpen)
@@ -76,11 +76,11 @@
                                     <div class="mud-picker-color-sliders">
 										@if (_activeColorPickerView != ColorPickerView.Grid)
 										{
-                                            <MudSlider Class="mud-picker-color-slider hue" dir="ltr" T="int" Value="(int)_color.H" ValueChanged="UpdateBaseColorSlider" Step="1" Min="0" Max="360" />
+                                            <MudSlider Class="mud-picker-color-slider hue" dir="ltr" T="int" Value="(int)_value.H" ValueChanged="UpdateBaseColorSlider" Step="1" Min="0" Max="360" />
                                         }
                                         @if (!DisableAlpha)
                                         {
-                                            <MudSlider Class="mud-picker-color-slider alpha" Value="_color.A" ValueChanged="SetAlpha" T="int"  Min="0" Max="255" Step="1" Style="@AlphaSliderStyle"  />
+                                            <MudSlider Class="mud-picker-color-slider alpha" Value="_value.A" ValueChanged="SetAlpha" T="int"  Min="0" Max="255" Step="1" Style="@AlphaSliderStyle"  />
                                         }
                                     </div>
                                 }
@@ -102,14 +102,14 @@
                                     @switch (ColorPickerMode)
                                     {
                                         case ColorPickerMode.RGB:
-                                            <MudNumericField Value="_color.R" T="int" ValueChanged="SetR" Class="mud-picker-color-inputfield" HelperText="R" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
-                                            <MudNumericField Value="_color.G" T="int" ValueChanged="SetG" Class="mud-picker-color-inputfield" HelperText="G" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
-                                            <MudNumericField Value="_color.B" T="int" ValueChanged="SetB" Class="mud-picker-color-inputfield" HelperText="B" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="_value.R" T="int" ValueChanged="SetR" Class="mud-picker-color-inputfield" HelperText="R" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="_value.G" T="int" ValueChanged="SetG" Class="mud-picker-color-inputfield" HelperText="G" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="_value.B" T="int" ValueChanged="SetB" Class="mud-picker-color-inputfield" HelperText="B" Min="0" Max="255" Variant="Variant.Outlined" HideSpinButtons="true" />
                                             break;
                                         case ColorPickerMode.HSL:
-                                            <MudNumericField Value="@_color.H" T="double" ValueChanged="SetH" Class="mud-picker-color-inputfield" HelperText="H" Step="1" Min="0" Max="360" Variant="Variant.Outlined" HideSpinButtons="true" />
-                                            <MudNumericField Value="@_color.S" T="double" ValueChanged="SetS" Class="mud-picker-color-inputfield" HelperText="S" Step="0.01" Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
-                                            <MudNumericField Value="@_color.L" T="double"  ValueChanged="SetL" Class="mud-picker-color-inputfield" HelperText="L"Step="0.01"  Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="@_value.H" T="double" ValueChanged="SetH" Class="mud-picker-color-inputfield" HelperText="H" Step="1" Min="0" Max="360" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="@_value.S" T="double" ValueChanged="SetS" Class="mud-picker-color-inputfield" HelperText="S" Step="0.01" Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                            <MudNumericField Value="@_value.L" T="double"  ValueChanged="SetL" Class="mud-picker-color-inputfield" HelperText="L"Step="0.01"  Min="0" Max="100" Variant="Variant.Outlined" HideSpinButtons="true" />
                                             break;
                                         case ColorPickerMode.HEX:
                                             <MudTextField Value="@GetColorTextValue()" ValueChanged="SetInputString" T="string" Class="mud-picker-color-inputfield" Variant="Variant.Outlined" MaxLength="@GetHexColorInputMaxLength()" HelperText="HEX" />
@@ -120,7 +120,7 @@
                         
                                     @if (!DisableAlpha && ColorPickerMode != ColorPickerMode.HEX)
                                     {
-                                        <MudNumericField Value="@(  Math.Round(_color.A / 255.0, 2))" T="double" ValueChanged="SetAlpha" Class="mud-picker-color-inputfield input-field-alpha" HelperText="A" Min="0" Max="1" Step="0.01" Variant="Variant.Outlined" HideSpinButtons="true" />
+                                        <MudNumericField Value="@(  Math.Round(_value.A / 255.0, 2))" T="double" ValueChanged="SetAlpha" Class="mud-picker-color-inputfield input-field-alpha" HelperText="A" Min="0" Max="1" Step="0.01" Variant="Variant.Outlined" HideSpinButtons="true" />
                                     }
                                 </div>
                                 @if (!DisableModeSwitch)


### PR DESCRIPTION
## Description

This PR follows the same logic as #5884 and #6195, the `MudColorPicker` component wouldn't trigger an update to the `IsTouched` property of a `FormComponent`. With these changes the `MudColorPicker` component should behave pretty much exactly like the other two from my previous PRs.

Fixes: #6841

## How Has This Been Tested?

Tested with unit tests and visual checks, to ensure the specific test case in #6841 passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![firefox_zasuqMtrvE](https://github.com/MudBlazor/MudBlazor/assets/15004223/3c47409d-f956-4a98-8d8a-2c38be44c76c)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
