### PR TITLE
MudSelect: Inherit Style from its MudComponentBase

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -3,7 +3,7 @@
 @inherits MudBaseInput<T>
 @using MudBlazor.Internal
 
-<div class="@Classname" style="@Style">
+<div class="@Classname" style="@(InputStyle ?? Style)">
 	@if (Adornment == Adornment.Start)
 	{
 	    <MudInputAdornment Class="@AdornmentClassname" 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -29,6 +29,13 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public InputType InputType { get; set; } = InputType.Text;
 
+        /// <summary>
+        /// User styles, specific style applied to the underlying MudInput item
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ComponentBase.Common)]
+        public string? InputStyle { get; set; }
+
         internal override InputType GetInputType() => InputType;
 
         protected string InputTypeString => InputType.ToDescriptionString();

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -16,7 +16,7 @@
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment"
                           AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
-                          @attributes="UserAttributes" OnBlur="@OnBlurAsync">
+                          @attributes="UserAttributes" OnBlur="@OnBlurAsync" Style="@Style">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -16,7 +16,7 @@
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment"
                           AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
-                          @attributes="UserAttributes" OnBlur="@OnBlurAsync" Style="@Style">
+                          @attributes="UserAttributes" OnBlur="@OnBlurAsync" InputStyle="@InputStyle">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -286,6 +286,13 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// User styles, specific style applied to the underlying MudInput item
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ComponentBase.Common)]
+        public string? InputStyle { get; set; }
+
         private Func<T, string> _toStringFunc = x => x?.ToString();
 
         private MudInput<string> _elementReference;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

MudSelect does not apply the styles provided to it's Style property because it doesn't get passed to its InputContent from the MudComponentBase.

This commit addresses that.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
