### PR TITLE
Snackbar: Improve trimming exclusion

### DIFF
--- a/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarMessage.cs
@@ -14,9 +14,7 @@ namespace MudBlazor.Components.Snackbar
         internal Dictionary<string, object> ComponentParameters { get; }
         internal string Key { get; }
 
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(InternalComponents.SnackbarMessageRenderFragment))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(InternalComponents.SnackbarMessageText))]
-        internal SnackbarMessage(Type componentType, Dictionary<string, object> componentParameters = null, string key = "")
+        internal SnackbarMessage([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType, Dictionary<string, object> componentParameters = null, string key = "")
         {
             ComponentType = componentType;
             ComponentParameters = componentParameters;

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -84,7 +84,7 @@ namespace MudBlazor
         /// <param name="configure">Additional configuration for the snackbar.</param>
         /// <param name="key">If a key is provided, this message will not be shown while any other message with the same key is being shown.</param>
         /// <returns>The snackbar created by the parameters.</returns>
-        public Snackbar Add<T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent
+        public Snackbar Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent
         {
             var type = typeof(T);
             var message = new SnackbarMessage(type, componentParameters, key);

--- a/src/MudBlazor/Interfaces/ISnackbar.cs
+++ b/src/MudBlazor/Interfaces/ISnackbar.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
@@ -17,7 +18,7 @@ namespace MudBlazor
 
         Snackbar Add(string message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "");
         Snackbar Add(RenderFragment message, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "");
-        Snackbar Add<T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent;
+        Snackbar Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Dictionary<string, object> componentParameters = null, Severity severity = Severity.Normal, Action<SnackbarOptions> configure = null, string key = "") where T : IComponent;
 
         [Obsolete("Use Add instead.", true)]
         Snackbar AddNew(Severity severity, string message, Action<SnackbarOptions> configure);


### PR DESCRIPTION
## Description
Improvement for https://github.com/MudBlazor/MudBlazor/pull/5711:

The issue with these changes above is that they currently safeguard only `SnackbarMessageRenderFragment` and `SnackbarMessageText` types from trimming. These types are indeed used in the majority of cases. However, the public API method `ISnackbar.Add<T>(...)` allows users to employ custom components if they wish. Consequently, these custom components will undergo trimming because the method instantiates `SnackbarMessage` with the generic type. 

As previously mentioned, only our MudBlazor types are protected from trimming. Therefore, this changes ensures that any type provided to `SnackbarMessage` is also protected from trimming.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
