### PR TITLE
MudTabs: Add IconColor, IconSize and IconViewBox properties to MudTabPanel

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsIconAndTextExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsIconAndTextExample.razor
@@ -2,6 +2,6 @@
 
 <MudTabs Outlined="true">
     <MudTabPanel Text="Api" Icon="@Icons.Material.Filled.Api"/>
-    <MudTabPanel Icon="@Icons.Material.Filled.Build"/>
-    <MudTabPanel Text="Bug Report" Icon="@Icons.Material.Filled.BugReport"/>
+    <MudTabPanel Icon="@Icons.Material.Filled.Build" IconColor="Color.Success" IconSize="Size.Large" />
+    <MudTabPanel Text="Bug Report" Icon="@Icons.Material.Filled.BugReport" IconColor="Color.Error"/>
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsIconAndTextExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsIconAndTextExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudTabs Outlined="true">
-    <MudTabPanel Text="Api" Icon="@Icons.Material.Filled.Api"/>
-    <MudTabPanel Icon="@Icons.Material.Filled.Build" IconColor="Color.Success" IconSize="Size.Large" />
-    <MudTabPanel Text="Bug Report" Icon="@Icons.Material.Filled.BugReport" IconColor="Color.Error"/>
+    <MudTabPanel Text="Api" Icon="@Icons.Material.Filled.Api" IconViewBox="0 0 23 23" />
+    <MudTabPanel Icon="@Icons.Material.Filled.Build" IconColor="Color.Success" IconSize="Size.Small" />
+    <MudTabPanel Text="Bug Report" Icon="@Icons.Material.Filled.BugReport" IconSize="Size.Large" IconColor="Color.Error" />
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -51,7 +51,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Icon Tabs">
-                <Description>Icons can be used in addition to regular text in the tabs.</Description>
+                <Description>
+                    Icons can be used in addition to regular text in the tabs.
+                    <br />Use properties <CodeInline>IconColor</CodeInline>, <CodeInline>IconSize</CodeInline> or <CodeInline>IconViewBox</CodeInline> to change the icon appearance.
+                </Description>
             </SectionHeader>
             <SectionContent Code="TabsIconAndTextExample" ShowCode="false">
                 <TabsIconAndTextExample />

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -1263,6 +1264,27 @@ namespace MudBlazor.UnitTests.Components
             tabs[0].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeTrue();
             tabs[1].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeFalse(); // The close icon is not shown.
             tabs[2].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeTrue();
+        }
+
+        [Test]
+        public void TabPanel_IconAppearance_Test()
+        {
+            var comp = Context.RenderComponent<TabsIconAndTextExample>();
+            var svgIcons = comp.FindAll("div.mud-tabs>>svg");
+
+            // 1st TabPanel Icon
+            svgIcons[0].ClassList.Should().Contain("mud-tab-icon-text");
+            svgIcons[0].ClassList.Should().Contain("mud-icon-size-medium");
+            svgIcons[0].OuterHtml.Contains("viewBox=\"0 0 23 23\"");
+
+            // 2nd TabPanel Icon
+            svgIcons[1].ClassList.Should().Contain("mud-success-text");
+            svgIcons[1].ClassList.Should().Contain("mud-icon-size-small");
+            svgIcons[1].OuterHtml.Contains("viewBox=\"0 0 24 24\"");
+
+            // 3rd TabPanel Icon
+            svgIcons[2].ClassList.Should().Contain("mud-error-text");
+            svgIcons[2].ClassList.Should().Contain("mud-icon-size-large");
         }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -41,6 +41,27 @@ else
     public string Icon { get; set; }
 
     /// <summary>
