### PR TITLE
ResizeService & BreakpointService: Obsolete

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
@@ -25,7 +25,7 @@
         <DocsPageSection>
             <SectionHeader Title="Listening to browser window breakpoint changes">
                 <Description>
-                    <MudText>The <strong> IBreakpointListenerService</strong> is the service that powers the MudBreakpoint Provider. It can be used in own components </MudText>
+                    <MudText>The <strong> IBrowserViewportService</strong> is the service that powers the MudBreakpoint Provider. It can be used in own components </MudText>
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="BreakpointListenerExample">

--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
@@ -6,7 +6,7 @@
 <MudAlert Severity="Severity.Warning">
     MudBlazor 5.2 introduced new implementations for handling browser resize events.
     The <strong>IResizeListenerService</strong> can still be used but we strongly encourage you to move to the
-    <strong>IResizeService </strong>
+    <strong>IBrowserViewportService </strong>
 </MudAlert>
 
 <MudCard Class="pa-5">

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -83,19 +83,22 @@ public class ServiceCollectionExtensionsTests
     {
         // Arrange
         var services = new ServiceCollection()
+            .AddLogging()
             .AddSingleton<IJSRuntime, MockJsRuntime>();
 
         // Act
         services.AddMudBlazorResizeListener();
         var serviceProvider = services.BuildServiceProvider();
+        var browserViewportService = serviceProvider.GetService<IBrowserViewportService>();
 #pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
-#pragma warning restore CS0618
+        var breakpointService = serviceProvider.GetService<IBreakpointService>();
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
-        var breakpointService = serviceProvider.GetService<IBreakpointService>();
+#pragma warning restore CS0618
 
         // Assert
+        Assert.IsNotNull(browserViewportService);
         Assert.IsNotNull(resizeListenerService);
         Assert.IsNotNull(browserWindowSizeProvider);
         Assert.IsNotNull(resizeService);
@@ -107,6 +110,7 @@ public class ServiceCollectionExtensionsTests
     {
         // Arrange
         var services = new ServiceCollection()
+            .AddLogging()
             .AddSingleton<IJSRuntime, MockJsRuntime>();
         ResizeOptions? expectedOptions = null;
 
@@ -124,15 +128,21 @@ public class ServiceCollectionExtensionsTests
             expectedOptions = options;
         });
         var serviceProvider = services.BuildServiceProvider();
+        var browserViewportService = serviceProvider.GetService<IBrowserViewportService>();
 #pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
-#pragma warning restore CS0618
+        var breakpointService = serviceProvider.GetService<IBreakpointService>();
+        var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
+#pragma warning restore CS0618
         var options = serviceProvider.GetRequiredService<IOptions<ResizeOptions>>();
         var actualOptions = options.Value;
 
         // Assert
+        Assert.IsNotNull(browserViewportService);
         Assert.IsNotNull(resizeListenerService);
+        Assert.IsNotNull(browserWindowSizeProvider);
+        Assert.IsNotNull(breakpointService);
         Assert.IsNotNull(resizeService);
         Assert.IsNotNull(expectedOptions);
         Assert.AreSame(expectedOptions, actualOptions);
@@ -429,11 +439,11 @@ public class ServiceCollectionExtensionsTests
         var snackBarService = serviceProvider.GetService<ISnackbar>();
 #pragma warning disable CS0618
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
-#pragma warning restore CS0618
+        var breakpointService = serviceProvider.GetService<IBreakpointService>();
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
-        var breakpointService = serviceProvider.GetService<IBreakpointService>();
-
+#pragma warning restore CS0618
+        var browserViewportService = serviceProvider.GetService<IBrowserViewportService>();
         var resizeObserver = serviceProvider.GetService<IResizeObserver>();
         var resizeObserverFactory = serviceProvider.GetService<IResizeObserverFactory>();
         var keyInterceptor = serviceProvider.GetService<IKeyInterceptor>();
@@ -458,6 +468,7 @@ public class ServiceCollectionExtensionsTests
         Assert.IsNotNull(dialogService);
         Assert.IsNotNull(snackBarService);
         Assert.IsNotNull(resizeListenerService);
+        Assert.IsNotNull(browserViewportService);
         Assert.IsNotNull(browserWindowSizeProvider);
         Assert.IsNotNull(resizeService);
         Assert.IsNotNull(breakpointService);
@@ -534,12 +545,12 @@ public class ServiceCollectionExtensionsTests
         var dialogService = serviceProvider.GetService<IDialogService>();
         var snackBarService = serviceProvider.GetService<ISnackbar>();
 #pragma warning disable CS0618
+        var breakpointService = serviceProvider.GetService<IBreakpointService>();
         var resizeListenerService = serviceProvider.GetService<IResizeListenerService>();
-#pragma warning restore CS0618
         var browserWindowSizeProvider = serviceProvider.GetService<IBrowserWindowSizeProvider>();
         var resizeService = serviceProvider.GetService<IResizeService>();
