### PR TITLE
DebouncedTextFieldFormatChangeRerenderTest: fix culture issue on non-english locales

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
@@ -4,7 +4,8 @@
               Immediate="@true"
               DebounceInterval="DebounceInterval"
               Required="@true"
-              RequiredError="Enter a star" />
+              RequiredError="Enter a star"
+              Culture="System.Globalization.CultureInfo.InvariantCulture" />
 
 <MudButton Variant="@Variant.Filled" 
            Color="@Color.Primary"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes format mismatch during TextFieldTests on non english systems.
On my system (set to german) the `DebouncedTextFieldFormatChangeRerenderTest` fails with the following message:
``Expected textField.Text to be "2023/07/12", but "2023.07.12" differs near ".07" (index 4).`` since commit 47a1372

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Ran the unit tests and `DebouncedTextFieldFormatChangeRerenderTest` worked afterwards

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
