### PR TITLE
DataGrid: GroupItems after server reload

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -884,6 +884,7 @@ namespace MudBlazor
                 CurrentPage = 0;
 
             Loading = false;
+            GroupItems(true);
             StateHasChanged();
             PagerStateHasChangedEvent?.Invoke();
         }


### PR DESCRIPTION
## Description
When using grouping and ServerData in MudDataGrid, groupings were not being updated after data was loaded so the UI was always behind.

## How Has This Been Tested?
I tested by replacing the MudBlazor NuGet package with the MudBlazor source code in my solution where I had run into this issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
