### PR TITLE
ResizeListenerService & BreakpointService: Allow user defined breakpoints

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -208,8 +208,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
         {
-            var srv = Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService;
-
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true));
 
             await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -87,7 +88,9 @@ public class ServiceCollectionExtensionsTests
         // Act
         services.AddMudBlazorResizeListener();
         var serviceProvider = services.BuildServiceProvider();
+#pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
+#pragma warning restore CS0618
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
         var breakpointService = serviceProvider.GetService<IBreakpointService>();
@@ -110,6 +113,10 @@ public class ServiceCollectionExtensionsTests
         // Act
         services.AddMudBlazorResizeListener(options =>
         {
+            options.BreakpointDefinitions = new Dictionary<Breakpoint, int>
+            {
+                { Breakpoint.Lg, 500 }
+            };
             options.EnableLogging = true;
             options.NotifyOnBreakpointOnly = false;
             options.ReportRate = 100;
@@ -117,7 +124,9 @@ public class ServiceCollectionExtensionsTests
             expectedOptions = options;
         });
         var serviceProvider = services.BuildServiceProvider();
+#pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
+#pragma warning restore CS0618
         var resizeService = serviceProvider.GetService<IResizeService>();
         var options = serviceProvider.GetRequiredService<IOptions<ResizeOptions>>();
         var actualOptions = options.Value;
@@ -401,7 +410,9 @@ public class ServiceCollectionExtensionsTests
         var serviceProvider = services.BuildServiceProvider();
         var dialogService = serviceProvider.GetService<IDialogService>();
         var snackBarService = serviceProvider.GetService<ISnackbar>();
+#pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
+#pragma warning restore CS0618
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
         var breakpointService = serviceProvider.GetService<IBreakpointService>();
@@ -479,6 +490,10 @@ public class ServiceCollectionExtensionsTests
             options.SnackbarConfiguration.SnackbarVariant = Variant.Outlined;
 
             // ResizeOptions
+            options.ResizeOptions.BreakpointDefinitions = new Dictionary<Breakpoint, int>
+            {
+                { Breakpoint.Lg, 500 }
+            };
             options.ResizeOptions.EnableLogging = true;
             options.ResizeOptions.NotifyOnBreakpointOnly = false;
             options.ResizeOptions.ReportRate = 100;
@@ -499,7 +514,9 @@ public class ServiceCollectionExtensionsTests
         var serviceProvider = services.BuildServiceProvider();
         var dialogService = serviceProvider.GetService<IDialogService>();
         var snackBarService = serviceProvider.GetService<ISnackbar>();
+#pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
+#pragma warning restore CS0618
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
         var breakpointService = serviceProvider.GetService<IBreakpointService>();
@@ -564,8 +581,7 @@ public class ServiceCollectionExtensionsTests
         Assert.AreEqual(expectedOptions.ResizeObserverOptions.EnableLogging, actualResizeObserverOptions.EnableLogging);
         Assert.AreEqual(expectedOptions.ResizeObserverOptions.ReportRate, actualResizeObserverOptions.ReportRate);
 
-        //BreakpointDefinitions -- doesn't work as the ResizeListenerService modifying the collection and doesn't care about the set values, this sounds like an unintentional mistake
-        //Assert.AreEqual(expectedOptions.ResizeOptions.BreakpointDefinitions, actualResizeOptions.BreakpointDefinitions);
+        Assert.AreEqual(expectedOptions.ResizeOptions.BreakpointDefinitions, actualResizeOptions.BreakpointDefinitions);
         Assert.AreEqual(expectedOptions.ResizeOptions.EnableLogging, actualResizeOptions.EnableLogging);
         Assert.AreEqual(expectedOptions.ResizeOptions.NotifyOnBreakpointOnly, actualResizeOptions.NotifyOnBreakpointOnly);
         Assert.AreEqual(expectedOptions.ResizeOptions.ReportRate, actualResizeOptions.ReportRate);

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -23,7 +23,9 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
+#pragma warning disable CS0618
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+#pragma warning restore CS0618
             ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
             ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -23,7 +23,9 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
+#pragma warning disable CS0618
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+#pragma warning restore CS0618
             ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
             ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();

