### PR TITLE
Popover: add Legacy mode (uses old MudPopoverService)

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
-using MudBlazor.Interop;
 using MudBlazor.Services;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
@@ -320,6 +319,7 @@ public class ServiceCollectionExtensionsTests
             options.ContainerClass = "container_class";
             options.FlipMargin = 100;
             options.ThrowOnDuplicateProvider = false;
+            options.Mode = PopoverMode.Legacy;
             expectedOptions = options;
         });
         var serviceProvider = services.BuildServiceProvider();
@@ -539,6 +539,7 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.ContainerClass = "container_class";
             options.PopoverOptions.FlipMargin = 100;
             options.PopoverOptions.ThrowOnDuplicateProvider = false;
+            options.PopoverOptions.Mode = PopoverMode.Legacy;
 
             expectedOptions = options;
         });
@@ -611,6 +612,7 @@ public class ServiceCollectionExtensionsTests
         Assert.AreEqual(expectedOptions.PopoverOptions.ContainerClass, actualPopoverOptions.ContainerClass);
         Assert.AreEqual(expectedOptions.PopoverOptions.FlipMargin, actualPopoverOptions.FlipMargin);
         Assert.AreEqual(expectedOptions.PopoverOptions.ThrowOnDuplicateProvider, actualPopoverOptions.ThrowOnDuplicateProvider);