+    /// The color of the icon. It supports the theme colors.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Tabs.Appearance)]
+    public Color? IconColor { get; set; }
+
+    /// <summary>
+    /// The Icon Size.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.FormComponent.Appearance)]
+    public Size IconSize { get; set; } = Size.Medium;
+
+    /// <summary>
+    /// The viewbox size of an svg element.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Icon.Behavior)]
+    public string ViewBox { get; set; } = "0 0 24 24";
+
+    /// <summary>
     /// If true, the tabpanel will be disabled.
     /// </summary>
     [Parameter]

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -59,7 +59,7 @@ else
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Icon.Behavior)]
-    public string ViewBox { get; set; } = "0 0 24 24";
+    public string IconViewBox { get; set; } = "0 0 24 24";
 
     /// <summary>
     /// If true, the tabpanel will be disabled.

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -76,37 +76,39 @@
 @code {
     RenderFragment RenderTab(MudTabPanel panel) => @<div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
         @if (TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
+        {
+            <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
+                @TabPanelHeader(panel)
+            </div>
+        }
+        @if (panel.TabContent != null)
+        {
+            @panel.TabContent
+        }
+        else
+        {
+            if (!string.IsNullOrWhiteSpace(panel.Text))
             {
-                <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
-                    @TabPanelHeader(panel)
-                </div>
-            }
-            @if (panel.TabContent != null)
-            {
-                @panel.TabContent
-            }
-            else if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
-            {
+                if (!string.IsNullOrWhiteSpace(panel.Icon))
+                {
+                    <MudIcon Icon="@panel.Icon" ViewBox="@panel.ViewBox" Color="@(panel.IconColor.HasValue ? panel.IconColor.Value : IconColor)" Size="@panel.IconSize" Class="mud-tab-icon-text" />
+                }
                 @panel.Text
             }
-            else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+            else if (!string.IsNullOrWhiteSpace(panel.Icon))
             {
-                <MudIcon Icon="@panel.Icon" Color="@IconColor" />
+                <MudIcon Icon="@panel.Icon" ViewBox="@panel.ViewBox" Color="@(panel.IconColor.HasValue ? panel.IconColor.Value : IconColor)" Size="@panel.IconSize" />
             }
-            else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-            {
-                <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                @panel.Text
-            }
-            @if (panel.BadgeData != null || panel.BadgeDot)
-            {
-                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
-            }
-            @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
-            {
-                <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
-                    @TabPanelHeader(panel)
-                </div>
-            }
-        </div>;
+        }
+        @if (panel.BadgeData != null || panel.BadgeDot)
+        {
+            <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+        }
+        @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
+        {
+            <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                @TabPanelHeader(panel)
+            </div>
+        }
+    </div>;
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -87,18 +87,14 @@
         }
         else
         {
-            if (!string.IsNullOrWhiteSpace(panel.Text))
+            var hasText = !string.IsNullOrWhiteSpace(panel.Text);
+            if (!string.IsNullOrWhiteSpace(panel.Icon))
             {
-                if (!string.IsNullOrWhiteSpace(panel.Icon))
-                {
-                    <MudIcon Icon="@panel.Icon" ViewBox="@panel.ViewBox" Color="@(panel.IconColor.HasValue ? panel.IconColor.Value : IconColor)" Size="@panel.IconSize" Class="mud-tab-icon-text" />
-                }
+                <MudIcon Icon="@panel.Icon" ViewBox="@panel.IconViewBox" Color="@(panel.IconColor.HasValue ? panel.IconColor.Value : IconColor)"
+                         Size="@panel.IconSize" Class="@(hasText ? "mud-tab-icon-text" : null)" />
+            }
+            if (hasText)
                 @panel.Text
-            }
-            else if (!string.IsNullOrWhiteSpace(panel.Icon))
-            {
-                <MudIcon Icon="@panel.Icon" ViewBox="@panel.ViewBox" Color="@(panel.IconColor.HasValue ? panel.IconColor.Value : IconColor)" Size="@panel.IconSize" />
-            }
         }
         @if (panel.BadgeData != null || panel.BadgeDot)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
MudTabs: Add `IconColor`, `IconSize` and `IconViewBox` properties to `MudTabPanel`

As our app grows, we combine multiple MudTabs on a sinlge page and use the Icon color and size
as visual indicators. When something needs attention it is instantly visible, like a big red icon.

Right now, we do it like this, but it's a bit much when you have multiple tab panels, I also
have to maintain the tab panel text. It makes binding icon properties easier as these can now be 
set on the tab panel level.

![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/4807f000-cd4e-4daf-b407-f3eceaa002e9)


<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
- [X] Visual inspection of doc examples.
![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/8c63c3ff-fa41-413f-9b5a-f8a970256812)

<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code tweak in MudTabs.razor

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
