### PR TITLE
PopoverService: Move StateHasChanged from responsibility

### DIFF
--- a/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
@@ -15,9 +15,9 @@ internal class PopoverObserverMock : IPopoverObserver
 
     public List<Guid> PopoverNotifications { get; } = new();
 
-    public Task PopoverCollectionUpdatedNotification(IEnumerable<IMudPopoverHolder> holders)
+    public Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container)
     {
-        foreach (var holder in holders)
+        foreach (var holder in container.Holders)
         {
             PopoverNotifications.Add(holder.Id);
         }

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -218,7 +218,7 @@ public class PopoverServiceTests
         Assert.AreEqual(newRenderFragment, updatedState.Fragment);
 
         //Assert
-        Assert.AreEqual(1, observer.PopoverNotifications.Count); //only one notification from CreatePopoverAsync
+        Assert.AreEqual(2, observer.PopoverNotifications.Count);
         Assert.Contains(popover.Id, observer.PopoverNotifications);
     }
 
@@ -258,7 +258,7 @@ public class PopoverServiceTests
         Assert.IsEmpty(updatedState.Style);
         Assert.IsNull(updatedState.Tag);
         Assert.IsEmpty(updatedState.UserAttributes);
-        Assert.AreEqual(2, observer.PopoverNotifications.Count); //only one notification from CreatePopoverAsync
+        Assert.AreEqual(2, observer.PopoverNotifications.Count);
         Assert.Contains(popover.Id, observer.PopoverNotifications);
     }
 

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor.Examples.Data.Models;
 using MudBlazor.UnitTests.Services.Popover.Mocks;
 using NUnit.Framework;
 
@@ -150,6 +151,7 @@ public class PopoverServiceTests
 
         // Assert
         Assert.IsFalse(result);
+        Assert.IsEmpty(observer.PopoverNotifications);
     }
 
     [Test]
@@ -167,6 +169,7 @@ public class PopoverServiceTests
 
         // Assert
         Assert.IsFalse(result);
+        Assert.IsEmpty(observer.PopoverNotifications);
     }
 
     [Test]
@@ -218,6 +221,7 @@ public class PopoverServiceTests
         Assert.AreEqual(newRenderFragment, updatedState.Fragment);
 
         //Assert
+        //two notifications from CreatePopoverAsync and UpdatePopoverAsync
         Assert.AreEqual(2, observer.PopoverNotifications.Count);
         Assert.Contains(popover.Id, observer.PopoverNotifications);
     }
@@ -258,6 +262,7 @@ public class PopoverServiceTests
         Assert.IsEmpty(updatedState.Style);
         Assert.IsNull(updatedState.Tag);
         Assert.IsEmpty(updatedState.UserAttributes);
+        //two notifications from CreatePopoverAsync and DestroyPopover, UpdatePopoverAsync shouldn't fire notification since destroyed
         Assert.AreEqual(2, observer.PopoverNotifications.Count);
         Assert.Contains(popover.Id, observer.PopoverNotifications);
     }
@@ -279,8 +284,41 @@ public class PopoverServiceTests
         // Assert
         Assert.True(isDestroyed);
         Assert.IsEmpty(service.ActivePopovers);
-        Assert.AreEqual(2, observer.PopoverNotifications.Count); //two notifications from CreatePopoverAsync and DestroyPopover
+        //two notifications from CreatePopoverAsync and DestroyPopover
+        Assert.AreEqual(2, observer.PopoverNotifications.Count);
         Assert.Contains(popover.Id, observer.PopoverNotifications);
