### PR TITLE
Allows the first date in the MudDateRangePicker to be set

### DIFF
--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -58,6 +58,10 @@ namespace MudBlazor
 
                 _dateRange = range;
                 _value = range?.End;
+                if (range.End == null)
+                {
+                    _firstDate = range.Start;
+                }
 
                 if (updateValue)
                 {


### PR DESCRIPTION
## Description
This change allows the start date of the MudDateRangePicker to be set by setting the Start date of the DateRange variable to a date and the End date to null. This will enable the user to set the end date with a single click.

## How Has This Been Tested?
All unit tests passed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
