### PR TITLE
DataGrid: Allow resizing when overflowing with sticky columns

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
@@ -1,0 +1,55 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="Model" Items="@_items" ShowMenuIcon="true" ColumnResizeMode="ResizeMode.Container" HorizontalScrollbar="true" Bordered="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Column1" StickyLeft="true" />
+        <PropertyColumn Property="x => x.Column2" />
+        <PropertyColumn Property="x => x.Column3" />
+        <PropertyColumn Property="x => x.Column4" />
+        <PropertyColumn Property="x => x.Column5" />
+        <PropertyColumn Property="x => x.Column6" />
+        <PropertyColumn Property="x => x.Column7" />
+        <PropertyColumn Property="x => x.Column8" />
+        <PropertyColumn Property="x => x.Column9" />
+        <PropertyColumn Property="x => x.Column10" />
+        <PropertyColumn Property="x => x.Column11" />
+        <PropertyColumn Property="x => x.Column12" />
+        <PropertyColumn Property="x => x.Column13" />
+        <PropertyColumn Property="x => x.Column14" />
+        <PropertyColumn Property="x => x.Column15" />
+        <PropertyColumn Property="x => x.Column16" />
+        <PropertyColumn Property="x => x.Column17" />
+        <PropertyColumn Property="x => x.Column18" />
+        <PropertyColumn Property="x => x.Column19" />
+        <PropertyColumn Property="x => x.Column20" />
+        <PropertyColumn Property="x => x.Column21" />
+        <PropertyColumn Property="x => x.Column22" />
+        <PropertyColumn Property="x => x.Column23" />
+        <PropertyColumn Property="x => x.Column24" StickyRight="true" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Model" PageSizeOptions=@(new int[] {5, 10, 20}) />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+        new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
+            "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 
+    };
+
+    public record Model(string Column1, string Column2, string Column3, string Column4, string Column5, string Column6, string Column7, 
+        string Column8, string Column9, string Column10, string Column11, string Column12, string Column13, string Column14, string Column15, 
+        string Column16, string Column17, string Column18, string Column19, string Column20, string Column21, string Column22, string Column23, string Column24);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3177,6 +3177,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridStickyColumnsResizerTest()
+        {
+            var comp = Context.RenderComponent<DataGridStickyColumnsResizerTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsResizerTest.Model>>();
+
+            var header = dataGrid.Find(".mud-table-toolbar");
+            header.GetAttribute("style").Should().Contain("position:sticky");
+            header.GetAttribute("style").Should().Contain("left:0px");
+
+            var footer = dataGrid.Find(".mud-table-pagination");
+            footer.GetAttribute("style").Should().Contain("position:sticky");
+            footer.GetAttribute("style").Should().Contain("left:0px");
+
+            var body = dataGrid.Find(".mud-table-container");
+            body.GetAttribute("style").Should().Contain("width:max-content");
+            body.GetAttribute("style").Should().Contain("overflow:clip");
+
+            dataGrid.Find("th").ClassList.Should().Contain("sticky-left");
+            dataGrid.FindAll("th").Last().ClassList.Should().Contain("sticky-right");
+        }
+
+        [Test]
         public async Task DataGridCellContextTest()
         {
             var comp = Context.RenderComponent<DataGridCellContextTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -16,7 +16,7 @@
         {
             @if (ToolBarContent != null)
             {
-                <MudToolBar Class="mud-table-toolbar">
+                <MudToolBar Class="mud-table-toolbar" Style="@_headerFooterStyle">
                     @ToolBarContent
                     @if (ShowMenuIcon)
                     {
@@ -29,7 +29,7 @@
                 @if (ShowMenuIcon)
                 {
                     @*Add the default toolbar.*@
-                    <MudToolBar Class="mud-table-toolbar">
+                    <MudToolBar Class="mud-table-toolbar" Style="@_headerFooterStyle">
                         <MudSpacer />
                         @ToolbarMenu(this)
                     </MudToolBar>
@@ -245,7 +245,7 @@
             </div>
             @if (PagerContent != null)
             {
-                <div class="mud-table-pagination">
+                <div class="mud-table-pagination" style="@_headerFooterStyle">
                     @PagerContent
                 </div>
             }
@@ -405,7 +405,7 @@
                     <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="Column" Dense="true" Margin="@Margin.Dense"
                                Class="filter-field">
                     @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false) ?? Enumerable.Empty<Column<T>>())
-                    {
+                        {
                             <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
                         }
                     </MudSelect>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -63,10 +63,10 @@ namespace MudBlazor
         protected string _tableStyle =>
             new StyleBuilder()
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
-                .AddStyle("width", "max-content", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && !hasStickyColumns)
+                .AddStyle("width", "max-content", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container))
+                .AddStyle("overflow", "clip", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && hasStickyColumns)
                 .AddStyle("display", "block", when: HorizontalScrollbar)
             .Build();
-
         protected string _tableClass =>
             new CssBuilder("mud-table-container")
                 .AddClass("cursor-col-resize", when: IsResizing)
@@ -77,6 +77,11 @@ namespace MudBlazor
 
         protected string _footClassname => new CssBuilder("mud-table-foot")
             .AddClass(FooterClass).Build();
+        protected string _headerFooterStyle =>
+            new StyleBuilder()
+                .AddStyle("position", "sticky", when: hasStickyColumns)
+                .AddStyle("left", "0px", when: hasStickyColumns)
+            .Build();
 
         internal SortDirection GetColumnSortDirection(string columnName)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Change the overflow behavior when there are sticky columns so resizing is still possible

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

### Fixes the conflict setting width to max-content had with sticky columns. 
By setting overflow:clip; we can set width to max-content when resizer is set to ResizeMode.Container even when there are sticky columns. That way, it is possible to resize columns even when the datagrid is overflowing while have sticky columns.

To prevent pager and toolbar from scrolling, we set them to style="position: sticky; left: 0px;" so they stay in place. This fixes #6794

https://github.com/MudBlazor/MudBlazor/assets/29356866/fffe5eb2-3433-4617-af4a-9c6ecf65053c

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Did a unit test with visual testing

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
