### PR TITLE
MudMask: Fix Clearable with non-PatternMasks (#7238)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldBasicExample.razor
@@ -1,34 +1,36 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker
-    Placeholder="Placeholder"
-    Label="Basic example"
-    @bind-Date="date"
-    Mask="@(new DateMask("dd/MM/yyyy"))"
-    DateFormat="dd/MM/yyyy" Clearable/>
 
-<MudDatePicker
-    Placeholder="Placeholder"
-    Label="Basic example"
-    @bind-Date="date"
-    Mask="@(new PatternMask("00/00/0000"))"
-    DateFormat="dd/MM/yyyy" Clearable/>
-
-<MudTextField
-Placeholder="Placeholder"
-Label="Basic example"
-Mask="@(new PatternMask("000"))"
-@bind-Value="@text" Clearable/>
-
-<MudTextField
-Placeholder="Placeholder"
-Label="Basic example"
-Mask="@(new DateMask("dd/MM/yyyy"))"
-@bind-Value="@dateText" Clearable/>
-
-@code {
-    DateTime? date = DateTime.Today;
-    TimeSpan? time = new TimeSpan(0, 0, 0, 2);
-    string? text = "123";
-    string? dateText = "20/07/2023";
-}
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Standard" Variant="Variant.Text">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Filled" Variant="Variant.Filled">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Outlined" Variant="Variant.Outlined">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
+    </MudItem>
+</MudGrid>
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Standard" Variant="Variant.Text"></MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Filled" Variant="Variant.Filled"></MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Outlined" Variant="Variant.Outlined"></MudField>
+    </MudItem>
+</MudGrid>
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Standard" Variant="Variant.Text" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CheckCircle" AdornmentColor="Color.Success"></MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Filled" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Money"></MudField>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudField Label="Outlined" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Warning" AdornmentColor="Color.Warning"></MudField>
+    </MudItem>
+</MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldBasicExample.razor
@@ -1,36 +1,34 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
+<MudDatePicker
+    Placeholder="Placeholder"
+    Label="Basic example"
+    @bind-Date="date"
+    Mask="@(new DateMask("dd/MM/yyyy"))"
+    DateFormat="dd/MM/yyyy" Clearable/>
 
-<MudGrid>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Standard" Variant="Variant.Text">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Filled" Variant="Variant.Filled">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Outlined" Variant="Variant.Outlined">Some Content <MudIcon Icon="@Icons.Material.Filled.Favorite" Color="@Color.Warning" /> follows here</MudField>
-    </MudItem>
-</MudGrid>
-<MudGrid>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Standard" Variant="Variant.Text"></MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Filled" Variant="Variant.Filled"></MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Outlined" Variant="Variant.Outlined"></MudField>
-    </MudItem>
-</MudGrid>
-<MudGrid>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Standard" Variant="Variant.Text" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CheckCircle" AdornmentColor="Color.Success"></MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Filled" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Money"></MudField>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Outlined" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Warning" AdornmentColor="Color.Warning"></MudField>
-    </MudItem>
-</MudGrid>
+<MudDatePicker
+    Placeholder="Placeholder"
+    Label="Basic example"
+    @bind-Date="date"
+    Mask="@(new PatternMask("00/00/0000"))"
+    DateFormat="dd/MM/yyyy" Clearable/>
+
+<MudTextField
+Placeholder="Placeholder"
+Label="Basic example"
+Mask="@(new PatternMask("000"))"
+@bind-Value="@text" Clearable/>
+
+<MudTextField
+Placeholder="Placeholder"
+Label="Basic example"
+Mask="@(new DateMask("dd/MM/yyyy"))"
+@bind-Value="@dateText" Clearable/>
+
+@code {
+    DateTime? date = DateTime.Today;
+    TimeSpan? time = new TimeSpan(0, 0, 0, 2);
+    string? text = "123";
+    string? dateText = "20/07/2023";
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/DifferentMaskImplementationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/DifferentMaskImplementationTest.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTextField Clearable
+              Mask="@_blockMask"
+              @bind-Value="@BlockMaskValue" />
+
+<MudTextField Clearable
+              Mask="@(new DateMask("dd/MM/yyyy"))"
+              @bind-Value="@DateMaskValue" />
+
+<MudTextField Clearable
+              Mask="@_multiMask"
+              @bind-Value="@MultiMaskValue" />
+
+<MudTextField Clearable
+              Mask="@_patternMask"
+              @bind-Value="@PatternMaskValue" />
+
+<MudTextField Clearable
+              Mask="@RegexMask.IPv4()"
+              @bind-Value="@RegexMaskValue" />
+
+@code {
+    [Parameter]
+    public string BlockMaskValue { get; set; } = "MUD 1337";
+    
+    [Parameter]
+    public string DateMaskValue { get; set; } = "20/07/2023";
+    
+    [Parameter]
+    public string MultiMaskValue { get; set; } = "1234 5678 9012 3456";
+    
+    [Parameter]
+    public string PatternMaskValue { get; set; } = "123";
+    
+    [Parameter]
+    public string RegexMaskValue { get; set; } = "127.000.000.001";
+    
+    private readonly BlockMask _blockMask = new(delimiters:" ", new Block('a', 1,3), new Block('0', 1,4));
+    private readonly MultiMask _multiMask = new("0000 0000 0000 0000");
+    private readonly PatternMask _patternMask = new("000");
+}

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -240,7 +240,6 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => tf.Value.Should().Be(null));
         }
 
