### PR TITLE
Nuget package: Use PackageLicenseExpression instead of PackageLicenseFile

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Nuget.png</PackageIcon>
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>


### PR DESCRIPTION
## Description
Use PackageLicenseExpression instead of PackageLicenseFile in the nuget package, so that it can be consumed by clearing automation tools. [Microsoft also suggests](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5033) to prefer it over the licence file when the package has well-known licence type.

Resolves #7165  

## How Has This Been Tested?
Visually: Packed the package locally and checked that it still contains the licence information.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
