### PR TITLE
Docs: Fixed content security policy for Carbon Ads

### DIFF
--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -48,6 +48,7 @@
                              *.fontawesome.com
                              https://fonts.gstatic.com;
                    connect-src 'self'
+                               https://*.carbonads.net
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
                                https://discord.com

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -44,6 +44,7 @@
                              *.fontawesome.com
                              https://fonts.gstatic.com;
                    connect-src 'self'
+                               https://*.carbonads.net
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
                                https://discord.com

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -53,6 +53,7 @@
                              *.fontawesome.com
                              https://fonts.gstatic.com;
                    connect-src 'self'
+                               https://*.carbonads.net
                                https://api.github.com
                                https://azuresearch-usnc.nuget.org
                                https://discord.com


### PR DESCRIPTION
## Description
Fixed content security policy for Carbon Ads.

Got contacted by email from them with following:
We have recently updated Carbon ad code to use Fetch API and it appears that ads are no longer appearing on your site due to the Content Security Policy configured on your site. Could you update your permission to allow requests coming from the script?

