### PR TITLE
MudDebouncedInput: Fix swallowed user input on component re-render (#7193)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldCultureChangeRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldCultureChangeRerenderTest.razor
@@ -1,0 +1,48 @@
+﻿@using System.Globalization
+
+<MudNumericField @bind-Value="@Value"
+                 Culture="@Culture"
+                 Format="@Format"
+                 Immediate="@true"
+                 DebounceInterval="@DebounceInterval"
+                 Required="@true"
+                 RequiredError="Enter the number of stars"/>
+ 
+<MudButton Id="culture-change"
+           Variant="@Variant.Filled" 
+           Color="@Color.Primary"
+           OnClick="@LaunchDelayedCultureChange">
+     Launch delayed culture change
+ </MudButton>
+ 
+<MudText>
+    RenderCount: @_renderCount
+</MudText>
+
+<MudText>
+    Value: @Value
+</MudText>
+ 
+@code {
+    public static string __description__ = "Test user input retention on component refresh before debounce with changed culture.";
+    
+    public int DebounceInterval = 500;
+    public int RerenderDelay = 2000;
+    public double Value { get; set; } = 1.0;
+    public CultureInfo Culture = new("en-US");
+    public string Format = "N2";
+    
+    private int _renderCount;
+    
+    protected override void OnAfterRender(bool firstRender)
+    {
+        _renderCount++;
+    }
+
+    async Task LaunchDelayedCultureChange()
+    {
+        await Task.Delay(RerenderDelay);
+        Culture = new CultureInfo("de-DE");
+        StateHasChanged();
+    }
+ }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldRerenderTest.razor
@@ -1,0 +1,43 @@
+﻿<MudNumericField @bind-Value="@Value"
+                 Immediate="@true"
+                 DebounceInterval="@DebounceInterval"
+                 Required="@true"
+                 RequiredError="Enter the number of stars" />
+ 
+<MudButton Id="re-render"
+           Variant="@Variant.Filled" 
+           Color="@Color.Primary"
+           OnClick="@LaunchDelayedRerender">
+    Launch delayed re-render
+</MudButton>
+ 
+<MudText>
+    RenderCount: @_renderCount
+</MudText>
+
+<MudText>
+    Value: @Value
+</MudText>
+ 
+@code {
+    public static string __description__ = "Test user input retention on component refresh before debounce.";
+    
+    [Parameter]
+    public int Value { get; set; }
+
+    public int DebounceInterval = 500;
+    public int RerenderDelay = 2000;
+    
+    private int _renderCount;
+    
+    protected override void OnAfterRender(bool firstRender)
+    {
+        _renderCount++;
+    }
+
+    async Task LaunchDelayedRerender()
+    {
+        await Task.Delay(RerenderDelay);
+        StateHasChanged();
+    }
+ }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
@@ -1,0 +1,44 @@
+﻿<MudTextField T="DateTime"
+              @bind-Value="@Date"
+              Format="@Format"
+              Immediate="@true"
+              DebounceInterval="DebounceInterval"
+              Required="@true"
+              RequiredError="Enter a star" />
+
+<MudButton Variant="@Variant.Filled" 
+           Color="@Color.Primary"
+           OnClick="@LaunchDelayedFormatChange">
+    Launch delayed format change
+</MudButton>
+
+<MudText>
+    RenderCount: @_renderCount
+</MudText>
+
+<MudText>
+    Value: @Date.ToString(Format)
+</MudText>
+
+@code {
+    public static string __description__ = "Test user input retention on component refresh before debounce with changed format.";
+
+    public int DebounceInterval = 500;
+    public int RerenderDelay = 2000;
+    public DateTime Date = new (2023, 07, 12);
+    public string Format = "yyyy/MM/dd";
+
+    private int _renderCount;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        _renderCount++;
+    }
+
+    async Task LaunchDelayedFormatChange()
+    {
+        await Task.Delay(RerenderDelay);
+        Format = "dd/MM/yyyy";
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
@@ -1,0 +1,41 @@
+﻿<MudTextField T="string"
+               @bind-Value="@_text"
+               Immediate="@true"
+               DebounceInterval="@DebounceInterval"
+               Required="@true"
+               RequiredError="Enter a star" />
+ 
+ <MudButton Variant="@Variant.Filled" 
+            Color="@Color.Primary"
+            OnClick="@LaunchDelayedRerender">
+     Launch delayed re-render
+ </MudButton>
+ 
+<MudText>
+    RenderCount: @_renderCount
+</MudText>
+
+<MudText>
+    Value: @_text
+</MudText>
+ 
+@code {
+    public static string __description__ = "Test user input retention on component refresh before debounce.";
+
+    public int DebounceInterval = 500;
+    public int RerenderDelay = 2000;
+    
+    private string _text;
+    private int _renderCount;
+    
+    protected override void OnAfterRender(bool firstRender)
+    {
+        _renderCount++;
+    }
+
+    async Task LaunchDelayedRerender()
+    {
+        await Task.Delay(RerenderDelay);
+        StateHasChanged();
+    }
+ }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
@@ -1,9 +1,9 @@
 ﻿<MudTextField T="string"
-               @bind-Value="@_text"
-               Immediate="@true"
-               DebounceInterval="@DebounceInterval"
-               Required="@true"
-               RequiredError="Enter a star" />
+              @bind-Value="@_text"
+              Immediate="@true"
+              DebounceInterval="@DebounceInterval"
+              Required="@true"
+              RequiredError="Enter a star" />
  
  <MudButton Variant="@Variant.Filled" 
             Color="@Color.Primary"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
@@ -1,5 +1,5 @@
 ﻿<MudTextField T="string"
-              @bind-Value="@_text"
+              @bind-Value="@Value"
               Immediate="@true"
               DebounceInterval="@DebounceInterval"
               Required="@true"
@@ -16,16 +16,18 @@
 </MudText>
 
 <MudText>
-    Value: @_text
+    Value: @Value
 </MudText>
  
 @code {
     public static string __description__ = "Test user input retention on component refresh before debounce.";
 
+    [Parameter]
+    public string Value { get; set; }
+
     public int DebounceInterval = 500;
     public int RerenderDelay = 2000;
-    
-    private string _text;
+
     private int _renderCount;
     
     protected override void OnAfterRender(bool firstRender)

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -812,5 +812,84 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => numericField.Text.Should().Be("1000"));
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1000));
         }
