### PR TITLE
PopoverService: do not call JS during OnInitializedAsync

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockPopoverServiceV2.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockPopoverServiceV2.cs
@@ -27,11 +27,11 @@ namespace MudBlazor.UnitTests.Mocks
         {
         }
 
-        public Task CreatePopoverAsync(IPopover mudPopover) => Task.CompletedTask;
+        public Task CreatePopoverAsync(IPopover popover) => Task.CompletedTask;
 
-        public Task<bool> UpdatePopoverAsync(IPopover mudPopover) => Task.FromResult(true);
+        public Task<bool> UpdatePopoverAsync(IPopover popover) => Task.FromResult(true);
 
-        public Task<bool> DestroyPopoverAsync(IPopover mudPopover) => Task.FromResult(true);
+        public Task<bool> DestroyPopoverAsync(IPopover popover) => Task.FromResult(true);
 
         public ValueTask<int> GetProviderCountAsync() => ValueTask.FromResult(0);
 

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.JSInterop;
@@ -47,7 +46,7 @@ public class PopoverServiceTests
     }
 
     [Test]
-    public async Task IsInitialized_ShouldConnectAutomaticallyAfterCreatePopoverAsync()
+    public async Task IsInitialized_ShouldNotConnectAutomaticallyAfterCreatePopoverAsync()
     {
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
@@ -61,7 +60,7 @@ public class PopoverServiceTests
         await service.CreatePopoverAsync(popover);
 
         // Assert
-        Assert.IsTrue(service.IsInitialized);
+        Assert.IsFalse(service.IsInitialized);
     }
 
     [Test]

--- a/src/MudBlazor/Services/Popover/IPopoverService.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverService.cs
@@ -47,22 +47,22 @@ public interface IPopoverService : IAsyncDisposable
     /// <summary>
     /// Creates a popover.
     /// </summary>
-    /// <param name="mudPopover">The popover to create.</param>
-    Task CreatePopoverAsync(IPopover mudPopover);
+    /// <param name="popover">The popover to create.</param>
+    Task CreatePopoverAsync(IPopover popover);
 
     /// <summary>
     /// Updates an existing popover.
     /// </summary>
-    /// <param name="mudPopover">The popover to update.</param>
+    /// <param name="popover">The popover to update.</param>
     /// <returns><c>true</c> if the update was successful; otherwise, <c>false</c>.</returns>
-    Task<bool> UpdatePopoverAsync(IPopover mudPopover);
+    Task<bool> UpdatePopoverAsync(IPopover popover);
 
     /// <summary>
     /// Destroys a popover.
     /// </summary>
-    /// <param name="mudPopover">The popover to destroy.</param>
+    /// <param name="popover">The popover to destroy.</param>
     /// <returns>The task result indicates whether the popover was successfully destroyed.</returns>
-    Task<bool> DestroyPopoverAsync(IPopover mudPopover);
+    Task<bool> DestroyPopoverAsync(IPopover popover);
 
     /// <summary>
     /// Counts the number of popover providers.

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -22,10 +22,10 @@ namespace MudBlazor;
 internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHolder>
 {
     private readonly SemaphoreSlim _semaphore;
+    private readonly PopoverJsInterop _popoverJsInterop;
     private readonly Dictionary<Guid, MudPopoverHolder> _holders;
     private readonly BatchPeriodicQueue<MudPopoverHolder> _batchExecutor;
     private readonly ObserverManager<Guid, IPopoverObserver> _observerManager;
-    private readonly PopoverJsInterop _popoverJsInterop;
 
     /// <inheritdoc />
     public IEnumerable<IMudPopoverHolder> ActivePopovers => _holders.Values;
@@ -85,7 +85,6 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
     {
         ArgumentNullException.ThrowIfNull(popover);
 
-        await InitializeServiceIfNeededAsync();
         var holder = new MudPopoverHolder(popover.Id)
             .SetFragment(popover.ChildContent)
             .SetClass(popover.PopoverClass)

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -167,11 +167,6 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (!IsInitialized)
-        {
-            return;
-        }
-
         foreach (var holderKeyValuePair in _holders)
         {
             // We just remove them from the dictionary, we don't care to queue for "mudPopover.disconnect" as the "mudPopover.dispose" will do it for us


### PR DESCRIPTION
## Description
I recently spoke with someone experiencing issues with BSS when deployed in a cloud environment. It appears that all components related to popovers exhibit a slight delay during the initial load, which subsequently disappears.

With this #7333, we understand that it's important not to execute any JavaScript during the `OnInitializedAsync` lifecycle method. The method `CreatePopoverAsync` is invoked during `OnInitializedAsync`, and within it, there's a call to `InitializeServiceIfNeededAsync`, which itself triggers a JavaScript call and employs a locking mechanism. This is likely the root cause of the delay.

In the previous implementation of `PopoverService` there were no JavaScript+locking on the `OnInitializedAsync` phase. My initial intention was to initialize the service as early as possible, but the removal of `InitializeServiceIfNeededAsync` from `CreatePopoverAsync` doesn't impact functionality. The `InitializeServiceIfNeededAsync` is invoked later in the `OnAfterRenderAsync` lifecycle anyway, where it should be called.

## How Has This Been Tested?
I sadly cannot really test if this fixes the delay, as it's hard to replicate the environment where it happens.
However, even if my identification of the root cause of the delay is incorrect, the proposed change is still a valid improvement as this logic doesn't work in prerendering.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
