### PR TITLE
MudDataGrid: #7440 Fix new groups doesnt respect GroupExpanded property.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseAsyncTest.razor
@@ -1,0 +1,59 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
+             GroupExpanded="false">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" Filterable="false" Groupable="false" />
+        <PropertyColumn Property="x => x.Count" />
+        <PropertyColumn Property="x => x.Category" Title="Category" Grouping="true" GroupBy="@_groupBy">
+            <GroupTemplate>
+                <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+            </GroupTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+    <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+</div>
+
+@code {
+    MudDataGrid<Fruit> dataGrid;
+    public record Fruit(string Name, int Count, string Category);
+
+    List<Fruit> Fruits { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(100); // Simulate async data loading
+        Fruits.Add(new("Apple", 2, "Pome"));
+        Fruits.Add(new("Pear", 4, "Pome"));
+        Fruits.Add(new("Orange", 4, "Citrus"));
+    }
+    
+    Func<Fruit, object> _groupBy = x => 
+    {
+        return x.Category;
+    };
+
+    public void AddFruit()
+    {
+        Fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void ExpandAllGroups()
+    {
+        dataGrid?.ExpandAllGroups();
+    }
+
+    public void CollapseAllGroups()
+    {
+        dataGrid?.CollapseAllGroups();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseServerDataTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseServerDataTest.razor
@@ -1,0 +1,66 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid @ref="dataGrid" T="Fruit" ServerData="ServerDataFunc" Filterable="true" Hideable="true" Groupable="true"
+             GroupExpanded="false">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" Filterable="false" Groupable="false" />
+        <PropertyColumn Property="x => x.Count" />
+        <PropertyColumn Property="x => x.Category" Title="Category" Grouping="true" GroupBy="@_groupBy">
+            <GroupTemplate>
+                <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+            </GroupTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+    <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+</div>
+
+@code {
+    MudDataGrid<Fruit> dataGrid;
+    public record Fruit(string Name, int Count, string Category);
+
+    List<Fruit> Fruits { get; set; } = new()
+    {
+        new("Apple", 2, "Pome"),
+        new("Pear", 4, "Pome"),
+        new("Orange", 4, "Citrus")
+    };
+
+    private async Task<GridData<Fruit>> ServerDataFunc(GridState<Fruit> gridState)
+    {
+        await Task.Delay(100);
+        return new GridData<Fruit>
+        {
+            Items = Fruits,
+            TotalItems = Fruits.Count()
+        };
+    }
+
+    Func<Fruit, object> _groupBy = x => 
+    {
+        return x.Category;
+    };
+
+    public void AddFruit()
+    {
+        Fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void ExpandAllGroups()
+    {
+        dataGrid?.ExpandAllGroups();
+    }
+
+    public void CollapseAllGroups()
+    {
+        dataGrid?.CollapseAllGroups();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseTest.razor
@@ -1,0 +1,56 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
+             GroupExpanded="false">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" Filterable="false" Groupable="false" />
+        <PropertyColumn Property="x => x.Count" />
+        <PropertyColumn Property="x => x.Category" Title="Category" Grouping="true" GroupBy="@_groupBy">
+            <GroupTemplate>
+                <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+            </GroupTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+    <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+</div>
+
+@code {
+    MudDataGrid<Fruit> dataGrid;
+    public record Fruit(string Name, int Count, string Category);
+
+    List<Fruit> Fruits { get; set; } = new()
+    {
+        new Fruit("Apple", 2, "Pome"),
+        new Fruit("Pear", 4, "Pome"),
+        new Fruit("Orange", 4, "Citrus")
+    };
+    
+    Func<Fruit, object> _groupBy = x => 
+    {
+        return x.Category;
+    };
+
+    public void AddFruit()
+    {
+        Fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void ExpandAllGroups()
+    {
+        dataGrid?.ExpandAllGroups();
+    }
+
+    public void CollapseAllGroups()
+    {
+        dataGrid?.CollapseAllGroups();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3740,7 +3740,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridGroupExpandedTest()
+        public async Task DataGridGroupExpandedTrueTest()
         {
             var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
@@ -3754,11 +3754,11 @@ namespace MudBlazor.UnitTests.Components
                 comp.Instance.AddFruit());
             // datagrid should be expanded with the new category
             dataGrid.Render();
-            comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(5);
         }
 
         [Test]
-        public async Task DataGridGroupExpandedAsyncTest()
+        public async Task DataGridGroupExpandedTrueAsyncTest()
         {
             var comp = Context.RenderComponent<DataGridGroupExpandedAsyncTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedAsyncTest.Fruit>>();
@@ -3772,11 +3772,11 @@ namespace MudBlazor.UnitTests.Components
                 comp.Instance.AddFruit());
             // datagrid should be expanded with the new category
             dataGrid.Render();
-            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(3));
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(5));
         }
-
+        
         [Test]
-        public async Task DataGridGroupExpandedServerDataTest()
+        public async Task DataGridGroupExpandedTrueServerDataTest()
         {
             var comp = Context.RenderComponent<DataGridGroupExpandedServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedServerDataTest.Fruit>>();
@@ -3789,7 +3789,60 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.AddFruit());
             // datagrid should be expanded with the new category
             dataGrid.Render();
-            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(3));
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(5));
+        }
+
+        [Test]
+        public async Task DataGridGroupExpandedFalseTest()
+        {
+            var comp = Context.RenderComponent<DataGridGroupExpandedFalseTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseTest.Fruit>>();
+
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
+            comp.Instance.ExpandAllGroups();
+            dataGrid.Render();
+            // after all groups are expanded
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(7);
+            await comp.InvokeAsync(() =>
+                comp.Instance.AddFruit());
+            // datagrid should be collapsed with the new category
+            dataGrid.Render();
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(8);
+        }
+
+        [Test]
+        public async Task DataGridGroupExpandedFalseAsyncTest()
+        {
+            var comp = Context.RenderComponent<DataGridGroupExpandedFalseAsyncTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseAsyncTest.Fruit>>();
+
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(2));
+            dataGrid.Instance.ExpandAllGroups();
+            dataGrid.Render();
+            // after all groups are expanded
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
+            await comp.InvokeAsync(() =>
+                comp.Instance.AddFruit());
+            // datagrid should be collapsed with the new category
+            dataGrid.Render();
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(8));
+        }
+        
+        [Test]
+        public async Task DataGridGroupExpandedFalseServerDataTest()
+        {
+            var comp = Context.RenderComponent<DataGridGroupExpandedFalseServerDataTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseServerDataTest.Fruit>>();
+
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(2));
+            dataGrid.Instance.ExpandAllGroups();
+            dataGrid.Render();
+            // after all groups are expanded
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
+            await comp.InvokeAsync(() => comp.Instance.AddFruit());
+            // datagrid should be collapsed with the new category
+            dataGrid.Render();
+            comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(8));
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -28,7 +28,7 @@ namespace MudBlazor
         private bool _columnsPanelVisible = false;
         private IEnumerable<T> _items;
         private T _selectedItem;