+    }
+
+    [Test]
+    public async Task CreatePopoverAsync_UpdatePopoverAsync_DestroyPopoverAsync_ShouldNotifyContainerWithCorrespondingOperation()
+    {
+        //Arrange
+        var containerNotificationList = new List<PopoverHolderContainer>();
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var popover = new PopoverMock();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var observerMock = new Mock<IPopoverObserver>();
+        service.Subscribe(observerMock.Object);
+
+        observerMock
+            .Setup(h => h.PopoverCollectionUpdatedNotificationAsync(
+                It.IsAny<PopoverHolderContainer>()))
+            .Returns(Task.CompletedTask)
+            .Callback<PopoverHolderContainer>(containerNotificationList.Add);
+
+        // Act
+        await service.CreatePopoverAsync(popover);
+        await service.UpdatePopoverAsync(popover);
+        await service.DestroyPopoverAsync(popover);
+
+        // Assert
+        var firstNotification = containerNotificationList.ElementAt(0);
+        var secondNotification = containerNotificationList.ElementAt(1);
+        var thirdNotification = containerNotificationList.ElementAt(2);
+        Assert.AreEqual(3, containerNotificationList.Count);
+        Assert.AreEqual(PopoverHolderOperation.Create, firstNotification.Operation);
+        Assert.AreEqual(PopoverHolderOperation.Update, secondNotification.Operation);
+        Assert.AreEqual(PopoverHolderOperation.Remove, thirdNotification.Operation);
     }
 
     [Test]

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -118,9 +118,29 @@ namespace MudBlazor
         Guid IPopoverObserver.Id { get; } = Guid.NewGuid();
 
         /// <inheritdoc />
-        Task IPopoverObserver.PopoverCollectionUpdatedNotification(IEnumerable<IMudPopoverHolder> holders)
+        async Task IPopoverObserver.PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container)
         {
-            return InvokeAsync(StateHasChanged);
+            switch (container.Operation)
+            {
+                //Update popover individually
+                case PopoverHolderOperation.Update:
+                    {
+                        foreach (var holder in container.Holders)
+                        {
+                            if (holder.ElementReference is not null)
+                            {
+                                await InvokeAsync(holder.ElementReference.StateHasChanged);
+                            }
+                        }
+
+                        break;
+                    }
+                //Update whole MudPopoverProvider
+                case PopoverHolderOperation.Create:
+                case PopoverHolderOperation.Remove:
+                    await InvokeAsync(StateHasChanged);
+                    break;
+            }
         }
     }
 }

--- a/src/MudBlazor/Services/Popover/IPopoverObserver.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverObserver.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MudBlazor;
@@ -21,12 +20,11 @@ public interface IPopoverObserver
 
     /// <summary>
     /// Notifies the observer of a popover collection update in <see cref="IPopoverService.ActivePopovers"/>.
-    /// This notification is triggered only when <see cref="IPopoverService.CreatePopoverAsync"/> or <see cref="IPopoverService.DestroyPopoverAsync"/> is called.
+    /// This notification is triggered only when <see cref="IPopoverService.CreatePopoverAsync"/>, <see cref="IPopoverService.UpdatePopoverAsync"/> or <see cref="IPopoverService.DestroyPopoverAsync"/> is called.
     /// </summary>
-    /// <param name="holders">Collection of the updated holder of the popover.</param>
-    /// <remarks>
-    /// Please note that this notification will not be triggered when <see cref="IPopoverService.UpdatePopoverAsync"/> is called, but this might change in future.
-    /// Currently, the <paramref name="holders"/> collection always contains one item. However, in the future, the behavior might change, and a list of updated states could be sent if the decision is made to update by batches.
+    /// <param name="container">The container holding the collection of updated popover holders and the corresponding operation.</param>
+    /// /// <remarks>
+    /// Please note that this notification will not be triggered if <see cref="IPopoverService.UpdatePopoverAsync"/>, <see cref="IPopoverService.DestroyPopoverAsync"/> return <c>false</c>.
     /// </remarks>
-    public Task PopoverCollectionUpdatedNotification(IEnumerable<IMudPopoverHolder> holders);
+    public Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container);
 }

