### PR TITLE
DataGrid: Add Editing Support For Bool and Bool? Types

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -20,6 +20,18 @@
             </EditTemplate>
         </PropertyColumn>
         <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
+        <PropertyColumn Property="x => x.IsMetal">
+            <CellTemplate>
+                @if (context.Item.IsMetal == true)
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.Done" />
+                }
+                else
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.Clear" />
+                }
+            </CellTemplate>
+        </PropertyColumn>
         <TemplateColumn Hidden="@(_isCellEditMode || _readOnly || _editTriggerRowClick)" CellClass="d-flex justify-end">
             <CellTemplate>
                 <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />

--- a/src/MudBlazor.Examples.Data/Models/Element.cs
+++ b/src/MudBlazor.Examples.Data/Models/Element.cs
@@ -14,6 +14,7 @@ namespace MudBlazor.Examples.Data.Models
         public string Sign { get; set; }
         public double Molar { get; set; }
         public IList<int> Electrons { get; set; }
+        public bool IsMetal { get; set; }
 
         /// <summary>
         /// Overriding Equals is essential for use with Select and Table because they use HashSets internally

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormEditTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFormEditTest.razor
@@ -6,6 +6,8 @@
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.IsMarried" />
+        <PropertyColumn Property="x => x.Gender" />
         <TemplateColumn>
             <CellTemplate>
                 snakex64
@@ -17,15 +19,17 @@
 @code {
     private IEnumerable<Model> _items = new List<Model>()
 {
-        new Model{ Name= "John", Age= 45 },
-        new Model{ Name= "Johanna", Age= 23 },
-        new Model{ Name= "Steve", Age= 32 }
+        new Model{ Name= "John", Age= 45, IsMarried = false, Gender = null },
+        new Model{ Name= "Johanna", Age= 23, IsMarried = true, Gender = true },
+        new Model{ Name= "Steve", Age= 32, IsMarried = true, Gender = false }
     };
 
     public class Model
     {
         public string Name { get; set; }
         public int Age { get; set; }
+        public bool IsMarried { get; set; }
+        public bool? Gender { get; set; }
         public string GetOnly => "snakex64";
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -446,13 +446,19 @@ namespace MudBlazor.UnitTests.Components
             //verify values before opening dialog
             dataGrid.FindAll("td")[0].Html().Trim().Should().Be("John");
             dataGrid.FindAll("td")[1].Html().Trim().Should().Be("45");
-            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("snakex64");
-            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("Johanna");
-            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("23");
-            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("snakex64");
-            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("Steve");
-            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("32");
-            dataGrid.FindAll("td")[8].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("");
+            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("23");
+            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("True");
+            dataGrid.FindAll("td")[8].Html().Trim().Should().Be("True");
+            dataGrid.FindAll("td")[9].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[10].Html().Trim().Should().Be("Steve");
+            dataGrid.FindAll("td")[11].Html().Trim().Should().Be("32");
+            dataGrid.FindAll("td")[12].Html().Trim().Should().Be("True");
+            dataGrid.FindAll("td")[13].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[14].Html().Trim().Should().Be("snakex64");
 
             //open edit dialog
             dataGrid.FindAll("tbody tr")[1].Click();
@@ -460,19 +466,27 @@ namespace MudBlazor.UnitTests.Components
             //edit data
             comp.FindAll("div input")[0].Change("Galadriel");
             comp.FindAll("div input")[1].Change(1);
+            comp.FindAll("div input")[2].Change(false);
+            comp.FindAll("div input")[3].Change(false);
 
             comp.Find(".mud-dialog-actions .mud-button-filled-primary").Click();
 
             //verify values after saving dialog
             dataGrid.FindAll("td")[0].Html().Trim().Should().Be("John");
             dataGrid.FindAll("td")[1].Html().Trim().Should().Be("45");
-            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("snakex64");
-            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("Galadriel");
-            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("1");
-            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("snakex64");
-            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("Steve");
-            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("32");
-            dataGrid.FindAll("td")[8].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("");
+            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("Galadriel");
+            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("1");
+            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[8].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[9].Html().Trim().Should().Be("snakex64");
+            dataGrid.FindAll("td")[10].Html().Trim().Should().Be("Steve");
+            dataGrid.FindAll("td")[11].Html().Trim().Should().Be("32");
+            dataGrid.FindAll("td")[12].Html().Trim().Should().Be("True");
+            dataGrid.FindAll("td")[13].Html().Trim().Should().Be("False");
+            dataGrid.FindAll("td")[14].Html().Trim().Should().Be("snakex64");
 
             //if no crash occurs, we know the datagrid is properly filtering out the GetOnly property when calling set
         }

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
         internal string? _valueString;
         internal double? _valueNumber;
         internal bool _valueBoolean;
-        internal bool? _valueNullBoolean;
+        internal bool? _valueNullableBoolean;
         internal bool _isEditing;
         internal CellContext<T> _cellContext;
 
@@ -113,7 +113,7 @@ namespace MudBlazor
             {
                 if (_column.dataType == typeof(bool?))
                 {
-                    _valueNullBoolean = null;
+                    _valueNullableBoolean = null;
                 }
                 return;
             }
@@ -149,7 +149,7 @@ namespace MudBlazor
                 }
                 else if (_column.dataType == typeof(bool?))
                 {
-                    _valueNullBoolean = (bool?)ComputedValue;
+                    _valueNullableBoolean = (bool?)ComputedValue;
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         internal string? _valueString;
         internal double? _valueNumber;
         internal bool _valueBoolean;
+        internal bool? _valueNullBoolean;
         internal bool _isEditing;
         internal CellContext<T> _cellContext;
 
@@ -97,10 +98,23 @@ namespace MudBlazor
                 await _dataGrid.CommitItemChangesAsync(_item);
         }
 
