### PR TITLE
TimePicker: Added MinuteSelectionStep Parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerStepExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerStepExample.razor
@@ -1,0 +1,5 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTimePicker PickerVariant="PickerVariant.Static" Color="Color.Primary" MinuteSelectionStep="1" Text="03:37 PM" OpenTo="OpenTo.Minutes" />
+<MudTimePicker PickerVariant="PickerVariant.Static" Color="Color.Secondary" MinuteSelectionStep="5" Text="03:35 PM" OpenTo="OpenTo.Minutes" />
+<MudTimePicker PickerVariant="PickerVariant.Static" Color="Color.Tertiary" MinuteSelectionStep="15" Text="03:45 PM" OpenTo="OpenTo.Minutes" />

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -90,6 +90,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="MinuteSelectionStep">
+                <Description>You can change the granularity of selectable times with the <CodeInline>MinuteSelectionStep</CodeInline> parameter.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Class="demo-datetime-margin" Code="TimePickerStepExample" ShowCode="false">
+                <TimePickerStepExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
                     <MudText>MudTimePicker accepts keys to keyboard navigation.</MudText>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
@@ -5,7 +5,8 @@
 			   @bind-Time="@Time"
 			   OpenTo="@OpenTo"
 			   AmPm="AmPm"
-			   TimeEditMode="TimeEditMode" />
+			   TimeEditMode="TimeEditMode"
+			   MinuteSelectionStep="MinuteSelectionStep" />
 
 @code {
 	private MudTimePicker _picker;
@@ -14,7 +15,7 @@
 	[Parameter] public TimeEditMode TimeEditMode { get; set; } = TimeEditMode.Normal;
 	[Parameter] public TimeSpan? Time { get; set; }
 	[Parameter] public Boolean AmPm { get; set; }
-
+	[Parameter] public int MinuteSelectionStep { get; set; } = 1;
 
 
 	public async Task Open() => await InvokeAsync(() => _picker.Open());

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -231,6 +231,58 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void MinuteSelectionStep_15_SelectTime_UsingClicks_CheckTime()
+        {
+            var comp = OpenPicker(Parameter(nameof(MudTimePicker.MinuteSelectionStep), 15));
+            var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
+
+            // select 16 hours on outer dial
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
+            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(16);
+
+            // click 2 minutes on the dial result rounds down to 00
+            comp.FindAll("div.mud-minute")[2].Click();
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(00);
+            comp.FindAll("div.mud-time-picker-minute p.mud-theme-primary")[0].TextContent.Should().Be("00");
+            // click 18 minutes on the dial result rounds down to 15
+            comp.FindAll("div.mud-minute")[18].Click();
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(15);
+            comp.FindAll("div.mud-time-picker-minute p.mud-theme-primary")[0].TextContent.Should().Be("15");
+            // click 30 minutes on the dial result is 30
+            comp.FindAll("div.mud-minute")[30].Click();
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(30);
+            comp.FindAll("div.mud-time-picker-minute p.mud-theme-primary")[0].TextContent.Should().Be("30");
+            // click 43 minutes on the dial result rounds up to 45
+            comp.FindAll("div.mud-minute")[43].Click();
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(45);
+            comp.FindAll("div.mud-time-picker-minute p.mud-theme-primary")[0].TextContent.Should().Be("45");
+            // click 57 minutes on the dial result rounds 'up' to 00
+            comp.FindAll("div.mud-minute")[57].Click();
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
+            comp.FindAll("div.mud-time-picker-minute p.mud-theme-primary")[0].TextContent.Should().Be("00");
+        }
+
+        /// <summary>
+        /// Check that using an invalid value of 0 is ignored
+        /// </summary>
+        [Test]
+        public void MinuteSelectionStep_0_SelectTime_UsingClicks_CheckTime()
+        {
+            var comp = Context.RenderComponent<MudTimePicker>(new ComponentParameter[] { Parameter(nameof(MudTimePicker.MinuteSelectionStep), 0), Parameter("TimeEditMode", TimeEditMode.OnlyMinutes), Parameter("PickerVariant", PickerVariant.Static), Parameter("OpenTo", OpenTo.Minutes) });
+            var picker = comp.Instance;
+
+            // Any minutes displayed
+            comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
+
+            // click every minute
+            for (var i = 0; i < 60; i++)
+            {
+                comp.FindAll("div.mud-minute")[i].Click();
+                picker.TimeIntermediate.Value.Minutes.Should().Be(i);
+            }
+        }
+
+        [Test]
         public void OpenToHours_CheckMinutesHidden()
         {
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Hours));

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -93,6 +93,13 @@ namespace MudBlazor
         public bool AutoClose { get; set; }
 
         /// <summary>
+        /// Sets the number interval for minutes.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerBehavior)]
+        public int MinuteSelectionStep { get; set; } = 1;
+
+        /// <summary>
         /// If true, sets 12 hour selection clock.
         /// </summary>
         [Parameter]
@@ -495,6 +502,7 @@ namespace MudBlazor
         {
             if (MouseDown)
             {
+                value = RoundToStepInterval(value);
                 _timeSet.Minute = value;
                 UpdateTime();
             }
@@ -505,9 +513,24 @@ namespace MudBlazor
         /// </summary>
         private void OnMouseClickMinute(int value)
         {
+            value = RoundToStepInterval(value);
             _timeSet.Minute = value;
             UpdateTime();
             SubmitAndClose();
+        }
+
+        private int RoundToStepInterval(int value)
+        {
+            if (MinuteSelectionStep > 1) // Ignore if step is less than or equal to 1
+            {
+                var interval = MinuteSelectionStep % 60;
+                value = (value + interval / 2) / interval * interval;
+                if (value == 60) // For when it rounds up to 60
+                {
+                    value = 0;
+                }
+            }
+            return value;
         }
 
         protected async void SubmitAndClose()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

## Description
<!-- Describe your changes in detail any why -->
This PR adds the option to limit the step interval for minutes using the `MinuteSelectionStep` parameter. The default behavior is the same.

## How Has This Been Tested?
* Visually - I tested all options using the Docs server.
* Unit - Created new tests
  * Test to check clicks are correctly rounding to the nearest interval
  * Tests to check that invalid step values are ignored ( step < 1 )
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