--- a/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
@@ -94,13 +94,13 @@ namespace MudBlazor.UnitTests.Mocks
 
         private Breakpoint GetBreakpointInternal()
         {
-            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+            if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Md])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Md])
                 return Breakpoint.Md;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Sm])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Sm])
                 return Breakpoint.Sm;
             else
                 return Breakpoint.Xs;

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
@@ -5,6 +5,7 @@ using MudBlazor.Services;
 namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
+    [Obsolete("Suppressed by BreakpointService")]
     public class MockResizeListenerService : IResizeListenerService
     {
         private int _width, _height;
@@ -82,15 +83,15 @@ namespace MudBlazor.UnitTests.Mocks
 
         private Breakpoint GetBreakpointInternal()
         {
-            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xxl])
+            if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Xxl])
                 return Breakpoint.Xxl;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Md])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Md])
                 return Breakpoint.Md;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Sm])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Sm])
                 return Breakpoint.Sm;
             else
                 return Breakpoint.Xs;

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
@@ -5,7 +5,7 @@ using MudBlazor.Services;
 namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
-    [Obsolete("Suppressed by BreakpointService")]
+    [Obsolete("Replaced by BreakpointService. Remove in v7.")]
     public class MockResizeListenerService : IResizeListenerService
     {
         private int _width, _height;

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
@@ -88,13 +88,13 @@ namespace MudBlazor.UnitTests.Mocks
 
         private Breakpoint GetBreakpointInternal()
         {
-            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+            if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Md])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Md])
                 return Breakpoint.Md;
-            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Sm])
+            else if (_width >= BreakpointGlobalOptions.DefaultBreakpointDefinitions[Breakpoint.Sm])
                 return Breakpoint.Sm;
             else
                 return Breakpoint.Xs;

--- a/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -21,7 +20,7 @@ namespace MudBlazor.UnitTests.Services
     public class BreakpointServiceTests
     {
         private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;
-        private Mock<IJSRuntime> _jsruntimeMock;
+        private Mock<IJSRuntime> _jsRuntimeMock;
         private BreakpointService _service;
 
         [SetUp]
@@ -29,37 +28,41 @@ namespace MudBlazor.UnitTests.Services
         {
             _browserWindowSizeProvider = new Mock<IBrowserWindowSizeProvider>();
             _browserWindowSizeProvider.Setup(x => x.GetBrowserWindowSize()).ReturnsAsync(new BrowserWindowSize { Width = 970, Height = 30 }).Verifiable();
-            _jsruntimeMock = new Mock<IJSRuntime>();
-            _service = new BreakpointService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object);
+            _jsRuntimeMock = new Mock<IJSRuntime>();
+            _service = new BreakpointService(_jsRuntimeMock.Object, _browserWindowSizeProvider.Object);
         }
 
 
-        private record ListenForResizeCallbackInfo(
-            DotNetObjectReference<BreakpointService> DotnetRef, ResizeOptions options, Guid ListenerId);
-
+        private record ListenForResizeCallbackInfo(DotNetObjectReference<BreakpointService> DotnetRef, ResizeOptions Options, Guid ListenerId);
 
         private void SetupJsMockForSubscription(ResizeOptions expectedOptions, bool setBreakpoints, Action<ListenForResizeCallbackInfo> callbackInfo = null)
         {
-            if (setBreakpoints == true)
+            if (setBreakpoints)
             {
-                expectedOptions.BreakpointDefinitions = BreakpointService.DefaultBreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
+                expectedOptions.BreakpointDefinitions = BreakpointGlobalOptions.DefaultBreakpointDefinitions.ToDictionary(x => x.Key, x => x.Value);
             }
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize",
-               It.Is<object[]>(z =>
-                   z[0] is DotNetObjectReference<BreakpointService> == true &&
-                   (ResizeOptions)z[1] == expectedOptions &&
-                   (Guid)z[2] != default
-               ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
-                    (DotNetObjectReference<BreakpointService>)z[0],
-                    (ResizeOptions)z[1], (Guid)z[2]
-                   ))).Verifiable();
-
+            _jsRuntimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize",
+                    It.Is<object[]>(args =>
+                        args[0] is DotNetObjectReference<BreakpointService> == true &&
+                        (ResizeOptions)args[1] == expectedOptions &&
+                        (Guid)args[2] != default
+                    )))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>)
+                .Callback<string, object[]>((_, args) =>
+                {
+                    var dotnetReference = (DotNetObjectReference<BreakpointService>)args[0];
+                    var resizeOptions = (ResizeOptions)args[1];
+                    var listenerId = (Guid)args[2];
+                    callbackInfo?.Invoke(new ListenForResizeCallbackInfo(dotnetReference, resizeOptions, listenerId));
+                })
+                .Verifiable();
         }
 
         private void SetupJsMockForUnsubscription(Guid listenerId)
         {
-            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener",
+            _jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener",
                It.Is<object[]>(z =>
                    (Guid)z[0] == listenerId
                ))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