-        var breakpointService = serviceProvider.GetService<IBreakpointService>();
-
+#pragma warning restore CS0618
+        var browserViewportService = serviceProvider.GetService<IBrowserViewportService>();
         var resizeObserver = serviceProvider.GetService<IResizeObserver>();
         var resizeObserverFactory = serviceProvider.GetService<IResizeObserverFactory>();
         var keyInterceptor = serviceProvider.GetService<IKeyInterceptor>();
@@ -572,6 +583,7 @@ public class ServiceCollectionExtensionsTests
         Assert.IsNotNull(dialogService);
         Assert.IsNotNull(snackBarService);
         Assert.IsNotNull(resizeListenerService);
+        Assert.IsNotNull(browserViewportService);
         Assert.IsNotNull(browserWindowSizeProvider);
         Assert.IsNotNull(resizeService);
         Assert.IsNotNull(breakpointService);

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -24,11 +24,13 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
 #pragma warning disable CS0618
+            //TODO: Remove in v7
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
+            ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
+            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
 #pragma warning restore CS0618
             ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
-            ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
@@ -36,7 +38,6 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
             ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
             ctx.Services.AddTransient<IEventListener, MockEventListener>();
-            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
             ctx.Services.AddSingleton<IMenuService, MenuService>();
 #pragma warning disable CS0618

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -24,16 +24,17 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
 #pragma warning disable CS0618
+            //TODO: Remove in v7
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
+            ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
+            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
 #pragma warning restore CS0618
             ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddSingleton<IResizeService>(new MockResizeService());
