### PR TITLE
MudHighlighter: Add Markup parameter to render Text using HTML Markup

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterUntilNextBoundaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterUntilNextBoundaryExample.razor
@@ -9,6 +9,7 @@
                          HighlightedText="@highlightedText"
                          UntilNextBoundary="@untilNextBoundary"
                          CaseSensitive="@caseSensitive"
+                         Markup="@markup"
                          Class="@(untilNextBoundary ? "pa-1 mud-elevation-2 mud-theme-primary":"")" />
         </MudText>
     }
@@ -16,16 +17,17 @@
 </MudPaper>
 <MudSwitch @bind-Checked="@untilNextBoundary" Label="UntilNextBoundary" Color="Color.Primary" />
 <MudSwitch @bind-Checked="@caseSensitive" Label="CaseSensitive" Color="Color.Primary" />
-
+<MudSwitch @bind-Checked="@markup" Label="Markup" Color="Color.Primary" />
 
 @code{
-    string highlightedText = "Mud";
-    bool untilNextBoundary;
-    bool caseSensitive;
-    IEnumerable<string> paragraphs = new List<string>
+   string highlightedText = "mud";
+   bool untilNextBoundary;
+   bool caseSensitive;
+   bool markup;
+   IEnumerable<string> paragraphs = new List<string>
     {
-        "MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure.",
-        "MudLists are easily customizable and scrollable lists. Make them suit your needs with avatars, icons, or something like checkboxes.",
-        "Use mud-* classes to customize your MudBlazor components."
+        $"<i>MudBlazor</i> is an ambitious <span style='color:{Colors.Purple.Default}'>Material Design</span> component framework for Blazor with an <span style='color:{Colors.Green.Default}'>emphasis</span> on <em>ease of use and clear structure</em>.",
+        $"MudLists are easily <span style='color:{Colors.Orange.Default}'>customizable</span> and <span style='color:{Colors.Red.Default}'>scrollable</span> lists. Make them suit your needs with <i>avatars</i>, <i>icons</i>, or something like <i>checkboxes</i>.",
+        $"Use <b>mud</b>-* classes to <span style='color:{Colors.Blue.Default}'>customize your MudBlazor components</span>."
     };
 }

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/HighlighterPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/HighlighterPage.razor
@@ -29,25 +29,49 @@
                         <HighlighterWithTableExample/>
                     </SectionContent>
                 </DocsPageSection>
+         </SectionSubGroups>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Search, appearance">
+                <Description></Description>
+            </SectionHeader>
+            <SectionSubGroups>
+               <DocsPageSection>
+                  <SectionHeader Title="UntilNextBoundary">
+                     <Description>Set the <code class="docs-code docs-code-primary">UntilNextBoundary</code> property to true if you want to highlight the text until the next regex boundary occurs.</Description>
+                  </SectionHeader>
+               </DocsPageSection>
             </SectionSubGroups>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Style">
-                <Description>Style it with the Class or Style properties:</Description>
-            </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="HighlighterWithCustomStyleExample" ShowCode="false">
-                <HighlighterWithCustomStyleExample />
-            </SectionContent>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Case sensitivity">
-                <Description>Set the <code class="docs-code docs-code-primary">UntilNextBoundary</code> property to true if you want to highlight the text until the next regex boundary occurs, or the <code class="docs-code docs-code-primary">CaseSensitive</code> property to decide if you want to perform a case-sensitive highlight.</Description>
-            </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="HighlighterUntilNextBoundaryExample" ShowCode="false">
-                <HighlighterUntilNextBoundaryExample />
-            </SectionContent>
+            <SectionSubGroups>
+               <DocsPageSection>
+                  <SectionHeader Title="CaseSensitive">
+                     <Description>Set the <code class="docs-code docs-code-primary">CaseSensitive</code> property to true to perform a case-sensitive highlight.</Description>
+                  </SectionHeader>
+               </DocsPageSection>
+            </SectionSubGroups>
+            <SectionSubGroups>
+               <DocsPageSection>
+                  <SectionHeader Title="Markup">
+                     <Description>
+                        Set the <code class="docs-code docs-code-primary">Markup</code> property to true to render markup content as a <code class="docs-code docs-code-primary">RenderFragment</code>.
+                     </Description>
+                  </SectionHeader>
+                  <SectionContent DarkenBackground="true" Code="HighlighterUntilNextBoundaryExample" ShowCode="false">
+                     <HighlighterUntilNextBoundaryExample />
+                  </SectionContent>
+               </DocsPageSection>
+         </SectionSubGroups>
+         <SectionSubGroups>
+            <DocsPageSection>
+               <SectionHeader Title="Style">
+                  <Description>Style it with the <code class="docs-code docs-code-primary">Class</code> or <code class="docs-code docs-code-primary">Style</code> properties.</Description>
+               </SectionHeader>
+               <SectionContent DarkenBackground="true" Code="HighlighterWithCustomStyleExample" ShowCode="false">
+                   <HighlighterWithCustomStyleExample />
+               </SectionContent>
+            </DocsPageSection>
+         </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -238,5 +238,28 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(text, highlightedText, caseInSensitive);
             comp.MarkupMatches("<mark>This</mark> is <mark>this</mark>");
         }
