### PR TITLE
MudNavLink: Fix line-height issue causing UI shift (#5848)

### DIFF
--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -228,6 +228,14 @@
     }
 }
 
+.mud-drawer-mini {
+    .mud-nav-link {
+        line-height: 1;
+        display: flex;
+        align-items: center;
+    }
+}
+
 .mud-drawer--closed.mud-drawer-mini {
     & > .mud-drawer-content > .mud-navmenu {
         & .mud-nav-link .mud-icon-root:first-child + .mud-nav-link-text {
@@ -270,4 +278,5 @@
             }
         }
     }
+
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/MudBlazor/MudBlazor/issues/5848
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This PR addresses the issue of UI shift caused by changes in the 'line-height' property of the '.mud-nav-link' class which is set to 1.75 when a 'MudNavLink' is in a mini 'MudDrawer' and the drawer is opened. When the drawer is closed, the display of MudNavLink is set to none so the styling doesn't affect the drawer. When the drawer is expanded, the 'line-height' property kicks in and causes the elements to shift, so the problem is only present when the mini drawer is open. MudNavLink inherits this same property from a and button classes as well, so the issue also affects MudNavLinks that are inside a MudNavGroup.

To fix this, I've overridden the 'line-height' property of .mud-nav-link within a .mud-drawer-mini to be 1, and adjusted the display and alignment properties to keep the MudNavLink in line with its corresponding icon in _navmenu.scss file:

.mud-drawer-mini {
    .mud-nav-link {
        line-height: 1;
        display: flex;
        align-items: center;
    }
}

I made sure to avoid touching the original '.mud-nav-link' class to prevent any unintended side effects in other places where it is used.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I have visually tested the changes in the browser and confirmed that the UI shift no longer occurs when the drawer is opened or closed.

The issue before commit: 
![error](https://github.com/MudBlazor/MudBlazor/assets/112777102/35f53604-8129-4fcb-9088-cf319c4b575f)

Solved issue:
![solution](https://github.com/MudBlazor/MudBlazor/assets/112777102/580df631-2630-4481-ab59-44ab59448fb6)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
