### PR TITLE
Doc: Fix wrong z-index order in themeing doc ( #6707)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/ZIndex.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/ZIndex.razor
@@ -10,9 +10,9 @@
             </SectionHeader>
             <ul class="docs-list mx-2">
                 <li><MudText Inline="true">Drawer</MudText></li>
+                <li><MudText Inline="true">Popover</MudText></li>
                 <li><MudText Inline="true">AppBar</MudText></li>
                 <li><MudText Inline="true">Dialog</MudText></li>
-                <li><MudText Inline="true">Popover</MudText></li>
                 <li><MudText Inline="true">Snackbar</MudText></li>
                 <li><MudText Inline="true">Tooltip</MudText></li>
             </ul>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
I've noticed an inconsistency in z-index ordering between doc pages [mudtheme-zindex](https://mudblazor.com/customization/default-theme#mudtheme-zindex) and [mudblazor-z-index's](https://mudblazor.com/customization/z-index#mudblazor-z-index's). As specified in #6707, it looks like the first one is correct while the second is not, so I fixed the second one.

Fixes: https://github.com/MudBlazor/MudBlazor/issues/6707

## How Has This Been Tested?
I deployed the server project and I've browsed to the documentation page I've modified, and I've seen that modifications had been applied successfully.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
