### PR TITLE
TestViewer: Better search and other minor tweaks

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -72,7 +72,6 @@
     RenderFragment TestComponent() => builder =>
     {
         builder.OpenComponent(0, selectedType);
-        //builder.AddAttribute(1, "Title", "Some title");
         builder.CloseComponent();
     };
 
@@ -116,11 +115,8 @@
     private Task<IEnumerable<Type>> Search(string text)
     {
         if (string.IsNullOrWhiteSpace(text))
-        {
-            // the user just clicked the autocomplete open, show the most popular pages as search result according to our analytics data
-            // ordered by popularity
             return Task.FromResult<IEnumerable<Type>>(new Type[0]);
-        }
+
         return Task.FromResult<IEnumerable<Type>>(
             availableComponentTypes.Where(type => type.Name.Contains(text, StringComparison.OrdinalIgnoreCase))
         );

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -66,7 +66,7 @@
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        availableComponentTypes = getTestComponenTypes().ToArray();
+        availableComponentTypes = getTestComponentTypes().ToArray();
     }
 
     RenderFragment TestComponent() => builder =>
@@ -76,7 +76,7 @@
         builder.CloseComponent();
     };
 
-    IEnumerable<Type> getTestComponenTypes()
+    IEnumerable<Type> getTestComponentTypes()
     {
         foreach (var type in typeof(Program).Assembly.GetTypes().OrderBy(x => x.Name))
         {

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -17,12 +17,12 @@
         <MudDrawerHeader>
             <MudText Typo="Typo.h6">TestComponents</MudText>
         </MudDrawerHeader>
-        <MudList>
+		<MudNavMenu>
             @foreach (var type in availableComponentTypes)
             {
-                <MudListItem OnClick="@(() => selectedType = type)" @key="type.Name">@type.Name</MudListItem>
+				<MudNavLink OnClick="@(() => selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
             }
-        </MudList>
+		</MudNavMenu>
     </MudDrawer>
     <MudMainContent Class="mt-4">
 

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -17,12 +17,12 @@
         <MudDrawerHeader>
             <MudText Typo="Typo.h6">Test Components</MudText>
         </MudDrawerHeader>
-		<MudNavMenu>
-			@foreach (var type in availableComponentTypes)
-			{
-				<MudNavLink OnClick="@(() => selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
-			}
-		</MudNavMenu>
+        <MudNavMenu>
+            @foreach (var type in availableComponentTypes)
+            {
+                <MudNavLink OnClick="@(() => selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
+            }
+        </MudNavMenu>
     </MudDrawer>
     <MudMainContent Class="mt-4">
 
@@ -58,7 +58,7 @@
     Type[] availableComponentTypes = new Type[0];
     MudAutocomplete<Type> autocomplete;
 
-	void DocsDrawerToggle()
+    void DocsDrawerToggle()
     {
         drawerOpen = !drawerOpen;
     }
@@ -101,10 +101,10 @@
     {
         if (type == null)
             return "";
-		var field = type.GetField("__description__", BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
-		if (field == null || field.FieldType != typeof(string))
-			return "This test component does not have a description. Field \"public static string __description__\" not found in this component.";
-		return (string)field.GetValue(null);
+        var field = type.GetField("__description__", BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
+        if (field == null || field.FieldType != typeof(string))
+            return "This test component does not have a description. Field \"public static string __description__\" not found in this component.";
+        return (string)field.GetValue(null);
     }
 
     private Task<IEnumerable<Type>> Search(string text)

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -18,10 +18,10 @@
             <MudText Typo="Typo.h6">TestComponents</MudText>
         </MudDrawerHeader>
 		<MudNavMenu>
-            @foreach (var type in availableComponentTypes)
-            {
+			@foreach (var type in availableComponentTypes)
+			{
 				<MudNavLink OnClick="@(() => selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
-            }
+			}
 		</MudNavMenu>
     </MudDrawer>
     <MudMainContent Class="mt-4">
@@ -58,7 +58,7 @@
     Type[] availableComponentTypes = new Type[0];
     MudAutocomplete<Type> autocomplete;
 
-    void DocsDrawerToggle()
+	void DocsDrawerToggle()
     {
         drawerOpen = !drawerOpen;
     }
@@ -121,9 +121,8 @@
             // ordered by popularity
             return Task.FromResult<IEnumerable<Type>>(new Type[0]);
         }
-        var lowerText = text.ToLowerInvariant();
         return Task.FromResult<IEnumerable<Type>>(
-            availableComponentTypes.Where(type => type.Name.ToLowerInvariant().StartsWith(lowerText))
+            availableComponentTypes.Where(type => type.Name.Contains(text, StringComparison.OrdinalIgnoreCase))
         );
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -15,7 +15,7 @@
     </MudAppBar>
     <MudDrawer Open="@drawerOpen" DisableOverlay="true" Variant="DrawerVariant.Responsive" ClipMode="DrawerClipMode.Always" Breakpoint="Breakpoint.Sm">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">TestComponents</MudText>
+            <MudText Typo="Typo.h6">Test Components</MudText>
         </MudDrawerHeader>
 		<MudNavMenu>
 			@foreach (var type in availableComponentTypes)
@@ -101,15 +101,10 @@
     {
         if (type == null)
             return "";
-        try
-        {
-            var field = type.GetField("__description__", BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
-            return (string)field.GetValue(null);
-        }
-        catch (Exception)
-        {
-            return "public static string __description__ = \"...\"; not found in this component.";
-        }
+		var field = type.GetField("__description__", BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField);
+		if (field == null || field.FieldType != typeof(string))
+			return "This test component does not have a description. Field \"public static string __description__\" not found in this component.";
+		return (string)field.GetValue(null);
     }
 
     private Task<IEnumerable<Type>> Search(string text)

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -1,7 +1,17 @@
 ﻿@inherits LayoutComponentBase
 
-<MudThemeProvider/>
+<MudThemeProvider Theme="@customTheme"/>
 <MudDialogProvider/>
 <MudSnackbarProvider/>
 
 @Body
+
+@code {
+	MudTheme customTheme = new MudTheme()
+		{
+			LayoutProperties = new LayoutProperties()
+			{
+				DrawerWidthLeft = "350px"
+			}
+		};
+}

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -7,11 +7,11 @@
 @Body
 
 @code {
-	MudTheme customTheme = new MudTheme()
-		{
-			LayoutProperties = new LayoutProperties()
-			{
-				DrawerWidthLeft = "350px"
-			}
-		};
+    MudTheme customTheme = new MudTheme()
+        {
+            LayoutProperties = new LayoutProperties()
+            {
+                DrawerWidthLeft = "350px"
+            }
+        };
 }


### PR DESCRIPTION
## Description
This applies a number of minor improvements and tweaks to the unit tests viewer:
* Made the drawer width a bit larger so that most of the test component names are no longer cut off
* Use MudNavMenu for the list, it looks more polished than the raw MudList
* Change the search behavior to also find test components by substrings, e.g. typing "chart" will now also find "LineChartWithBigValuesTests". Before it would search by prefix only.
* A couple of other minor tweaks/refactorings.

## How Has This Been Tested?
Tested all changes manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
