### PR TITLE
PopoverService: Clear all observers on DisposeAsync & nits

### DIFF
--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -192,7 +192,7 @@ public class PopoverServiceTests
         popover.PopoverClass = "popoverClass";
         popover.PopoverStyles = "popoverStyle";
         popover.Tag = "my-tag";
-        popover.UserAttributes = new Dictionary<string, object>
+        popover.UserAttributes = new Dictionary<string, object?>
         {
             { "key1", "value1" },
             { "key2", false }
@@ -246,7 +246,7 @@ public class PopoverServiceTests
         popover.PopoverClass = "popoverClass";
         popover.PopoverStyles = "popoverStyle";
         popover.Tag = "my-tag";
-        popover.UserAttributes = new Dictionary<string, object>
+        popover.UserAttributes = new Dictionary<string, object?>
         {
             { "key1", "value1" },
             { "key2", false }
@@ -509,5 +509,29 @@ public class PopoverServiceTests
         // Assert
         Assert.Zero(service.QueueCount);
         Assert.IsEmpty(service.ActivePopovers);
+    }
+
+    [Test]
+    public async Task DisposeAsync_ShouldClearAllObservers()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var popover = new PopoverMock();
+        service.Subscribe(new PopoverObserverMock());
+        service.Subscribe(new PopoverObserverMock());
+        service.Subscribe(new PopoverObserverMock());
+        service.Subscribe(new PopoverObserverMock());
+        service.Subscribe(new PopoverObserverMock());
+        var beforeObserversCount = service.ObserversCount;
+
+        // Act
+        await service.CreatePopoverAsync(popover);
+        await service.DisposeAsync();
+        var afterObserversCount = service.ObserversCount;
+
+        // Assert
+        Assert.AreEqual(5, beforeObserversCount);
+        Assert.Zero(afterObserversCount);
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -79,8 +79,8 @@ namespace MudBlazor
             }
 #pragma warning restore CS0618
 
-            //Let's in our new case ignore _isConnectedToService and always update the subscription except IsEnabled = false. The manager is specifically designed for it.
-            //The reason is because If an observer throws an exception during the PopoverCollectionUpdatedNotification, indicating a malfunction, it will be automatically unsubscribed.
+            // Let's in our new case ignore _isConnectedToService and always update the subscription except IsEnabled = false. The manager is specifically designed for it.
+            // The reason is because If an observer throws an exception during the PopoverCollectionUpdatedNotification, indicating a malfunction, it will be automatically unsubscribed.
             if (IsEnabled)
             {
                 PopoverService.Subscribe(this);
@@ -122,7 +122,7 @@ namespace MudBlazor
         {
             switch (container.Operation)
             {
-                //Update popover individually
+                // Update popover individually
                 case PopoverHolderOperation.Update:
                     {
                         foreach (var holder in container.Holders)
@@ -135,7 +135,7 @@ namespace MudBlazor
 
                         break;
                     }
-                //Update whole MudPopoverProvider
+                // Update whole MudPopoverProvider
                 case PopoverHolderOperation.Create:
                 case PopoverHolderOperation.Remove:
                     await InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Services/Popover/IPopoverObserver.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverObserver.cs
@@ -16,15 +16,16 @@ public interface IPopoverObserver
     /// <summary>
     /// Gets the unique identifier of the observer.
     /// </summary>
-    public Guid Id { get; }
+    Guid Id { get; }
 
     /// <summary>
     /// Notifies the observer of a popover collection update in <see cref="IPopoverService.ActivePopovers"/>.
     /// This notification is triggered only when <see cref="IPopoverService.CreatePopoverAsync"/>, <see cref="IPopoverService.UpdatePopoverAsync"/> or <see cref="IPopoverService.DestroyPopoverAsync"/> is called.
     /// </summary>
     /// <param name="container">The container holding the collection of updated popover holders and the corresponding operation.</param>
+    /// <returns>A task representing the asynchronous notification operation.</returns>
     /// /// <remarks>
     /// Please note that this notification will not be triggered if <see cref="IPopoverService.UpdatePopoverAsync"/>, <see cref="IPopoverService.DestroyPopoverAsync"/> return <c>false</c>.
     /// </remarks>
-    public Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container);
+    Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container);
 }


### PR DESCRIPTION
## Description
I realized  that if someone has a custom implementation utilizing the `IPopoverService` and forgets to unsubscribe the observer, it is important to perform cleanup in such cases.

## How Has This Been Tested?
New unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
