### PR TITLE
Prerendering: Check if JSRuntime is available

### DIFF
--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
 
 namespace MudBlazor
@@ -44,9 +45,21 @@ namespace MudBlazor
         public Dictionary<string, object?> UserAttributes { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
+        /// Gets or sets a value indicating whether <see cref="JSRuntime" /> is available.
+        /// </summary>
+        protected bool IsJSRuntimeAvailable { get; set; }
+
+        /// <summary>
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>
         public string FieldId => (UserAttributes?.ContainsKey("id") == true ? UserAttributes["id"]?.ToString() ?? $"mudinput-{Guid.NewGuid()}" : $"mudinput-{Guid.NewGuid()}");
+
+        /// <inheritdoc />
+        protected override void OnAfterRender(bool firstRender)
+        {
+            IsJSRuntimeAvailable = true;
+            base.OnAfterRender(firstRender);
+        }
 
         /// <inheritdoc />
         void IMudStateHasChanged.StateHasChanged() => StateHasChanged();

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -42,7 +42,10 @@ namespace MudBlazor
 
         public async ValueTask DisposeAsync()
         {
-            await BrowserViewportService.UnsubscribeAsync(this);
+            if (IsJSRuntimeAvailable)
+            {
+                await BrowserViewportService.UnsubscribeAsync(this);
+            }
         }
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -246,7 +246,10 @@ namespace MudBlazor
                 if (_keyInterceptor is not null)
                 {
                     _keyInterceptor.KeyDown -= HandleKeyDown;
-                    _keyInterceptor.Dispose();
+                    if (IsJSRuntimeAvailable)
+                    {
+                        _keyInterceptor.Dispose();
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -590,7 +590,10 @@ namespace MudBlazor
         {
             if (_throttledEventManager == null) { return; }
 
-            await _throttledEventManager.DisposeAsync();
+            if (IsJSRuntimeAvailable)
+            {
+                await _throttledEventManager.DisposeAsync();
+            }
         }
 
         #endregion

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -342,7 +342,10 @@ namespace MudBlazor
                     if (_keyInterceptor != null)
                     {
                         _keyInterceptor.KeyDown -= HandleKeyDown;
-                        _keyInterceptor.Dispose();
+                        if (IsJSRuntimeAvailable)
+                        {
+                            _keyInterceptor.Dispose();
+                        }
                     }
                 }
 

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -298,7 +298,10 @@ namespace MudBlazor
                 {
                     DrawerContainer?.Remove(this);
 
-                    BrowserViewportService.UnsubscribeAsync(this).AndForget();
+                    if (IsJSRuntimeAvailable)
+                    {
+                        BrowserViewportService.UnsubscribeAsync(this).AndForget();
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -94,7 +94,10 @@ namespace MudBlazor
 
         public async ValueTask DisposeAsync()
         {
-            await BrowserViewportService.UnsubscribeAsync(this);
+            if (IsJSRuntimeAvailable)
+            {
+                await BrowserViewportService.UnsubscribeAsync(this);
+            }
         }
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -67,7 +67,7 @@ namespace MudBlazor
         private ElementReference _elementReference1;
         private IJsEvent _jsEvent;
         private IKeyInterceptor _keyInterceptor;
-        
+
         [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
         [Inject] private IJsEventFactory _jsEventFactory { get; set; }
@@ -396,7 +396,7 @@ namespace MudBlazor
             Mask.Selection = null;
             Mask.CaretPos = pos;
         }
-        
+
         private void SetMask(IMask other)
         {
             if (other == null)
@@ -405,14 +405,14 @@ namespace MudBlazor
                 _mask = new PatternMask("null ********");
                 return;
             }
-            
+
             if (_mask.GetType() == other.GetType())
             {
                 // update mask while retaining current state
                 _mask.UpdateFrom(other);
                 return;
             }
-           
+
             // swap masks while retaining text
             // note: this is required for `BaseMask` instances other than `PatternMask` to work as expected
             other.SetText(Text);
@@ -423,7 +423,7 @@ namespace MudBlazor
         {
             if (GetReadOnlyState())
                 return;
-            
+
             if (_selection!=null)
                 Mask.Delete();
             await Update();
@@ -435,15 +435,16 @@ namespace MudBlazor
 
             if (disposing == true)
             {
-                _jsEvent?.Dispose();
-
                 if (_keyInterceptor != null)
                 {
                     _keyInterceptor.KeyDown -= HandleKeyDownInternally;
-                    _keyInterceptor.Dispose();
                 }
 
-                _keyInterceptor?.Dispose();
+                if (IsJSRuntimeAvailable)
+                {
+                    _jsEvent?.Dispose();
+                    _keyInterceptor?.Dispose();
+                }
             }
         }
     }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -174,7 +174,12 @@ namespace MudBlazor
         //When disposing the overlay, remove the class that prevented scrolling
         public ValueTask DisposeAsync()
         {
-            return UnblockScrollAsync();
+            if (IsJSRuntimeAvailable)
+            {
+                return UnblockScrollAsync();
+            }
+
+            return ValueTask.CompletedTask;
         }
     }
 }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -183,12 +183,18 @@ namespace MudBlazor
             }
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            if (_scrollSpy is null) { return ValueTask.CompletedTask; }
+            if (_scrollSpy is null)
+            {
+                return;
+            }
 
             _scrollSpy.ScrollSectionSectionCentered -= ScrollSpy_ScrollSectionSectionCentered;