--- a/src/MudBlazor/Services/Popover/PopoverHolderContainer.cs
+++ b/src/MudBlazor/Services/Popover/PopoverHolderContainer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace MudBlazor;
+
+#nullable enable
+/// <summary>
+/// Represents a container for <see cref="IMudPopoverHolder"/>, along with the associated <see cref="PopoverHolderOperation"/>.
+/// </summary>
+public class PopoverHolderContainer
+{
+    /// <summary>
+    /// Gets the operation associated with the container.
+    /// </summary>
+    public PopoverHolderOperation Operation { get; }
+
+    /// <summary>
+    /// Gets the collection of popover holders in the container.
+    /// </summary>
+    public IReadOnlyCollection<IMudPopoverHolder> Holders { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PopoverHolderContainer"/> class.
+    /// </summary>
+    /// <param name="operation">The operation associated with the container.</param>
+    /// <param name="holders">The collection of <see cref="IMudPopoverHolder"/>.</param>
+    public PopoverHolderContainer(PopoverHolderOperation operation, IReadOnlyCollection<IMudPopoverHolder> holders)
+    {
+        Holders = holders;
+        Operation = operation;
+    }
+}

--- a/src/MudBlazor/Services/Popover/PopoverHolderContainer.cs
+++ b/src/MudBlazor/Services/Popover/PopoverHolderContainer.cs
@@ -20,6 +20,10 @@ public class PopoverHolderContainer
     /// <summary>
     /// Gets the collection of popover holders in the container.
     /// </summary>
+    /// <remarks>
+    /// Currently, the collection always contains one item.
+    /// However, in the future, the behavior might change, and a list of updated states could be sent if the decision is made to update by batches.
+    /// </remarks>
     public IReadOnlyCollection<IMudPopoverHolder> Holders { get; }
 
     /// <summary>

--- a/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
+++ b/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+#nullable enable
+/// <summary>
+/// Represents the operation types for <see cref="IMudPopoverHolder"/>.
+/// </summary>
+public enum PopoverHolderOperation
+{
+    /// <summary>
+    /// Specifies the creation operation for a popover holder.
+    /// </summary>
+    Create = 0,
+
+    /// <summary>
+    /// Specifies the removal operation for a popover holder.
+    /// </summary>
+    Remove = 1,
+
+    /// <summary>
+    /// Specifies the update operation for a popover holder.
+    /// </summary>
+    Update = 2
+}

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -116,7 +116,6 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
                 .SetTag(popover.Tag)
                 .SetUserAttributes(popover.UserAttributes);
 
-            //This basically calls StateHasChanged on the popover.
             await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotificationAsync(new PopoverHolderContainer(PopoverHolderOperation.Update, new[] { holder })));
 
             return true;

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -79,7 +79,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             .SetUserAttributes(popover.UserAttributes);
 
         _holders.TryAdd(holder.Id, holder);
-        await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotification(new[] { holder }));
+        await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotificationAsync(new PopoverHolderContainer(PopoverHolderOperation.Create, new[] { holder })));
     }
 
     /// <inheritdoc />
@@ -106,7 +106,6 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 
         try
         {
-
             await _semaphore.WaitAsync();
 
             holder
@@ -118,11 +117,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
                 .SetUserAttributes(popover.UserAttributes);
 
             //This basically calls StateHasChanged on the popover.
-            //To be honest, there's no real need for us to update each popover individually through MudRendered as we currently do.
-            //Instead, we can consider invoking PopoverCollectionUpdatedNotification (or make new function).
-            //This function would trigger a StateHasChanged on the entire MudPopoverProvider, effectively updating all the underlying popovers at once.
-            //By performing these updates in batches, we can minimize the number of re-renders to a minimum.
-            holder.ElementReference?.StateHasChanged();
+            await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotificationAsync(new PopoverHolderContainer(PopoverHolderOperation.Update, new[] { holder })));
 
             return true;
         }
@@ -199,7 +194,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         // Perhaps we could consider adding a state indicating that the object is queued for detaching instead.
         holder.IsDetached = true;
 
-        await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotification(new[] { holder }));
+        await _observerManager.NotifyAsync(observer => observer.PopoverCollectionUpdatedNotificationAsync(new PopoverHolderContainer(PopoverHolderOperation.Remove, new[] { holder })));
 
         return true;
     }


### PR DESCRIPTION
## Description
Addresses the problem that was discussed here https://github.com/MudBlazor/MudBlazor/pull/6981#issuecomment-1581605624
This change moves the responsibility to trigger the `MudRenderer` from the service to the provider by introducing the `PopoverHolderContainer` with `PopoverHolderOperation`.

## How Has This Been Tested?
Updated existing tests and added new test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] Updated the test
