### PR TITLE
SortDefinition: Fix build warning about missing nullable

### DIFF
--- a/src/MudBlazor/Components/DataGrid/SortDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/SortDefinition.cs
@@ -8,5 +8,5 @@ using System.Collections.Generic;
 namespace MudBlazor
 {
 #nullable enable
-    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc, IComparer<object> Comparer = null);
+    public sealed record SortDefinition<T>(string SortBy, bool Descending, int Index, Func<T, object> SortFunc, IComparer<object>? Comparer = null);
 }


### PR DESCRIPTION
## Description
This PR https://github.com/MudBlazor/MudBlazor/pull/6368 added IComparer<object>, but nullable was not added in SortDefinition which now results in a compiler warning.

## How Has This Been Tested?
No need.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
