### PR TITLE
DataGrid: Add GridStateChanged event

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureEditableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureEditableTest.razor
@@ -2,12 +2,13 @@
 @using System.Globalization
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudDataGrid Items="@_items"
+<MudDataGrid T="Model" Items="@_items"
     Filterable="true"
     ReadOnly="@false"
     EditMode="@DataGridEditMode.Cell"
     EditTrigger=@DataGridEditTrigger.OnRowClick
-    FilterMode="@DataGridFilterMode.ColumnFilterRow">
+    FilterMode="@DataGridFilterMode.ColumnFilterRow"
+    GridStateChanged="OnGridStateChanged">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -26,4 +27,16 @@
     };
 
     public record Model(string Name, int? Age, double? Amount, double? Total);
+
+    public bool GridStateChangedEventCalled = false;
+    public int GridStateChangedEventCalledCounter = 0;
+    public GridState<Model> LastGridStateReceived;
+
+    private void OnGridStateChanged(GridState<Model> gridState)
+    {
+        GridStateChangedEventCalled = true;
+        GridStateChangedEventCalledCounter++;
+        LastGridStateReceived = gridState;
+    }
+
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureSimpleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCultureSimpleTest.razor
@@ -2,7 +2,7 @@
 @using System.Globalization
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudDataGrid Items="@_items" Filterable="true">
+<MudDataGrid T="Model" Items="@_items" Filterable="true" GridStateChanged="OnGridStateChanged">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -21,4 +21,15 @@
     };
 
     public record Model(string Name, int? Age, double? Amount, double? Total);
