### PR TITLE
Fix: Generation of DocStrings fails when generic class with same name exists

### DIFF
--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -47,7 +47,10 @@ namespace MudBlazor.Docs.Compiler
                             || type == typeof(Utilities.CssBuilder) || type == typeof(TableContext) || GetSaveTypename(type).StartsWith("EventUtil_"))
                         continue;
 
-                    foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy))
+                    // Check if base class has same name as derived class and use only declared to prevent double generation of methods
+                    var declaredOnly = type.BaseType is not null && GetSaveTypename(type.BaseType) == GetSaveTypename(type);
+
+                    foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy | (declaredOnly ? BindingFlags.DeclaredOnly : BindingFlags.Default)))
                     {
                         if (!hiddenMethods.Any(x => x.Contains(method.Name)) && !method.Name.StartsWith("get_") && !method.Name.StartsWith("set_"))
                         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Check if generator would use identical type names and use `BindingFlags.DeclaredOnly` to prevent redefinition of Methods from the base class
fixes #7015 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
- [x] Compare DocStrings.generated.cs with and without the fix -> 0 changes
- [x] Create class with same name `DialogParameters<T>` and compare DocStrings.generated.cs with and without the fix 
-> only the breaking lines are removed
```diff
public const string DialogParameters_method_Void_Add_System_String__System_Object_ = @"";

public const string DialogParameters_method_T_TryGet_T__System_String_ = @"";

public const string DialogParameters_method_System_Collections_Generic_IEnumerator_1_System_Collections_Generic_KeyValuePair_2_System_String_System_Object___GetEnumerator__ = @"";

public const string DialogParameters_method_Void_Add_TParam__System_Linq_Expressions_Expression_1_System_Func_2_T_TParam____TParam_ = @"";

public const string DialogParameters_method_TParam_TryGet_TParam__System_Linq_Expressions_Expression_1_System_Func_2_T_TParam___ = @"";

- public const string DialogParameters_method_Void_Add_System_String__System_Object_ = @"";

- public const string DialogParameters_method_T_TryGet_T__System_String_ = @"";

- public const string DialogParameters_method_System_Collections_Generic_IEnumerator_1_System_Collections_Generic_KeyValuePair_2_System_String_System_Object___GetEnumerator__ = @"";

public const string DialogPositionMudEnumExtensions_method_System_String_ToDescriptionString_MudBlazor_DialogPosition_ = @"
    <summary>
    Returns the value of the <see cref=""T:System.ComponentModel.DescriptionAttribute"" /> attribute.
    If no description attribute was found the default ToString method will be used.
    </summary>
";
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
