### PR TITLE
MudProgressCircular: Add option to render percentage in determinate version

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularDeterminateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularDeterminateExample.razor
@@ -5,9 +5,9 @@
 @implements IDisposable
 
 <MudProgressCircular Color="Color.Default" Value="@Value" />
-<MudProgressCircular Color="Color.Primary" Value="@Value" />
+<MudProgressCircular Color="Color.Primary" Value="@Value" ShowPercentage="true" />
 <MudProgressCircular Color="Color.Secondary" Value="@Value" />
-<MudProgressCircular Color="Color.Success" Value="@Value" />
+<MudProgressCircular Color="Color.Success" Value="@Value" ShowPercentage="true" />
 <MudProgressCircular Color="Color.Info" Value="@Value" />
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularDeterminateWithPercentageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularDeterminateWithPercentageExample.razor
@@ -3,12 +3,14 @@
 @using System.Threading;
 
 @implements IDisposable
-
-<MudProgressCircular Color="Color.Default" Value="@Value" />
-<MudProgressCircular Color="Color.Primary" Value="@Value" />
-<MudProgressCircular Color="Color.Secondary" Value="@Value" />
-<MudProgressCircular Color="Color.Success" Value="@Value" />
-<MudProgressCircular Color="Color.Info" Value="@Value" />
+    
+<MudProgressCircular Color="Color.Primary" Value="@Value" ShowPercentage="true" />
+<MudProgressCircular Color="Color.Primary" Value="@Value" ShowPercentage="true" Size="Size.Large" PercentageTypo="Typo.subtitle1" />
+<MudProgressCircular Color="Color.Primary" Value="@Value" ShowPercentage="true" Size="Size.Large">
+    <PercentageContent>
+        <MudText Typo="Typo.h6">@context</MudText>
+    </PercentageContent>
+</MudProgressCircular>
 
 @code {
 	public int Value { get; set; }

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -29,10 +29,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Circular Progress">
-                
+
             </SectionHeader>
             <SectionSubGroups>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Indeterminate">
                         <Description></Description>
@@ -44,10 +44,19 @@
 
                 <DocsPageSection>
                     <SectionHeader Title="Determinate">
-                        <Description>You can show value in percentages with <CodeInline>@(nameof(MudProgressCircular.ShowPercentage))</CodeInline>.</Description>
+                        <Description></Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressCircularDeterminateExample" ShowCode="false">
                         <ProgressCircularDeterminateExample/>
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Determinate with percentage">
+                        <Description>You can show value in percentages with <CodeInline>@(nameof(MudProgressCircular.ShowPercentage))</CodeInline>.</Description>
+                    </SectionHeader>
+                    <SectionContent Code="ProgressCircularDeterminateWithPercentageExample" ShowCode="false">
+                        <ProgressCircularDeterminateWithPercentageExample/>
                     </SectionContent>
                 </DocsPageSection>
 
@@ -56,17 +65,17 @@
                         <Description>You can change the size with the pre-defined <CodeInline>Size</CodeInline> prop or change the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> in css.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressCircularSizesExample">
-                        <ProgressCircularSizesExample />
+                        <ProgressCircularSizesExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
             </SectionSubGroups>
         </DocsPageSection>
-        
+
         <DocsPageSection>
-            <SectionHeader Title="Linear Progress" />
+            <SectionHeader Title="Linear Progress"/>
             <SectionSubGroups>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Indeterminate">
                         <Description></Description>
@@ -75,25 +84,25 @@
                         <ProgressLinearInterminateExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Determinate">
                         <Description></Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearDeterminateExample" ShowCode="false">
-                        <ProgressLinearDeterminateExample />
+                        <ProgressLinearDeterminateExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Sizes">
                         <Description></Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearSizeExample" ShowCode="false">
-                        <ProgressLinearSizeExample />
+                        <ProgressLinearSizeExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Min Max">
                         <Description>
@@ -101,10 +110,10 @@
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearMinMaxExample" ShowCode="false">
-                        <ProgressLinearMinMaxExample />
+                        <ProgressLinearMinMaxExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Buffer">
                         <Description>
@@ -112,43 +121,43 @@
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearBufferExample" ShowCode="false">
-                        <ProgressLinearBufferExample />
+                        <ProgressLinearBufferExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Rounded">
                         <Description>Sets the border radius on the progress linear to the set theme value.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearRoundedExample" ShowCode="false">
-                        <ProgressLinearRoundedExample />
+                        <ProgressLinearRoundedExample/>
                     </SectionContent>
                 </DocsPageSection>
-                
+
                 <DocsPageSection>
                     <SectionHeader Title="Striped">
                         <Description>Applies a striped background over the progress bar.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearStripedExample" ShowCode="false">
-                        <ProgressLinearStripedExample />
+                        <ProgressLinearStripedExample/>
                     </SectionContent>
                 </DocsPageSection>
-        
+
                 <DocsPageSection>
                     <SectionHeader Title="Labels">
                         <Description>While using the <CodeInline>ChildContent</CodeInline> of the component you can add a text to display current value.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearLabelsExample" ShowCode="false">
-                        <ProgressLinearLabelsExample />
+                        <ProgressLinearLabelsExample/>
                     </SectionContent>
                 </DocsPageSection>
-        
+
                 <DocsPageSection>
                     <SectionHeader Title="Vertical">
                         <Description>Vertical progress bars works exactly the same way as the default horizontal ones.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressLinearVerticalExample" ShowCode="false">
-                        <ProgressLinearVerticalExample />
+                        <ProgressLinearVerticalExample/>
                     </SectionContent>
                 </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -44,7 +44,7 @@
 
                 <DocsPageSection>
                     <SectionHeader Title="Determinate">
-                        <Description></Description>
+                        <Description>You can show value in percentages with <CodeInline>@(nameof(MudProgressCircular.ShowPercentage))</CodeInline>.</Description>
                     </SectionHeader>
                     <SectionContent Code="ProgressCircularDeterminateExample" ShowCode="false">
                         <ProgressCircularDeterminateExample/>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -13,12 +13,11 @@
         <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @_magicNumber; stroke-dashoffset: @_svgValue;"></circle>
         </svg>
-        @if (ShowPercentage)
+        if (ShowPercentage)
         {
             <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;">
                 <MudText Typo="PercentageTypo">@(RoundedPercentage)%</MudText>
             </div>
         }
     }
