### PR TITLE
MudDataGrid: Add ability to completely use own IFilterDefinition

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor.UnitTests.Components;
+
+#nullable enable
+public class CustomFilterDefinitionMock<TType> : IFilterDefinition<TType>
+{
+    public Guid Id { get; set; }
+
+    public Column<TType>? Column { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? Operator { get; set; }
+
+    public object? Value { get; set; }
+
+    public Func<TType, bool>? FilterFunction { get; set; }
+
+    public Func<TType, bool> GenerateFilterFunction(FilterOptions? filterOptions = null)
+    {
+        return _ => true;
+    }
+
+    public IFilterDefinition<TType> Clone()
+    {
+        return new CustomFilterDefinitionMock<TType>()
+        {
+            Id = Id,
+            Column = Column,
+            Title = Title,
+            Operator = Operator,
+            Value = Value,
+            FilterFunction = FilterFunction,
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
@@ -19,8 +19,6 @@ public class CustomFilterDefinitionMock<TType> : IFilterDefinition<TType>
 
     public object? Value { get; set; }
 
-    public Func<TType, bool>? FilterFunction { get; set; }
-
     public Func<TType, bool> GenerateFilterFunction(FilterOptions? filterOptions = null)
     {
         return _ => true;
@@ -34,8 +32,7 @@ public class CustomFilterDefinitionMock<TType> : IFilterDefinition<TType>
             Column = Column,
             Title = Title,
             Operator = Operator,
-            Value = Value,
-            FilterFunction = FilterFunction,
+            Value = Value
         };
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2542,6 +2542,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task FilterDefinitionReplaceWithCustom()
+        {
+            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+            var filterDefinition = new CustomFilterDefinitionMock<DataGridFiltersTest.Model>()
+            {
+                FilterFunction = model => model.Age == 56
+            };
+            dataGrid.Instance.SetDefaultFilterDefinition(() => filterDefinition);
+
+            await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
+
+            // add a filter via the AddFilter method
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
+
+            // check the number of filters displayed in the filters panel
+            dataGrid.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(1);
+
+            var filterDefinitionInstance = dataGrid.Instance.FilterDefinitions.FirstOrDefault();
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            filterDefinitionInstance.Should().NotBeNull();
+            filterDefinitionInstance.Should().BeOfType<CustomFilterDefinitionMock<DataGridFiltersTest.Model>>();
+        }
+
+        [Test]
         public async Task DataGridFiltersTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2546,11 +2546,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
-            var filterDefinition = new CustomFilterDefinitionMock<DataGridFiltersTest.Model>()
-            {
-                FilterFunction = model => model.Age == 56
-            };
-            dataGrid.Instance.SetDefaultFilterDefinition(() => filterDefinition);
+            dataGrid.Instance.SetDefaultFilterDefinition<CustomFilterDefinitionMock<DataGridFiltersTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -272,15 +272,11 @@ namespace MudBlazor
                 if (filterContext.FilterDefinition == null)
                 {
                     var operators = FilterOperator.GetOperatorByDataType(PropertyType);
-                    filterContext.FilterDefinition = new FilterDefinition<T>()
-                    {
-                        DataGrid = DataGrid,
-                        //Field = PropertyName,
-                        //FieldType = PropertyType,
-                        Title = Title,
-                        Operator = operators.FirstOrDefault(),
-                        Column = this,
-                    };
+                    var filterDefinition = DataGrid.CreateFilterDefinitionInstance();
+                    filterDefinition.Title = Title;
+                    filterDefinition.Operator = operators.FirstOrDefault();
+                    filterDefinition.Column = this;
+                    filterContext.FilterDefinition = filterDefinition;
                 }
 
                 return filterContext;

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
     {
         private readonly MudDataGrid<T> _dataGrid;
 
-        internal FilterDefinition<T>? FilterDefinition { get; set; }
+        internal IFilterDefinition<T>? FilterDefinition { get; set; }
 
         internal HeaderCell<T>? HeaderCell { get; set; }
 
@@ -37,10 +37,10 @@ namespace MudBlazor
 
         public class FilterActions
         {
-            public Func<FilterDefinition<T>, Task> ApplyFilterAsync { get; init; } = null!;
-            public Func<IEnumerable<FilterDefinition<T>>, Task> ApplyFiltersAsync { get; init; } = null!;
-            public Func<FilterDefinition<T>, Task> ClearFilterAsync { get; init; } = null!;
-            public Func<IEnumerable<FilterDefinition<T>>, Task> ClearFiltersAsync { get; init; } = null!;
+            public Func<IFilterDefinition<T>, Task> ApplyFilterAsync { get; init; } = null!;
+            public Func<IEnumerable<IFilterDefinition<T>>, Task> ApplyFiltersAsync { get; init; } = null!;
+            public Func<IFilterDefinition<T>, Task> ClearFilterAsync { get; init; } = null!;
+            public Func<IEnumerable<IFilterDefinition<T>>, Task> ClearFiltersAsync { get; init; } = null!;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -185,7 +185,7 @@ namespace MudBlazor
             }
         }
 
-        internal async Task ApplyFilterAsync(FilterDefinition<T> filterDefinition)
+        internal async Task ApplyFilterAsync(IFilterDefinition<T> filterDefinition)
         {
             if (!DataGrid.FilterDefinitions.Any(x => x.Id == filterDefinition.Id))
                 DataGrid.FilterDefinitions.Add(filterDefinition);
@@ -214,7 +214,7 @@ namespace MudBlazor
             }
         }
 
-        internal async Task ClearFilterAsync(FilterDefinition<T> filterDefinition)
+        internal async Task ClearFilterAsync(IFilterDefinition<T> filterDefinition)
         {
             await DataGrid.RemoveFilterAsync(filterDefinition.Id);
         }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -367,7 +367,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal async Task ApplyFilterAsync(FilterDefinition<T> filterDefinition)
+        internal async Task ApplyFilterAsync(IFilterDefinition<T> filterDefinition)
         {
             DataGrid.FilterDefinitions.Add(filterDefinition);
             if (DataGrid.ServerData is not null) await DataGrid.ReloadServerData();
@@ -376,7 +376,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal async Task ApplyFiltersAsync(IEnumerable<FilterDefinition<T>> filterDefinitions)
+        internal async Task ApplyFiltersAsync(IEnumerable<IFilterDefinition<T>> filterDefinitions)
         {
             DataGrid.FilterDefinitions.AddRange(filterDefinitions);
             if (DataGrid.ServerData is not null) await DataGrid.ReloadServerData();
@@ -394,7 +394,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal async Task ClearFilterAsync(FilterDefinition<T> filterDefinition)
+        internal async Task ClearFilterAsync(IFilterDefinition<T> filterDefinition)
         {
             await DataGrid.RemoveFilterAsync(filterDefinition.Id);
             if (DataGrid.ServerData is null) ((IMudStateHasChanged)DataGrid).StateHasChanged();
@@ -402,7 +402,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal async Task ClearFiltersAsync(IEnumerable<FilterDefinition<T>> filterDefinitions)
+        internal async Task ClearFiltersAsync(IEnumerable<IFilterDefinition<T>> filterDefinitions)
         {
             DataGrid.FilterDefinitions.RemoveAll(x => filterDefinitions.Any(y => y.Id == x.Id));
             if (DataGrid.ServerData != null) await DataGrid.ReloadServerData();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
     [CascadingTypeParameter(nameof(T))]
     public partial class MudDataGrid<T> : MudComponentBase
     {
+        private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
         private int _currentPage = 0;
         internal int? _rowsPerPage;
         private bool _isFirstRendered = false;
@@ -906,16 +907,13 @@ namespace MudBlazor
             }
         }
 
-
-        private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
-
         internal IFilterDefinition<T> CreateFilterDefinitionInstance()
         {
             return _defaultFilterDefinitionFactory();
         }
 
         /// <summary>
-        /// Sets the default <see cref="IFilterDefinition{T}"/> that <see cref="AddFilter"/> and <see cref="Column{T}.FilterContext"/> are going to use.
+        /// Specifies the default <see cref="IFilterDefinition{T}"/> to be used by <see cref="AddFilter"/> and <see cref="Column{T}.FilterContext"/>.
         /// </summary>
         public void SetDefaultFilterDefinition<TFilterDefinition>() where TFilterDefinition : IFilterDefinition<T>, new()
         {
@@ -923,7 +921,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Sets the default <see cref="IFilterDefinition{T}"/> that <see cref="AddFilter"/> and <see cref="Column{T}.FilterContext"/> are going to use.
+        /// Specifies the default <see cref="IFilterDefinition{T}"/> to be used by <see cref="AddFilter"/> and <see cref="Column{T}.FilterContext"/>.
         /// </summary>
         /// <param name="factory">The factory function to create the default filter definition.</param>
         public void SetDefaultFilterDefinition(Func<IFilterDefinition<T>> factory)


### PR DESCRIPTION
## Description
Resolves: https://github.com/MudBlazor/MudBlazor/issues/6787

Previously, we made this PR #6848, which introduced the `IFilterDefinition` interface to provide consumers with the flexibility to create their own filter definitions. For instance, a filter definition capable of generating compatible expressions with EF. However, the implementation was not fully completed since I had not yet figured out a way to replace the internal usage of `FilterDefinition` in the `AddFilter` method and `FilterContext` property without causing any breaking changes. After careful consideration, I realized that that most simple solution would be to use a factory function.

## How Has This Been Tested?
Visual and bUnit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