@@ -75,7 +78,7 @@ namespace MudBlazor.UnitTests.Services
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
             subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
         }
 
         [Test]
@@ -94,17 +97,16 @@ namespace MudBlazor.UnitTests.Services
             option.BreakpointDefinitions.Should().NotBeNull();
 
             option.BreakpointDefinitions.Should().NotBeNull();
-            option.BreakpointDefinitions.Keys.Should().BeEquivalentTo(BreakpointService.DefaultBreakpointDefinitions.Keys.Select(x => x.ToString()).ToList());
-            option.BreakpointDefinitions.Values.Should().BeEquivalentTo(BreakpointService.DefaultBreakpointDefinitions.Values);
+            option.BreakpointDefinitions.Should().BeEquivalentTo(BreakpointGlobalOptions.DefaultBreakpointDefinitions);
         }
 
         [Test]
         public async Task Subscribe_WithDefaultOptions_DontSetBreakpoint()
         {
-            var breakpointDict = new Dictionary<string, int>
-                {
-                    { "something", 12 },
-                };
+            var breakpointDict = new Dictionary<Breakpoint, int>
+            {
+                { Breakpoint.Xl, 12 },
+            };
 
             var option = new ResizeOptions
             {
@@ -119,63 +121,63 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public async Task Subscribe_WithOptionsSetInConstructor()
         {
-            var customResizeOptioons = new ResizeOptions
+            var customResizeOptions = new ResizeOptions
             {
                 ReportRate = 120,
             };
 
             var optionGetter = new Mock<IOptions<ResizeOptions>>();
-            optionGetter.SetupGet(x => x.Value).Returns(customResizeOptioons);
+            optionGetter.SetupGet(x => x.Value).Returns(customResizeOptions);
 
-            _service = new BreakpointService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object, optionGetter.Object);
-            await CheckSubscriptionOptions(customResizeOptioons, true);
+            _service = new BreakpointService(_jsRuntimeMock.Object, _browserWindowSizeProvider.Object, optionGetter.Object);
+            await CheckSubscriptionOptions(customResizeOptions, true);
         }
 
         [Test]
         public async Task Subscribe_WithPerCallOption()
         {
-            var customResizeOptioons = new ResizeOptions
+            var customResizeOptions = new ResizeOptions
             {
                 ReportRate = 130,
             };
 
-            SetupJsMockForSubscription(customResizeOptioons, true);
+            SetupJsMockForSubscription(customResizeOptions, true);
 
-            var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
+            var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptions);
 
             subscriptionResult.Should().NotBeNull();
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
             subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
         }
 
         [Test]
         public async Task Subscribe_WithPerCallOptionSetAsNull()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
-            SetupJsMockForSubscription(customResizeOptioons, true);
+            SetupJsMockForSubscription(customResizeOptions, true);
             var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
             subscriptionResult.Should().NotBeNull();
             subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
             subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
         }
 
         [Test]
         public void Subscribe_Failed_NullCallback()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null, new ResizeOptions()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null!));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.SubscribeAsync(null!, new ResizeOptions()));
         }
 
         [Test]
-        public async Task SubscribeAndUnsubcribe_SingleSubscription()
+        public async Task SubscribeAndUnsubscribe_SingleSubscription()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
             Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
             {
@@ -188,7 +190,7 @@ namespace MudBlazor.UnitTests.Services
 
             };
 