-
 </div>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -2,15 +2,20 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@DivClassname" role="progressbar" style="@Style" aria-valuenow="@Value">
-    <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
-        @if (Indeterminate)
-        {
+    @if (Indeterminate)
+    {
+        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth"></circle>
-        }
-        else
-        {
+        </svg>
+    }
+    else
+    {
+        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @_magicNumber; stroke-dashoffset: @_svgValue;"></circle>
-        }
-    </svg>
-</div>
+        </svg>
+        <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;">
+            <MudText Typo="PercentageTypo">@(RoundedPercentage)%</MudText>
+        </div>
+    }
 
+</div>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -15,8 +15,15 @@
         </svg>
         if (ShowPercentage)
         {
-            <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;">
-                <MudText Typo="PercentageTypo">@(RoundedPercentage)%</MudText>
+            <div class="mud-progress-circular-percentage">
+                @if (PercentageContent is null)
+                {
+                    <MudText Typo="PercentageTypo">@GetRoundedPercentage()%</MudText>
+                }
+                else
+                {
+                    @PercentageContent(GetRoundedPercentage())
+                }
             </div>
         }
     }

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -13,9 +13,12 @@
         <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @_magicNumber; stroke-dashoffset: @_svgValue;"></circle>
         </svg>
-        <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;">
-            <MudText Typo="PercentageTypo">@(RoundedPercentage)%</MudText>
-        </div>
+        @if (ShowPercentage)
+        {
+            <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;">
+                <MudText Typo="PercentageTypo">@(RoundedPercentage)%</MudText>
+            </div>
+        }
     }
 
 </div>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -74,7 +74,7 @@ namespace MudBlazor
         }
 
         private double _fraction;
-        private double RoundedPercentage => Math.Round(_fraction * 100, 0);
+        private int GetRoundedPercentage() => (int)Math.Round(_fraction * 100, 0);
 
         private int ToSvgValue(double value)
         {
@@ -102,6 +102,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public Typo PercentageTypo { get; set; } = Typo.caption;
+        
+        /// <summary>
+        /// RenderFragment for rendering custom content when <see cref="ShowPercentage"/> is true
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ProgressCircular.Appearance)]
+        public RenderFragment<int>? PercentageContent { get; set; }
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -73,18 +73,35 @@ namespace MudBlazor
             }
         }
 
+        private double _fraction;
+        private double RoundedPercentage => Math.Round(_fraction * 100, 0);
+
         private int ToSvgValue(double value)
         {
             var minValue = Math.Min(Math.Max(Min, value), Max);
             // calculate fraction, which is a value between 0 and 1
-            var fraction = (minValue - Min) / (Max - Min);
+            _fraction = (minValue - Min) / (Max - Min);
             // now project into the range of the SVG value (126 .. 0)
-            return (int)Math.Round(_magicNumber - _magicNumber * fraction);
+            return (int)Math.Round(_magicNumber - _magicNumber * _fraction);
         }
 
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public int StrokeWidth { get; set; } = 3;
+
+        /// <summary>
+        /// Sets, whether should be shown percentage for determinate progress. Default is false
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ProgressCircular.Behavior)]
+        public bool ShowPercentage { get; set; }
+
+        /// <summary>
+        /// Typography variant to use if <see cref="ShowPercentage"/> is true
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ProgressCircular.Appearance)]
+        public Typo PercentageTypo { get; set; } = Typo.caption;
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Styles/components/_progresscircular.scss
+++ b/src/MudBlazor/Styles/components/_progresscircular.scss
@@ -1,6 +1,7 @@
 ﻿
 .mud-progress-circular {
     display: inline-block;
+    position: relative;
     color: var(--mud-palette-text-secondary);
 
     &.mud-progress-indeterminate {

--- a/src/MudBlazor/Styles/components/_progresscircular.scss
+++ b/src/MudBlazor/Styles/components/_progresscircular.scss
@@ -28,6 +28,17 @@
     }
 }
 
+.mud-progress-circular-percentage {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 
 .mud-progress-circular-svg {
     display: block;


### PR DESCRIPTION
## Description
Added option to show progress percentage of the determinate version of the circular progress. Also, I added an option to choose Typo for the value -> will be mainly used for larger sizes. 

Resolves #2520 
Resolves #6437

## How Has This Been Tested?
Tests will be provided.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
