### PR TITLE
MudTimePicker: Fix hour not updating when changed more than once (#7483)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -408,7 +408,6 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(18);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].Click();
             // Are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
@@ -550,7 +549,6 @@ namespace MudBlazor.UnitTests.Components
                 {
                     comp.FindAll("div.mud-minute")[i].MouseUp();
                     underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
-                    comp.FindAll("div.mud-minute")[i].Click();
                 }
             }
 
@@ -598,7 +596,6 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].Click();
 
             // check if the view changed to minutes
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
@@ -610,7 +607,6 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
             comp.FindAll("div.mud-minute")[37].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
-            comp.FindAll("div.mud-minute")[37].Click();
 
             // check if closed
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
@@ -944,18 +940,25 @@ namespace MudBlazor.UnitTests.Components
 
         // See #7483 for details
         [Test]
-        public void Selecting_hour_multiple_times_should_immediately_update_displayed_hour()
+        [TestCase(12, 16, 3, 17, 4)]
+        [TestCase(17, 16, 3, 17, 4, Description = "Switching back to original hour")]
+        public void Selecting_hour_multiple_times_should_immediately_update_displayed_hour(
+            int initialHour,
+            int nextHour,
+            int nextHourIndex,
+            int finalHour,
+            int finalHourIndex)
         {
-            var comp = OpenPicker();
+            var comp = OpenPicker(Parameter(nameof(MudTimePicker.Time), TimeSpan.FromHours(initialHour)));
             var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
 
             // click on the hour input
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseUp();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
-            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be("16");
-            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(16);
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[nextHourIndex].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[nextHourIndex].Click();
+            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be(nextHour.ToString());
+            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(nextHour);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
             // are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
@@ -964,11 +967,11 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             // are hours displayed
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].MouseUp();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[finalHourIndex].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[finalHourIndex].Click();
             // ensure displayed hour text is has updated
-            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be("17");
-            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(17);
+            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be(finalHour.ToString());
+            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(finalHour);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -408,6 +408,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(18);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].Click();
             // Are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
@@ -549,6 +550,7 @@ namespace MudBlazor.UnitTests.Components
                 {
                     comp.FindAll("div.mud-minute")[i].MouseUp();
                     underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
+                    comp.FindAll("div.mud-minute")[i].Click();
                 }
             }
 
@@ -596,6 +598,7 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].Click();
 
             // check if the view changed to minutes
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
@@ -607,6 +610,7 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
             comp.FindAll("div.mud-minute")[37].MouseUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
+            comp.FindAll("div.mud-minute")[37].Click();
 
             // check if closed
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -361,7 +361,7 @@ namespace MudBlazor.UnitTests.Components
             // should be closed
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            // should be 13 hours            
+            // should be 13 hours
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
 
             // click to to open picker
@@ -936,6 +936,36 @@ namespace MudBlazor.UnitTests.Components
             // Check that the time have been changed
             comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
 
+        }
+
+        // See #7483 for details
+        [Test]
+        public void Selecting_hour_multiple_times_should_immediately_update_displayed_hour()
+        {
+            var comp = OpenPicker();
+            var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
+
+            // click on the hour input
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
+            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be("16");
+            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(16);
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
+            // are minutes displayed
+            comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
+
+            // return to hour input
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            // are hours displayed
+            comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
+            // ensure displayed hour text is has updated
+            comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be("17");
+            underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(17);
+            underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
         }
     }
 }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -324,8 +324,8 @@ namespace MudBlazor
           .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
         .Build();
 
-        private bool IsAm => _timeSet.Hour >= 00 && _timeSet.Hour < 12; // am is 00:00 to 11:59 
-        private bool IsPm => _timeSet.Hour >= 12 && _timeSet.Hour < 24; // pm is 12:00 to 23:59 
+        private bool IsAm => _timeSet.Hour >= 00 && _timeSet.Hour < 12; // am is 00:00 to 11:59
+        private bool IsPm => _timeSet.Hour >= 12 && _timeSet.Hour < 24; // pm is 12:00 to 23:59
 
         private string GetClockPinColor()
         {
@@ -454,17 +454,11 @@ namespace MudBlazor
         /// </summary>
         private void OnMouseUp(MouseEventArgs e)
         {
-            if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
-            {
-                MouseDown = false;
-                SubmitAndClose();
-            }
-
             MouseDown = false;
 
-            if (_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.Normal)
+            if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
             {
-                _currentView = OpenTo.Minutes;
+                SubmitAndClose();
             }
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -249,6 +249,7 @@ namespace MudBlazor
 
         private void UpdateTime()
         {
+            _lastSelectedHour = _timeSet.Hour;
             TimeIntermediate = new TimeSpan(_timeSet.Hour, _timeSet.Minute, 0);
             if ((PickerVariant == PickerVariant.Static && PickerActions == null) || (PickerActions != null && AutoClose))
             {
@@ -415,6 +416,7 @@ namespace MudBlazor
 
         private readonly SetTime _timeSet = new();
         private int _initialHour;
+        private int _lastSelectedHour;
         private int _initialMinute;
 
         protected override void OnInitialized()
@@ -423,6 +425,7 @@ namespace MudBlazor
             UpdateTimeSetFromTime();
             _currentView = OpenTo;
             _initialHour = _timeSet.Hour;
+            _lastSelectedHour = _timeSet.Hour;
             _initialMinute = _timeSet.Minute;
         }
 
@@ -454,11 +457,17 @@ namespace MudBlazor
         /// </summary>
         private void OnMouseUp(MouseEventArgs e)
         {
-            MouseDown = false;
-
             if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
             {
+                MouseDown = false;
                 SubmitAndClose();
+            }
+
+            MouseDown = false;
+
+            if (_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.Normal)
+            {
+                _currentView = OpenTo.Minutes;
             }
         }
 
@@ -489,7 +498,8 @@ namespace MudBlazor
             }
             _timeSet.Hour = h;
 
-            if (_currentView == OpenTo.Hours)
+            if (_currentView == OpenTo.Hours
+                || _timeSet.Hour != _lastSelectedHour)
             {
                 UpdateTime();
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes: #7483

As described in the original issue: when changing the hour more than once, the hour is not immediately updated, only when the minutes are updated.

I removed a check in the `OnMouseUp` function (that to me does not seem necessary, maybe a leftover from previous implementations?) that stopped the hour from updating.


## How Has This Been Tested?
Visually verified + bUnit-tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
