### PR TITLE
Palette: suppress obsolete warning in our code base

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -212,7 +212,9 @@
 
     private void LoadPalette()
     {
+#pragma warning disable CS0618
         foreach (var value in typeof(Palette).GetProperties())
+#pragma warning restore CS0618
         {
             var newprop = new ApiDefaultTheme()
             {

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -303,7 +303,9 @@ namespace MudBlazor.UnitTests.Components
             Assert.AreEqual(new MudColor(Colors.Shades.White), DefaultTheme.PaletteDark.White);
 
             //Light theme
+#pragma warning disable CS0618
             Assert.IsInstanceOf(typeof(Palette), DefaultTheme.Palette);
+#pragma warning restore CS0618
             Assert.AreEqual(new MudColor("#594AE2"), DefaultTheme.Palette.Primary);
             Assert.AreEqual(new MudColor(Colors.Red.Default), DefaultTheme.Palette.Error);
             Assert.AreEqual(new MudColor(Colors.Shades.White), DefaultTheme.Palette.White);

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -615,7 +615,9 @@ namespace MudBlazor.UnitTests.Utilities
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Palette palette = new PaletteLight();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             palette.Should().NotBeNull();
         }

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -2,7 +2,9 @@
 
 namespace MudBlazor
 {
+#pragma warning disable CS0618
     public class PaletteDark : Palette
+#pragma warning restore CS0618
     {
         public override MudColor Black { get; set; } = "#27272f";
         public override MudColor Primary { get; set; } = "#776be7";

--- a/src/MudBlazor/Themes/Models/PaletteLight.cs
+++ b/src/MudBlazor/Themes/Models/PaletteLight.cs
@@ -4,7 +4,9 @@
 
 namespace MudBlazor;
 
+#pragma warning disable CS0618
 public class PaletteLight : Palette
+#pragma warning restore CS0618
 {
     // everything is inherited from Palette so people will know about it.
 }

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -2,9 +2,10 @@
 {
     public class MudTheme
     {
-        //public Breakpoints Breakpoints { get; set; }
+#pragma warning disable CS0618
         public Palette Palette { get; set; }
         public Palette PaletteDark { get; set; }
+#pragma warning restore CS0618
         public Shadow Shadows { get; set; }
         public Typography Typography { get; set; }
         public LayoutProperties LayoutProperties { get; set; }


### PR DESCRIPTION
## Description
We should suppress the Palette obsoletion, the changes are scheduled for v7 and as for now it just generates unnecessary noise during build.
