### PR TITLE
mudResizeListener.js: Fix cancelListener

### DIFF
--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -11,6 +11,7 @@ class MudResizeListener {
         this.dotnet = undefined;
         this.breakpoint = -1;
         this.id = id;
+        this.handleResize = this.throttleResizeHandler.bind(this);
     }
 
     listenForResize(dotnetRef, options) {
@@ -18,12 +19,12 @@ class MudResizeListener {
             this.options = options;
             return;
         }
-        //this.logger("[MudBlazor] listenForResize:", { options, dotnetRef });
+
         this.options = options;
         this.dotnet = dotnetRef;
         this.logger = options.enableLogging ? console.log : (message) => { };
         this.logger(`[MudBlazor] Reporting resize events at rate of: ${(this.options || {}).reportRate || 100}ms`);
-        window.addEventListener("resize", this.throttleResizeHandler.bind(this), false);
+        window.addEventListener("resize", this.handleResize, false);
         if (!this.options.suppressInitEvent) {
             this.resizeHandler();
         }
@@ -32,7 +33,6 @@ class MudResizeListener {
 
     throttleResizeHandler() {
         clearTimeout(this.throttleResizeHandlerId);
-        //console.log("[MudBlazor] throttleResizeHandler ", {options:this.options});
         this.throttleResizeHandlerId = window.setTimeout(this.resizeHandler.bind(this), ((this.options || {}).reportRate || 100));
     }
 
@@ -46,7 +46,6 @@ class MudResizeListener {
         }
 
         try {
-            //console.log("[MudBlazor] RaiseOnResized invoked");
             if (this.id) {
                 this.dotnet.invokeMethodAsync('RaiseOnResized',
                     {
@@ -65,7 +64,6 @@ class MudResizeListener {
                     this.getBreakpoint(window.innerWidth));
             }
 
-            //this.logger("[MudBlazor] RaiseOnResized invoked");
         } catch (error) {
             this.logger("[MudBlazor] Error in resizeHandler:", { error });
         }
@@ -73,18 +71,15 @@ class MudResizeListener {
 
     cancelListener() {
         this.dotnet = undefined;
-        //console.log("[MudBlazor] cancelListener");
-        window.removeEventListener("resize", this.throttleResizeHandler);
+        window.removeEventListener("resize", this.handleResize);
     }
 
     matchMedia(query) {
         let m = window.matchMedia(query).matches;
-        //this.logger(`[MudBlazor] matchMedia "${query}": ${m}`);
         return m;
     }
 
     getBrowserWindowSize() {
-        //this.logger("[MudBlazor] getBrowserWindowSize");
         return {
             height: window.innerHeight,
             width: window.innerWidth


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/4100

The issue seems to be related to how binding was done i.e. the problem is that the bound function is different each time `throttleResizeHandler` is called, so when you try to remove the event listener with `window.removeEventListener`, it doesn't match the previously added listener.
In this approach, instead of binding the `throttleResizeHandler` method directly, we create a new method called `handleResize` that is bound to the instance of `MudResizeListener` in the constructor. The `handleResize` method references the `throttleResizeHandler` method, which maintains the correct `this` context.

## How Has This Been Tested?
Manually with debugging, sadly unit test can't catch this since it assumes the JS part works as expected. Really bad that we don't have JEST.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