+
+        /// <summary>
+        /// Check RenderFragment output using Markup property 
+        /// </summary>
+        [Test]
+        public void MudHighlighterMarkupRenderFragmentTest()
+        {
+            var searchFor = "mud";
+            var markupText = $"<i>MudBlazor</i>";
+            var rawOutput = "&lt;i&gt;<mark>Mud</mark>Blazor&lt;/i&gt;";
+            var formattedOutput = "<i><mark>Mud</mark>Blazor</i>";
+
+            var text = Parameter(nameof(MudHighlighter.Text), markupText);
+            var highlightedText = Parameter(nameof(MudHighlighter.HighlightedText), searchFor);
+
+            var textAsMarkupFalse = Parameter(nameof(MudHighlighter.Markup), false);
+            var comp = Context.RenderComponent<MudHighlighter>(text, highlightedText, textAsMarkupFalse);
+            comp.MarkupMatches(rawOutput);
+
+            var textAsMarkupTrue = Parameter(nameof(MudHighlighter.Markup), true);
+            comp = Context.RenderComponent<MudHighlighter>(text, highlightedText, textAsMarkupTrue);
+            comp.MarkupMatches(formattedOutput);
+        }
     }
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -1,22 +1,25 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-
 @using System.Text.RegularExpressions
 @using static MudBlazor.Components.Highlighter.Splitter
 
 @foreach (var fragment in _fragments.Span)
 {
-    if (!string.IsNullOrWhiteSpace(_regex)
-        && Regex.IsMatch(fragment,
-            _regex,
-            CaseSensitive
-                ? RegexOptions.None
-                : RegexOptions.IgnoreCase))
-    {
-        <mark class="@Class" style="@Style" @attributes="@UserAttributes"> @fragment </mark>
-    }
-    else
-    {
-        @fragment
-    }
+   if (!string.IsNullOrWhiteSpace(_regex)
+       && Regex.IsMatch(fragment,
+           _regex,
+           CaseSensitive
+               ? RegexOptions.None
+               : RegexOptions.IgnoreCase))
+   {
+      <mark class="@Class" style="@Style" @attributes="@UserAttributes"> @fragment </mark>
+   }
+   else if (Markup)
+   {
+      @ToRendeFragment(fragment)
+   }
+   else
+   {
+      @fragment
+   }
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -5,12 +5,7 @@
 
 @foreach (var fragment in _fragments.Span)
 {
-   if (!string.IsNullOrWhiteSpace(_regex)
-       && Regex.IsMatch(fragment,
-           _regex,
-           CaseSensitive
-               ? RegexOptions.None
-               : RegexOptions.IgnoreCase))
+    if (IsMatch(fragment))
    {
       <mark class="@Class" style="@Style" @attributes="@UserAttributes"> @fragment </mark>
    }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -16,7 +16,7 @@
    }
    else if (Markup)
    {
-      @ToRendeFragment(fragment)
+      @ToRenderFragment(fragment)
    }
    else
    {

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -67,5 +67,5 @@ public partial class MudHighlighter : MudComponentBase
         _fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
     }
 
-    static RenderFragment ToRendeFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
+    static RenderFragment ToRenderFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using static MudBlazor.Components.Highlighter.Splitter;
 
@@ -66,6 +67,10 @@ public partial class MudHighlighter : MudComponentBase
     {
         _fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
     }
+
+    bool IsMatch(string fragment) => !string.IsNullOrWhiteSpace(fragment) &&
+                                     !string.IsNullOrWhiteSpace(_regex) &&
+                                     Regex.IsMatch(fragment, _regex, CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
 
     static RenderFragment ToRenderFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -51,6 +51,13 @@ public partial class MudHighlighter : MudComponentBase
     [Category(CategoryTypes.Highlighter.Behavior)]
     public bool UntilNextBoundary { get; set; }
 
+    /// <summary>
+    /// If true, renders text as a <see cref="RenderFragment"/>.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Highlighter.Appearance)]
+    public bool Markup { get; set; }
+
     //TODO
     //Accept regex highlightings
     // [Parameter] public bool IsRegex { get; set; }
@@ -59,4 +66,6 @@ public partial class MudHighlighter : MudComponentBase
     {
         _fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
     }
+
+    static RenderFragment ToRendeFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Continuation of reverted PR #6989
Resolves #6988
Resolves #7091

Problem:

The text with highlighted fragments is always rendered as a text string.
We often have input-text (or PowerShell, XML) with HTML markup which is not rendered:

![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/c1de8da4-f9b1-419e-beaa-00770030ffb6)

Solution: 

Add parameter ```bool Markup``` to render the input-text using RenderFragment:

![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/82120488-6bd5-4ed2-ba8e-5ac29c05545f)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [X] I've added relevant tests.
- [X] I've updated the docs.
