### PR TITLE
Added touch support to TimePicker wheel

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -341,19 +341,19 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public void DragMouse_SelectHour_CheckMinutesAppear()
+        public void DragPointer_SelectHour_CheckMinutesAppear()
         {
             var comp = OpenPicker();
             var picker = comp.Instance;
             var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
 
             // click on the minutes input
-            comp.Find("div.mud-time-picker-hour").MouseDown();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseOver();
+            comp.Find("div.mud-time-picker-hour").PointerDown();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(16);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseOver();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].PointerOver();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(18);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
             // Are minutes displayed
@@ -361,7 +361,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DragMouse_SelectMinutes()
+        public void DragPointer_SelectMinutes()
         {
             // Use bare component
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Minutes));
@@ -371,13 +371,13 @@ namespace MudBlazor.UnitTests.Components
             // Any hours displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
             // click and drag
-            comp.Find("div.mud-time-picker-minute").MouseDown();
-            comp.FindAll("div.mud-minute")[3].MouseOver();
+            comp.Find("div.mud-time-picker-minute").PointerDown();
+            comp.FindAll("div.mud-minute")[3].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(3);
-            comp.FindAll("div.mud-minute")[31].MouseOver();
+            comp.FindAll("div.mud-minute")[31].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(31);
-            comp.FindAll("div.mud-minute")[5].MouseOver();
-            comp.FindAll("div.mud-minute")[5].MouseUp();
+            comp.FindAll("div.mud-minute")[5].PointerOver();
+            comp.FindAll("div.mud-minute")[5].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(5);
         }
 
@@ -409,10 +409,10 @@ namespace MudBlazor.UnitTests.Components
             // click and drag
             for (var i = 0; i < 12; i++)
             {
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-hour")[i].PointerOver();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-hour")[i].PointerUp();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-hour")[i].Click();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
@@ -431,10 +431,10 @@ namespace MudBlazor.UnitTests.Components
             // click and drag 13 to 00 on outer dial
             for (var i = 0; i < 12; i++)
             {
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].PointerOver();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].PointerUp();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].Click();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
@@ -442,10 +442,10 @@ namespace MudBlazor.UnitTests.Components
             // click and drag 1 to 12 on inner dial
             for (var i = 0; i < 12; i++)
             {
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].PointerOver();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].PointerUp();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].Click();
                 underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
@@ -453,10 +453,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// drag and mouseup on minutes for test coverage
+        /// drag and Pointerup on minutes for test coverage
         /// </summary>
         [Test]
-        public void DragAndMouseUp_AllMinutes()
+        public void DragAndPointerUp_AllMinutes()
         {
             var comp = OpenPicker(Parameter("TimeEditMode", TimeEditMode.OnlyMinutes));
             var picker = comp.Instance;
@@ -465,16 +465,16 @@ namespace MudBlazor.UnitTests.Components
             // Any minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
 
-            // click and drag (hold mouse down)
-            comp.Find("div.mud-time-picker-minute").MouseDown();
+            // click and drag (hold Pointer down)
+            comp.Find("div.mud-time-picker-minute").PointerDown();
             for (var i = 0; i < 60; i++)
             {
-                comp.FindAll("div.mud-minute")[i].MouseOver();
+                comp.FindAll("div.mud-minute")[i].PointerOver();
                 underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
 
                 if (i == 59)
                 {
-                    comp.FindAll("div.mud-minute")[i].MouseUp();
+                    comp.FindAll("div.mud-minute")[i].PointerUp();
                     underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
                 }
             }
@@ -504,7 +504,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// drag and mouseup in every view
+        /// drag and Pointerup in every view
         /// </summary>
         [Test]
         public void SelectTime_UsingDrag_DefaultMode_CheckCloseWhenFinished()
@@ -517,22 +517,22 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-time-picker-hour").Count.Should().Be(1);
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
 
-            // drag to 13 and mouse up
-            comp.Find("div.mud-time-picker-hour").MouseDown();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseOver();
+            // drag to 13 and Pointer up
+            comp.Find("div.mud-time-picker-hour").PointerDown();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
 
             // check if the view changed to minutes
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
             comp.FindAll("div.mud-time-picker-minute").Count.Should().Be(1);
 
-            // drag to 37 minutes and mouse up
-            comp.Find("div.mud-time-picker-minute").MouseDown();
-            comp.FindAll("div.mud-minute")[37].MouseOver();
+            // drag to 37 minutes and Pointer up
+            comp.Find("div.mud-time-picker-minute").PointerDown();
+            comp.FindAll("div.mud-minute")[37].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
-            comp.FindAll("div.mud-minute")[37].MouseUp();
+            comp.FindAll("div.mud-minute")[37].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
 
             // check if closed
@@ -849,11 +849,11 @@ namespace MudBlazor.UnitTests.Components
             });
 
             // Select 16 hours