-            SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+            SetupJsMockForSubscription(customResizeOptions, true, feedbackCaller);
             var subscriptionId = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
             var result = await _service.UnsubscribeAsync(subscriptionId.SubscriptionId);
@@ -196,14 +198,14 @@ namespace MudBlazor.UnitTests.Services
             result.Should().BeTrue();
 
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
 
         }
 
         [Test]
-        public async Task SubscribeAndUnsubcribe_DisposeOfDotNet()
+        public async Task SubscribeAndUnsubscribe_DisposeOfDotNet()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
             for (int i = 0; i < 4; i++)
             {
@@ -227,53 +229,53 @@ namespace MudBlazor.UnitTests.Services
 
                 };
 
-                SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+                SetupJsMockForSubscription(customResizeOptions, true, feedbackCaller);
                 var subscritionResult = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
                 var result = await _service.UnsubscribeAsync(subscritionResult.SubscriptionId);
 
                 result.Should().BeTrue();
 
-                _jsruntimeMock.Verify();
+                _jsRuntimeMock.Verify();
             }
         }
 
         [Test]
-        public async Task SubscribeAndUnsubcribe_MultipleSubscription()
+        public async Task SubscribeAndUnsubscribe_MultipleSubscription()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
             var feedbackCallerCount = 0;
 
-            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            void FeedbackCaller(ListenForResizeCallbackInfo callbackInfo)
             {
-                if (x.ListenerId == default)
+                if (callbackInfo.ListenerId == default)
                 {
                     throw new ArgumentException();
                 }
 
                 feedbackCallerCount++;
-            };
+            }
 
-            SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+            SetupJsMockForSubscription(customResizeOptions, true, FeedbackCaller);
 
-            HashSet<Guid> subscriptionIds = new HashSet<Guid>();
+            var subscriptionIds = new HashSet<Guid>();
 
             for (int i = 0; i < 10; i++)
             {
-                var subscritionResult = await _service.SubscribeAsync((Breakpoint size) => { });
-                subscriptionIds.Add(subscritionResult.SubscriptionId);
+                var subscriptionResult = await _service.SubscribeAsync((Breakpoint size) => { });
+                subscriptionIds.Add(subscriptionResult.SubscriptionId);
             }
 
             feedbackCallerCount.Should().Be(1);
             subscriptionIds.Should().HaveCount(10);
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
         }
 
         [Test]
-        public async Task SubscribeAndUnsubcribe_MultipleSubscription_WithMultipleOptions()
+        public async Task SubscribeAndUnsubscribe_MultipleSubscription_WithMultipleOptions()
         {
             List<ListenForResizeCallbackInfo> callerFeedbacks = new();
 
@@ -320,12 +322,12 @@ namespace MudBlazor.UnitTests.Services
             for (int i = 0; i < callerFeedbacks.Count; i++)
             {
                 var feedback = callerFeedbacks[i];
-                feedback.options.Should().Be(options[i]);
+                feedback.Options.Should().Be(options[i]);
             }
 
             callerFeedbacks.Select(x => x.ListenerId).ToHashSet().Should().HaveCount(4);
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
         }
 
@@ -338,11 +340,11 @@ namespace MudBlazor.UnitTests.Services
         }
 
         [Test]
-        public async Task Unsubscribe_Failed_SubscriptioonIdNotFound()
+        public async Task Unsubscribe_Failed_SubscriptionIdNotFound()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
-            SetupJsMockForSubscription(customResizeOptioons, true);
+            SetupJsMockForSubscription(customResizeOptions, true);
             var subscriptionId = await _service.SubscribeAsync((Breakpoint size) => { }, null);
 
             var result = await _service.UnsubscribeAsync(Guid.NewGuid());
@@ -405,7 +407,7 @@ namespace MudBlazor.UnitTests.Services
                  }
              };
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners",
+            _jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners",
              It.Is<object[]>(z =>
                  z[0] is IEnumerable<Guid> &&
                  idChecker((IEnumerable<Guid>)z[0]) == true
@@ -413,7 +415,7 @@ namespace MudBlazor.UnitTests.Services
 
             await _service.DisposeAsync();
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
         }
 
         private class FakeSubscriber