+        Assert.AreEqual(expectedOptions.PopoverOptions.Mode, actualPopoverOptions.Mode);
 
         Assert.AreEqual(expectedOptions.ResizeObserverOptions.EnableLogging, actualResizeObserverOptions.EnableLogging);
         Assert.AreEqual(expectedOptions.ResizeObserverOptions.ReportRate, actualResizeObserverOptions.ReportRate);

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -8,10 +8,6 @@ namespace MudBlazor
 #nullable enable
     public partial class MudPopover : MudPopoverBase
     {
-        [Inject]
-        [Obsolete($"Replaced by {nameof(PopoverService)}. Will be removed in v7.")]
-        public IMudPopoverService Service { get; set; } = null!;
-
         protected internal override string PopoverClass =>
             new CssBuilder("mud-popover")
                 .AddClass($"mud-popover-fixed", Fixed)

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -20,13 +20,13 @@ namespace MudBlazor;
 /// </remarks>
 public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposable
 {
-    [Obsolete("For Legacy compatibility mode, will be removed in v7.")]
+    [Obsolete("For Legacy compatibility mode only, will be removed in v7.")]
     private MudPopoverHandler? _handler;
 
     private bool _afterFirstRender;
 
     /// <inheritdoc />
-    public virtual Guid Id { get; [Obsolete("Set is only needed for legacy. Remove in v7.")] private set; } = Guid.NewGuid();
+    public virtual Guid Id { get; [Obsolete("Set is only needed for legacy mode only. Remove in v7.")] private set; } = Guid.NewGuid();
 
     [Inject]
     [Obsolete($"Replaced by {nameof(PopoverService)}. Will be removed in v7.")]
@@ -58,7 +58,7 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        if (PopoverService.PopoverOptions.Legacy)
+        if (PopoverService.PopoverOptions.Mode == PopoverMode.Legacy)
 #pragma warning disable CS0618 // Type or member is obsolete
         {
             _handler = Service.Register(ChildContent ?? new RenderFragment((x) => { }));
@@ -81,7 +81,7 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
 
         if (_afterFirstRender)
         {
-            if (PopoverService.PopoverOptions.Legacy)
+            if (PopoverService.PopoverOptions.Mode == PopoverMode.Legacy)
 #pragma warning disable CS0618 // Type or member is obsolete
             {
                 if (_handler is not null)
@@ -102,7 +102,7 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
     {
         if (firstRender)
         {
-            if (PopoverService.PopoverOptions.Legacy)
+            if (PopoverService.PopoverOptions.Mode == PopoverMode.Legacy)
 #pragma warning disable CS0618 // Type or member is obsolete
             {
                 if (_handler is not null)
@@ -133,7 +133,7 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
             if (IsJSRuntimeAvailable)
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                if (PopoverService.PopoverOptions.Legacy)
+                if (PopoverService.PopoverOptions.Mode == PopoverMode.Legacy)
                 {
                     await Service.Unregister(_handler);
                 }

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -20,10 +20,17 @@ namespace MudBlazor;
 /// </remarks>
 public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposable
 {
+    [Obsolete("For Legacy compatibility mode, will be removed in v7.")]
+    private MudPopoverHandler? _handler;
+
     private bool _afterFirstRender;
 
     /// <inheritdoc />
-    public virtual Guid Id { get; } = Guid.NewGuid();
+    public virtual Guid Id { get; [Obsolete("Set is only needed for legacy. Remove in v7.")] private set; } = Guid.NewGuid();
+
+    [Inject]
+    [Obsolete($"Replaced by {nameof(PopoverService)}. Will be removed in v7.")]
+    public IMudPopoverService Service { get; set; } = null!;
 
     [Inject]
     protected IPopoverService PopoverService { get; set; } = null!;
@@ -51,7 +58,18 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        await PopoverService.CreatePopoverAsync(this);
+        if (PopoverService.PopoverOptions.Legacy)
+#pragma warning disable CS0618 // Type or member is obsolete
+        {
+            _handler = Service.Register(ChildContent ?? new RenderFragment((x) => { }));
+            _handler.SetComponentBaseParameters(this, PopoverClass, PopoverStyles, Open);
+            Id = _handler.Id;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+        else
+        {
+            await PopoverService.CreatePopoverAsync(this);
+        }
 
         await base.OnInitializedAsync();
     }
@@ -63,7 +81,19 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
 
         if (_afterFirstRender)
         {
-            await PopoverService.UpdatePopoverAsync(this);
+            if (PopoverService.PopoverOptions.Legacy)
+#pragma warning disable CS0618 // Type or member is obsolete
+            {
+                if (_handler is not null)
+                {
+                    await _handler.UpdateFragmentAsync(ChildContent, this, PopoverClass, PopoverStyles, Open);
+                }
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+            else
+            {
+                await PopoverService.UpdatePopoverAsync(this);
+            }
         }
     }
 
@@ -72,7 +102,22 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
     {
         if (firstRender)
         {
-            await PopoverService.UpdatePopoverAsync(this);
+            if (PopoverService.PopoverOptions.Legacy)
+#pragma warning disable CS0618 // Type or member is obsolete
+            {
+                if (_handler is not null)
+                {
+                    await _handler.Initialize();
+                    await Service.InitializeIfNeeded();
+                    await _handler.UpdateFragmentAsync(ChildContent, this, PopoverClass, PopoverStyles, Open);
+                }
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+            else
+            {
+                await PopoverService.UpdatePopoverAsync(this);
+            }
+
             _afterFirstRender = true;
         }
 
@@ -87,7 +132,16 @@ public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposa
         {
             if (IsJSRuntimeAvailable)
             {
-                await PopoverService.DestroyPopoverAsync(this);
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (PopoverService.PopoverOptions.Legacy)
+                {
+                    await Service.Unregister(_handler);
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else
+                {
+                    await PopoverService.DestroyPopoverAsync(this);
+                }
             }
         }
         catch (JSDisconnectedException) { }

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -297,7 +297,7 @@ namespace MudBlazor.Services
                 popoverOptions.FlipMargin = options.FlipMargin;
                 popoverOptions.QueueDelay = options.QueueDelay;
                 popoverOptions.ThrowOnDuplicateProvider = options.ThrowOnDuplicateProvider;
-                popoverOptions.Legacy = options.Legacy;
+                popoverOptions.Mode = options.Mode;
             });
 
             return services;
@@ -471,7 +471,7 @@ namespace MudBlazor.Services
                     popoverOptions.FlipMargin = options.PopoverOptions.FlipMargin;
                     popoverOptions.QueueDelay = options.PopoverOptions.QueueDelay;
                     popoverOptions.ThrowOnDuplicateProvider = options.PopoverOptions.ThrowOnDuplicateProvider;
-                    popoverOptions.Legacy = options.PopoverOptions.Legacy;
+                    popoverOptions.Mode = options.PopoverOptions.Mode;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -297,6 +297,7 @@ namespace MudBlazor.Services
                 popoverOptions.FlipMargin = options.FlipMargin;
                 popoverOptions.QueueDelay = options.QueueDelay;
                 popoverOptions.ThrowOnDuplicateProvider = options.ThrowOnDuplicateProvider;
+                popoverOptions.Legacy = options.Legacy;
             });
 
             return services;
@@ -470,6 +471,7 @@ namespace MudBlazor.Services
                     popoverOptions.FlipMargin = options.PopoverOptions.FlipMargin;
                     popoverOptions.QueueDelay = options.PopoverOptions.QueueDelay;
                     popoverOptions.ThrowOnDuplicateProvider = options.PopoverOptions.ThrowOnDuplicateProvider;
+                    popoverOptions.Legacy = options.PopoverOptions.Legacy;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Services/Popover/MudPopoverHandler.cs
+++ b/src/MudBlazor/Services/Popover/MudPopoverHandler.cs
@@ -92,7 +92,7 @@ public class MudPopoverHandler : IMudPopoverHolder
             Fragment = fragment;
             SetComponentBaseParameters(componentBase, @class, @style, showContent);
             ElementReference?.StateHasChanged();
-            _updater.Invoke(); // <-- this doesn't do anything anymore except making unit tests happy
+            _updater?.Invoke(); // <-- this doesn't do anything anymore except making unit tests happy
         }
         finally
         {

--- a/src/MudBlazor/Services/Popover/PopoverMode.cs
+++ b/src/MudBlazor/Services/Popover/PopoverMode.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+#nullable enable
+
+/// <summary>
+/// Specifies the mode for displaying popovers.
+/// </summary>
+public enum PopoverMode
+{
+    /// <summary>
+    /// The default popover mode that uses the <see cref="IPopoverService"/>.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// The legacy popover mode used for backward compatibility, which utilizes the old <see cref="IMudPopoverService"/> instead of <see cref="IPopoverService"/>.
+    /// </summary>
+    /// <remarks>
+    /// This property is only for backward compatibility with old behaviour. This will be removed in v7. 
+    /// </remarks>
+    Legacy = 1,
+}

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -37,11 +37,13 @@ namespace MudBlazor
         public bool ThrowOnDuplicateProvider { get; set; } = true;
 
         /// <summary>
-        /// When <c>True</c> popovers will use the old <see cref="IMudPopoverService"/> instead of <see cref="IPopoverService"/>.
+        /// Gets or sets the mode for displaying popovers.
         /// </summary>
         /// <remarks>
-        /// This property is only for backward compatibility with old behaviour. This will be removed in v7. 
+        /// This property determines the behavior of popovers. You can set it to either <see cref="PopoverMode.Default"/>
+        /// to use the <see cref="IPopoverService"/> or <see cref="PopoverMode.Legacy"/> to use the old <see cref="IMudPopoverService"/>
+        /// for backward compatibility.
         /// </remarks>
-        public bool Legacy { get; set; }
+        public PopoverMode Mode { get; set; }
     }
 }

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -35,5 +35,13 @@ namespace MudBlazor
         /// The default value is <c>true</c>.
         /// </summary>
         public bool ThrowOnDuplicateProvider { get; set; } = true;
+
+        /// <summary>
+        /// When <c>True</c> popovers will use the old <see cref="IMudPopoverService"/> instead of <see cref="IPopoverService"/>.
+        /// </summary>
+        /// <remarks>
+        /// This property is only for backward compatibility with old behaviour. This will be removed in v7. 
+        /// </remarks>
+        public bool Legacy { get; set; }
     }
 }

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -38,12 +38,13 @@ namespace MudBlazor
 
         /// <summary>
         /// Gets or sets the mode for displaying popovers.
+        /// The default value is <c>PopoverMode.Default</c>.
         /// </summary>
         /// <remarks>
         /// This property determines the behavior of popovers. You can set it to either <see cref="PopoverMode.Default"/>
         /// to use the <see cref="IPopoverService"/> or <see cref="PopoverMode.Legacy"/> to use the old <see cref="IMudPopoverService"/>
         /// for backward compatibility.
         /// </remarks>
-        public PopoverMode Mode { get; set; }
+        public PopoverMode Mode { get; set; } = PopoverMode.Default;
     }
 }


### PR DESCRIPTION
## Description
See for context https://github.com/MudBlazor/MudBlazor/discussions/7434
TL;DR - A customer reported an issue with Blazor Server Side performance with the popovers (only the initial load), and we identified that PR #6953 was the cause. I intend to investigate and address the root cause when I have more time. Meanwhile, to provide a quick solution, we decided to introduce a backward compatibility option that allows users to easily switch to the old popover service (that contains it's own issues tho).

To enable the old popover:

```C#
services.AddMudServices(config =>
{
	config.PopoverOptions.Mode = PopoverMode.Legacy;
});
```

## How Has This Been Tested?
Manually, https://github.com/MudBlazor/MudBlazor/discussions/7434#discussioncomment-6980328

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
