### PR TITLE
MudTable: Add doc for default column sorting direction and allow unsorted

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -64,11 +64,13 @@
 
         <DocsPageSection>
             <SectionHeader Title="Sorting">
-                <Description>
-                    To enable sorting, add <CodeInline>&lt;MudTableSortLabel></CodeInline> to the header cells and define a function that simply returns the value which should be sorted by when sorting by the specific column.
-                    Click on a header to sort the table by that column, then click to cycle through sorting directions.
-                    Sorting can be allowed and disallowed on the column level with the property <CodeInline>Enabled</CodeInline>.
-                </Description>
+                    <Description>
+                        To enable sorting, add <CodeInline>&lt;MudTableSortLabel></CodeInline> to the header cells and define a function that simply returns the value which should be sorted by when sorting by the specific column.
+                        You can also specify whether default ordering direction should be ascending or descending by specifying the <CodeInline>&lt;InitialDirection></CodeInline> parameter of <CodeInline>&lt;MudTableSortLabel></CodeInline>.<br />
+                        Click on a header to sort the table by that column, then click to cycle through sorting directions.
+                        By default, sorting directions are ascending, descending and unsorted; if you want to cycle through ascending and descending only, you need to specify the <CodeInline>&lt;AllowUnsorted></CodeInline> parameter of the <CodeInline>&lt;MudTable></CodeInline>.
+                        Sorting can be allowed and disallowed on the column level with the property <CodeInline>Enabled</CodeInline>.
+                    </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="TableSortingExample" ShowCode="false" Block="true" FullWidth="true">
                 <TableSortingExample />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
When I first started working with MudTable sorting, I thought that 
- It was not possible to set the default sorting direction for a given column
- When clicking on a given sortable column in order to change the sorting direction, I noticed that the change was not just "ascending --> descending --> ascending" and so on but the behavior was different, and I thought it was a bug (#6685).

Later on, looking at the doc examples I understood that it is actually possible to obtain the desider behavior in both cases, and that the second one is not a bug but the intended behavior. 

Since I'm pretty sure that if those informations were in the component doc (and not just in the code examples) I'd have solved my problems way earlier, I think it would be important to add these informations to the component doc.

## How Has This Been Tested?
I deployed the server project and I've browsed to the documentation page I've modified, and I've seen that modifications had been applied successfully.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