+        
+        /// <summary>
+        /// Validate that a re-render of a debounced numeric field does not cause a loss of uncommitted text.
+        /// </summary>
+        [Test]
+        public async Task DebouncedNumericFieldRerenderTest()
+        {
+            var comp = Context.RenderComponent<DebouncedNumericFieldRerenderTest>();
+            var numericField = comp.FindComponent<MudNumericField<int>>().Instance;
+            var input = comp.Find("input");
+            var delayedRerenderButton = comp.Find("button#re-render");
+            var converter = new DefaultConverter<int>();
+            input.Input(new ChangeEventArgs { Value = "1" });
+            // trigger first value change
+            await Task.Delay(comp.Instance.DebounceInterval);
+            // trigger delayed re-render
+            delayedRerenderButton.Click();
+            // imitate "typing in progress" by extending the debounce interval until component re-renders
+            var elapsedTime = 0;
+            var currentText = "1";
+            while (elapsedTime < comp.Instance.RerenderDelay)
+            {
+                var delay = comp.Instance.DebounceInterval / 2;
+                currentText += "2";
+                input.Input(new ChangeEventArgs { Value = currentText });
+                await Task.Delay(delay);
+                elapsedTime += delay;
+            }
+            // after the final debounce, the value should be updated without swallowing any user input 
+            await Task.Delay(comp.Instance.DebounceInterval);
+            comp.Instance.Value.Should().Be(converter.Get(currentText));
+            numericField.Text.Should().Be(currentText);
+        }
+        
+        [Test]
+        public async Task DebouncedNumericField_Should_RenderDefaultValueTextOnFirstRender()
+        {
+            var defaultValue = 1;
+            var converter = new DefaultConverter<int>();
+            var comp = Context.RenderComponent<DebouncedNumericFieldRerenderTest>(
+                Parameter(nameof(MudNumericField<int>.Value), defaultValue));
+            var textfield = comp.FindComponent<MudNumericField<int>>().Instance;
+            textfield.Text.Should().Be(converter.Set(defaultValue));
+        }
+        
+        /// <summary>
+        /// Validate that a re-render of a debounced numeric field does not cause a loss of uncommitted text while changing culture.
+        /// </summary>
+        [Test]
+        public async Task DebouncedNumericFieldCultureChangeRerenderTest()
+        {
+            var comp = Context.RenderComponent<DebouncedNumericFieldCultureChangeRerenderTest>();
+            var numericField = comp.FindComponent<MudNumericField<double>>().Instance;
+            var input = comp.Find("input");
+            var delayedCultureChange = comp.Find("button#culture-change");
+            // ensure text is updated on initialize 
+            numericField.Text.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture));
+            // trigger first value change
+            await Task.Delay(comp.Instance.DebounceInterval);
+            // trigger the culture change
+            delayedCultureChange.Click();
+            // imitate "typing in progress" by extending the debounce interval until component re-renders
+            var elapsedTime = 0;
+            var currentText = comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture);
+            while (elapsedTime < comp.Instance.RerenderDelay)
+            {
+                var delay = comp.Instance.DebounceInterval / 2;
+                currentText += "2";
+                input.Input(new ChangeEventArgs { Value = currentText });
+                await Task.Delay(delay);
+                elapsedTime += delay;
+            }
+            // after the culture change delay has elapsed, the uncommitted text is retained (with the old culture)
+            numericField.Text.Should().Be(currentText);
+            // once debounce occurs, both value and text are translated into the new culture
+            // e.g. 1.00222222 (one comma something in en-US) turns into 100.222.222 (hundred million something in de-DE)
+            await Task.Delay(comp.Instance.DebounceInterval * 2);
+            numericField.Text.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -894,5 +894,15 @@ namespace MudBlazor.UnitTests.Components
             textField.Value.Should().Be(currentText);
             textField.Text.Should().Be(currentText);
         }
