### PR TITLE
Workflow: increase deploy-trymudblazor sleep time to 10m

### DIFF
--- a/.github/workflows/deploy-trymudblazor.yml
+++ b/.github/workflows/deploy-trymudblazor.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Wait for nuget
       if: ${{ github.ref_type == 'tag' }}
-      run: sleep 300s
+      run: sleep 600s
 
 
   deploy-web-app:


### PR DESCRIPTION
## Description
Today I noticed that after v6.9.0 release, it took 8 minutes for nuget package to appear in the [listing](https://www.nuget.org/packages/MudBlazor/6.9.0).
It seems that sometimes the nuget is slower than expected, therefore we need to increase the sleep time.
I have changed from 5 minutes to 10 minutes.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
