### PR TITLE
MudMask: Handle multiline input case 

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -333,6 +333,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("textarea").InnerHtml.Should().Be(text);
         }
 
+
+        /// <summary>
+        /// Ensures that a text field with both 'Lines' > 1 and 'Mask' parameters generates a 'textarea'.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task TextFieldMultilineWithMask_CheckRendered()
+        {
+            var comp = Context.RenderComponent<MudTextField<string>>(
+                Parameter(nameof(MudTextField<string>.Mask), new RegexMask(@"\d")),
+                Parameter(nameof(MudTextField<string>.Lines), 2));
+            comp.Find("textarea").Should().NotBeNull();
+        }
+
         [Test]
         public async Task MultilineTextField_Should_UpdateTextOnInput()
         {

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -14,7 +14,26 @@
                            AdornmentClick="@OnAdornmentClick"/>
     }
 
-    <input class="@InputClassname"
+    @if(Lines > 1){
+        <textarea class="@InputClassname"
+           @ref="_elementReference"
+           @attributes="UserAttributes"
+           type="@InputType.ToDescriptionString()"
+           value="@Text"
+           placeholder="@Placeholder"
+           disabled=@GetDisabledState()
+           readonly="@GetReadOnlyState()"
+           @onblur="@OnBlurredAsync"
+           @onfocus="OnFocused"
+           @oncut="OnCut"
+           @oncopy="OnCopy"
+           inputmode="@InputMode.ToString()"
+           >
+            @Text
+        </textarea>
+    }
+    else{
+        <input class="@InputClassname"
            @ref="_elementReference"
            @attributes="UserAttributes"
            type="@InputType.ToDescriptionString()"
@@ -28,7 +47,8 @@
            @oncopy="OnCopy"
            inputmode="@InputMode.ToString()"
            />
-
+    }    
+    
     @if (GetDisabledState())
     {
          @*Note: this div must always be there to avoid crashes in WASM, but it is hidden most of the time except if ChildContent should be shown.


### PR DESCRIPTION
## Description
While using the 'MudTextField' component I've face an issue when I tried to pass the 'Lines' parameter with a value greater than 1 along with the Mask parameter.
In the normal case this should have generated a text area, however it had generated an input field.
I found that the problem was due to a missing condition in the 'MudMask' component, which should handle the case if, 'Lines' parameter has a value > 1, and generate a text area instead.

## How Has This Been Tested?
All existing tests have passed successfully.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
Reproduction link before changes : https://try.mudblazor.com/snippet/wamRENGxdVufhxYr
Screenshot after changes:
![new-version](https://github.com/MudBlazor/MudBlazor/assets/48494859/50fbf0ed-d36b-4572-b538-fc8ed5014ce3)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
