### PR TITLE
Build: Fix warnings

### DIFF
--- a/src/MudBlazor/Components/DataGrid/SortDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/SortDefinition.cs
@@ -8,5 +8,5 @@ using System.Collections.Generic;
 namespace MudBlazor
 {
 #nullable enable
-    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc, IComparer<object> Comparer = null);
+    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc, IComparer<object>? Comparer = null);
 }

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -16,15 +16,15 @@ namespace MudBlazor
     /// The container of a drag and drop zones
     /// </summary>
     /// <typeparam name="T">Type of items</typeparam>
-    public partial class MudDropContainer<T> : MudComponentBase
+    public partial class MudDropContainer<T> : MudComponentBase where T : notnull
     {
         private MudDragAndDropItemTransaction<T>? _transaction;
         private Dictionary<string, MudDropZone<T>> _mudDropZones = new();
 
         protected string Classname =>
-        new CssBuilder("mud-drop-container")
-            .AddClass(Class)
-            .Build();
+            new CssBuilder("mud-drop-container")
+                .AddClass(Class)
+                .Build();
 
         /// <summary>
         /// Child content of component. This should include the drop zones
@@ -138,8 +138,8 @@ namespace MudBlazor
             }
 
             var capturedTransaction = _transaction;
-            return capturedTransaction.Item;
 
+            return capturedTransaction.Item;
         }
 
         public bool TransactionInProgress() => _transaction is not null;
@@ -263,10 +263,12 @@ namespace MudBlazor
         {
             return _mudDropZones.TryAdd(dropZone.Identifier, dropZone);
         }
+
         internal void RemoveDropZone(string identifier)
         {
             _mudDropZones.Remove(identifier);
         }
