### PR TITLE
MudScrollManager: fix scroll lock for touch devices

### DIFF
--- a/src/MudBlazor/Styles/layout/_scroll.scss
+++ b/src/MudBlazor/Styles/layout/_scroll.scss
@@ -1,4 +1,4 @@
-﻿.scroll-locked{
+﻿.scroll-locked {
     padding-right: 8px;
     overflow: hidden;
 
@@ -13,6 +13,10 @@
             }
         }
     }
+}
+
+.scroll-locked-no-padding {
+    overflow: hidden;
 }
 
 @-moz-document url-prefix() {

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -49,17 +49,25 @@ class MudScrollManager {
     lockScroll(selector, lockclass) {
         let element = document.querySelector(selector) || document.body;
 
-        //if the body doesn't have a scroll bar, don't add the lock class
+        //if the body doesn't have a scroll bar, don't add the lock class with padding
         let hasScrollBar = window.innerWidth > document.body.clientWidth;
+
         if (hasScrollBar) {
             element.classList.add(lockclass);
+        } else {
+            let lockClassNoPadding = lockclass + "-no-padding";
+            element.classList.add(lockClassNoPadding);
         }
+
     }
 
     //unlocks the scroll. Default is body
     unlockScroll(selector, lockclass) {
         let element = document.querySelector(selector) || document.body;
+
+        // remove both lock classes to be sure it's unlocked
         element.classList.remove(lockclass);
+        element.classList.remove(lockclass + "-no-padding");
     }
 };
 window.mudScrollManager = new MudScrollManager();


### PR DESCRIPTION
LockScroll Parameter was missing for MudDialog. As seen on [Material dialog](https://material.angular.io/components/dialog/overview), the dialog should be able to block the background. 

To make it work on touch devices, mudScrollManager.js has been slightly modified. 

## Description
Resolves #7454
Resolves #6108

- lockScroll in mudScrollManager.js modified to work on touch devices as well
- <s>added LockScroll parameter in DialogOptions for MudDialog</s>

## How Has This Been Tested?
Manually.

Example has been added in Docs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
