### PR TITLE
Fix: Fix behavior When Tab Pressed at AutoComplete

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1262,5 +1262,39 @@ namespace MudBlazor.UnitTests.Components
             var mudText = comp.FindAll("p.mud-typography");
             mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
         }
+
+        /// <summary>
+        /// Test for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/7018"/>
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_UpdateText_WhenTabIsPressed()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            // select elements needed for the test
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // NOTE: We need to catch Tab in Keydown because a tab will move focus to the next element 
+            autocompletecomp.Find("input").Input("Calif");
+            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Alabama");
+
+            // reset
+            await comp.InvokeAsync(() => autocomplete.ResetAsync());
+
+            // now test with CoerceText = false
+            // Text should not be updated
+            autocomplete.CoerceText = false;
+            autocompletecomp.Find("input").Input("Calif");
+            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Calif");
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -617,7 +617,7 @@ namespace MudBlazor
                     if (SelectValueOnTab)
                         await OnEnterKey();
                     else
-                        IsOpen = false;
+                        await ToggleMenu();
                     break;
             }
             await base.InvokeKeyDownAsync(args);
@@ -666,15 +666,6 @@ namespace MudBlazor
                     break;
                 case "Escape":
                     await ChangeMenu(open: false);
-                    break;
-                case "Tab":
-                    await Task.Delay(1);
-                    if (!IsOpen)
-                        return;
-                    if (SelectValueOnTab)
-                        await OnEnterKey();
-                    else
-                        await ToggleMenu();
                     break;
                 case "Backspace":
                     if (args.CtrlKey == true && args.ShiftKey == true)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
The issue where the drop-down closes but the text does not update when pressing the Tab key has been fixed.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Upon pressing the Tab key, if TextCorce is true, it has been confirmed that the Value and Text match. If it is false, it has been confirmed that the Text does not update.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