-            ctx.Services.AddSingleton<IBreakpointService>(new MockBreakpointService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
             ctx.Services.AddTransient<IEventListener, MockEventListener>();
             ctx.Services.AddTransient<IKeyInterceptorFactory, MockKeyInterceptorServiceFactory>();

--- a/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockBreakpointService.cs
@@ -5,6 +5,7 @@ using MudBlazor.Services;
 namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
+    [Obsolete("Replaced by IBrowserViewportService. Remove in v7.")]
     public class MockBreakpointService : IBreakpointService
     {
         private int _width, _height;

--- a/src/MudBlazor.UnitTests/Mocks/MockBrowserWindowSizeProvider.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockBrowserWindowSizeProvider.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using MudBlazor.Services;
 
 namespace MudBlazor.UnitTests.Mocks
 {
+    [Obsolete("Replaced by IBrowserViewportService. Remove in v7.")]
     public class MockBrowserWindowSizeProvider : IBrowserWindowSizeProvider
     {
         public ValueTask<BrowserWindowSize> GetBrowserWindowSize()

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
@@ -5,7 +5,7 @@ using MudBlazor.Services;
 namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
-    [Obsolete("Replaced by BreakpointService. Remove in v7.")]
+    [Obsolete("Replaced by IBrowserViewportService. Remove in v7.")]
     public class MockResizeListenerService : IResizeListenerService
     {
         private int _width, _height;

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeService.cs
@@ -5,6 +5,7 @@ using MudBlazor.Services;
 namespace MudBlazor.UnitTests.Mocks
 {
 #pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
+    [Obsolete("Replaced by IBrowserViewportService. Remove in v7.")]
     public class MockResizeService : IResizeService
     {
         private int _width, _height;

--- a/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BreakpointServiceTests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Services
 {
     [TestFixture]
+    [Obsolete]
     public class BreakpointServiceTests
     {
         private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;

--- a/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeBasedServiceTests.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Services
 {
     [TestFixture]
+    [Obsolete]
     public class ResizeBasedServiceTests
     {
         private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -59,7 +59,9 @@ namespace MudBlazor
             .AddStyle(Style)
         .Build();
 
-        [Inject] public IBreakpointService Breakpointistener { get; set; }
+        [Inject]
+        [Obsolete]
+        public IBreakpointService Breakpointistener { get; set; }
 
         [Inject]
         protected IBrowserViewportService BrowserViewportService { get; set; }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -14,6 +14,7 @@ namespace MudBlazor
         private Breakpoint _currentBreakpoint = Breakpoint.None;
 
         [Inject]
+        [Obsolete]
         public IBreakpointService BreakpointService { get; set; } = null!;
 
         [Inject]

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -21,8 +21,6 @@ namespace MudBlazor
 
         private string _elementId = "picker" + Guid.NewGuid().ToString().Substring(0, 8);
 
-        [Inject] private IBrowserWindowSizeProvider WindowSizeListener { get; set; }
-
         protected string PickerClass =>
             new CssBuilder("mud-picker")
                 .AddClass($"mud-picker-inline", PickerVariant != PickerVariant.Static)

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -106,10 +106,10 @@ namespace MudBlazor.Services
         {
 #pragma warning disable CS0618
             services.TryAddScoped<IResizeListenerService, ResizeListenerService>();
-#pragma warning restore CS0618
-            services.TryAddScoped<IBrowserWindowSizeProvider, BrowserWindowSizeProvider>();
             services.TryAddScoped<IResizeService, ResizeService>();
             services.TryAddScoped<IBreakpointService, BreakpointService>();
+            services.TryAddScoped<IBrowserWindowSizeProvider, BrowserWindowSizeProvider>();
+#pragma warning restore CS0618
             services.TryAddScoped<IBrowserViewportService, BrowserViewportService>();
 
             return services;

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -96,7 +96,7 @@ internal class BrowserViewportService : IBrowserViewportService
             await _semaphore.WaitAsync();
 
             // Always clone the ResizeOptions, regardless of the circumstances.
-            // This is necessary because the options may originate from the "ResizeOptions" variable (IOptions<ResizeOptions>) - these are the user-defined options when adding BreakpointService in the DI container.
+            // This is necessary because the options may originate from the "ResizeOptions" variable (IOptions<ResizeOptions>) - these are the user-defined options when adding this service in the DI container.
             // Only the user should be allowed to modify these settings, and the service should not directly modify the reference to prevent potential bugs.
             var optionsClone = (observer.ResizeOptions ?? ResizeOptions).Clone();
             // Safe to modify now
@@ -304,7 +304,7 @@ internal class BrowserViewportService : IBrowserViewportService
 
     private async Task<BrowserViewportSubscription> CreateJavaScriptListener(ResizeOptions clonedOptions, Guid observerId)
     {
-        // We check if we have and observer with equals options or same observer id
+        // We check if we have an observer with equals options or same observer id
         var javaScriptListenerId = _observerManager
             .Observers
             .Where(x => clonedOptions.Equals(x.Key.Options ?? clonedOptions) || x.Key.ObserverId == observerId)

--- a/src/MudBlazor/Services/BrowserWindowSizeProvider.cs
+++ b/src/MudBlazor/Services/BrowserWindowSizeProvider.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.JSInterop;
 using MudBlazor.Services;
 
 namespace MudBlazor
 {
+    [Obsolete("This will be removed in v7.")]
     public interface IBrowserWindowSizeProvider
     {
         ValueTask<BrowserWindowSize> GetBrowserWindowSize();
@@ -12,6 +14,7 @@ namespace MudBlazor
     /// <summary>
     /// This provider calls the JS method resizeListener.getBrowserWindowSize to get the browser window size
     /// </summary>
+    [Obsolete("This will be removed in v7.")]
     public class BrowserWindowSizeProvider : IBrowserWindowSizeProvider
     {
         private readonly IJSRuntime _jsRuntime;

--- a/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointService .cs
@@ -13,6 +13,7 @@ using MudBlazor.Extensions;
 namespace MudBlazor.Services
 {
 #nullable enable
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public class BreakpointService :
         ResizeBasedService<BreakpointService, BreakpointServiceSubscriptionInfo, Breakpoint, ResizeOptions>,
         IBreakpointService
@@ -202,6 +203,7 @@ namespace MudBlazor.Services
     /// <param name="Breakpoint">The current breakpoint of the window</param>
     public record BreakpointServiceSubscribeResult(Guid SubscriptionId, Breakpoint Breakpoint);
 
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public interface IBreakpointService : IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeBasedService.cs
@@ -13,6 +13,7 @@ using Microsoft.JSInterop;
 namespace MudBlazor.Services
 {
 #nullable enable
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public abstract class ResizeBasedService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TSelf, TInfo, TAction, TTaskOption> : IAsyncDisposable
         where TSelf : class
         where TInfo : SubscriptionInfo<TAction, TTaskOption>

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Services
     /// <summary>
     /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
     /// </summary>
-    [Obsolete($"Use {nameof(BreakpointService)} instead. This will be removed in v7.")]
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public class ResizeListenerService : IResizeListenerService, IDisposable
     {
         private readonly IJSRuntime _jsRuntime;
@@ -205,7 +205,7 @@ namespace MudBlazor.Services
         }
     }
 
-    [Obsolete($"Use {nameof(IBreakpointService)} instead. This will be removed in v7.")]
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public interface IResizeListenerService : IDisposable
     {
         event EventHandler<BrowserWindowSize>? OnResized;

--- a/src/MudBlazor/Services/ResizeListener/ResizeService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeService.cs
@@ -11,6 +11,7 @@ namespace MudBlazor.Services
     /// <summary>
     /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
     /// </summary>
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public class ResizeService :
         ResizeBasedService<ResizeService, ResizeServiceSubscriptionInfo, BrowserWindowSize, ResizeOptions>,
         IResizeService
@@ -103,6 +104,7 @@ namespace MudBlazor.Services
         }
     }
 
+    [Obsolete($"Use {nameof(IBrowserViewportService)} instead. This will be removed in v7.")]
     public interface IResizeService : IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace MudBlazor.Services
 {
 #nullable enable
+    [Obsolete("This will be removed in v7.")]
     public class SubscriptionInfo<TAction,TOption>
     {
         private readonly Dictionary<Guid, Action<TAction>> _subscriptions;


### PR DESCRIPTION
## Description
Obsolete `ResizeService` and `BreakpointService` in favor of `BrowserViewportSevice` (https://github.com/MudBlazor/MudBlazor/pull/7098).


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