+        public async Task NullableBoolValueChangedAsync(bool? value)
+        {
+            _column.SetProperty(_item, value);
+
+            // If the edit mode is Cell, we update immediately.
+            if (_dataGrid.EditMode == DataGridEditMode.Cell)
+                await _dataGrid.CommitItemChangesAsync(_item);
+        }
+
         private void OnStartedEditingItem()
         {
             if (ComputedValue is null)
             {
+                if (_column.dataType == typeof(bool?))
+                {
+                    _valueNullBoolean = null;
+                }
                 return;
             }
 
@@ -132,6 +146,10 @@ namespace MudBlazor
                 else if (_column.dataType == typeof(bool))
                 {
                     _valueBoolean = (bool)ComputedValue;
+                }
+                else if (_column.dataType == typeof(bool?))
+                {
+                    _valueNullBoolean = (bool?)ComputedValue;
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         internal T _item;
         internal string? _valueString;
         internal double? _valueNumber;
+        internal bool _valueBoolean;
         internal bool _isEditing;
         internal CellContext<T> _cellContext;
 
@@ -87,6 +88,15 @@ namespace MudBlazor
                 await _dataGrid.CommitItemChangesAsync(_item);
         }
 
+        public async Task BoolValueChangedAsync(bool value)
+        {
+            _column.SetProperty(_item, value);
+
+            // If the edit mode is Cell, we update immediately.
+            if (_dataGrid.EditMode == DataGridEditMode.Cell)
+                await _dataGrid.CommitItemChangesAsync(_item);
+        }
+
         private void OnStartedEditingItem()
         {
             if (ComputedValue is null)
@@ -104,6 +114,10 @@ namespace MudBlazor
                 {
                     _valueNumber = element.GetDouble();
                 }
+                else if (_column.dataType == typeof(bool))
+                {
+                    _valueBoolean = element.GetBoolean();
+                }
             }
             else
             {
@@ -114,6 +128,10 @@ namespace MudBlazor
                 else if (_column.isNumber)
                 {
                     _valueNumber = Convert.ToDouble(ComputedValue);
+                }
+                else if (_column.dataType == typeof(bool))
+                {
+                    _valueBoolean = (bool)ComputedValue;
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -277,6 +277,11 @@
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
                                      Required="true" Variant="@Variant.Outlined" Disabled="@(!column.IsEditable || ReadOnly)" Class="mt-4" />
                             }
+                            else if (propertyType == typeof(bool))
+                            {
+                                <MudCheckBox T="bool" Label="@column.Title" Checked="@cell._valueBoolean" CheckedChanged="@cell.BoolValueChangedAsync"
+                                  Color="Color.Primary" Disabled="@(!column.IsEditable || ReadOnly)" />
+                            }
                         }
                     }
                 </MudForm>