+        
+        [Test]
+        public async Task DebouncedTextField_Should_RenderDefaultValueTextOnFirstRender()
+        {
+            var defaultValue = "test";
+            var comp = Context.RenderComponent<DebouncedTextFieldRerenderTest>(
+                Parameter(nameof(MudTextField<string>.Value), defaultValue));
+            var textfield = comp.FindComponent<MudTextField<string>>().Instance;
+            textfield.Text.Should().Be(defaultValue);
+        }
     }
 }

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -48,6 +48,18 @@ namespace MudBlazor
 
             return Task.CompletedTask;
         }
+        
+        protected override Task UpdateTextPropertyAsync(bool updateValue)
+        {
+            var suppressTextUpdate = !updateValue
+                                     && DebounceInterval > 0
+                                     && _timer != null
+                                     && (!Value?.Equals(Converter.Get(Text)) ?? false);
+            
+            return suppressTextUpdate
+                ? Task.CompletedTask
+                : base.UpdateTextPropertyAsync(updateValue);
+        }
 
         protected override Task UpdateValuePropertyAsync(bool updateText)
         {

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -53,7 +53,7 @@ namespace MudBlazor
         {
             var suppressTextUpdate = !updateValue
                                      && DebounceInterval > 0
-                                     && _timer != null
+                                     && _timer is { Enabled: true } 
                                      && (!Value?.Equals(Converter.Get(Text)) ?? false);
             
             return suppressTextUpdate


### PR DESCRIPTION
## Description

Follows #7159 in fixing swallowed user input.

After updating to `6.7.0` we noticed we still had issues with text disappearing on some of our debounced inputs which made me realise the issue was component refreshes in general.

This PR makes it so that `MudDebouncedInput`s don't update the text property unless the caller requests a `Value` update, or the `Value` property was actually changed.

I checked my use case as well as one edge case I thought of, having `Clearable` set to `true` and attempting to clear a value while there is uncommitted text, which works fine.

Let me know if you see any potential issues that you want me to write tests for, or if you have any ideas for a "safer" way to implement this.

Fixes: #7193

## How Has This Been Tested?
- Visually
- Current tests still pass
- Added a new component + accompanying unit test for the described issue, similar to #7159

### Before

https://github.com/MudBlazor/MudBlazor/assets/15004223/0a94ff6c-5c18-45c8-b680-bcd479419165

### After

https://github.com/MudBlazor/MudBlazor/assets/15004223/c7fd18fd-40e8-4adf-b49f-2be2dd3eb761


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
