### PR TITLE
MudDataGrid: SelectColumn not rendered in DataGrid with enabled edit mode

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
@@ -1,0 +1,49 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items=@_items ReadOnly=false EditMode=DataGridEditMode.Cell Dense FixedHeader=true MultiSelection="true">
+    <Columns>
+        <SelectColumn/>        
+        <PropertyColumn Property="x => x.Name" IsEditable=false/>
+        <PropertyColumn Property="x => x.Value">
+            <EditTemplate>
+                <MudSelect @bind-Value=context.Item.Value>
+                    <MudSelectItem Value=1/>
+                    <MudSelectItem Value=10/>
+                    <MudSelectItem Value=100/>
+                    <MudSelectItem Value=1000/>
+                </MudSelect>
+            </EditTemplate>
+        </PropertyColumn>
+        <PropertyColumn Property="x => x.Misc" IsEditable=false/>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "SelectColumn should be rendered in DataGrid in Edit mode .";
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new("B", 42, "555"),
+        new("A", 73, "7"),
+        new("A", 11, "4444"),
+        new("C", 33, "33333"),
+        new("A", 99, "66"),
+        new("C", 44, "1111111"),
+        new("C", 55, "222222")
+    };
+
+
+    public class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public string Misc { get; set; }
+
+        public Item(string name, int value, String misc)
+        {
+            Name = name;
+            Value = value;
+            Misc = misc;
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -394,8 +394,33 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Find("tfoot input").Change(false);
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
         }
-
+        
         [Test]
+        public async Task DataGridEditableSelectionTest()
+        {
+            var comp = Context.RenderComponent<DataGridEditableWithSelectColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditableWithSelectColumnTest.Item>>();
+            
+            // test that all rows, header and footer have cell with a checkbox
+            dataGrid.FindAll("input.mud-checkbox-input").Count().Should().Be(dataGrid.Instance.Items.Count()+2);
+
+            //test that changing header sets all items selected
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll("input.mud-checkbox-input")[0].Change(true);
+            dataGrid.Instance.SelectedItems.Count.Should().Be(dataGrid.Instance.Items.Count());
+            //test that changing footer unselects all items
+            dataGrid.FindAll("input.mud-checkbox-input")[^1].Change(false);
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            //test that changing value in each row selects an item in grid
+            for (int i = 1; i < dataGrid.Instance.Items.Count(); i++)
+            {
+                dataGrid.FindAll("input.mud-checkbox-input")[i].Change(true);
+                dataGrid.Instance.SelectedItems.Count.Should().Be(i);
+            }
+
+
+        }
+
         public async Task DataGridPaginationTest()
         {
             var comp = Context.RenderComponent<DataGridPaginationTest>();

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -2,7 +2,7 @@
 @typeparam T
 
 <TemplateColumn T="T" Tag="@("select-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-    Filterable="false">
+    Filterable="false" IsEditable="false">
     <HeaderTemplate>
         @if (ShowInHeader)
         {


### PR DESCRIPTION

## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7070
Fixes: https://github.com/MudBlazor/MudBlazor/issues/6710

SelectColumn is not rendered in DataGrid with enabled edit mode because internal Template Column is Editable by default.

## How Has This Been Tested?
visually, added unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
