### PR TITLE
Buttons: Add ClickPropagation parameter

### DIFF
--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -76,6 +76,10 @@ namespace MudBlazor
         [Category(CategoryTypes.Button.Behavior)]
         public bool Disabled { get; set; }
 
+        [Parameter]
+        [Category(CategoryTypes.Button.Behavior)]
+        public bool OnClickStopPropagation { get; set; } = true;
+
         /// <summary>
         /// If true, no drop-shadow will be used.
         /// </summary>

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -78,7 +78,7 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
-        public bool OnClickStopPropagation { get; set; } = true;
+        public bool ClickPropagation { get; set; }
 
         /// <summary>
         /// If true, no drop-shadow will be used.

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -12,7 +12,7 @@
             target="@Target"
             rel="@GetRel()"
             disabled="@GetDisabledState()"
-            OnClickStopPropagation="@OnClickStopPropagation">
+            ClickPropagation="@ClickPropagation">
     <span class="mud-button-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -11,7 +11,8 @@
             href="@Href" 
             target="@Target"
             rel="@GetRel()"
-            disabled="@GetDisabledState()">
+            disabled="@GetDisabledState()"
+            OnClickStopPropagation="@OnClickStopPropagation">
     <span class="mud-button-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -12,7 +12,8 @@
             target="@Target"
             rel="@GetRel()"
             disabled="@GetDisabledState()"
-            title="@Title">
+            title="@Title"
+            OnClickStopPropagation="@OnClickStopPropagation">
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -13,7 +13,7 @@
             rel="@GetRel()"
             disabled="@GetDisabledState()"
             title="@Title"
-            OnClickStopPropagation="@OnClickStopPropagation">
+            ClickPropagation="@ClickPropagation">
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -13,7 +13,7 @@
             rel="@GetRel()"
             disabled="@GetDisabledState()"
             title="@Title"
-            OnClickStopPropagation="@OnClickStopPropagation">
+            ClickPropagation="@ClickPropagation">
     @if (!String.IsNullOrEmpty(Icon))
     {
         <span class="mud-icon-button-label">

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -12,7 +12,8 @@
             target="@Target"
             rel="@GetRel()"
             disabled="@GetDisabledState()"
-            title="@Title">
+            title="@Title"
+            OnClickStopPropagation="@OnClickStopPropagation">
     @if (!String.IsNullOrEmpty(Icon))
     {
         <span class="mud-icon-button-label">

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
-        public bool OnClickStopPropagation { get; set; } = true;
+        public bool ClickPropagation { get; set; } = true;
 
         /// <summary>
         /// Calling StateHasChanged to refresh the component's state
@@ -68,7 +68,7 @@ namespace MudBlazor
 
             // StopPropagation
             // the order matters. This has to be before content is added
-            if (HtmlTag == "button" && OnClickStopPropagation == true)
+            if (HtmlTag == "button" && ClickPropagation == false)
                 builder.AddEventStopPropagationAttribute(5, "onclick", true);
 
             //Reference capture

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -36,6 +36,10 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<ElementReference> RefChanged { get; set; }
 
+        [Parameter]
+        [Category(CategoryTypes.Button.Behavior)]
+        public bool OnClickStopPropagation { get; set; } = true;
+
         /// <summary>
         /// Calling StateHasChanged to refresh the component's state
         /// </summary>
@@ -64,7 +68,7 @@ namespace MudBlazor
 
             // StopPropagation
             // the order matters. This has to be before content is added
-            if (HtmlTag == "button")
+            if (HtmlTag == "button" && OnClickStopPropagation == true)
                 builder.AddEventStopPropagationAttribute(5, "onclick", true);
 
             //Reference capture


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

We have hardcoded state that all buttons have stopPropagation for click events. Its not ideal for all solutions. Example i need to catch click event on extension speeddial component (the outer div), but button's stopPropagation feature prevents it. So we change the stopPropagation as option. Not a breaking change, it still stopPropagation by default.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
