### PR TITLE
Docs: Support dark mode loading screen depending on user settings

### DIFF
--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -70,7 +70,7 @@
 
 <body>
     <div id="app">
-        <div style="height:100%;width:100%;margin:0;position:fixed;background-color:rgba(26,26,39,1);">
+        <div id="loading-screen" style="height:100%;width:100%;margin:0;position:fixed;background-color:rgba(26,26,39,1);">
             <div style="display: flex;justify-content: center;align-items:center;height:100%;width:100%;">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1404 1404" height="400px">
                     <path d="M406.89,219.14c-51.85,6.86-134.7-55.37-142.65-115.43-7.95-60.07,62.01-95.23,113.86-102.09,51.85-6.86,112.62,11.94,120.57,72.01,7.95,60.07-39.93,138.66-91.78,145.52Z" style="fill:#7e6fff;" />

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -70,7 +70,7 @@
 
 <body>
     <div id="app">
-        <div style="height:100%;width:100%;margin:0;position:fixed;">
+        <div style="height:100%;width:100%;margin:0;position:fixed;background-color:rgba(26,26,39,1);">
             <div style="display: flex;justify-content: center;align-items:center;height:100%;width:100%;">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1404 1404" height="400px">
                     <path d="M406.89,219.14c-51.85,6.86-134.7-55.37-142.65-115.43-7.95-60.07,62.01-95.23,113.86-102.09,51.85-6.86,112.62,11.94,120.57,72.01,7.95,60.07-39.93,138.66-91.78,145.52Z" style="fill:#7e6fff;" />

--- a/src/MudBlazor.Docs/wwwroot/JS/docs.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/docs.js
@@ -31,3 +31,35 @@ if(typeof window.GoogleAnalyticsInterop === 'undefined') {
         configure(){}
     };
 }
+
+// Updates the background colour of the loading screen.
+function setThemeForLoader(loadingScreen, observer) {
+    let darkLightThemeValue = (JSON.parse(localStorage.getItem('userPreferences') || '{}')).DarkLightTheme;
+
+    let useLightTheme = darkLightThemeValue === 1 ||
+        (darkLightThemeValue !== 2 && window.matchMedia('(prefers-color-scheme: light)').matches);
+
+    if (useLightTheme) {
+        // Set background-color for light theme
+        loadingScreen.style.backgroundColor = '#ffffff';
+    }
+
+    observer.disconnect();
+}
+
+// Observes for DOM changes to detect the loading-screen element.
+const loadingScreenObserver = new MutationObserver((mutationsList, observer) => {
+    for (let mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+            let loadingScreen = document.getElementById('loading-screen');
+
+            if (loadingScreen) {
+                setThemeForLoader(loadingScreen, observer);
+                break;
+            }
+        }
+    }
+});
+
+// Start observing the document body for changes in the DOM.
+loadingScreenObserver.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
## Description
Closes #6068

Sets the default background to dark until the application determines user preference.

## How Has This Been Tested?
Visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![Screenshot 2023-08-12 215429](https://github.com/MudBlazor/MudBlazor/assets/57046415/472bc698-69c2-45a1-b8c5-cd40b568f8a8)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