@@ -433,7 +435,7 @@ namespace MudBlazor.UnitTests.Services
         public async Task RaiseOnResized_MultipleSubscription_WithMultipleOptions()
         {
             Dictionary<ResizeOptions, Guid> listenerIds = new();
-            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) => listenerIds.Add(x.options, x.ListenerId); ;
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) => listenerIds.Add(x.Options, x.ListenerId);
 
             var options = new[]
             {
@@ -472,7 +474,7 @@ namespace MudBlazor.UnitTests.Services
                 item.Key.ActualSize.Should().Be(item.Value);
             }
 
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
         }
 
@@ -483,7 +485,7 @@ namespace MudBlazor.UnitTests.Services
 
             SetupJsMockForSubscription(customResizeOptions, true);
 
-            FakeSubscriber subscriber = new FakeSubscriber();
+            var subscriber = new FakeSubscriber();
             await subscriber.Subscribe(_service, customResizeOptions);
 
             _service.RaiseOnResized(new BrowserWindowSize { }, Breakpoint.Xl, Guid.NewGuid());
@@ -494,20 +496,20 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public async Task Subscribe_ChangeHappens_SecondSubscriptionGetNewValue()
         {
-            var customResizeOptioons = new ResizeOptions();
+            var customResizeOptions = new ResizeOptions();
 
-            SetupJsMockForSubscription(customResizeOptioons, true);
-            var firstSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
+            SetupJsMockForSubscription(customResizeOptions, true);
+            var firstSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptions);
 
             firstSubscribeResult.Breakpoint.Should().Be(Breakpoint.Md);
 
             _service.RaiseOnResized(new BrowserWindowSize { }, Breakpoint.Xl, Guid.NewGuid());
 
-            var secondSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptioons);
+            var secondSubscribeResult = await _service.SubscribeAsync((Breakpoint size) => { }, customResizeOptions);
             secondSubscribeResult.Breakpoint.Should().Be(Breakpoint.Xl);
 
             _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
-            _jsruntimeMock.Verify();
+            _jsRuntimeMock.Verify();
 
         }
 
@@ -518,7 +520,7 @@ namespace MudBlazor.UnitTests.Services
         {
             var input = "some input, not relevant for test";
 
-            _jsruntimeMock.Setup(x => x.InvokeAsync<bool>("mudResizeListener.matchMedia",
+            _jsRuntimeMock.Setup(x => x.InvokeAsync<bool>("mudResizeListener.matchMedia",
             It.Is<object[]>(z =>
                 z[0] is string &&
                 (string)z[0] == input
@@ -532,11 +534,11 @@ namespace MudBlazor.UnitTests.Services
         [Test]
         public void DefaultBreakpointDefinitions()
         {
-            BreakpointService.DefaultBreakpointDefinitions.Keys.Should().BeEquivalentTo(new[] {
-                Breakpoint.Xl, Breakpoint.Lg, Breakpoint.Md, Breakpoint.Sm, Breakpoint.Xs });
+            BreakpointGlobalOptions.DefaultBreakpointDefinitions.Keys.Should().BeEquivalentTo(new[] {
+                Breakpoint.Xxl, Breakpoint.Xl, Breakpoint.Lg, Breakpoint.Md, Breakpoint.Sm, Breakpoint.Xs });
 
-            BreakpointService.DefaultBreakpointDefinitions.Values.Should().BeEquivalentTo(new[] {
-                1920, 1280, 960, 600, 0 });
+            BreakpointGlobalOptions.DefaultBreakpointDefinitions.Values.Should().BeEquivalentTo(new[] {
+                2560, 1920, 1280, 960, 600, 0 });
         }
 
         // 0 - 599
@@ -618,7 +620,6 @@ namespace MudBlazor.UnitTests.Services
         {
             var actual = await _service.IsMediaSize(Breakpoint.None);
             actual.Should().BeFalse();
-
         }
 
         [Test]
@@ -626,7 +627,6 @@ namespace MudBlazor.UnitTests.Services
         {
             var actual = await _service.IsMediaSize(Breakpoint.Always);
             actual.Should().BeTrue();
-
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using MudBlazor.Services;
@@ -7,6 +8,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Services
 {
     [TestFixture]
+    [Obsolete]
     public class ResizeListenerServiceTests
     {
         private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;

--- a/src/MudBlazor.UnitTests/Services/ResizeOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeOptionsTests.cs
@@ -70,22 +70,22 @@ namespace MudBlazor.UnitTests.Services
         {
             var option1 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
-                    { "someKey2", 24 },
-                    { "someKey3", 36 },
+                    { Breakpoint.Xl, 12 },
+                    { Breakpoint.Lg, 24 },
+                    { Breakpoint.Md, 36 },
 
                 }
             };
 
             var option2 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
-                    { "someKey2", 24 },
-                    { "someKey3", 36 },
+                    { Breakpoint.Xl, 12 },
+                    { Breakpoint.Lg, 24 },
+                    { Breakpoint.Md, 36 },
                 }
             };
 
@@ -156,9 +156,9 @@ namespace MudBlazor.UnitTests.Services
 
             var option2 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
+                    { Breakpoint.Xl, 12 },
                 }
             };
 
@@ -171,18 +171,18 @@ namespace MudBlazor.UnitTests.Services
         {
             var option1 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
-                    { "someKey2", 24 },
+                    { Breakpoint.Xl, 12 },
+                    { Breakpoint.Lg, 24 },
                 }
             };
 
             var option2 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
+                    { Breakpoint.Xl, 12 },
                 }
             };
 
@@ -195,17 +195,17 @@ namespace MudBlazor.UnitTests.Services
         {
             var option1 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
+                    { Breakpoint.Xl, 12 },
                 }
             };
 
             var option2 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey1", 12 },