+
+    public bool GridStateChangedEventCalled = false;
+    public int GridStateChangedEventCalledCounter = 0;
+    public GridState<Model> LastGridStateReceived;
+
+    private void OnGridStateChanged(GridState<Model> gridState)
+    {
+        GridStateChangedEventCalled = true;
+        GridStateChangedEventCalledCounter++;
+        LastGridStateReceived = gridState;
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomFilteringTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomFilteringTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudDataGrid Items="@_items" Filterable>
+<MudDataGrid T="Model" Items="@_items" Filterable GridStateChanged="OnGridStateChanged">
     <Columns>
         <PropertyColumn Property="x => x.Name" Filterable="false" />
         <PropertyColumn Property="x => x.Age" Filterable="false" />
@@ -14,7 +14,7 @@
     </FilterTemplate>
 </MudDataGrid>
 
-@code {
+ @code {
     public record Model (string Name, int? Age, Severity? Status, bool? Hired, DateTime? HiredOn);
 
     private IEnumerable<Model> _items = new List<Model>()
@@ -26,6 +26,10 @@
     };
 
     public bool FilterHired = false;
+
+    public bool GridStateChangedEventCalled = false;
+    public int GridStateChangedEventCalledCounter = 0;
+    public GridState<Model> LastGridStateReceived;
 
     public async Task FilterHiredToggled(bool value, MudDataGrid<Model> dataGrid)
     {
@@ -44,5 +48,12 @@
         {
             await dataGrid.ClearFiltersAsync();
         }
+    }
+
+    private void OnGridStateChanged(GridState<Model> gridState)
+    {
+        GridStateChangedEventCalled = true;
+        GridStateChangedEventCalledCounter++;
+        LastGridStateReceived = gridState;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomSortableTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 @using System.Globalization;
 
-<MudDataGrid @ref="DataGrid" Items="@_items" Sortable="true">
+<MudDataGrid T="Item" @ref="DataGrid" Items="@_items" Sortable="true", GridStateChanged="OnGridStateChanged">
     <Columns>
         <PropertyColumn Property="x => x.Name" Comparer="@(NaturalSortingEnabled ? new MudBlazor.Utilities.NaturalComparer() : null)" />
         <PropertyColumn Property="x => x.Value" />
@@ -27,11 +27,21 @@
         new Item("1_11", 44, "1111111"),
         new Item("0", 55, "222222")
     };
-   
+
+    public bool GridStateChangedEventCalled = false;
+    public int GridStateChangedEventCalledCounter = 0;
+    public GridState<Item> LastGridStateReceived;
 
     private async Task CallSort()
     {
         await DataGrid.SetSortAsync(nameof(Item.Name), SortDirection.Ascending, x => x.Name, new MudBlazor.Utilities.NaturalComparer());
+    }
+
+    private void OnGridStateChanged(GridState<Item> gridState)
+    {
+        GridStateChangedEventCalled = true;
+        GridStateChangedEventCalledCounter++;
+        LastGridStateReceived = gridState;
     }
 
     public class Item

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerPaginationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerPaginationTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDataGrid T="Model" ServerData="@(new Func<GridState<Model>, Task<GridData<Model>>>(ServerReload))">
+<MudDataGrid T="Model" ServerData="@(new Func<GridState<Model>, Task<GridData<Model>>>(ServerReload))" GridStateChanged="OnGridStateChanged">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -15,6 +15,10 @@
     public record Model (string Name, int Age, Severity Status);
     private int _totalItems = 100;
     IEnumerable<Model> _data;
+
+    public bool GridStateChangedEventCalled = false;
+    public int GridStateChangedEventCalledCounter = 0;
+    public GridState<Model> LastGridStateReceived;
 
     protected override void OnInitialized()
     {
@@ -37,4 +41,10 @@
         return await Task.FromResult(new GridData<Model>() { TotalItems = _totalItems, Items = data });
     }
 
+    private void OnGridStateChanged(GridState<Model> gridState)
+    {
+        GridStateChangedEventCalled = true;
+        GridStateChangedEventCalledCounter++;
+        LastGridStateReceived = gridState;
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2645,7 +2645,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
 
             // add a filter via the AddFilter method
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
+            await comp.InvokeAsync(dataGrid.Instance.AddFilter);
 
             // check the number of filters displayed in the filters panel
             dataGrid.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(1);
@@ -2715,7 +2715,7 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(6);
 
             // add a filter via the AddFilter method
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
+            await comp.InvokeAsync(dataGrid.Instance.AddFilter);
 
             // check the number of filters displayed in the filters panel is 1 more because we added a filter
             dataGrid.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(7);
@@ -2948,6 +2948,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DataGridServerPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerPaginationTest.Model>>();
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeFalse();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(0);
+            comp.Instance.LastGridStateReceived.Should().BeNull();
+
             // test that we are on the first page of results
             dataGrid.Find(".mud-table-body td").TextContent.Trim().Should().Be("Name 0");
 
@@ -2957,8 +2961,21 @@ namespace MudBlazor.UnitTests.Components
             // test that we are on the second page of results
             dataGrid.Find(".mud-table-body td").TextContent.Trim().Should().Be("Name 10");
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+
             // test reloading server side results programmatically
             await comp.InvokeAsync(async () => await dataGrid.Instance.ReloadServerData());
+
+            //verify that GridStateChangedEvent is not called on ReloadServerData()
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
         }
 
         [Test]
@@ -3207,6 +3224,10 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeFalse();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(0);
+            comp.Instance.LastGridStateReceived.Should().BeNull();
+
             await comp.InvokeAsync(() =>
             {
                 comp.Instance.FilterHiredToggled(true, dataGrid.Instance);
@@ -3214,6 +3235,34 @@ namespace MudBlazor.UnitTests.Components
             
             dataGrid.Render();
             dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(dataGrid.Instance.FilterDefinitions.Count);
+            var filterDefinitionToCheck = comp.Instance.LastGridStateReceived.FilterDefinitions.First();
+            filterDefinitionToCheck.Column.Identifier.Should().Be(dataGrid.Instance.GetColumnByPropertyName<DataGridCustomFilteringTest.Model>("Hired").Identifier);
+            filterDefinitionToCheck.Operator.Should().Be(FilterOperator.Boolean.Is);
+            filterDefinitionToCheck.Value.Should().Be(true);
+
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+
+            comp.Instance.GridStateChangedEventCalled = false;
+
+            await comp.InvokeAsync(() =>
+            {
+                comp.Instance.FilterHiredToggled(false, dataGrid.Instance);
+            });
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(2);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
         }
 
         [Test]
@@ -3651,6 +3700,10 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.SortMode = SortMode.Single;
             dataGrid.Instance.SortMode.Should().Be(SortMode.Single);
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeFalse();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(0);
+            comp.Instance.LastGridStateReceived.Should().BeNull();
+
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Ascending, x => x.Value, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.DropContainerHasChanged();
             dataGrid.FindAll("th .sortable-column-header")[1].TextContent.Trim().Should().Be("Value");
@@ -3659,12 +3712,40 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Ascending);
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
+
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Descending, x => x.Value, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.DropContainerHasChanged();
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Descending);
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(false);
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-desc").Should().Be(true);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(2);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeTrue();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
 
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Ascending, x => x.Value));
             dataGrid.Instance.DropContainerHasChanged();