@@ -355,6 +360,13 @@
                                              ValueChanged="@cell.NumberValueChangedAsync"
                                              Margin="@Margin.Dense" Style="margin-top:0"
                                              Required="true" Variant="@Variant.Text" Culture="@column.Culture" />
+                        }
+                        else if (column.PropertyType == typeof(bool))
+                        {
+                        <MudCheckBox T="bool"
+                                     Checked="@cell._valueBoolean"
+                                     CheckedChanged="@cell.BoolValueChangedAsync"
+                                     Color="Color.Primary" />
                         }
                     }
                 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -282,6 +282,11 @@
                                 <MudCheckBox T="bool" Label="@column.Title" Checked="@cell._valueBoolean" CheckedChanged="@cell.BoolValueChangedAsync"
                                   Color="Color.Primary" Disabled="@(!column.IsEditable || ReadOnly)" />
                             }
+                            else if (propertyType == typeof(bool?))
+                            {
+                                <MudCheckBox T="bool?" TriState="true" Label="@column.Title" Checked="@cell._valueNullBoolean" CheckedChanged="@cell.NullableBoolValueChangedAsync"
+                                             Color="Color.Primary" Disabled="@(!column.IsEditable || ReadOnly)" />
+                            }
                         }
                     }
                 </MudForm>
@@ -363,12 +368,20 @@
                         }
                         else if (column.PropertyType == typeof(bool))
                         {
-                        <MudCheckBox T="bool"
-                                     Checked="@cell._valueBoolean"
-                                     CheckedChanged="@cell.BoolValueChangedAsync"
-                                     Color="Color.Primary" />
+                            <MudCheckBox T="bool"
+                                         Checked="@cell._valueBoolean"
+                                         CheckedChanged="@cell.BoolValueChangedAsync"
+                                         Color="Color.Primary" />
                         }
-                    }
+                        else if (column.PropertyType == typeof(bool?))
+                        {
+                            <MudCheckBox T="bool?"
+                                         TriState="true"
+                                         Checked="@cell._valueNullBoolean"
+                                         CheckedChanged="@cell.NullableBoolValueChangedAsync"
+                                         Color="Color.Primary" />
+                        }
+                }
                 }
                 else
                 {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -284,7 +284,7 @@
                             }
                             else if (propertyType == typeof(bool?))
                             {
-                                <MudCheckBox T="bool?" TriState="true" Label="@column.Title" Checked="@cell._valueNullBoolean" CheckedChanged="@cell.NullableBoolValueChangedAsync"
+                                <MudCheckBox T="bool?" TriState="true" Label="@column.Title" Checked="@cell._valueNullableBoolean" CheckedChanged="@cell.NullableBoolValueChangedAsync"
                                              Color="Color.Primary" Disabled="@(!column.IsEditable || ReadOnly)" />
                             }
                         }
@@ -377,7 +377,7 @@
                         {
                             <MudCheckBox T="bool?"
                                          TriState="true"
-                                         Checked="@cell._valueNullBoolean"
+                                         Checked="@cell._valueNullableBoolean"
                                          CheckedChanged="@cell.NullableBoolValueChangedAsync"
                                          Color="Color.Primary" />
                         }

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -88,7 +88,7 @@ namespace MudBlazor
             if (Property.Body is MemberExpression { Member: PropertyInfo propertyInfo })
             {
                 var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
-                propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
+                propertyInfo.SetValue(item, value == null ? null : Convert.ChangeType(value, actualType), null);
             }
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
MudDataGrid doesn't have direct support for bool types in inline or dialog editing. This PR added the support.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->


https://github.com/MudBlazor/MudBlazor/assets/78308169/e1916f82-0419-4e70-880b-59598c9a8c31



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
