### PR TITLE
MudTable/MudDataGrid: Fix row background color for mobile view.

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -428,7 +428,7 @@
         }
 
         .mud-table-row {
-            display: initial;
+            display: revert;
 
             .mud-table-cell:last-child {
                 border-bottom: 1px solid var(--mud-palette-table-lines);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
This PR fixes a CSS issue for the MudTable and MudDataGrid, which prevents to apply any background color to the rows and cells, when the table is in mobile view.
See MudTable example "Click Event and display for selected Row" utilizing RowClassFunc and reduce width to trigger Mobile View:
[MudTable](https://mudblazor.com/components/table#click-event-and-display-for-selected-row)

See MudDataGrid example "Advanced Data Grid", enable hover and striped, change to dark mode (to see striped, default striped color in light mode seem not different), compare with MobileView:
[MudDataGrid](https://mudblazor.com/components/datagrid#advanced-data-grid)

Resolve #4468

### What changed in the code
I changed the styles.scss and replaced "display: initial" with display: revert" for the .mud-table-row class (for small devices).

"display: revert" is supported by all Browsers since April 2021. [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/revert)

"display: revert" changes the display back to it's default value for the <tr /> element, which is table-row.

"display: initial" changed the display to inline, which caused the error.

I could remove the display property totally from the class, which works also, but I was not sure if this would lead to a breaking change, if the display is set on a parent element. That's why I chose to use "display: revert" instead to avoid a breaking change.


### Screenshots before:
#### Normal View
Here you can see how it looks in selected state, and hover, when using the RowClassFunc to change background color.
![image](https://github.com/MudBlazor/MudBlazor/assets/106679495/71f0f3ca-627a-41b8-91af-0582eeb86784)

#### Mobile View
Here you can see, how the selected element (2nd) does not have a different background color, only a different font color (white).
Also the hovered and striped items does not have a different background color.
![image](https://github.com/MudBlazor/MudBlazor/assets/106679495/a522328a-538d-49be-b8ca-1e1b8a842180)

### Screenshots after:

#### Mobile View
Here you can see the selected using the RowClassFunc row.
![image](https://github.com/MudBlazor/MudBlazor/assets/106679495/8df11937-bc36-4485-8fac-aea22085442d)

Here you can see the striped rows and hovered row (3rd row)
![image](https://github.com/MudBlazor/MudBlazor/assets/106679495/f687d889-515a-4917-bcce-4b01de01c594)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I run all unit tests.
I run WASM Host and visually checked on MudDataGrid and MudTable if the striped and hover color works in mobile view. On MudTable I cheked the example, which changes the background color. Now it looks like expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
