### PR TITLE
MudDatePicker: Retain specific DateTime.Kind when setting undefined kind

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1188,5 +1188,19 @@ namespace MudBlazor.UnitTests.Components
             //changed_text should not be updated
             changed_text.Should().Be("44");
         }
+
+        [Test]
+        public async Task OldDateWithDefinedKind_SetValue_KindUnchanged()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+            var picker = comp.Instance;
+            var oldDate = DateTime.Now;
+            var newDate = oldDate.AddDays(1);
+            picker.Date = oldDate;
+
+            comp.SetParam(p => p.Text, newDate.ToShortDateString());
+
+            picker.Date.Value.Kind.Should().Be(oldDate.Kind);
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -29,6 +29,11 @@ namespace MudBlazor
 
         protected async Task SetDateAsync(DateTime? date, bool updateValue)
         {
+            if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
+            {
+                date = DateTime.SpecifyKind(date.Value, _value.Value.Kind);
+            }
+
             if (_value != date)
             {
                 Touched = true;


### PR DESCRIPTION
## Description
Fixes #7563 

## How Has This Been Tested?
Created a blank blazor webassembly app and reproduced the TryMudBlazor https://try.mudblazor.com/snippet/cOwdYNGLVhwGqZoq

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
