### PR TITLE
PropertyColumn: Use Title as property name when Property.Body is not …

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridDragAndDropWithDynamicColumnsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridDragAndDropWithDynamicColumnsTest.razor
@@ -1,0 +1,37 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Reflection;
+@using System.Linq.Expressions;
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items" DragDropColumnReordering="true" DragIndicatorIcon="@Icons.Material.Filled.DragIndicator">
+    <Columns>
+        @foreach (var propertyColumn in _columnInfos)
+        {
+            <PropertyColumn DragAndDropEnabled="@propertyColumn.DragAndDropEnabled" Property="@propertyColumn.Property" Title="@propertyColumn.Title"></PropertyColumn>
+        }
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, Severity.Normal, false, null), 
+        new Model("Alicia", 54, Severity.Info, null, null), 
+        new Model("Ira", 27, Severity.Success, true, new DateTime(2011, 1, 2)),
+        new Model("John", 32, Severity.Warning, false, null)
+    };
+
+    private List<ColumnInfo> _columnInfos = new List<ColumnInfo>();
+
+    protected override void OnInitialized()
+    {       
+        Type modelType = typeof(Model);
+        foreach (PropertyInfo propertyInfo in modelType.GetProperties())
+        {
+            _columnInfos.Add(new ColumnInfo(true, x => propertyInfo.GetValue(x), propertyInfo.Name));
+        }        
+    }
+
+    public record Model (string Name, int? Age, Severity? Status, bool? Hired, DateTime? HiredOn);
+    public record ColumnInfo(bool DragAndDropEnabled, Expression<Func<Model, object>> Property, string Title);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3762,6 +3762,47 @@ namespace MudBlazor.UnitTests.Components
             newHeaderValues[4].InnerHtml.Should().Be("HiredOn");
 
         }
-    
+
+        [Test]
+        public async Task DataGridDragAndDropWithDynamicColumnsTest()
+        {
+            var comp = Context.RenderComponent<DataGridDragAndDropWithDynamicColumnsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridDragAndDropWithDynamicColumnsTest.Model>>();
+            dataGrid.Instance.DropContainerHasChanged();
+
+            var headerValues = dataGrid.FindAll(".sortable-column-header");
+            headerValues.Count.Should().Be(5, because: "5 columns in DataGridFiltersTest");
+
+            headerValues[0].InnerHtml.Should().Be("Name");
+            headerValues[1].InnerHtml.Should().Be("Age");
+            headerValues[2].InnerHtml.Should().Be("Status");
+            headerValues[3].InnerHtml.Should().Be("Hired");
+            headerValues[4].InnerHtml.Should().Be("HiredOn");
+
+            var container = dataGrid.Find(".mud-drop-container");
+            container.Children.Should().HaveCount(1);
+
+            var zone = dataGrid.FindAll(".mud-drop-zone");
+            zone.Count.Should().Be(5, because: "5 columns in DataGridFiltersTest");
+
+            var firstDropZone = zone[1];
+            var firstDropItem = firstDropZone.Children[0];
+
+            var secondDropZone = zone[2];
+            var secondDropItem = secondDropZone.Children[0];
+
+            await firstDropItem.DragStartAsync(new DragEventArgs());
+            await secondDropItem.DropAsync(new DragEventArgs());
+
+            var newHeaderValues = dataGrid.FindAll(".sortable-column-header");
+            newHeaderValues.Count.Should().Be(5, because: "5 columns in DataGridFiltersTest");
+
+            newHeaderValues[0].InnerHtml.Should().Be("Name");
+            newHeaderValues[1].InnerHtml.Should().Be("Status");
+            newHeaderValues[2].InnerHtml.Should().Be("Age");
+            newHeaderValues[3].InnerHtml.Should().Be("Hired");
+            newHeaderValues[4].InnerHtml.Should().Be("HiredOn");
+
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -47,7 +47,7 @@ namespace MudBlazor
             }
             else
             {
-                _propertyName = _fullPropertyName = Property.Body.ToString();
+                _propertyName = _fullPropertyName = Title ?? Property.Body.ToString();
             }
 
             CompileGroupBy();


### PR DESCRIPTION
This issue happens because Property.Body is used to resolve property name. And if there are identical  Property.Body expressions, multiple PropertyColumn in one column will be shown 

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #6927

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
