### PR TITLE
TimePicker: Handle conversion errors

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -296,16 +296,16 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<SimpleTimePickerTest>((Parameter("TimeEditMode", TimeEditMode.OnlyHours)));
             var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
-            
+
             // click to to open picker
             comp.Find("input").Click();
-            
+
             // should be open
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
-            
+
             // click on 13 hour
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].Click();
-            
+
             // should be closed
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
@@ -314,7 +314,7 @@ namespace MudBlazor.UnitTests.Components
 
             // click to to open picker
             comp.Find("input").Click();
-            
+
             // should be open
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
@@ -328,7 +328,7 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(14);
 
         }
-        
+
         [Test]
         public void ChangeToMinutes_FromHours_CheckHoursHidden()
         {
@@ -386,16 +386,37 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudTimePicker>();
             var picker = comp.Instance;
+
             // valid time
             comp.Find("input").Change("23:02");
             picker.TimeIntermediate.Should().Be(new TimeSpan(23, 2, 0));
+            picker.ConversionError.Should().BeFalse();
+            picker.ConversionErrorMessage.Should().BeNull();
             // empty string equals null TimeSpan?
             comp.Find("input").Change("");
             picker.TimeIntermediate.Should().BeNull();
-            picker.Error.Should().BeFalse();
-            // invalid time
+            picker.ConversionError.Should().BeFalse();
+            picker.ConversionErrorMessage.Should().BeNull();
+            // invalid time (format, AmPm)
+            comp.Find("input").Change("09:o6 AM");
+            picker.TimeIntermediate.Should().BeNull();
+            picker.ConversionError.Should().BeTrue();
+            picker.ConversionErrorMessage.Should().Be("Not a valid time span");
+            // invalid time (overflow, AmPm)
+            comp.Find("input").Change("13:45 AM");
+            picker.TimeIntermediate.Should().BeNull();
+            picker.ConversionError.Should().BeTrue();
+            picker.ConversionErrorMessage.Should().Be("Not a valid time span");
+            // invalid time (format)
+            comp.Find("input").Change("2o:32");
+            picker.TimeIntermediate.Should().BeNull();
+            picker.ConversionError.Should().BeTrue();
+            picker.ConversionErrorMessage.Should().Be("Not a valid time span");
+            // invalid time (overflow)
             comp.Find("input").Change("25:06");
             picker.TimeIntermediate.Should().BeNull();
+            picker.ConversionError.Should().BeTrue();
+            picker.ConversionErrorMessage.Should().Be("Not a valid time span");
         }
 
         [Test]
@@ -632,7 +653,7 @@ namespace MudBlazor.UnitTests.Components
             // Select 16 hours
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
             picker.TimeIntermediate.Value.Hours.Should().Be(16);
-            
+
             // Select 30 minutes
             comp.FindAll("div.mud-minute")[30].Click();
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -371,23 +371,27 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         public void ErrorCheckingTest()
         {
-            //format exception
+            // datetime format exception
             var dt1 = new DefaultConverter<DateTime>();
             dt1.Get("12/34/56").Should().Be(default);
             var dtn1 = new DefaultConverter<DateTime?>();
             dtn1.Get("12/34/56").Should().Be(null);
 
-            // format exception
+            // timespan format exception
             var tm1 = new DefaultConverter<TimeSpan>();
             tm1.Get("12:o1").Should().Be(default);
+            tm1.GetErrorMessage.Should().Be("Not a valid time span");
             var tmn1 = new DefaultConverter<TimeSpan?>();
             tmn1.Get("12:o1").Should().Be(null);
+            tmn1.GetErrorMessage.Should().Be("Not a valid time span");
 
-            // overflow
+            // timespan overflow exception
             var tm2 = new DefaultConverter<TimeSpan>();
             tm2.Get("25:00").Should().Be(default);
-            var tm2n = new DefaultConverter<TimeSpan?>();
-            tm2n.Get("25:00").Should().Be(null);
+            tm2.GetErrorMessage.Should().Be("Not a valid time span");
+            var tmn2 = new DefaultConverter<TimeSpan?>();
+            tmn2.Get("25:00").Should().Be(null);
+            tmn2.GetErrorMessage.Should().Be("Not a valid time span");
 
             // not a valid number
             var c1 = new DefaultConverter<sbyte>();

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -5,8 +5,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
-using MudBlazor.Services;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -44,18 +42,35 @@ namespace MudBlazor
             {
                 return time.TimeOfDay;
             }
-            else
+
+            var m = Regex.Match(value, "AM|PM", RegexOptions.IgnoreCase);
+            if (m.Success)
             {
-                var m = Regex.Match(value, "AM|PM", RegexOptions.IgnoreCase);
-                if (m.Success)
+                if (DateTime.TryParseExact(value, format12Hours, CultureInfo.InvariantCulture, DateTimeStyles.None,
+                        out time))
                 {
-                    return DateTime.ParseExact(value, format12Hours, CultureInfo.InvariantCulture).TimeOfDay;
-                }
-                else
-                {
-                    return DateTime.ParseExact(value, format24Hours, CultureInfo.InvariantCulture).TimeOfDay;
+                    return time.TimeOfDay;
                 }
             }
+            else
+            {
+                if (DateTime.TryParseExact(value, format24Hours, CultureInfo.InvariantCulture, DateTimeStyles.None,
+                        out time))
+                {
+                    return time.TimeOfDay;
+                }
+            }
+
+            HandleParsingError();
+            return null;
+        }
+
+        private void HandleParsingError()
+        {
+            const string ParsingErrorMessage = "Not a valid time span";
+            Converter.GetError = true;
+            Converter.GetErrorMessage = ParsingErrorMessage;
+            Converter.OnError?.Invoke(ParsingErrorMessage);
         }
 
         private bool _amPm = false;
@@ -228,7 +243,7 @@ namespace MudBlazor
         private void UpdateTime()
         {
             TimeIntermediate = new TimeSpan(_timeSet.Hour, _timeSet.Minute, 0);
-            if((PickerVariant == PickerVariant.Static && PickerActions == null) || (PickerActions != null && AutoClose))
+            if ((PickerVariant == PickerVariant.Static && PickerActions == null) || (PickerActions != null && AutoClose))
             {
                 Submit();
             }
@@ -473,7 +488,7 @@ namespace MudBlazor
             }
             _timeSet.Hour = h;
 
-            if(_currentView == OpenTo.Hours)
+            if (_currentView == OpenTo.Hours)
             {
                 UpdateTime();
             }

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -161,7 +161,7 @@ namespace MudBlazor
                     {
                         return (T)(object)TimeSpan.ParseExact(value, Format ?? DefaultTimeSpanFormat, Culture);
                     }
-                    catch (FormatException)
+                    catch (Exception e) when (e is FormatException or OverflowException)
                     {
                         UpdateGetError("Not a valid time span");
                     }


### PR DESCRIPTION
## Description
The TimePicker did not use the DefaultConverter for the conversion of TimeSpan values and therefore had the bug that it did not invoke its OnConversionError action when errors occured during conversion.
Now, when having a conversion error, the Action will be invoked and the component will show the conversion error message:
"Not a valid time span" instead of the  exception message of a DateTime.Parse FormatException.

This change set fixes the conversion error handling in the TimePicker.
It also contains a small bug fix for the DefaultConverter, which did not handle the OverflowException when converting TimeSpan values into Strings.

## How Has This Been Tested?
- Extended unit tests for TimePicker and Converter
- Visually tested behavior in Docs.Server project (manually edited TimePickerBasicUsageExample to include binding for the editable TimePicker to be able to do this, reverted those changes after test)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
