### PR TITLE
MudAppBar: Fix default value of WrapContent (#6808, #6869)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2023
+﻿// Copyright (c) MudBlazor 2023
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -67,5 +67,16 @@ namespace MudBlazor.UnitTests.Components
                .And
                .Contain("mud-appbar-fixed-bottom");
         }
+
+        /// <summary>
+        /// AppBar must not set WrapContent true by default as this is not backwards compatible
+        /// </summary>
+        [Test]
+        public void AppBar_WrapContent_ShouldBeFalseByDefault()
+        {
+            var comp = Context.RenderComponent<MudAppBar>();
+            comp.FindComponent<MudToolBar>().Instance.WrapContent.Should().Be(false);
+        }
+
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -16,12 +16,14 @@ namespace MudBlazor.UnitTests.Components
         public void Init()
         {
             AssertionOptions.FormattingOptions.MaxDepth = 100;
+            AssertionOptions.FormattingOptions.MaxLines = 500;
         }
 
         [OneTimeTearDown]
         public void Cleanup()
         {
             AssertionOptions.FormattingOptions.MaxDepth = 5;
+            AssertionOptions.FormattingOptions.MaxLines = 100;
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         public void Init()
         {
             AssertionOptions.FormattingOptions.MaxDepth = 100;
-            AssertionOptions.FormattingOptions.MaxLines = 500;
+            AssertionOptions.FormattingOptions.MaxLines = 5000;
         }
 
         [OneTimeTearDown]

--- a/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
@@ -20,5 +20,16 @@ namespace MudBlazor.UnitTests.Components
 
             mudToolBar.ClassList.Should().Contain("mud-toolbar-wrap-content");
         }
+
+        /// <summary>
+        /// ToolBar's WrapContent should be false by default
+        /// </summary>
+        [Test]
+        public void ToolBar_WrapContent_ShouldBeFalseByDefault()
+        {
+            var comp = Context.RenderComponent<MudToolBar>();
+            comp.Instance.WrapContent.Should().Be(false);
+        }
+
     }
 }

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AppBar.Behavior)]
-        public bool WrapContent { get; set; } = true;
+        public bool WrapContent { get; set; } = false;
 
         /// <summary>
         /// User class names, separated by spaces for the nested toolbar.


### PR DESCRIPTION
This is a hotfix of an accidental breaking change made by the PR #6808, which was remedied for MudToolbar with #6869 but for MudAppBar the wrong (breaking) default value was chosen, which is remedied in this PR.