### PR TITLE
MudTimeline: Make horizontal layout responsive

### DIFF
--- a/src/MudBlazor/Styles/components/_timeline.scss
+++ b/src/MudBlazor/Styles/components/_timeline.scss
@@ -53,6 +53,7 @@
         padding-left: 24px;
         padding-right: 24px;
         width: 100%;
+        min-width: 0;
 
         .mud-timeline-item-content {
             max-height: calc(50% - 48px);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Added a min-width property to the `mud-timeline-item` CSS class nested within the `mud-timeline-horizontal` class, both defined in the SASS partial `_timeline.scss`. This allows the horizontal timeline to be responsive, and prevents overflow on any screen size down to ~325px wide.
Resolves #7368 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
This was visually tested using the MudBlazor.UnitTests.Viewer project. No new tests were created.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![Recording 2023-08-21 at 17 58 44](https://github.com/MudBlazor/MudBlazor/assets/38573633/89b513e8-1a3a-4301-b187-d3b8aed22727)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
