### PR TITLE
MudDialog: Add generic DialogParameters<T>

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
@@ -17,7 +17,7 @@
 
     async Task DeleteServer(Server server)
     {
-        var parameters = new DialogParameters { ["server"]=server };
+        var parameters = new DialogParameters<DialogPassingDataExample_Dialog> { { x => x.server, server } };
 
         var dialog = await DialogService.ShowAsync<DialogPassingDataExample_Dialog>("Delete Server", parameters);
         var result = await dialog.Result;

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample.razor
@@ -11,10 +11,10 @@
 
     private void DeleteUser()
     {
-        var parameters = new DialogParameters();
-        parameters.Add("ContentText", "Do you really want to delete these records? This process cannot be undone.");
-        parameters.Add("ButtonText", "Delete");
-        parameters.Add("Color", Color.Error);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
+        parameters.Add(x => x.ContentText, "Do you really want to delete these records? This process cannot be undone.");
+        parameters.Add(x => x.ButtonText, "Delete");
+        parameters.Add(x => x.Color, Color.Error);
 
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
 
@@ -23,20 +23,20 @@
 
     private void Confirm()
     {
-        var parameters = new DialogParameters();
-        parameters.Add("ContentText", "Are you sure you want to remove thisguy@emailz.com from this account?");
-        parameters.Add("ButtonText", "Yes");
-        parameters.Add("Color", Color.Success);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
+        parameters.Add(x => x.ContentText, "Are you sure you want to remove thisguy@emailz.com from this account?");
+        parameters.Add(x => x.ButtonText, "Yes");
+        parameters.Add(x => x.Color, Color.Success);
 
         DialogService.Show<DialogTemplateExample_Dialog>("Confirm", parameters);
     }
 
     private void Download()
     {
-        var parameters = new DialogParameters();
-        parameters.Add("ContentText", "Your computer seems very slow, click the download button to download free RAM.");
-        parameters.Add("ButtonText", "Download");
-        parameters.Add("Color", Color.Info);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
+        parameters.Add(x => x.ContentText, "Your computer seems very slow, click the download button to download free RAM.");
+        parameters.Add(x => x.ButtonText, "Download");
+        parameters.Add(x => x.Color, Color.Info);
 
         DialogService.Show<DialogTemplateExample_Dialog>("Slow Computer Detected", parameters);
     }

--- a/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components.Dialog;
+
+#nullable enable
+[TestFixture]
+public sealed class DialogParametersTests
+{
+    [Test]
+    public void DialogParametersGeneric_Add_ShouldAddParameter()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        Assert.IsEmpty(dialogParameters._parameters);
+
+        dialogParameters.Add(x => x.TestValue, "Test");
+        Assert.Contains(new KeyValuePair<string, object>("TestValue", "Test"), dialogParameters._parameters);
+    }
+
+    [Test]
+    public void DialogParametersGeneric_Add_ShouldThrow_IfNotMemberExpression()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        Assert.Throws<ArgumentException>(() => dialogParameters.Add(x => 1, 2));
+    }
+
+    [Test]
+    public void DialogParametersGeneric_Get_ShouldGetParameter()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        dialogParameters._parameters = new() { { "TestValue", "Test" } };
+
+        var parameter = dialogParameters.Get(x => x.TestValue);
+        Assert.AreEqual("Test", parameter);
+    }
+
+    [Test]
+    public void DialogParametersGeneric_Get_ShouldThrow_IfNotMemberExpression()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        Assert.Throws<ArgumentException>(() => dialogParameters.Get(x => 1));
+    }
+
+    [Test]
+    public void DialogParametersGeneric_TryGet_ShouldGetParameter()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        dialogParameters._parameters = new() { { "TestValue", "Test" } };
+
+        var parameter = dialogParameters.TryGet(x => x.TestValue);
+        Assert.AreEqual("Test", parameter!);
+    }
+
+    [Test]
+    public void DialogParametersGeneric_TryGet_ShouldGetDefault_IfParameterDoesNotExist()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+
+        var parameter = dialogParameters.TryGet(x => x.TestValue);
+        Assert.AreEqual(default(string), parameter);
+    }
+
+    [Test]
+    public void DialogParametersGeneric_TryGet_ShouldThrow_IfNotMemberExpression()
+    {
+        var dialogParameters = new DialogParameters<DialogWithParameters>();
+        Assert.Throws<ArgumentException>(() => dialogParameters.TryGet(x => 1));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -856,6 +856,28 @@ namespace MudBlazor.UnitTests.Components
             Func<IDialogReference> createMock = Moq.Mock.Of<IDialogReference>;
             createMock.Should().NotThrow();
         }
+
+        [Test]
+        public async Task AsyncDialogParametersGenericShouldPassParameters()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+
+            var parameters = new DialogParameters<DialogWithParameters>
+            {
+                { x => x.TestValue, "test" },
+                { x => x.Color_Test, Color.Error }
+            };
+
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogWithParameters>(string.Empty, parameters));
+            dialogReference.Should().NotBe(null);
+
+            var textField = comp.FindComponent<MudInput<string>>().Instance;
+            textField.Text.Should().Be("test");
+        }
     }
 
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) 2019 - Blazored
 // Copyright (c) 2023 - Adaptations by Simon Schulze
 
-#nullable enable
-
 using System;
 using System.Linq.Expressions;
 
 namespace MudBlazor;
 
+#nullable enable
 public class DialogParameters<T> : DialogParameters
 {
-	public DialogParameters() : base()
-	{
-	}
-
     public void Add<TParam>(Expression<Func<T, TParam>> propertyExpression, TParam value)
     {
         ArgumentNullException.ThrowIfNull(propertyExpression);
@@ -21,6 +16,7 @@ public class DialogParameters<T> : DialogParameters
         {
             throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
         }
+
         Add(memberExpression.Member.Name, value);
     }
 
@@ -31,6 +27,7 @@ public class DialogParameters<T> : DialogParameters
         {
             throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
         }
+
         return Get<TParam>(memberExpression.Member.Name);
     }
 
@@ -41,6 +38,7 @@ public class DialogParameters<T> : DialogParameters
         {
             throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
         }
+
         return TryGet<TParam>(memberExpression.Member.Name);
     }
 }

--- a/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2019 - Blazored
+// Copyright (c) 2023 - Adaptations by Simon Schulze
+
+#nullable enable
+
+using System;
+using System.Linq.Expressions;
+
+namespace MudBlazor;
+
+public class DialogParameters<T> : DialogParameters
+{
+	public DialogParameters() : base()
+	{
+	}
+
+    public void Add<TParam>(Expression<Func<T, TParam>> propertyExpression, TParam value)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+        if (propertyExpression.Body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
+        }
+        Add(memberExpression.Member.Name, value);
+    }
+
+    public TParam Get<TParam>(Expression<Func<T, TParam>> propertyExpression)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+        if (propertyExpression.Body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
+        }
+        return Get<TParam>(memberExpression.Member.Name);
+    }
+
+    public TParam? TryGet<TParam>(Expression<Func<T, TParam>> propertyExpression)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+        if (propertyExpression.Body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
+        }
+        return TryGet<TParam>(memberExpression.Member.Name);
+    }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Add generic variant of `DialogParameters` to make pasing parameters to Dialogs easier
closes #6987 

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Added new class `DialogParameters<T>` with generic Add and Get methods for the parameters.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added unit test to check if parameters are properly passed.
This also checks the correct type inference from the Expression and the constructio with initializer list.
No changes needed to be made to previous tests with `DialogParameters`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