+                    { Breakpoint.Lg, 12 },
                 }
             };
 
@@ -218,17 +218,17 @@ namespace MudBlazor.UnitTests.Services
         {
             var option1 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 12 },
+                    { Breakpoint.Xl, 12 },
                 }
             };
 
             var option2 = new ResizeOptions
             {
-                BreakpointDefinitions = new Dictionary<string, int>
+                BreakpointDefinitions = new Dictionary<Breakpoint, int>
                 {
-                    { "someKey", 23 },
+                    { Breakpoint.Xl, 23 },
                 }
             };
 

--- a/src/MudBlazor/Extensions/ResizeOptionsExtensions.cs
+++ b/src/MudBlazor/Extensions/ResizeOptionsExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using MudBlazor.Services;
+
+namespace MudBlazor.Extensions;
+
+#nullable enable
+internal static class ResizeOptionsExtensions
+{
+    internal static ResizeOptions Clone(this ResizeOptions options)
+    {
+        return new ResizeOptions
+        {
+            BreakpointDefinitions = (options.BreakpointDefinitions ?? new Dictionary<Breakpoint, int>()).ToDictionary(entry => entry.Key, entry => entry.Value),
+            EnableLogging = options.EnableLogging,
+            NotifyOnBreakpointOnly = options.NotifyOnBreakpointOnly,
+            ReportRate = options.ReportRate,
+            SuppressInitEvent = options.SuppressInitEvent
+        };
+    }
+}

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -312,7 +312,6 @@ namespace MudBlazor.Services
             return services;
         }
 
