### PR TITLE
ColorPickerTests: Fix flaky test

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -953,7 +953,7 @@ namespace MudBlazor.UnitTests.Components
                 colorElement.ClassList.Should().Contain("mud-picker-color-dot");
 
                 colorElement.Click();
-                comp.Instance.ColorValue.Should().Be(expectedColor);
+                comp.WaitForAssertion(() => comp.Instance.ColorValue.Should().Be(expectedColor));
 
                 comp.Find(".mud-picker-color-grid").Children[i].ClassList.Should().BeEquivalentTo("mud-picker-color-dot", "selected");
             }


### PR DESCRIPTION
## Description
I noticed that a test has failed in the following run: https://github.com/MudBlazor/MudBlazor/actions/runs/5282305763/jobs/9557040930
This failure **is not related** to the pull request https://github.com/MudBlazor/MudBlazor/pull/6998, as I was able to reproduce it locally in debug mode even without this change.
It seems that the issue is similar to the one I encountered with the autocomplete. The color value change is triggered in a fire-and-forget manner.
The changes relies on the `WaitForAssertion` method to wait for a re-render.

## How Has This Been Tested?
Locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