-
         [Test]
         public async Task MaskTest_InsertCharactersIntoMiddle()
         {
@@ -756,6 +755,43 @@ namespace MudBlazor.UnitTests.Components
                 maskInput.Cut(new ClipboardEventArgs { Type = "cut" });
             });
             comp.WaitForAssertion(() => textField.Value.Should().Be(""));
+        }
+
+        [Test]
+        public async Task DifferentMaskImplementationTests()
+        {
+            // arrange
+            var comp = Context.RenderComponent<DifferentMaskImplementationTest>();
+            var masks = comp.FindComponents<MudMask>();
+            var textFields = comp.FindComponents<MudTextField<string>>();
+            var blockMaskComponent = masks[0];
+            var blockMaskField = textFields[0].Instance;
+            var dateMaskComponent = masks[1];
+            var dateMaskField = textFields[1].Instance;
+            var multiMaskComponent = masks[2];
+            var multiMaskField = textFields[2].Instance;
+            var patternMaskComponent = masks[3];
+            var patternMaskField = textFields[3].Instance;
+            var regexMaskComponent = masks[4];
+            var regexMaskField = textFields[4].Instance;
+            
+            // act
+            
+            // assert
+            blockMaskComponent.Markup.Contains(blockMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            blockMaskField.Mask.Text.Should().Be(comp.Instance.BlockMaskValue);
+            
+            dateMaskComponent.Markup.Contains(dateMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            dateMaskField.Mask.Text.Should().Be(comp.Instance.DateMaskValue);
+            
+            multiMaskComponent.Markup.Contains(multiMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            multiMaskField.Mask.Text.Should().Be(comp.Instance.MultiMaskValue);
+            
+            patternMaskComponent.Markup.Contains(patternMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            patternMaskField.Mask.Text.Should().Be(comp.Instance.PatternMaskValue);
+            
+            regexMaskComponent.Markup.Contains(regexMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            regexMaskField.Mask.Text.Should().Be(comp.Instance.RegexMaskValue);
         }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -399,11 +399,10 @@ namespace MudBlazor
 
         private void SetMask(IMask other)
         {
-            if (_mask == null || other == null || _mask?.GetType() != other?.GetType())
+            if (other == null)
             {
-                _mask = other;
-                if (_mask == null)
-                    _mask = new PatternMask("null ********"); // warn the user that the mask parameter is missing
+                // warn the user that the mask parameter is missing
+                _mask = new PatternMask("null ********");
                 return;
             }
 

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -396,7 +396,7 @@ namespace MudBlazor
             Mask.Selection = null;
             Mask.CaretPos = pos;
         }
-
+        
         private void SetMask(IMask other)
         {
             if (other == null)
@@ -405,9 +405,18 @@ namespace MudBlazor
                 _mask = new PatternMask("null ********");
                 return;
             }
-
-            // set new mask properties without loosing state
-            _mask.UpdateFrom(other);
+            
+            if (_mask.GetType() == other.GetType())
+            {
+                // update mask while retaining current state
+                _mask.UpdateFrom(other);
+                return;
+            }
+           
+            // swap masks while retaining text
+            // note: this is required for `BaseMask` instances other than `PatternMask` to work as expected
+            other.SetText(Text);
+            _mask = other;
         }
 
         private async void OnCut(ClipboardEventArgs obj)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -73,7 +73,7 @@
                              Value="@Text"
                              ValueChanged="OnMaskedValueChanged"
                              Placeholder="@Placeholder"
-                            Disabled=@GetDisabledState()
+                             Disabled=@GetDisabledState()
                              DisableUnderLine="@DisableUnderLine"
                              ReadOnly="@GetReadOnlyState()"
                              MaxLength="@MaxLength"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -121,7 +121,6 @@ namespace MudBlazor
             _maskReference.OnPaste(text);
         }
 
-
         private IMask _mask = null;
 
         /// <summary>


### PR DESCRIPTION
## Description

Fixed an issue where using an `IMask` other than `PatternMask` was not working as expected. In this case, the `ClearIcon` would not be displayed in a `MudDatePicker` with a `DateMask` applied (see #7238), but the issue was reproducible with `MudTextField`s with different masks.

Fixes: #7238 

## How Has This Been Tested?

Added bUnit tests:

![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/009ee8f4-6f0e-4686-9e00-6928a2c674fd)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