-            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click(new MouseEventArgs()));
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click(new PointerEventArgs()));
             picker.TimeIntermediate.Value.Hours.Should().Be(16);
 
             // Select 30 minutes
-            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new MouseEventArgs()));
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new PointerEventArgs()));
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);
 
             Assert.AreEqual(1, count);

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -1,12 +1,14 @@
-﻿@using MudBlazor.Internal
+﻿@using Microsoft.JSInterop;
+@using MudBlazor.Internal
 @namespace MudBlazor
+@inject IJSRuntime jsRuntime
 @inherits MudPicker<TimeSpan?>
 
 @Render
 
-@code{
+@code {
 
-    protected override RenderFragment PickerContent=> 
+    protected override RenderFragment PickerContent =>
     @<CascadingValue Value="@this" IsFixed="true">
         <MudPickerToolbar Class="@ToolbarClass" Style="@Style" DisableToolbar="@DisableToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
             <div class="mud-timepicker-hourminute mud-ltr">
@@ -32,65 +34,65 @@
         <MudPickerContent>
             <div class="mud-picker-time-container">
                 <div class="mud-picker-time-clock">
-                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onmousedown="OnMouseDown" @onmouseup="OnMouseUp">
+                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onpointerdown="OnPointerDown" @onpointerup="OnPointerUp">
                         <div class="@GetClockPinColor()"></div>
                         <div class="@GetClockPointerColor()" style="height: @GetPointerHeight(); transform: @GetPointerRotation()">
                             <div class="@GetClockPointerThumbColor()"></div>
                         </div>
-                        <div class="@HourDialClass">
+                        <div @onpointerdown="ReleasePointer" style="touch-action: none;" class="@HourDialClass">
                             @if (AmPm)
                             {
                                 @*Hours from 1 to 12*@
-                                for(int i = 1; i <= 12; ++i)
+                                for (int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    var angle =  (6 - _i) * 30;
+                                    var angle = (6 - _i) * 30;
                                     <MudText Class="@GetNumberColor(_i)" Style="@GetTransform(angle, 109, 0, 5)">@_i</MudText>
                                 }
-                                for(int i = 1; i <= 12; ++i)
+                                for (int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(() => OnMouseClickHour(_i))" @onmouseover="(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
+                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(() => OnClickHour(_i))" @onpointerover="((e) => OnOverHour(_i))" @onclick:stopPropagation="true"></div>
                                 }
                             }
                             else
                             {
                                 @*Hours from 13 to 24 (00)*@
-                                for(int i = 1; i <= 12; ++i)
+                                for (int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    var angle =  (6 - _i) * 30;
+                                    var angle = (6 - _i) * 30;
                                     <MudText Class="@GetNumberColor((_i + 12) % 24)" Style="@GetTransform(angle, 109, 0, 5)">@(((_i + 12) % 24).ToString("D2"))</MudText>
                                 }
                                 @*Hours from 1 to 12*@
-                                for(int i = 1; i <= 12; ++i)
+                                for (int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    var angle =  (6 - _i) * 30;
+                                    var angle = (6 - _i) * 30;
                                     <MudText Class="@GetNumberColor(_i)" Typo="Typo.body2" Style="@GetTransform(angle, 74, 0, 40)">@(_i.ToString("D2"))</MudText>
                                 }
-                                for(int i = 1; i <= 12; ++i)
+                                for (int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
                                     <div class="mud-picker-stick" style="@($"transform: rotateZ({_i * 30}deg);")">
-                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(() => OnMouseClickHour(_i))" @onmouseover="(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
-                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(() => OnMouseClickHour((_i + 12) % 24))" @onmouseover="(() => OnMouseOverHour((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(() => OnClickHour(_i))" @onpointerover="(() => OnOverHour(_i))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(() => OnClickHour((_i + 12) % 24))" @onpointerover="(() => OnOverHour((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
                                     </div>
                                 }
                             }
                         </div>
-                        <div class="@MinuteDialClass">   
-                            @*Minutes from 05 to 60 (00) - step 5*@                     
+                        <div @onpointerdown="ReleasePointer" style="touch-action: none;" class="@MinuteDialClass">
+                            @*Minutes from 05 to 60 (00) - step 5*@
                             @for (int i = 0; i < 12; ++i)
                             {
                                 var _i = i;
-                                var angle =  (6 - _i) * 30;
+                                var angle = (6 - _i) * 30;
                                 <MudText Class="@GetNumberColor(_i * 5)" Style="@GetTransform(angle, 109, 0, 5)">@((_i * 5).ToString("D2"))</MudText>
                             }
                             @for (int i = 0; i < 60; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(() => OnMouseClickMinute(_i))" @onmouseover="(() => OnMouseOverMinute(_i))" @onclick:stopPropagation="true"></div>
+                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(() => OnClickMinute(_i))" @onpointerover="(() => OnOverMinute(_i))" @onclick:stopPropagation="true"></div>
                             }
                         </div>
                     </div>
@@ -98,5 +100,5 @@
             </div>
         </MudPickerContent>
     </CascadingValue>;
-    
+
 }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Extensions;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
@@ -312,7 +313,7 @@ namespace MudBlazor
 
         private string GetClockPointerColor()
         {
-            if (MouseDown)
+            if (pointerDown)
                 return $"mud-picker-time-clock-pointer mud-{Color.ToDescriptionString()}";
             else
                 return $"mud-picker-time-clock-pointer mud-picker-time-clock-pointer-animation mud-{Color.ToDescriptionString()}";
@@ -417,28 +418,33 @@ namespace MudBlazor
             _timeSet.Minute = TimeIntermediate.Value.Minutes;
         }
 
-        public bool MouseDown { get; set; }
+        void ReleasePointer()
+        {
+            jsRuntime.InvokeVoidAsync("releasePointer").AndForget();
+        }
+
+        public bool pointerDown { get; set; }
 
         /// <summary>
-        /// Sets Mouse Down bool to true if mouse is inside the clock mask.
+        /// Sets pointerDown bool to true if pointer is inside the clock mask.
         /// </summary>
-        private void OnMouseDown(MouseEventArgs e)
+        private void OnPointerDown(PointerEventArgs e)
         {
-            MouseDown = true;
+            pointerDown = true;
         }
 
         /// <summary>
-        /// Sets Mouse Down bool to false if mouse is inside the clock mask.
+        /// Sets pointer Down bool to false if mouse is inside the clock mask.
         /// </summary>
-        private void OnMouseUp(MouseEventArgs e)
+        private void OnPointerUp(PointerEventArgs e)
         {
-            if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
+            if (pointerDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
             {
-                MouseDown = false;
+                pointerDown = false;
                 SubmitAndClose();
             }
 
-            MouseDown = false;
+            pointerDown = false;
 
             if (_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.Normal)
             {
@@ -447,11 +453,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// If MouseDown is true enables "dragging" effect on the clock pin/stick.
+        /// If pointerDown is true enables "dragging" effect on the clock pin/stick.
         /// </summary>
-        private void OnMouseOverHour(int value)
+        private void OnOverHour(int value)
         {
-            if (MouseDown)
+            if (pointerDown)
             {
                 _timeSet.Hour = value;
                 UpdateTime();
@@ -461,7 +467,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the hour "sticks", sets the hour.
         /// </summary>
-        private void OnMouseClickHour(int value)
+        private void OnClickHour(int value)
         {
             var h = value;
             if (AmPm)
@@ -471,6 +477,7 @@ namespace MudBlazor
                 else if (IsPm && value < 12)
                     h = value + 12;
             }
+
             _timeSet.Hour = h;
 
             if(_currentView == OpenTo.Hours)
@@ -489,11 +496,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// On mouse over for the minutes "sticks", sets the minute.
+        /// On pointer over for the minutes "sticks", sets the minute.
         /// </summary>
-        private void OnMouseOverMinute(int value)
+        private void OnOverMinute(int value)
         {
-            if (MouseDown)
+            if (pointerDown)
             {
                 _timeSet.Minute = value;
                 UpdateTime();
@@ -503,7 +510,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private void OnMouseClickMinute(int value)
+        private void OnClickMinute(int value)
         {
             _timeSet.Minute = value;
             UpdateTime();

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -418,9 +418,9 @@ namespace MudBlazor
             _timeSet.Minute = TimeIntermediate.Value.Minutes;
         }
 
-        void ReleasePointer()
+        async Task ReleasePointer()
         {
-            jsRuntime.InvokeVoidAsync("releasePointer").AndForget();
+            await jsRuntime.InvokeVoidAsync("releasePointer");
         }
 
         public bool pointerDown { get; set; }

--- a/src/MudBlazor/TScripts/mudPointerEventHelper.js
+++ b/src/MudBlazor/TScripts/mudPointerEventHelper.js
@@ -1,0 +1,10 @@
+// Copyright (c) MudBlazor 2023
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+function releasePointer() {
+    var e = window.event;
+    if (e.target.hasPointerCapture(e.pointerId)) {
+        e.target.releasePointerCapture(e.pointerId);
+    }
+}


### PR DESCRIPTION
## Description
Change the event in TimePicker razor file, so it can pick up other input than mouse.

To make the onpointerover event work when we start touching outside the elements, I added an onpointerdown event on the container element that call a bit of JavaScript code to make it work.

I've searched the internet and I did not find a way to do the JavaScript bit in C#.
Feel free to correct me if I'm wrong or my code is not correctly formatted, I don't usually use JavaScript.

resolves #6022
resolves #4122

## How Has This Been Tested?
I changed the unit test to send PointerEvent instead of MouseEvent.
I tested the change in a Maui Blazor project on a physical android device.
Also, I tested in browser. I tested the touch behaviour with the mobile device simulator in dev tool.
Tested in edge.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
