### PR TITLE
Fixed dateformat on the Releases-page

### DIFF
--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -21,7 +21,7 @@
                         <div class="docs-sticky-info">
                             <MudText Typo="Typo.h5" Inline="true">Version </MudText>
                             <MudText Typo="Typo.h5" Inline="true" Color="Color.Primary"><b>@release.TagName</b></MudText>
-                            <MudText Typo="Typo.subtitle1">Released on @release.PublishedAt.ToString("MMMM MM, yyyy")</MudText>
+                            <MudText Typo="Typo.subtitle1">Released on @release.PublishedAt.ToString("MMMM dd, yyyy")</MudText>
                         </div>
                     </MudItem>
                     <MudItem xs="12" md="8">


### PR DESCRIPTION
## Description
Currently the Releasedates on the Releases-Page are formatted `MMMM MM, yyyy ` which does not make any sense.
I changed it to `MMMM dd, yyyy`.
Fixes #6934 

## How Has This Been Tested?
Visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