@@ -3674,12 +3755,40 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.None);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.Ascending);
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(3);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeNull();
+            }
+
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => x.Name, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.DropContainerHasChanged();
             dataGrid.Instance.GetColumnSortDirection("Name").Should().Be(SortDirection.Ascending);
             dataGrid.Instance.GetColumnSortDirection("Value").Should().Be(SortDirection.None);
             dataGrid.FindAll("th .sort-direction-icon")[0].ClassList.Contains("mud-direction-asc").Should().Be(true);
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-asc").Should().Be(false);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(4);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Name");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
 
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => x.Name, new MudBlazor.Utilities.NaturalComparer()));
             dataGrid.Instance.DropContainerHasChanged();
@@ -3690,6 +3799,20 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.SortMode = SortMode.Multiple;
             dataGrid.Instance.SortMode.Should().Be(SortMode.Multiple);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(5);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Name");
+                sortDefinitionToCheck.Descending.Should().BeTrue();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
 
             //Assign a comparer to a column
             var column = dataGrid.FindComponent<Column<DataGridCustomSortableTest.Item>>();
@@ -3710,19 +3833,88 @@ namespace MudBlazor.UnitTests.Components
             cells[15].TextContent.Should().Be("2");
             cells[18].TextContent.Should().Be("10");
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            //called 2 more times one to remove sorting and one to sort by Name
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(7);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Name");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
+
             //Multi click second column
             var headerCell = dataGrid.FindComponents<HeaderCell<DataGridCustomSortableTest.Item>>()[1];
             await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new MouseEventArgs() { CtrlKey = true, Button = 0 }));
             headerCell.Instance.SortDirection.Should().Be(SortDirection.Ascending);
+            
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(8);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(2);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First(_ => _.SortBy == "Name");
+                sortDefinitionToCheck.SortBy.Should().Be("Name");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First(_ => _.SortBy == "Value");
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeNull();
+            }
 
             //Multi click second column a second time to change it to descending
             await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new MouseEventArgs() { CtrlKey = true, Button = 0 }));
             headerCell.Instance.SortDirection.Should().Be(SortDirection.Descending);
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(9);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(2);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First(_ => _.SortBy == "Name");
+                sortDefinitionToCheck.SortBy.Should().Be("Name");
+                sortDefinitionToCheck.Descending.Should().BeFalse();
+                sortDefinitionToCheck.Comparer.Should().BeOfType<MudBlazor.Utilities.NaturalComparer>();
+            }
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First(_ => _.SortBy == "Value");
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeTrue();
+                sortDefinitionToCheck.Comparer.Should().BeNull();
+            }
+
             //remove first column from sort
             headerCell = dataGrid.FindComponents<HeaderCell<DataGridCustomSortableTest.Item>>()[0];
             await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new MouseEventArgs() { AltKey = true, Button = 0 }));
             headerCell.Instance.SortDirection.Should().Be(SortDirection.None);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(10);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(1);
+            {
+                var sortDefinitionToCheck = comp.Instance.LastGridStateReceived.SortDefinitions.First();
+                sortDefinitionToCheck.SortBy.Should().Be("Value");
+                sortDefinitionToCheck.Descending.Should().BeTrue();
+                sortDefinitionToCheck.Comparer.Should().BeNull();
+            }
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3568,6 +3568,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeFalse();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(0);
+            comp.Instance.LastGridStateReceived.Should().BeNull();
+
             // amount with invariant culture (decimals separated by point)
             var amountHeader = dataGrid.FindAll("th .mud-menu button")[2];
             amountHeader.Click();
@@ -3582,6 +3586,22 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
             dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(22.0);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(dataGrid.Instance.FilterDefinitions.Count);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(1);
+
+            {
+                var filterDefinitionToCheck = comp.Instance.LastGridStateReceived.FilterDefinitions.First();
+                filterDefinitionToCheck.Column.Identifier.Should().Be(dataGrid.Instance.GetColumnByPropertyName<DataGridCultureSimpleTest.Model>("Amount").Identifier);
+                filterDefinitionToCheck.Operator.Should().Be(FilterOperator.Number.Equal);
+                filterDefinitionToCheck.Value.Should().Be(22.0);
+            }
 
             dataGrid.Instance.FilterDefinitions.Clear();
             dataGrid.Render();
@@ -3600,6 +3620,22 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
             dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(2.2);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(2);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(dataGrid.Instance.FilterDefinitions.Count);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(1);
+
+            {
+                var filterDefinitionToCheck = comp.Instance.LastGridStateReceived.FilterDefinitions.First();
+                filterDefinitionToCheck.Column.Identifier.Should().Be(dataGrid.Instance.GetColumnByPropertyName<DataGridCultureSimpleTest.Model>("Total").Identifier);
+                filterDefinitionToCheck.Operator.Should().Be(FilterOperator.Number.Equal);
+                filterDefinitionToCheck.Value.Should().Be(2.2);
+            }
         }
 
         [Test]
