### PR TITLE
MudMenu: Add IsOpen property (#7266)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -83,6 +83,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task IsOpen_CheckState()
+        {
+            var comp = Context.RenderComponent<MenuTest1>();
+            var menu = comp.FindComponent<MudMenu>().Instance;
+            menu.IsOpen.Should().BeFalse();
+
+            var args = new MouseEventArgs { OffsetX = 1.0, OffsetY = 1.0 };
+            await comp.InvokeAsync(() => menu.OpenMenu(args));
+            menu.IsOpen.Should().BeTrue();
+
+            await comp.InvokeAsync(() => menu.CloseMenu());
+            menu.IsOpen.Should().BeFalse();
+        }
+
+        [Test]
         public async Task MenuMouseLeave_CheckClosed()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -249,6 +249,17 @@ namespace MudBlazor
 
         public string PopoverStyle { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the menu is currently open or not.
+        /// </summary>
+        public bool IsOpen
+        {
+            get { return _isOpen; }
+        }
+
+        /// <summary>
+        /// Closes the menu.
+        /// </summary>
         public void CloseMenu()
         {
             _isOpen = false;
@@ -257,6 +268,12 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        /// <summary>
+        /// Opens the menu.
+        /// </summary>
+        /// <param name="args">The arguments of the calling mouse event. If
+        /// <see cref="PositionAtCursor"/> is true, the menu will be positioned using the
+        /// coordinates in this parameter.</param>
         public void OpenMenu(EventArgs args)
         {
             if (Disabled)


### PR DESCRIPTION
## Description
Adds a new MudMenu.IsOpen property as described in #7266 . This makes it possible to handle the &lt;ESC&gt; key / back button correctly, by either closing the menu or by navigating backwards. It is especially useful for Blazor Hybrid apps.

fixes #7266

## How Has This Been Tested?
There is a unit test checking the state after opening / closing the menu.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
