### PR TITLE
MudTable: Fix the shifting of striped rows when loading

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Filter="new Func<Element, bool>(FilterFunc)">
+<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Filter="new Func<Element, bool>(FilterFunc)" Striped>
     <ToolBarContent>
         <MudTextField id="searchString" @bind-Value="searchString" Placeholder="Search"></MudTextField>
     </ToolBarContent>
@@ -25,7 +25,7 @@
 <MudSwitch id="switch" @bind-Checked="_loading">Show Loading</MudSwitch>
 
 @code {
-    public static string __description__ = "When loading is true a progress bar should appear";
+    public static string __description__ = "When loading is set to true, a progress bar should appear in the table header, which would not affect the striped table.";
 
     private bool _loading = false;
     private IEnumerable<Element> Elements = new List<Element>();

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -118,6 +118,38 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Ensure that when the loading switch is enabled,
+        /// a new row appears in the table header without affecting the table body.
+        /// </summary>
+        [Test]
+        public void LoadingSwitchAddsRowToHeaderWithoutAffectingBody()
+        {
+            // Render the component
+            var comp = Context.RenderComponent<TableLoadingTest>();
+
+            // Initial count of header and body rows
+            var initialHeaderRows = comp.FindAll("thead tr");
+            var initialBodyRows = comp.FindAll("tbody tr");
+
+            // Verify initial state: 1 row in the header and 2 rows in the body
+            initialHeaderRows.Count.Should().Be(1);
+            initialBodyRows.Count.Should().Be(2);
+
+            // Toggle the loading switch to the 'loading' state
+            var loadingSwitch = comp.Find("#switch");
+            loadingSwitch.Change(true);
+
+            // Count rows after toggling the switch
+            var updatedHeaderRows = comp.FindAll("thead tr");
+            var updatedBodyRows = comp.FindAll("tbody tr");
+
+            // Verify updated state:
+            // 2 rows in the header (original + loading row) and 2 rows in the body (unchanged)
+            updatedHeaderRows.Count.Should().Be(2);
+            updatedBodyRows.Count.Should().Be(2);
+        }
+
+        /// <summary>
         /// Check if the loading and no records functionnality is working in grouped table.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -64,7 +64,7 @@
                         @if (Loading)
                         {
                             <MudTHeadRow>
-                                <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent != null ? "mud-table-loading" : "")">
+                                <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent is not null ? "mud-table-loading" : "")">
                                     <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                                 </th>
                             </MudTHeadRow>
@@ -75,7 +75,7 @@
                 {
                     <thead class="@HeadClassname">
                         <MudTHeadRow>
-                            <th colspan="1000" class="@(CurrentPageItems.Count() > 0 || LoadingContent != null ? "mud-table-loading" : "")">
+                            <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent is not null ? "mud-table-loading" : "")">
                                 <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                             </th>
                         </MudTHeadRow>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -61,17 +61,17 @@
                                 }
                             </MudTHeadRow>
                         }
+                        @if (Loading)
+                        {
+                            <MudTHeadRow>
+                                <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent != null ? "mud-table-loading" : "")">
+                                    <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
+                                </td>
+                            </MudTHeadRow>
+                        }
                     </thead>
                 }
                 <tbody class="mud-table-body">
-                    @if (Loading)
-                    {
-                        <tr>
-                            <td colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent != null ? "mud-table-loading" : "")">
-                                <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
-                            </td>
-                        </tr>
-                    }
                     @if(GroupBy != null)
                     {
                         @foreach (var group in GroupItemsPage)

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -66,9 +66,19 @@
                             <MudTHeadRow>
                                 <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent != null ? "mud-table-loading" : "")">
                                     <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
-                                </td>
+                                </th>
                             </MudTHeadRow>
                         }
+                    </thead>
+                }
+                else if (Loading)
+                {
+                    <thead class="@HeadClassname">
+                        <MudTHeadRow>
+                            <th colspan="1000" class="@(CurrentPageItems.Count() > 0 || LoadingContent != null ? "mud-table-loading" : "")">
+                                <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
+                            </th>
+                        </MudTHeadRow>
                     </thead>
                 }
                 <tbody class="mud-table-body">


### PR DESCRIPTION
Based on the work by @aldakloran; The original PR #4628 appears to have gone stale.
- brought up to speed with current dev
- added unit test
- minor perf improvements

## Description
Fixes #3103

## How Has This Been Tested?
visually + unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->](https://github.com/MudBlazor/MudBlazor/assets/57046415/63b1d72c-52b7-431e-8e58-a7f44f704ccc)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
