### PR TITLE
MudForm/MudBaseInput: Fix swallowed user input on `FieldChanged` re-render (#7158)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAsyncValidationWithFieldChangedSubscriberTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAsyncValidationWithFieldChangedSubscriberTest.razor
@@ -2,13 +2,16 @@
 @using FluentValidation
 
 <MudForm Model="_model" Validation="@_validator.ValidateValue" FieldChanged="@FieldChanged">
-    <MudTextField T="string" @bind-Value="@_model.Value" For="() => _model.Value" Immediate="true" DebounceInterval="500" Required="true" RequiredError="Enter a star"></MudTextField>
+    <MudTextField T="string" @bind-Value="@_model.Value" For="() => _model.Value" Immediate="true" DebounceInterval="@DebounceInterval" Required="true" RequiredError="Enter a star"></MudTextField>
 </MudForm>
 
 <MudText>RenderCount: @_renderCount</MudText>
 
 @code {
     public static string __description__ = "User validation should not be swallowed when new text is added during async validation.";
+
+    public int DebounceInterval = 500;
+    public int AsyncTaskDelay = 2000;
 
     private Model _model = new();
 
@@ -27,7 +30,7 @@
         return;
     }
     
-    private class Model
+    public class Model
     {
         public string Value { get; set; }
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAsyncValidationWithFieldChangedSubscriberTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAsyncValidationWithFieldChangedSubscriberTest.razor
@@ -1,0 +1,58 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using FluentValidation
+
+<MudForm Model="_model" Validation="@_validator.ValidateValue" FieldChanged="@FieldChanged">
+    <MudTextField T="string" @bind-Value="@_model.Value" For="() => _model.Value" Immediate="true" DebounceInterval="500" Required="true" RequiredError="Enter a star"></MudTextField>
+</MudForm>
+
+<MudText>RenderCount: @_renderCount</MudText>
+
+@code {
+    public static string __description__ = "User validation should not be swallowed when new text is added during async validation.";
+
+    private Model _model = new();
+
+    private ModelFluentValidator _validator = new();
+
+    private int _renderCount;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        _renderCount++;
+    }
+
+    private void FieldChanged()
+    {
+        return;
+    }
+    
+    private class Model
+    {
+        public string Value { get; set; }
+    }
+
+    private class ModelFluentValidator : AbstractValidator<Model>
+    {
+        public ModelFluentValidator()
+        {
+            RuleFor(x => x.Value)
+                .NotEmpty()
+                .MustAsync(async (value, _) => await CustomValidation(value));
+        }
+        
+        private async Task<bool> CustomValidation(string val)
+        {
+            await Task.Delay(2000);
+            return val == "star";
+        }
+        
+        public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
+        {
+            var result = await ValidateAsync(ValidationContext<Model>.CreateWithOptions((Model)model, x => x.IncludeProperties(propertyName)));
+            if (result.IsValid)
+                return Array.Empty<string>();
+            return result.Errors.Select(e => e.ErrorMessage);
+        };
+    }
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -378,8 +378,8 @@ namespace MudBlazor
                 await ValueChanged.InvokeAsync(Value);
                 if (updateText)
                     await UpdateTextPropertyAsync(false);
-                await BeginValidateAsync();
                 FieldChanged(Value);
+                await BeginValidateAsync();
             }
         }
 


### PR DESCRIPTION
## Description

When using async validation on a `MudForm` and a re-render occurs on the `FieldChanged` callback, user input entered during the async validation would be swallowed and replaced by the previous input value.

By calling `FieldChanged` before validation we fix this issue.

I don't *think* this has any other impact, unit tests all pass.

Fixes: #7158

## How Has This Been Tested?

I added a test component for the unit test viewer based on the original code snippet, visually tested and confirmed the bug & fix.

#### Before

https://github.com/MudBlazor/MudBlazor/assets/15004223/6d04fc72-812f-47a8-82f1-d000ebac76d4

#### After

https://github.com/MudBlazor/MudBlazor/assets/15004223/f76554c8-bb08-4063-980b-673d14bb2531

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
