### PR TITLE
Docs: Fix reference type issue on `DropZone` reorder save example (#7191)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneReorderSaveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneReorderSaveExample.razor
@@ -28,7 +28,7 @@
 	</MudDropContainer>
 </div>
 @code {
-	private MudDropContainer<DropItem> _container;
+    private MudDropContainer<DropItem> _container;
 
 	private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
 	{
@@ -36,11 +36,11 @@
 
 		var indexOffset = dropItem.DropzoneIdentifier switch
 		{
-			"2"  => _serverData.Count(x => x.Selector == "1"),
-			_ => 0,
+			"2"  => _dropzoneItems.Count(x => x.Selector == "1"),
+			_ => 0
 		};
 
-		_serverData.UpdateOrder(dropItem, item => item.Order, indexOffset);
+		_dropzoneItems.UpdateOrder(dropItem, item => item.Order, indexOffset);
 	}
 
 	private List<DropItem> _dropzoneItems = new();
@@ -70,18 +70,26 @@
 
 	private void LoadServerData()
 	{
-		List<DropItem> newdata = new List<DropItem>();
-
-		foreach (var item in _serverData.OrderBy(x => x.Order))
-		{
-			newdata.Add(item);
-		}
-
-		_dropzoneItems = newdata;
+	    _dropzoneItems = _serverData
+	        .OrderBy(x => x.Order)
+	        .Select(item => new DropItem
+	        {
+	            Order = item.Order,
+	            Name = item.Name,
+	            Selector = item.Selector
+	        })
+	        .ToList();
 		RefreshContainer();
 	}
 
-	private void SaveData() => _serverData = _dropzoneItems;
+	private void SaveData()
+	    => _serverData = _dropzoneItems
+	        .OrderBy(x => x.Order)
+	        .Select(item => new DropItem
+	        {
+	            Order = item.Order, Name = item.Name, Selector = item.Selector
+	        })
+	        .ToList();
 
 	private void Reset()
 	{
@@ -97,16 +105,16 @@
 				new DropItem() { Order = 6, Name = "Item 7", Selector = "2" },
 				new DropItem() { Order = 7, Name = "Item 8", Selector = "2" },
 				new DropItem() { Order = 8, Name = "Item 9", Selector = "2" },
-				new DropItem() { Order = 9, Name = "Item 10", Selector = "2" },
+				new DropItem() { Order = 9, Name = "Item 10", Selector = "2" }
 			};
 
 		RefreshContainer();
 	}
-
-	public class DropItem
-	{
-		public string Name { get; init; }
-		public string Selector { get; set; }
-		public int Order { get; set; }
-	}
+    
+    public class DropItem
+    {
+        public string Name { get; init; }
+        public string Selector { get; set; }
+        public int Order { get; set; }
+    }
 }


### PR DESCRIPTION
## Description
Fixes an issue where, due to using a reference type with multiple lists, a "server load" example in the docs wouldn't work as expected.

Fixes: #7191

### Before

https://github.com/MudBlazor/MudBlazor/assets/15004223/444650ad-79db-4417-9a80-187f55a2d0c8

### After

https://github.com/MudBlazor/MudBlazor/assets/15004223/69876f2f-e9db-41fe-b27a-8c3744d88bc1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
