### PR TITLE
DataGrid : feature to allow cell to render a RenderFragment

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellFragmentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellFragmentTest.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="TestModel" Items="@Items">
+    <Columns>
+        <CustomPropertyColumn Property="x => x.Name" />
+        <CustomPropertyColumn Property="x => x.Age" />
+    </Columns>
+</MudDataGrid>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellFragmentTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellFragmentTest.razor.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.UnitTests.TestComponents;
+
+public partial class DataGridCellFragmentTest : ComponentBase
+{
+    public static readonly TestModel[] Items =
+    {
+        new("John", 45),
+        new("Johanna", 23),
+        new("Steve", 32)
+    };
+
+    public record TestModel(string Name, int Age);
+}
+
+public class CustomPropertyColumn<T, TProperty> : PropertyColumn<T, TProperty>
+{
+    protected override object CellContent(T item)
+    {
+        var value = base.CellContent(item);
+            
+        return value switch
+        {
+            string sValue => CreateFragment(sValue),
+            _ => value
+        };
+    }
+
+    private static RenderFragment CreateFragment(string content)
+    {
+        return builder =>
+        {
+            builder.OpenElement(0, "span");
+            builder.AddContent(1, content);
+            builder.CloseElement();
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3782,7 +3782,6 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridGroupCollapseAllTest()
         {
             var comp = Context.RenderComponent<DataGridGroupCollapseAllTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupCollapseAllTest.TestObject>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
             comp.Instance.ExpandAllGroups();
@@ -3801,7 +3800,6 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridGroupExpandAllCollapseAllTest()
         {
             var comp = Context.RenderComponent<DataGridGroupExpandAllCollapseAllTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandAllCollapseAllTest.Element>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
             comp.Instance.ExpandAllGroups();
@@ -3824,12 +3822,31 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridFormatTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormatTest.Employee>>();
-
+            
             comp.FindAll("tbody.mud-table-body td")[3].TextContent.Should().Be("$87,000.00");
             var column = (PropertyColumn<DataGridFormatTest.Employee, int>)dataGrid.Instance.GetColumnByPropertyName("Salary");
             await comp.InvokeAsync(() => column.Format = "C0");
             comp.Find(".mud-switch-input").Change(new ChangeEventArgs { Value = true });
             comp.FindAll("tbody.mud-table-body td")[3].TextContent.Should().Be("$87,000");
+        }
+        
+        [Test]
+        public async Task DataGridPropertyColumn_ShouldRenderFragment()
+        {
+            var component = Context.RenderComponent<DataGridCellFragmentTest>();
+
+            var rows = component.FindAll("tbody .mud-table-row");
+            component.FindAll("tbody .mud-table-row").Should().HaveCount(DataGridCellFragmentTest.Items.Length);
+            for (var i = 0; i < DataGridCellFragmentTest.Items.Length; i++)
+            {
+                var row = rows[i];
+                var cells = row.QuerySelectorAll("td");
+                cells.Should().HaveCount(2);
+                
+                var item = DataGridCellFragmentTest.Items[i];
+                cells[0].InnerHtml.Should().Be($"<span>{item.Name}</span>");
+                cells[1].InnerHtml.Should().Be($"{item.Age}");
+            }
         }
 
         [Test]
@@ -3851,7 +3868,7 @@ namespace MudBlazor.UnitTests.Components
 
 
             var column = dataGrid.FindComponent<Column<DataGridSortableTest.Item>>();
-            await comp.InvokeAsync(() => column.Instance.SortBy = x => { return x.Name; });
+            await comp.InvokeAsync(() => column.Instance.SortBy = x => x.Name);
             dataGrid.Render();
             dataGrid.Instance.FilteringRunCount.Should().Be(initialFilterCount + 4);
 

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -97,14 +97,9 @@ namespace MudBlazor
                 case JsonElement element when _column.dataType == typeof(string):
                     _valueString = element.GetString();
                     return;
-                case JsonElement element:
-                    {
-                        if (_column.isNumber)
-                        {
-                            _valueNumber = element.GetDouble();
-                        }
-                        return;
-                    }
+                case JsonElement element when _column.isNumber:
+                    _valueNumber = element.GetDouble();
+                    return;
                 default:
                     {
                         if (_column.dataType == typeof(string))

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -89,32 +90,33 @@ namespace MudBlazor
 
         private void OnStartedEditingItem()
         {
-            if (ComputedValue is null)
+            switch (ComputedValue)
             {
-                return;
-            }
-
-            if (ComputedValue is JsonElement element)
-            {
-                if (_column.dataType == typeof(string))
-                {
+                case null: return;
+                case RenderFragment: return;
+                case JsonElement element when _column.dataType == typeof(string):
                     _valueString = element.GetString();
-                }
-                else if (_column.isNumber)
-                {
-                    _valueNumber = element.GetDouble();
-                }
-            }
-            else
-            {
-                if (_column.dataType == typeof(string))
-                {
-                    _valueString = (string)ComputedValue;
-                }
-                else if (_column.isNumber)
-                {
-                    _valueNumber = Convert.ToDouble(ComputedValue);
-                }
+                    return;
+                case JsonElement element:
+                    {
+                        if (_column.isNumber)
+                        {
+                            _valueNumber = element.GetDouble();
+                        }
+                        return;
+                    }
+                default:
+                    {
+                        if (_column.dataType == typeof(string))
+                        {
+                            _valueString = (string)ComputedValue;
+                        }
+                        else if (_column.isNumber)
+                        {
+                            _valueNumber = Convert.ToDouble(ComputedValue);
+                        }
+                        return;
+                    }
             }
         }
     }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -207,24 +207,23 @@ namespace MudBlazor
         {
             get
             {
-                // Handle case where T is IDictionary.
-                if (typeof(T) == typeof(IDictionary<string, object>))
+                if (typeof(T) != typeof(IDictionary<string, object>))
                 {
-                    // We need to get the actual type here so we need to look at actual data.
-                    // get the first item where we have a non-null value in the field to be filtered.
-                    var first = DataGrid.Items.FirstOrDefault(x => ((IDictionary<string, object>)x)[PropertyName] != null);
-
-                    if (first != null)
-                    {
-                        return ((IDictionary<string, object>)first)[PropertyName].GetType();
-                    }
-                    else
-                    {
-                        return typeof(object);
-                    }
+                    return dataType;
                 }
 
-                return dataType;
+                // Handle case where T is IDictionary.
+                // We need to get the actual type here so we need to look at actual data.
+                // get the first item where we have a non-null value in the field to be filtered.
+                var first = DataGrid.Items.FirstOrDefault(x => ((IDictionary<string, object>)x)[PropertyName] != null);
+
+                if (first != null)
+                {
+                    return ((IDictionary<string, object>)first)[PropertyName].GetType();
+                }
+                    
+                return typeof(object);
+
             }
         }
 
@@ -293,8 +292,7 @@ namespace MudBlazor
             if (groupable && Grouping)
                 grouping = Grouping;
 
-            if (DataGrid != null)
-                DataGrid.AddColumn(this);
+            DataGrid?.AddColumn(this);
 
             // Add the HeaderContext
             headerContext = new HeaderContext<T>(DataGrid);
@@ -327,7 +325,7 @@ namespace MudBlazor
             {
                 if (this is TemplateColumn<T>)
                 {
-                    _sortBy = x => true;
+                    _sortBy = _ => true;
                 }
                 else
                     _sortBy = PropertyFunc;

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -207,24 +207,26 @@ namespace MudBlazor
         {
             get
             {
-                if (typeof(T) != typeof(IDictionary<string, object>))
-                {
-                    return dataType;
-                }
-
                 // Handle case where T is IDictionary.
-                // We need to get the actual type here so we need to look at actual data.
-                // get the first item where we have a non-null value in the field to be filtered.
-                var first = DataGrid.Items.FirstOrDefault(x => ((IDictionary<string, object>)x)[PropertyName] != null);
-
-                if (first != null)
+                if (typeof(T) == typeof(IDictionary<string, object>))
                 {
-                    return ((IDictionary<string, object>)first)[PropertyName].GetType();
-                }
+                    // We need to get the actual type here so we need to look at actual data.
+                    // get the first item where we have a non-null value in the field to be filtered.
+                    var first = DataGrid.Items.FirstOrDefault(x => ((IDictionary<string, object>)x)[PropertyName] != null);
                     
-                return typeof(object);
-
+                    if (first != null)
+                    {
+                        return ((IDictionary<string, object>)first)[PropertyName].GetType();
+                    }
+                    else
+                    {
+                        return typeof(object);
+                    }
+                }
+                
+                return dataType;
             }
+
         }
 
         internal bool isNumber
@@ -291,8 +293,9 @@ namespace MudBlazor
 
             if (groupable && Grouping)
                 grouping = Grouping;
-
-            DataGrid?.AddColumn(this);
+            
+            if(DataGrid != null)
+                DataGrid.AddColumn(this);
 
             // Add the HeaderContext
             headerContext = new HeaderContext<T>(DataGrid);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -370,7 +370,7 @@
                     {
                         if (column.ContentFormat is not null)
                         {
-                            @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
+                            @cell._valueNumber?.ToString(column.ContentFormat, column.Culture)
                         }
                         else
                         {
@@ -382,6 +382,10 @@
                         if (column.ContentFormat is not null)
                         {
                             @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
+                        }
+                        else if (cell.ComputedValue is RenderFragment fragment)
+                        {
+                            @fragment
                         }
                         else
                         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -370,7 +370,7 @@
                     {
                         if (column.ContentFormat is not null)
                         {
-                            @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
+                            @(cell._valueNumber?.ToString(column.ContentFormat, column.Culture))
                         }
                         else
                         {
@@ -382,6 +382,10 @@
                         if (column.ContentFormat is not null)
                         {
                             @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
+                        }
+                        else if (cell.ComputedValue is RenderFragment fragment)
+                        {
+                            @fragment
                         }
                         else
                         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -370,7 +370,7 @@
                     {
                         if (column.ContentFormat is not null)
                         {
-                            @(cell._valueNumber?.ToString(column.ContentFormat, column.Culture))
+                            @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
                         }
                         else
                         {
@@ -382,10 +382,6 @@
                         if (column.ContentFormat is not null)
                         {
                             @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
-                        }
-                        else if (cell.ComputedValue is RenderFragment fragment)
-                        {
-                            @fragment
                         }
                         else
                         {


### PR DESCRIPTION
## Description
This PR adds the option to use `RenderFragment` to format a property cell using `PropertyColumn`. 
Before DataGrid didn't allow user to use it because it was render as string so the result was `Microsoft.AspNetCore.Components.RenderFragment`.

## How Has This Been Tested?
There is a new unit test `DataGridPropertyColumn_ShouldRenderFragment` checking the `RenderFragment` is display.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
