### PR TITLE
Chip: Fix hover effect occuring when component wasn't interactive (#7243)

### DIFF
--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -90,17 +90,21 @@
     color: var(--mud-palette-text-primary);
     background-color: var(--mud-palette-action-disabled-background);
 
-    &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-        background-color: var(--mud-palette-action-disabled);
+    &.mud-clickable {
+        &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+            background-color: var(--mud-palette-action-disabled);
+        }
     }
 
     @each $color in $mud-palette-colors {
         &.mud-chip-color-#{$color} {
             color: var(--mud-palette-#{$color}-text);
             background-color: var(--mud-palette-#{$color});
-
-            &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-                background-color: var(--mud-palette-#{$color}-darken);
+        
+            &.mud-clickable {
+                &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+                    background-color: var(--mud-palette-#{$color}-darken);
+                }
             }
         }
     }
@@ -109,8 +113,10 @@
     color: var(--mud-palette-text-primary);
     border: 1px solid var(--mud-palette-lines-inputs);
 
-    &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-        background-color: var(--mud-palette-action-default-hover);
+    &.mud-clickable {
+        &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+            background-color: var(--mud-palette-action-default-hover);
+        }
     }
 
     @each $color in $mud-palette-colors {
@@ -118,13 +124,15 @@
             color: var(--mud-palette-#{$color});
             border: 1px solid var(--mud-palette-#{$color});
 
-            &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-                background-color: var(--mud-palette-#{$color}-hover);
+            &.mud-clickable {
+                &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+                    background-color: var(--mud-palette-#{$color}-hover);
+                }
             }
 
             &.mud-chip-selected {
                 background-color: var(--mud-palette-#{$color}-hover);
-
+              
                 &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
                     background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
                 }
@@ -136,8 +144,10 @@
     color: var(--mud-palette-text-primary);
     background-color: var(--mud-palette-action-default-hover);
 
-    &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-        background-color: var(--mud-palette-action-disabled-background);
+    &.mud-clickable {
+        &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+            background-color: var(--mud-palette-action-disabled-background);
+        }
     }
 
     @each $color in $mud-palette-colors {
@@ -145,8 +155,10 @@
             color: var(--mud-palette-#{$color});
             background-color: var(--mud-palette-#{$color}-hover);
 
-            &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
-                background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+            &.mud-clickable {
+                &:hover:not(.mud-disabled), &:focus-visible:not(.mud-disabled) {
+                    background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves  (#7243), fixes hover effect occuring on chip component event if it was'nt interactive.
The only change is to modify scss in order to add hover classes if component has `.mud-clickable` class


## How Has This Been Tested?
I do not created any tests, I tested it locally with MudBlazor.Docs.Server by applying OnClick Event handler and checking if hover effects occurs. I also checked if ChipSet working wasnt change 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
