### PR TITLE
MudDataGrid: Add SimpleFilterTemplate to columns

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringSimpleFilterTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringSimpleFilterTemplateExample.razor
@@ -1,0 +1,87 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudDataGrid Items="@Elements" Filterable="true" FilterMode="@_filterMode" FilterCaseSensitivity="@_caseSensitivity">
+    <Columns>
+        <PropertyColumn Property="x => x.Number" Title="Nr" Filterable="false" />
+        <PropertyColumn Property="x => x.Sign" />
+        <PropertyColumn Property="x => x.Name">
+            <SimpleFilterTemplate>
+                <MudItem xs="3">
+                    <MudSelect @bind-Value="context.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-operator">
+                        @foreach (var fieldOperator in operators_local)
+                        {
+                            <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="4">
+                    <MudTextField T="string" ValueChanged="@(x => context.Value = x)" FullWidth="true" Label="Value" Placeholder="FilterValue" Margin="@Margin.Dense"
+                                  Immediate="true" Class="filter-input" />
+                </MudItem>
+            </SimpleFilterTemplate>
+        </PropertyColumn>
+        <PropertyColumn Property="x => x.Position" Filterable="false" />
+        <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
+        <PropertyColumn Property="x => x.Group" Title="Category">
+            <SimpleFilterTemplate>
+                @Filter(context)
+            </SimpleFilterTemplate>
+        </PropertyColumn>
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Element" />
+    </PagerContent>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudRadioGroup T="DataGridFilterMode" @bind-SelectedOption="@_filterMode">
+        <MudRadio Dense="true" Option="@DataGridFilterMode.Simple" Color="Color.Primary">Simple</MudRadio>
+        <MudRadio Dense="true" Option="@DataGridFilterMode.ColumnFilterMenu" Color="Color.Tertiary">Column Menu</MudRadio>
+        <MudRadio Dense="true" Option="@DataGridFilterMode.ColumnFilterRow">Column Row</MudRadio>
+    </MudRadioGroup>
+</div>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudRadioGroup T="DataGridFilterCaseSensitivity" @bind-SelectedOption="@_caseSensitivity">
+        <MudRadio Dense="true" Option="@DataGridFilterCaseSensitivity.Default" Color="Color.Primary">Default Case Sensitivity</MudRadio>
+        <MudRadio Dense="true" Option="@DataGridFilterCaseSensitivity.CaseInsensitive" Color="Color.Tertiary">Case Insensitive</MudRadio>
+    </MudRadioGroup>
+</div>
+
+
+@code {
+    IEnumerable<Element> Elements = new List<Element>();
+    DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
+    DataGridFilterCaseSensitivity _caseSensitivity = DataGridFilterCaseSensitivity.Default;
+    string[] operators_local = new string[] { "contains", "not contains" };
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+
+    internal RenderFragment Filter(IFilterDefinition<Element> filterDefinition) =>
+    @<text>
+        @{
+            string[] operators = new string[] { "contains", "not contains" };
+        }
+
+        <MudItem xs="3">
+            <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
+                       Class="filter-operator">
+                @foreach (var fieldOperator in operators)
+                {
+                    <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="4">
+            <MudTextField T="string" ValueChanged="@(x => filterDefinition.Value = x)" FullWidth="true" Label="Value" Placeholder="FilterValue" Margin="@Margin.Dense"
+                          Immediate="true" Class="filter-input" />
+        </MudItem>
+    </text>;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterableSimpleFilterTemplateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterableSimpleFilterTemplateTest.razor
@@ -1,0 +1,47 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items" Filterable="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name">
+            <SimpleFilterTemplate>
+                <MudItem xs="3">
+                    <MudSelect @bind-Value="context.Operator" FullWidth="true" Label="Operator" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-operator">
+                        @foreach (var fieldOperator in operators_local)
+                        {
+                            <MudSelectItem Value="@fieldOperator">@fieldOperator</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="4">
+                    <MudTextField T="string" ValueChanged="@(x => context.Value = x)" FullWidth="true" Label="Value" Placeholder="FilterValue" Margin="@Margin.Dense"
+                                  Immediate="true" Class="filter-input" />
+                </MudItem>
+            </SimpleFilterTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "SimpleFilterTemplate test";
+    string[] operators_local = new string[] { "contains", "not contains" };
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("B"), 
+        new Item("A"), 
+        new Item("C"),
+        new Item("C")
+    };
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public Item(string name)
+        {
+            Name = name;
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -233,6 +233,39 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridFilterableSimpleFilterTemplateTest()
+        {
+            var comp = Context.RenderComponent<DataGridFilterableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterableTest.Item>>();
+
+            // Count the number of rows including header.
+            dataGrid.FindAll("tr").Count.Should().Be(6); // header row + four rows + footer row
+
+            // Check the values of rows
+            dataGrid.FindAll("td")[0].TextContent.Trim().Should().Be("B");
+            dataGrid.FindAll("td")[1].TextContent.Trim().Should().Be("A");
+            dataGrid.FindAll("td")[2].TextContent.Trim().Should().Be("C");
+            dataGrid.FindAll("td")[3].TextContent.Trim().Should().Be("C");
+
+            // Add a FilterDefinition to filter where the Name = "C".
+            await comp.InvokeAsync(() =>
+            {
+                return dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterableTest.Item>
+                {
+                    Column = dataGrid.Instance.RenderedColumns.First(),
+                    Operator = FilterOperator.String.Equal,
+                    Value = "C"
+                });
+            });
+
+            // Check the values of rows
+            dataGrid.FindAll("td")[0].TextContent.Trim().Should().Be("C");
+            dataGrid.FindAll("td")[1].TextContent.Trim().Should().Be("C");
+
+            dataGrid.Instance.Filterable = false;
+        }
+
+        [Test]
         public async Task DataGridFilterableServerDataTest()
         {
             var comp = Context.RenderComponent<DataGridFilterableServerDataTest>();

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -125,6 +125,7 @@ namespace MudBlazor
 
         [Parameter] public RenderFragment<FilterContext<T>> FilterTemplate { get; set; }
 
+        [Parameter] public RenderFragment<IFilterDefinition<T>> SimpleFilterTemplate { get; set; }
         public string Identifier { get; set; }
         
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -66,7 +66,7 @@
                                     <MudGrid Spacing="0">
                                         @foreach (var f in FilterDefinitions)
                                         {
-                                            @Filter(f, null)
+                                            @Filter(f, f.Column)
                                         }
                                     </MudGrid>
                                     <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">@Localizer["MudDataGrid.AddFilter"]</MudButton>
@@ -398,7 +398,23 @@
                 var filter = new Filter<T>(this, filterDefinition, column);
                 var fieldType = filterDefinition.FieldType;
             }
-            @if (column is null)
+            @if (column != null && FilterMode == DataGridFilterMode.Simple && column.SimpleFilterTemplate != null)
+            {
+                <MudItem xs="1" Class="d-flex">
+                    <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
+                </MudItem>
+                <MudItem xs="4">
+                    <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Column"]" Dense="true" Margin="@Margin.Dense"
+                               Class="filter-field">
+                    @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false) ?? Enumerable.Empty<Column<T>>())
+                        {
+                            <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                @column.SimpleFilterTemplate(filterDefinition)
+            }
+            else if (column is null || FilterMode == DataGridFilterMode.Simple)
             {
                 <MudItem xs="1" Class="d-flex">
                     <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Resolves #7453
Add possibility to create own visual filter implementation for DataGridFilterMode.Simple without breaking logic of filters.
Example here: https://try.mudblazor.com/snippet/GEcHuXkvShRIuuiJ

## How Has This Been Tested?
Tested visual, debugging, code equal to https://try.mudblazor.com/snippet/GEcHuXkvShRIuuiJ

## Types of changes
Column.razor.cs - adds SimpleFilterTemplate
`[Parameter] public RenderFragment<IFilterDefinition<T>> SimpleFilterTemplate { get; set; }`
MudDataGrid.razor - change Filter function to support SimpleFilterTemplate. Template handles only 'operator' and 'value' part of simple template filter.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
