### PR TITLE
Tooltip: Fix arrow placement when using ChildContent

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -131,7 +131,7 @@ namespace MudBlazor.UnitTests.Components
 
             //content should be visible
             popoverContentNode.ClassList.Should().Contain("mud-tooltip");
-            popoverContentNode.ClassList.Should().Contain("d-block");
+            popoverContentNode.ClassList.Should().Contain("d-flex");
 
             comp.Find(".my-customer-paper").Children[0].TextContent.Should().Be("My content");
 
@@ -162,6 +162,19 @@ namespace MudBlazor.UnitTests.Components
 
             container.ClassList.Should().BeEquivalentTo(expectedClasses);
         }
+        
+        [Test]
+        public async Task InnerClass_ChildContentWrapper()
+        {
+            var comp = Context.RenderComponent<ToolTipPopoverClassPropertyTest>();
+
+            var button = comp.Find("button");
+            await button.ParentElement.TriggerEventAsync("onmouseenter", new MouseEventArgs());
+
+            var wrapperDivNode = comp.Find("#my-tooltip-content").ParentElement;
+
+            wrapperDivNode.ClassList.Should().BeEquivalentTo(new[] { "d-block" });
+        }
 
         [Test]
         [TestCase(false, new[] { "mud-tooltip" })]
@@ -174,7 +187,7 @@ namespace MudBlazor.UnitTests.Components
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onmouseenter", new MouseEventArgs());
 
-            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
+            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
             popoverContentNode.ClassList.Should().Contain(expectedClasses);
         }
@@ -192,7 +205,7 @@ namespace MudBlazor.UnitTests.Components
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onmouseenter", new MouseEventArgs());
 
-            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
+            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
             popoverContentNode.ClassList.Should().Contain(expectedClasses);
         }
@@ -213,7 +226,7 @@ namespace MudBlazor.UnitTests.Components
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onmouseenter", new MouseEventArgs());
 
-            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
+            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
             popoverContentNode.ClassList.Should().Contain(expectedClasses);
         }
@@ -247,7 +260,7 @@ namespace MudBlazor.UnitTests.Components
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onmouseenter", new MouseEventArgs());
 
-            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
+            var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
             popoverContentNode.ClassList.Should().Contain(expectedClasses);
         }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -8,7 +8,9 @@
         <MudPopover Open="_isVisible" Duration="@Duration" Delay="@Delay" AnchorOrigin="@_anchorOrigin" TransformOrigin="@_transformOrigin" Class="@Classname" Style="@Style" Paper="false">
             @if (TooltipContent is not null)
             {
-                @TooltipContent
+                <div class="d-block">
+                    @TooltipContent
+                </div>
             }
             else if (!string.IsNullOrEmpty(Text))
             {

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -18,13 +18,12 @@ namespace MudBlazor
             .Build();
 
         protected string Classname => new CssBuilder("mud-tooltip")
+            .AddClass("d-flex")
             .AddClass($"mud-tooltip-default", Color == Color.Default)
             .AddClass($"mud-tooltip-{ConvertPlacement().ToDescriptionString()}")
             .AddClass($"mud-tooltip-arrow", Arrow)
             .AddClass($"mud-border-{Color.ToDescriptionString()}", Arrow && Color != Color.Default)
             .AddClass($"mud-theme-{Color.ToDescriptionString()}", Color != Color.Default)
-            .AddClass($"d-block", TooltipContent is not null)
-            .AddClass($"d-flex", !string.IsNullOrEmpty(Text))
             .AddClass(Class)
             .Build();
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

As far back as December of 2021, using the `Arrow` property of the tooltip did not work when using custom HTML tooltip content:

![image](https://github.com/MudBlazor/MudBlazor/assets/26885142/e0d385e4-8e1d-441e-9926-2b278d855e8b)
![image](https://github.com/MudBlazor/MudBlazor/assets/26885142/1ea99f85-2e1e-4a8c-af1b-582091c91296)

This was due to `d-flex` being used on the popover in text based scenarios, and `d-block` in render fragment scenarios. The solution was to use `d-flex` in all scenarios and introduce a wrapper div with `d-block` to ensure the HTML content renders correctly:

```csharp
 @if (TooltipContent is not null)
            {
                <div class="d-block">
                    @TooltipContent
                </div>
            }
            else if (!string.IsNullOrEmpty(Text))
            {
                @Text
            }
```

The result is a tooltip arrow that renders in the expected position:

![image](https://github.com/MudBlazor/MudBlazor/assets/26885142/89d3d809-aafe-4614-8830-6494d133e83c)

Fixes #6718.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

I have added a unit test and updated several existing ones that were broken by the insertion of the new div.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