-
         /// <summary>
         /// Adds ScrollSpy as a transient instance.
         /// </summary>

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -104,7 +104,9 @@ namespace MudBlazor.Services
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddMudBlazorResizeListener(this IServiceCollection services)
         {
+#pragma warning disable CS0618
             services.TryAddScoped<IResizeListenerService, ResizeListenerService>();
+#pragma warning restore CS0618
             services.TryAddScoped<IBrowserWindowSizeProvider, BrowserWindowSizeProvider>();
             services.TryAddScoped<IResizeService, ResizeService>();
             services.TryAddScoped<IBreakpointService, BreakpointService>();

--- a/src/MudBlazor/Services/ResizeListener/BreakpointGlobalOptions.cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointGlobalOptions.cs
@@ -10,7 +10,7 @@ namespace MudBlazor;
 
 #nullable enable
 /// <summary>
-/// Shares breakpoint definition between <see cref="BreakpointService"/> and <see cref="ResizeListenerService"/>.
+/// Shares breakpoint definitions between <see cref="BreakpointService"/> and <see cref="ResizeListenerService"/>.
 /// </summary>
 /// <remarks>
 /// This class is not really needed when <see cref="ResizeListenerService"/> will be removed, for now it's for consistency.

--- a/src/MudBlazor/Services/ResizeListener/BreakpointGlobalOptions.cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointGlobalOptions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using MudBlazor.Services;
+
+namespace MudBlazor;
+
+#nullable enable
+/// <summary>
+/// Shares breakpoint definition between <see cref="BreakpointService"/> and <see cref="ResizeListenerService"/>.
+/// </summary>
+/// <remarks>
+/// This class is not really needed when <see cref="ResizeListenerService"/> will be removed, for now it's for consistency.
+/// </remarks>
+internal class BreakpointGlobalOptions
+{
+    public static Dictionary<Breakpoint, int> DefaultBreakpointDefinitions { get; set; } = new()
+    {
+        [Breakpoint.Xxl] = 2560,
+        [Breakpoint.Xl] = 1920,
+        [Breakpoint.Lg] = 1280,
+        [Breakpoint.Md] = 960,
+        [Breakpoint.Sm] = 600,
+        [Breakpoint.Xs] = 0,
+    };
+
+    public static Dictionary<Breakpoint, int> GetDefaultOrUserDefinedBreakpointDefinition(ResizeOptions options)
+    {
+        if (options.BreakpointDefinitions is not null && options.BreakpointDefinitions.Count != 0)
+        {
+            //Copy as we don't want any unexpected modification
+            return options.BreakpointDefinitions.ToDictionary(entry => entry.Key, entry => entry.Value);
+        }
+
+        return DefaultBreakpointDefinitions.ToDictionary(entry => entry.Key, entry => entry.Value);
+    }
+}

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -143,7 +143,7 @@ namespace MudBlazor.Services
             //Always wrap in new instance of ResizeOptions and clone values no matter what
             //Because the options can come from the _options(IOptions<ResizeOptions>) - these are the options that user sets when adding BreakpointService in DI
             //Only user is allowed to modify these settings, service should not touch that reference and change it or we get nasty bugs
-            //If we don't always wrap then we would need to write tedious code like if null then wrap, then check the references of options and _options are same and make logic when can't we modify and when we can etc.
+            //If we don't always wrap then we would need to write tedious code like if null then wrap, then check the references of options and _options are same and make logic when we can't modify and when we can etc.
             options = new ResizeOptions
             {
                 BreakpointDefinitions = BreakpointGlobalOptions.GetDefaultOrUserDefinedBreakpointDefinition(options),

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -12,6 +10,7 @@ namespace MudBlazor.Services
     /// <summary>
     /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
     /// </summary>
+    [Obsolete($"Use {nameof(BreakpointService)} instead. This will be removed in v7.")]
     public class ResizeListenerService : IResizeListenerService, IDisposable
     {
         private readonly IJSRuntime _jsRuntime;
@@ -33,7 +32,6 @@ namespace MudBlazor.Services
         {
             _dotNetRef = DotNetObjectReference.Create(this);
             _options = options?.Value ?? new ResizeOptions();
-            _options.BreakpointDefinitions = BreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
             _jsRuntime = jsRuntime;
             _browserWindowSizeProvider = browserWindowSizeProvider;
         }
@@ -129,32 +127,23 @@ namespace MudBlazor.Services
             _onBreakpointChanged?.Invoke(this, breakpoint);
         }
 
-        public static Dictionary<Breakpoint, int> BreakpointDefinitions { get; set; } = new Dictionary<Breakpoint, int>()
-        {
-            [Breakpoint.Xxl] = 2560,
-            [Breakpoint.Xl] = 1920,
-            [Breakpoint.Lg] = 1280,
-            [Breakpoint.Md] = 960,
-            [Breakpoint.Sm] = 600,
-            [Breakpoint.Xs] = 0,
-        };
-
         public async Task<Breakpoint> GetBreakpoint()
         {
+            var defaultBreakpointDefinitions = BreakpointGlobalOptions.GetDefaultOrUserDefinedBreakpointDefinition(_options);
             // note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
             if (_onResized == null || _windowSize == null)
                 _windowSize = await _browserWindowSizeProvider.GetBrowserWindowSize();
             if (_windowSize == null)
                 return Breakpoint.Xs;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Xxl])
+            if (_windowSize.Width >= defaultBreakpointDefinitions[Breakpoint.Xxl])
                 return Breakpoint.Xxl;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Xl])
