### PR TITLE
MudDataGrid Fix: Added the EditDialogOptions to inline MudDialog for the DataGridEditMode.Form

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditFormCustomizedDialogTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditFormCustomizedDialogTest.razor
@@ -1,0 +1,32 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDialogProvider />
+
+<MudDataGrid T="Model" Items="@_items" ReadOnly="false" EditMode="@DataGridEditMode.Form" EditDialogOptions="Options" EditTrigger="@DataGridEditTrigger.OnRowClick">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+        <TemplateColumn>
+            <CellTemplate>
+                snakex64
+            </CellTemplate>
+        </TemplateColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private DialogOptions Options = new DialogOptions() { CloseButton = true };
+    private IEnumerable<Model> _items = new List<Model>()
+{
+        new Model{ Name= "John", Age= 45 },
+        new Model{ Name= "Johanna", Age= 23 },
+        new Model{ Name= "Steve", Age= 32 }
+    };
+
+    public class Model
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public string GetOnly => "snakex64";
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -457,6 +457,7 @@ namespace MudBlazor.UnitTests.Components
             //open edit dialog
             dataGrid.FindAll("tbody tr")[1].Click();
 
+            comp.Find("button[aria-label=\"close\"]").Should().BeNull();
             //edit data
             comp.FindAll("div input")[0].Change("Galadriel");
             comp.FindAll("div input")[1].Change(1);
@@ -3804,6 +3805,35 @@ namespace MudBlazor.UnitTests.Components
             newHeaderValues[4].InnerHtml.Should().Be("HiredOn");
 
         }
-    
+        [Test]
+        public void DataGridEditFormDialogIsCustomizableTest()
+        {
+            var comp = Context.RenderComponent<DataGridEditFormCustomizedDialogTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditFormCustomizedDialogTest.Model>>();
+
+            //open edit dialog
+            dataGrid.FindAll("tbody tr")[1].Click();
+            //check if dialog is open
+            comp.FindAll("div.mud-dialog-container").Should().NotBeEmpty();
+            //find button with arialabel close in dialog
+            var closeButton = comp.Find("button[aria-label=\"close\"]");
+            closeButton.Should().NotBeNull();
+            //click close button
+            comp.Find("button[aria-label=\"close\"]").Click();
+            //check if dialog is closed
+            comp.FindAll("div.mud-dialog-container").Should().BeEmpty();
+
+            dataGrid.Instance.EditDialogOptions = new DialogOptions() { CloseButton = false};
+
+            //open edit dialog
+            dataGrid.FindAll("tbody tr")[1].Click();
+
+            //check if dialog is open
+            comp.FindAll("div.mud-dialog-container").Should().NotBeEmpty();
+            //find button with arialabel close in dialog
+            comp.FindAll("button[aria-label=\"close\"]").Should().BeEmpty();
+
+
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -456,8 +456,8 @@ namespace MudBlazor.UnitTests.Components
 
             //open edit dialog
             dataGrid.FindAll("tbody tr")[1].Click();
-
-            comp.Find("button[aria-label=\"close\"]").Should().BeNull();
+            //No close button
+            comp.FindAll("button[aria-label=\"close\"]").Should().BeEmpty();
             //edit data
             comp.FindAll("div input")[0].Change("Galadriel");
             comp.FindAll("div input")[1].Change(1);
@@ -3822,18 +3822,6 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("button[aria-label=\"close\"]").Click();
             //check if dialog is closed
             comp.FindAll("div.mud-dialog-container").Should().BeEmpty();
-
-            dataGrid.Instance.EditDialogOptions = new DialogOptions() { CloseButton = false};
-
-            //open edit dialog
-            dataGrid.FindAll("tbody tr")[1].Click();
-
-            //check if dialog is open
-            comp.FindAll("div.mud-dialog-container").Should().NotBeEmpty();
-            //find button with arialabel close in dialog
-            comp.FindAll("button[aria-label=\"close\"]").Should().BeEmpty();
-
-
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -254,7 +254,7 @@
         }
     </div>
     <CascadingValue Value="true" IsFixed Name="IsNested">
-        <MudDialog @bind-IsVisible="isEditFormOpen">
+        <MudDialog Options="EditDialogOptions" @bind-IsVisible="isEditFormOpen">
             <DialogContent>
                 <MudForm FieldChanged="FormFieldChanged">
                     @foreach (var column in RenderedColumns)


### PR DESCRIPTION
Fixes: #7132 
Fixes: #6621
You cannot add dialog options to the edit form (dialog) built-in to the datagrid.
I inspected it and it was a simple fix.

Just added the `EditDialogOptions` property that was not used anywhere in `DataGrid.razor.cs` to the inline `<MudDialog>` tag.


## How Has This Been Tested?
Visually tested, might look into a unit test soon, but I could use some guidance or pointers which test I can use as reference.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
