### PR TITLE
PopoverService: Fix DisposeAsync deadlock on WPF/WinForm platforms

### DIFF
--- a/src/MudBlazor/Utilities/Background/BackgroundWorkerBase.cs
+++ b/src/MudBlazor/Utilities/Background/BackgroundWorkerBase.cs
@@ -69,7 +69,7 @@ internal abstract class BackgroundWorkerBase : IAsyncDisposable
     public virtual async Task StopAsync(CancellationToken cancellationToken)
     {
         // Stop called without start
-        if (_executeTask == null)
+        if (_executeTask is null)
         {
             return;
         }
@@ -94,7 +94,7 @@ internal abstract class BackgroundWorkerBase : IAsyncDisposable
     public virtual ValueTask DisposeAsync()
     {
         _stoppingCts?.Cancel();
-        
+
         return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7041

Similar to the issue with `mudPopover.dispose` JavaScript call causing a UI thread block (https://github.com/MudBlazor/MudBlazor/pull/5367#issuecomment-1258649968), we have addressed the problem by not awaiting the JS call. 

In this case, I have made some changes to the approach. Initially, I believed that when we dispose the `PopoverService` during application exit and there are active popovers on the page, we needed to disconnect each popover with the `mudPopover.disconnect` method to ensure proper cleanup on the JS side. As a result, the dispose operation was immediately executing the batch: **DisposeAsync** -> **OnBatchTimerElapsedAsync** -> **DetachRange** -> **mudPopover.disconnect**(JS call), leading to a hang. 

However, upon examining the implementation of `mudPopover.dispose`, I discovered that it already handles the disconnect for each popover on the JS side. Therefore, I have decided to __exclude__ the disconnect operation on our side during dispose.

## How Has This Been Tested?
Two reproduction repositories, updated tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
