### PR TITLE
MudTable/MudDataGrid: Add ItemSize parameter for virtualization

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -153,7 +153,7 @@
 
                                     @if (g.IsExpanded)
                                     {
-                                        <MudVirtualize IsEnabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount=@OverscanCount Context="item">
+                                        <MudVirtualize IsEnabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                             @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var tmpRowIndex = rowIndex; }
@@ -188,7 +188,7 @@
                             else
                             {
                                 var rowIndex = 0;
-                                <MudVirtualize IsEnabled="@Virtualize" Items="@resolvedPageItems" OverscanCount=@OverscanCount Context="item">
+                                <MudVirtualize IsEnabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -381,6 +381,11 @@ namespace MudBlazor
         [Parameter] public int OverscanCount { get; set; } = 3;
 
         /// <summary>
+        /// Gets the size of each item in pixels. Defaults to 50px.
+        /// </summary>
+        [Parameter] public float ItemSize { get; set; } = 50f;
+
+        /// <summary>
         /// CSS class for the table rows. Note, many CSS settings are overridden by MudTd though
         /// </summary>
         [Parameter] public string RowClass { get; set; }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -87,7 +87,7 @@
                         @if (CurrentPageItems != null && CurrentPageItems.Count() > 0)
                         {
                             var rowIndex = 0;
-                            <MudVirtualize IsEnabled="@Virtualize" OverscanCount="@OverscanCount" Items="@CurrentPageItems?.ToList()" Context="item">
+                                <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable"
@@ -195,8 +195,8 @@
 
          RenderFragment rootNode =
             @<text>
-                <MudVirtualize IsEnabled="@Virtualize" Items="@source?.ToList()" Context="item" ChildContent="@child()">              
-                </MudVirtualize>
+        <MudVirtualize IsEnabled="@Virtualize" Items="@source?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item" ChildContent="@child()">
+        </MudVirtualize>
             </text>;
 
          RenderFragment<T> child() => item =>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -448,6 +448,13 @@ namespace MudBlazor
         [Category(CategoryTypes.Table.Behavior)]
         public int OverscanCount { get; set; } = 3;
 
+        /// <summary>
+        /// Gets the size of each item in pixels. Defaults to 50px.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Behavior)]
+        public float ItemSize { get; set; } = 50f;
+
         #region --> Obsolete Forwarders for Backwards-Compatiblilty
         /// <summary>
         /// Alignment of the table cell text when breakpoint is smaller than <see cref="Breakpoint" />

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -5,7 +5,7 @@
 
 @if (IsEnabled)
 {
-    <Virtualize Items="@Items" Context="item" OverscanCount=@OverscanCount>
+    <Virtualize Items="@Items" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize">
         @if (ChildContent is not null)
         {
             @ChildContent(item)

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -36,5 +36,11 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public int OverscanCount { get; set; } = 3;
+
+        /// <summary>
+        /// Gets the size of each item in pixels. Defaults to 50px.
+        /// </summary>
+        [Parameter]
+        public float ItemSize { get; set; } = 50f;
     }
 }


### PR DESCRIPTION
Enable usage of the Virtualize component's ItemSize property in MudTable and MudDataGrid.

## Description
Adds ItemSize parameter from Virtualize component to MudVirtualize component
Adds ItemSize parameter to MudTable component
Adds ItemSize parameter to MudDataGrid component

Fixes #5868 

## How Has This Been Tested?
- Ran test suite
- Build package locally and tested in own project --> itemsize works as expected

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
