### PR TITLE
MudAutocomplete: Fix double scrollbars with Before/AfterItemsTemplate

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListBeforeAndAfterRendersWithItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListBeforeAndAfterRendersWithItemsTest.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search" MaxItems="10">
+    <BeforeItemsTemplate>
+        <MudText>StartList_Content</MudText>
+    </BeforeItemsTemplate>
+    <AfterItemsTemplate>
+        <MudText>EndList_Content</MudText>
+    </AfterItemsTemplate>
+</MudAutocomplete>
+
+@code {
+    public static string __description__ = "The BeforeItemsTemplate and AfterItemsTemplate should be rendered with items present.";
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private Task<IEnumerable<string>> Search(string value)
+    {
+        var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+        return Task.FromResult(result);
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1229,9 +1229,40 @@ namespace MudBlazor.UnitTests.Components
             component.WaitForAssertion(() => autocompleteInstance.Text.Should().Be(string.Empty));
         }
 
+        /// <summary>
+        /// BeforeItemsTemplate should render when there are items
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_LoadListStartWhenSetAndThereAreItems()
+        {
+            var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
+
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[0].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+        }
+        
+        /// <summary>
+        /// AfterItemsTemplate should render when there are items
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_LoadListEndWhenSetAndThereAreItems()
+        {
+            var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
+
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var mudText = comp.FindAll("p.mud-typography");
+            mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
+        }
 
         /// <summary>
-        /// ListEndTemplate should render when there are no items
+        /// BeforeItemsTemplate should render when there are no items
         /// </summary>
         [Test]
         public async Task Autocomplete_Should_LoadListStartWhenSet()
@@ -1248,7 +1279,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// ListEndTemplate should render when there are no items
+        /// AfterItemsTemplate should render when there are no items
         /// </summary>
         [Test]
         public async Task Autocomplete_Should_LoadListEndWhenSet()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -44,13 +44,13 @@
                     }
                     else if (_items != null && _items.Length != 0)
                     {
-                        @if (BeforeItemsTemplate != null)
-                        {
-                            <div class="pa-1">
-                                @BeforeItemsTemplate
-                            </div>
-                        }
                         <MudList Class="@ListClass" Clickable="true" Dense="@Dense">
+                            @if (BeforeItemsTemplate != null)
+                            {
+                                <div class="pa-1">
+                                    @BeforeItemsTemplate
+                                </div>
+                            }
                             @for (var index = 0; index < _items.Length; index++)
                             {
                                 var item = _items[index];
@@ -83,6 +83,12 @@
                             {
                                 <div class="pa-1">
                                     @MoreItemsTemplate
+                                </div>
+                            }
+                            @if (AfterItemsTemplate != null)
+                            {
+                                <div class="pa-1">
+                                    @AfterItemsTemplate
                                 </div>
                             }
                         </MudList>


### PR DESCRIPTION
…Templates (#7254)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Two scrollbars are fixed. Fixes #7254 

## How Has This Been Tested?
Doesn't break unit tests for this fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
