### PR TITLE
MudTablePager: Fix Vertical Alignment of Select text (#7501)

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -360,6 +360,7 @@
 
     & .mud-select-input {
         margin-top: 0px !important;
+        padding: 0 7px;
     }
 
     & .mud-input .mud-input-root {


### PR DESCRIPTION
Fixes: #7501
Fixes the misaligned text of the MudTablePager Select element.

Adds a padding other than for input-root, which should be used in MudTablePager Select item.

## Description
Add padding to existing style.

## How Has This Been Tested?
Build the css out of the edited file and replaced it in a local project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

See #7501 for before and after comparison.

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
