### PR TITLE
MudDataGrid FilterDefinitions exposed as IList instead of List in order to allow custom implementations

### DIFF
--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
 
         public IEnumerable<T> Items => _dataGrid.Items;
 
-        public List<IFilterDefinition<T>> FilterDefinitions => _dataGrid.FilterDefinitions;
+        public IList<IFilterDefinition<T>> FilterDefinitions => _dataGrid.FilterDefinitions;
 
         public FilterActions Actions { get; }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -981,7 +981,7 @@ namespace MudBlazor
 
         internal async Task RemoveFilterAsync(Guid id)
         {
-            FilterDefinitions.RemoveAll(x => x.Id == id);            
+            FilterDefinitions.RemoveAll(x => x.Id == id);
             await InvokeServerLoadFunc();
             GroupItems();
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -357,7 +357,7 @@ namespace MudBlazor
         /// grid automatically when using the built in filter UI. You can also programmatically manage these definitions
         /// through this collection.
         /// </summary>
-        [Parameter] public List<IFilterDefinition<T>> FilterDefinitions { get; set; } = new List<IFilterDefinition<T>>();
+        [Parameter] public IList<IFilterDefinition<T>> FilterDefinitions { get; set; } = new List<IFilterDefinition<T>>();
 
         /// <summary>
         /// The list of SortDefinitions that have been added to the data grid. SortDefinitions are managed by the data
@@ -981,7 +981,7 @@ namespace MudBlazor
 
         internal async Task RemoveFilterAsync(Guid id)
         {
-            FilterDefinitions.RemoveAll(x => x.Id == id);
+            FilterDefinitions.RemoveAll(x => x.Id == id);            
             await InvokeServerLoadFunc();
             GroupItems();
         }

--- a/src/MudBlazor/Extensions/IListExtensions.cs
+++ b/src/MudBlazor/Extensions/IListExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudBlazor
+{
+    public static class IListExtensions
+    {
+        public static void RemoveAll<T>(this IList<T> list, Predicate<T> match)
+        {
+            var i = 0;
+            while (i < list.Count)
+            {
+                if (match(list[i]))
+                {
+                    list.RemoveAt(i);
+                }
+                else
+                {
+                    i++;
+                }
+            }
+        }
+
+        public static void AddRange<T>(this IList<T> list, IEnumerable<T> collection)
+        {
+            foreach (var v in collection)
+            {
+                list.Add(v);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
MudDataGrid exposes the FilterDefinitions property containing all the filters applied to the data grid. A filter can be added automatically by the filter UI of the data grid or manually by the user code.

This PR changes the property type from `List<IFilterDefinition<T>>` to `IList<IFilterDefinition<T>>`.

By doing so, the developer could provide a custom implementation of IList, i.e. `ObservabelCollection<T>` that could be used to be notified of when a filter is added or removed from the list.

Knowing when the filter list changes is particularly important to adopt global state managers like Fluxor

Resolves https://github.com/MudBlazor/MudBlazor/issues/6583

## How Has This Been Tested?
All tests dealing with this property worked fine

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
