### PR TITLE
ResizeService & BreakpointService: Fix Obsolete

### DIFF
--- a/src/MudBlazor.UnitTests/Services/SubscriptionInfoTests.cs
+++ b/src/MudBlazor.UnitTests/Services/SubscriptionInfoTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Services
 {
+    [Obsolete]
     [TestFixture]
     public class SubscriptionInfoTests
     {

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -23,6 +23,7 @@ namespace MudBlazor
         protected IBrowserViewportService BrowserViewportService { get; set; } = null!;
 
         [Inject]
+        [Obsolete]
         public IBreakpointService Service { get; set; } = null!;
 
         [Parameter]

--- a/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
@@ -48,6 +48,7 @@ namespace MudBlazor.Services
         }
     }
 
+    [Obsolete("This will be removed in v7.")]
     public class ResizeServiceSubscriptionInfo : SubscriptionInfo<BrowserWindowSize,ResizeOptions>
     {
         public ResizeServiceSubscriptionInfo(ResizeOptions options) : base(options)
@@ -55,6 +56,7 @@ namespace MudBlazor.Services
         }
     }
 
+    [Obsolete("This will be removed in v7.")]
     public class BreakpointServiceSubscriptionInfo : SubscriptionInfo<Breakpoint, ResizeOptions>
     {
         public BreakpointServiceSubscriptionInfo(ResizeOptions options) : base(options)


### PR DESCRIPTION
## Description
Follow up PR of this https://github.com/MudBlazor/MudBlazor/pull/7139
I missed some types and didn't mark them obsolete and it generates now build noise.

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
