### PR TITLE
PopoverService: Remove ConfigureAwait(false)

### DIFF
--- a/src/MudBlazor/Utilities/Background/Batch/BatchPeriodicQueue.cs
+++ b/src/MudBlazor/Utilities/Background/Batch/BatchPeriodicQueue.cs
@@ -56,15 +56,15 @@ internal class BatchPeriodicQueue<T> : BackgroundWorkerBase
         if (_tickOnDispose)
         {
             //If there is anything left over in the list we trigger so the handler could do something with this for example cleanup
-            await OnBatchTimerElapsedAsync().ConfigureAwait(false);
+            await OnBatchTimerElapsedAsync();
         }
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (await _periodicTimer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        while (await _periodicTimer.WaitForNextTickAsync(stoppingToken))
         {
-            await OnBatchTimerElapsedAsync(stoppingToken).ConfigureAwait(false);
+            await OnBatchTimerElapsedAsync(stoppingToken);
         }
     }
 

--- a/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
+++ b/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
@@ -124,7 +124,7 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
 
             try
             {
-                await notification(observer.Value.Observer).ConfigureAwait(false);
+                await notification(observer.Value.Observer);
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Description
Fixes https://github.com/MudBlazor/MudBlazor/issues/6980

My bad. I know it's not recommended to use `ConfigureAwait(false)` within a Blazor component because Blazor Server Side has a synchronization context. Therefore, I avoided calling `UpdatePopoverAsync` with `ConfigureAwait(false)` in the component. 


However, I was unaware of how JavaScript works in Blazor Server Side. It appears that in Blazor Server Side, the `IJSRuntime` (JSInterop invocations) utilizes **separate execution contexts** that are not associated with the synchronization context of the Blazor component. As a result, after the `InitializePopoverIfNeededAsync.ConfigureAwait(false)` call, the execution **does not resume on the original synchronization context**. This sequence of execution from `UpdatePopoverAsync` -> `InitializePopoverIfNeededAsync().ConfigureAwait(false)` -> `_popoverJsInterop.Initialize(...).ConfigureAwait(false)` caused a disruption of synchronization context and this line was throwing (because it requires to update the UI):
https://github.com/MudBlazor/MudBlazor/blob/54c6a11c10b4a1e8fb447f54b534f8a707f877e7/src/MudBlazor/Services/Popover/PopoverService.cs#L125
To err on the side of caution, I decided to remove `ConfigureAwait(false)` entirely. The optimization provided by `ConfigureAwait(false)` is not worth the potential problems, as it's easy to make mistake here, because behavior testing on Blazor Server Side is rarely done from our side(I did some testing before with the new popoverservice on BSS, but not extensive one, and sadly this only breaks under certain conditions like fetching data in OnInitializedAsync).

I apologize for the lengthy explanation, but I sincerely hope that it provides clarity on why the situation occurred.

## How Has This Been Tested?
Manually by hands via creating BSS app.
Sadly we can't make BSS bUnit tests to catch this.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
