### PR TITLE
MudFileUpload: Update summary for MaximumFileCount to better convey its intention (#7227)

### DIFF
--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -115,7 +115,10 @@ namespace MudBlazor
         public string InputStyle { get; set; }
 
         /// <summary>
-        /// Maximum number of files that can be uploaded
+        /// Represents the maximum number of files that can be selected at one time
+        /// in the file dialog. It does not limit the total number of uploaded files
+        /// when AppendMultipleFiles="true". A limit should be validated manually, for
+        /// example in the FilesChanged event callback. 
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -115,8 +115,9 @@ namespace MudBlazor
         public string InputStyle { get; set; }
 
         /// <summary>
-        /// Represents the maximum number of files that can be selected at one time
-        /// in the file dialog. It does not limit the total number of uploaded files
+        /// Represents the maximum number of files that can retrieved from the internal call to
+        /// InputFileChangeEventArgs.GetMultipleFiles().
+        /// It does not limit the total number of uploaded files
         /// when AppendMultipleFiles="true". A limit should be validated manually, for
         /// example in the FilesChanged event callback. 
         /// </summary>


### PR DESCRIPTION
## Description
Updates the summary for MaximumFileCount in the MudFileUpload component. The new summary better conveys the intention of the property when AppendMultipleFiles="true", which is that it only limits the number of files that can be selected in a file dialog instance, and does not limit the total number of files that may be uploaded by the component. 

Resolves #7227 

## How Has This Been Tested?
Commit was tested by building and running MudBlazor.Docs.Server and confirming that the changes made are visible in the API docs for MudFileUpload. No new unit tests have been created. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