@@ -3608,12 +3644,32 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DataGridCultureEditableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
 
+            comp.Instance.GridStateChangedEventCalled.Should().BeFalse();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(0);
+            comp.Instance.LastGridStateReceived.Should().BeNull();
+
             // amount with invariant culture (decimals separated by point)
             var filterAmount = dataGrid.FindAll("th.filter-header-cell input")[2];
             filterAmount.Input(new ChangeEventArgs() { Value = "2,2" });
 
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
             dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(22.0);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(1);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(dataGrid.Instance.FilterDefinitions.Count);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(1);
+
+            {
+                var filterDefinitionToCheck = comp.Instance.LastGridStateReceived.FilterDefinitions.First();
+                filterDefinitionToCheck.Column.Identifier.Should().Be(dataGrid.Instance.GetColumnByPropertyName<DataGridCultureEditableTest.Model>("Amount").Identifier);
+                filterDefinitionToCheck.Operator.Should().Be(FilterOperator.Number.Equal);
+                filterDefinitionToCheck.Value.Should().Be(22.0);
+            }
 
             dataGrid.Instance.FilterDefinitions.Clear();
             dataGrid.Render();
@@ -3624,6 +3680,22 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
             dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(2.2);
+
+            comp.Instance.GridStateChangedEventCalled.Should().BeTrue();
+            comp.Instance.GridStateChangedEventCalledCounter.Should().Be(2);
+            comp.Instance.LastGridStateReceived.Should().NotBeNull();
+            comp.Instance.LastGridStateReceived.Page.Should().Be(dataGrid.Instance.CurrentPage);
+            comp.Instance.LastGridStateReceived.PageSize.Should().Be(dataGrid.Instance.RowsPerPage);
+            comp.Instance.LastGridStateReceived.SortDefinitions.Count.Should().Be(0);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(dataGrid.Instance.FilterDefinitions.Count);
+            comp.Instance.LastGridStateReceived.FilterDefinitions.Count.Should().Be(1);
+
+            {
+                var filterDefinitionToCheck = comp.Instance.LastGridStateReceived.FilterDefinitions.First();
+                filterDefinitionToCheck.Column.Identifier.Should().Be(dataGrid.Instance.GetColumnByPropertyName<DataGridCultureEditableTest.Model>("Amount").Identifier);
+                filterDefinitionToCheck.Operator.Should().Be(FilterOperator.Number.Equal);
+                filterDefinitionToCheck.Value.Should().Be(2.2);
+            }
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -189,7 +189,8 @@ namespace MudBlazor
         {
             if (!DataGrid.FilterDefinitions.Any(x => x.Id == filterDefinition.Id))
                 DataGrid.FilterDefinitions.Add(filterDefinition);
-            if (DataGrid.ServerData is not null) await DataGrid.ReloadServerData();
+            //if (DataGrid.ServerData is not null) await DataGrid.ReloadServerData();
+            await DataGrid.ApplyFiltersAsync();
 
             DataGrid.GroupItems();
             ((IMudStateHasChanged)DataGrid).StateHasChanged();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -970,10 +970,11 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        internal Task ApplyFiltersAsync()
+        internal async Task ApplyFiltersAsync()
         {
             _filtersMenuVisible = false;
-            return InvokeServerLoadFunc();
+            await GridStateChanged.InvokeAsync(BuildGridState());
+            await InvokeServerLoadFunc();
         }
 
         public async Task ClearFiltersAsync()


### PR DESCRIPTION
Introduce the new DataGrid `GridStateChanged `event that is raised whenever `FilterDefinitions`, `SortDefinitions`, `CurrentPage`, or `RowsPerPage `change

## Description
The intention of the event is to notify the developer code that the user has changed filtering, sorting, or pagination properties through the data grid UI.

The new event GridStateChanged is raised when one of the following cases occurs:

1) A filter is added/removed from the FilterDefinitions collection or the collection is cleared.
NOTE: the event is not raised if the user code directly adds or removes a filter from the list (i.e. FilterDefinitions.Add(...))

2) A sort definition is added or removed from the SortDefinitions collection or the collection is cleared.
NOTE: the event is not raised if the user code directly adds or removes a sort definition from the list (i.e. SortDefinitions.Add(...))

3) The CurrentPage or the RowsPerPage property changes (after the initialization stage)

This PR should fix the #6433 and #6583 

## How Has This Been Tested?
I've updated 3 tests:

DataGridCustomFilteringTest
DataGridCustomSortTest
DataGridServerPaginationTest

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