+
         internal MudDropZone<T>? GetDropZone(string identifier)
         {
             return _mudDropZones.TryGetValue(identifier, out var dropZone) ? dropZone : null;

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -135,7 +135,7 @@ namespace MudBlazor
 
         private T[] GetItems()
         {
-            var predicate = ItemsSelector ?? (item => Container?.ItemsSelector != null && Container.ItemsSelector(item, Identifier));
+            var predicate = ItemsSelector ?? (item => Container?.ItemsSelector is not null && Container.ItemsSelector(item, Identifier));
 
             var items = Container?.Items.Where(predicate).OrderBy(GetItemIndex).ToArray() ?? Array.Empty<T>();
             return items;

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -13,7 +13,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-    public partial class MudDropZone<T> : MudComponentBase, IDisposable
+    public partial class MudDropZone<T> : MudComponentBase, IDisposable where T : notnull
     {
         private bool _containerIsInitialized = false;
         private bool _canDrop = false;
@@ -23,7 +23,8 @@ namespace MudBlazor
 
         private Dictionary<T, int> _indices = new();
 
-        [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
+        [Inject]
+        private IJSRuntime JsRuntime { get; set; } = null!;
 
         [CascadingParameter]
         protected MudDropContainer<T>? Container { get; set; }
@@ -127,17 +128,14 @@ namespace MudBlazor
 
         private int GetItemIndex(T item)
         {
-            if (!_indices.ContainsKey(item))
-            {
-                _indices.Add(item, _indices.Count);
-            }
+            _indices.TryAdd(item, _indices.Count);
 
             return _indices[item];
         }
 
         private T[] GetItems()
         {
-            var predicate = ItemsSelector ?? (item => Container is not null && Container.ItemsSelector is not null && Container.ItemsSelector(item, Identifier));
+            var predicate = ItemsSelector ?? (item => Container?.ItemsSelector != null && Container.ItemsSelector(item, Identifier));
 
             var items = Container?.Items.Where(predicate).OrderBy(GetItemIndex).ToArray() ?? Array.Empty<T>();
             return items;
@@ -214,7 +212,7 @@ namespace MudBlazor
                     result = CanDrop(item);
                 }
             }
-            else if (Container.CanDrop != null)
+            else if (Container.CanDrop is not null)
             {
                 if (item is not null)
                 {
@@ -242,7 +240,7 @@ namespace MudBlazor
 
             if (e.Success)
             {
-                if (e.OriginatedDropzoneIdentifier== Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
+                if (e.OriginatedDropzoneIdentifier == Identifier && e.DestinationDropzoneIdentifier != e.OriginatedDropzoneIdentifier)
                 {
                     if (e.Item is not null)
                     {
@@ -382,6 +380,7 @@ namespace MudBlazor
         }
 
         private void FinishedDragOperation() => _dragInProgress = false;
+
         private void DragOperationStarted() => _dragInProgress = true;
 
         #endregion

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -12,7 +12,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-public partial class MudDynamicDropItem<T> : MudComponentBase
+public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
 {
     private bool _dragOperationIsInProgress = false;
     private Guid _id = Guid.NewGuid();
@@ -21,7 +21,8 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
     private double _onTouchLastX;
     private double _onTouchLastY;
 
-    [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
+    [Inject]
+    private IJSRuntime JsRuntime { get; set; } = null!;
 
     [CascadingParameter]
     protected MudDropContainer<T>? Container { get; set; }
@@ -271,9 +272,9 @@ public partial class MudDynamicDropItem<T> : MudComponentBase
     #endregion
 
     protected string Classname =>
-    new CssBuilder("mud-drop-item")
-        .AddClass(DraggingClass, _dragOperationIsInProgress)
-        .AddClass(DisabledClass, Disabled)
-        .AddClass(Class)
-        .Build();
+        new CssBuilder("mud-drop-item")
+            .AddClass(DraggingClass, _dragOperationIsInProgress)
+            .AddClass(DisabledClass, Disabled)
+            .AddClass(Class)
+            .Build();
 }

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
         }
 
         [Obsolete("Use the bool parameter version. This will be removed in v7.")]
-        public static async void AndForget(this ValueTask task, TaskOption option) => AndForget(task);
+        public static void AndForget(this ValueTask task, TaskOption option) => AndForget(task);
 
         /// <summary>
         /// ValueTask will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
@@ -51,7 +51,7 @@ namespace MudBlazor
         }
 
         [Obsolete("Use the bool parameter version. This will be removed in v7.")]
-        public static async void AndForget<T>(this ValueTask<T> task, TaskOption option) => AndForget(task, option);
+        public static void AndForget<T>(this ValueTask<T> task, TaskOption option) => AndForget(task);
 
         /// <summary>
         /// ValueTask(bool) will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -2,7 +2,9 @@
 
 namespace MudBlazor
 {
+#pragma warning disable CS0618
     public class PaletteDark : Palette
+#pragma warning restore CS0618
     {
         public override MudColor Black { get; set; } = "#27272f";
         public override MudColor Primary { get; set; } = "#776be7";

--- a/src/MudBlazor/Themes/Models/PaletteLight.cs
+++ b/src/MudBlazor/Themes/Models/PaletteLight.cs
@@ -4,7 +4,9 @@
 
 namespace MudBlazor;
 
+#pragma warning disable CS0618
 public class PaletteLight : Palette
+#pragma warning restore CS0618
 {
     // everything is inherited from Palette so people will know about it.
 }

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -2,9 +2,10 @@
 {
     public class MudTheme
     {
-        //public Breakpoints Breakpoints { get; set; }
+#pragma warning disable CS0618
         public Palette Palette { get; set; }
         public Palette PaletteDark { get; set; }
+#pragma warning restore CS0618
         public Shadow Shadows { get; set; }
         public Typography Typography { get; set; }
         public LayoutProperties LayoutProperties { get; set; }


### PR DESCRIPTION
1. AndForget on 54 line was recursively calling itself (bug).
2. Suppressed `Palette` obsolete warnings in out codebase, we know it will be replaced so we should not generate additional junk warnings that doesn't provide valuable information.
3. Some nullable warnings.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