-            return _scrollSpy.DisposeAsync();
+            if (IsJSRuntimeAvailable)
+            {
+                await _scrollSpy.DisposeAsync();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -584,13 +584,13 @@ namespace MudBlazor
                 if (_keyInterceptor != null)
                 {
                     _keyInterceptor.KeyDown -= HandleKeyDown;
-                    _keyInterceptor.Dispose();
+                    if (IsJSRuntimeAvailable)
+                    {
+                        _keyInterceptor.Dispose();
+                    }
                 }
 
             }
         }
-
-
-
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -85,7 +85,10 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
     {
         try
         {
-            await PopoverService.DestroyPopoverAsync(this);
+            if (IsJSRuntimeAvailable)
+            {
+                await PopoverService.DestroyPopoverAsync(this);
+            }
         }
         catch (JSDisconnectedException) { }
         catch (TaskCanceledException) { }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1070,7 +1070,10 @@ namespace MudBlazor
                     _keyInterceptor.KeyDown -= HandleKeyDown;
                     _keyInterceptor.KeyUp -= HandleKeyUp;
 
-                    _keyInterceptor.Dispose();
+                    if (IsJSRuntimeAvailable)
+                    {
+                        _keyInterceptor.Dispose();
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -190,7 +190,10 @@ namespace MudBlazor
                 if(_keyInterceptor != null)
                 {
                     _keyInterceptor.KeyDown -= HandleKeyDown;
-                    _keyInterceptor.Dispose();
+                    if (IsJSRuntimeAvailable)
+                    {
+                        _keyInterceptor.Dispose();
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -350,7 +350,10 @@ namespace MudBlazor
                 return;
             _isDisposed = true;
             _resizeObserver.OnResized -= OnResized;
-            await _resizeObserver.DisposeAsync();
+            if (IsJSRuntimeAvailable)
+            {
+                await _resizeObserver.DisposeAsync();
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Description
Fixes #7155
To understand the problem, please. read the issue. In short, we need to make sure if the JsRuntime is available before calling any JS, for example in the Dispose methods. Doesn't apply for the `OnAfterRender`.

I was thinking to fix it in v7, but since it's not a breaking change why just not improve it in the current  version.

Even thought this idea how to fix it came in my mind on my own, but apparently Radzen is using this mechanics as well.

## How Has This Been Tested?
Manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