+            if (_windowSize.Width >= defaultBreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Lg])
+            if (_windowSize.Width >= defaultBreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Md])
+            if (_windowSize.Width >= defaultBreakpointDefinitions[Breakpoint.Md])
                 return Breakpoint.Md;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Sm])
+            if (_windowSize.Width >= defaultBreakpointDefinitions[Breakpoint.Sm])
                 return Breakpoint.Sm;
             return Breakpoint.Xs;
         }
@@ -216,7 +205,7 @@ namespace MudBlazor.Services
         }
     }
 
-
+    [Obsolete($"Use {nameof(IBreakpointService)} instead. This will be removed in v7.")]
     public interface IResizeListenerService : IDisposable
     {
         event EventHandler<BrowserWindowSize>? OnResized;

--- a/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace MudBlazor.Services
 {
@@ -31,7 +30,7 @@ namespace MudBlazor.Services
         /// <summary>
         /// Breakpoint definitions.
         /// </summary>
-        public Dictionary<string, int>? BreakpointDefinitions { get; set; } = new();
+        public Dictionary<Breakpoint, int>? BreakpointDefinitions { get; set; } = new();
 
         public static bool operator ==(ResizeOptions? l, ResizeOptions? r)
         {
@@ -47,8 +46,10 @@ namespace MudBlazor.Services
 
         public static bool operator !=(ResizeOptions l, ResizeOptions r) => !(l == r);
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => obj is ResizeOptions options && Equals(options);
 
+        /// <inheritdoc />
         public bool Equals(ResizeOptions? other)
         {
             if (other is null)
@@ -77,7 +78,27 @@ namespace MudBlazor.Services
             return true;
         }
 
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            // ReSharper disable NonReadonlyMemberInGetHashCode
+            hashCode.Add(ReportRate);
+            hashCode.Add(EnableLogging);
+            hashCode.Add(SuppressInitEvent);
+            hashCode.Add(NotifyOnBreakpointOnly);
+            hashCode.Add(ReportRate);
+            if (BreakpointDefinitions is not null)
+            {
+                foreach (var pair in BreakpointDefinitions)
+                {
+                    hashCode.Add(pair.Key);
+                    hashCode.Add(pair.Value);
+                }
+            }
+            // ReSharper restore NonReadonlyMemberInGetHashCode
 
-        public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+            return hashCode.ToHashCode();
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes this: https://github.com/MudBlazor/MudBlazor/pull/7065#issuecomment-1604603646

We made a slight breaking change in the public API of `ResizeOptions` by switching from `Dictionary<string, int>` to `Dictionary<Breakpoint, int>`. This change is an improvement over the previous broken behavior. In the previous implementation, setting values would have no effect on the `BreakpointService` and `ResizeListenerService` except when you use `IBreakpointService.SubscribeAsync(Action<Breakpoint> callback, ResizeOptions? options)` overload..

The code now handles this change by always cloning the `ResizeOptions` to ensure that we don't mutate the original options injected via dependency injection (`services.Configure(Action<ResizeOptions>...)`). Additionally, we need now a proper `GetHashCode` method for `ResizeOptions` to ensure the correctness of our tests. This is important because we use indexers where the key is a `ResizeOption`, and since we clone `ResizeOptions`, the key would not be found otherwise.

Lastly, the `ResizeListenerService` is marked as `[Obsolete]`. According to this PR https://github.com/MudBlazor/MudBlazor/pull/2658 the `ResizeListenerService` was suppressed by `BreakpointService`.

## How Has This Been Tested?
Existing tests, debugging.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