-        internal HashSet<object> _groupExpansions = new HashSet<object>();
+        internal Dictionary<object, bool> _groupExpansionsDict = new Dictionary<object, bool>();
         private List<GroupDefinition<T>> _currentPageGroups = new List<GroupDefinition<T>>();
         private List<GroupDefinition<T>> _allGroups = new List<GroupDefinition<T>>();
         internal HashSet<T> _openHierarchies = new HashSet<T>();
@@ -670,8 +670,7 @@ namespace MudBlazor
                     {
                         _currentPageGroups.Clear();
                         _allGroups.Clear();
-                        _groupExpansions.Clear();
-                        _groupExpansions.Add("__initial__");
+                        _groupExpansionsDict.Clear();
 
                         foreach (var column in RenderedColumns)
                             column.RemoveGrouping();
@@ -1375,23 +1374,22 @@ namespace MudBlazor
             var currentPageGroupings = CurrentPageItems.GroupBy(GroupedColumn.groupBy);
 
             // Maybe group Items to keep groups expanded after clearing a filter?
-            var allGroupings = FilteredItems.GroupBy(GroupedColumn.groupBy);
+            var allGroupings = FilteredItems.GroupBy(GroupedColumn.groupBy).ToArray();
 
-            if (GetFilteredItemsCount() > 0 && _groupExpansions.Count == 0 && GroupExpanded)
+            if (GetFilteredItemsCount() > 0)
             {
-                _groupExpansions.Add("__initial__");
                 foreach (var group in allGroupings)
                 {
-                    _groupExpansions.Add(group.Key);
+                    _groupExpansionsDict.TryAdd(group.Key, GroupExpanded);
                 }
             }
 
             // construct the groups
             _currentPageGroups = currentPageGroupings.Select(x => new GroupDefinition<T>(x,
-                _groupExpansions.Contains(x.Key))).ToList();
+                _groupExpansionsDict[x.Key])).ToList();
 
             _allGroups = allGroupings.Select(x => new GroupDefinition<T>(x,
-                _groupExpansions.Contains(x.Key))).ToList();                
+                _groupExpansionsDict[x.Key])).ToList();                
 
             if ((_isFirstRendered || ServerData != null) && !noStateChange)
                 StateHasChanged();
@@ -1410,15 +1408,11 @@ namespace MudBlazor
 
         internal void ToggleGroupExpansion(GroupDefinition<T> g)
         {
-            if (_groupExpansions.Contains(g.Grouping.Key))
+            if (_groupExpansionsDict.ContainsKey(g.Grouping.Key))
             {
-                _groupExpansions.Remove(g.Grouping.Key);
+                _groupExpansionsDict[g.Grouping.Key] = !_groupExpansionsDict[g.Grouping.Key];
             }
-            else
-            {
-                _groupExpansions.Add(g.Grouping.Key);
-            }
-
+ 
             GroupItems();
         }
 
@@ -1427,17 +1421,17 @@ namespace MudBlazor
             foreach (var group in _allGroups)
             {
                 group.IsExpanded = true;
-                _groupExpansions.Add(group.Grouping.Key);
+                _groupExpansionsDict[group.Grouping.Key] = true;
             }
         }
 
         public void CollapseAllGroups()
         {
-            _groupExpansions.Clear();
-            _groupExpansions.Add("__initial__");
-
             foreach (var group in _allGroups)
+            {
                 group.IsExpanded = false;
+                _groupExpansionsDict[group.Grouping.Key] = false;
+            }
         }
 
         #endregion

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1408,9 +1408,9 @@ namespace MudBlazor
 
         internal void ToggleGroupExpansion(GroupDefinition<T> g)
         {
-            if (_groupExpansionsDict.ContainsKey(g.Grouping.Key))
+            if (_groupExpansionsDict.TryGetValue(g.Grouping.Key, out var value))
             {
-                _groupExpansionsDict[g.Grouping.Key] = !_groupExpansionsDict[g.Grouping.Key];
+                _groupExpansionsDict[g.Grouping.Key] = !value;
             }
  
             GroupItems();


### PR DESCRIPTION
## Description
Fixed #7440
Added dictionary to track the status (expanded/collapsed) of groups. 
New added groups respect GroupExpanded property.

## How Has This Been Tested?
by unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
