### PR TITLE
DataGridExamples: Fix item removal when list is empty

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridObservabilityExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridObservabilityExample.razor
@@ -40,6 +40,9 @@
 
     void RemoveItem()
     {
-        _items.RemoveAt(0);
+        if (_items.Any())
+        {
+            _items.RemoveAt(0);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridObservabilityTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridObservabilityTest.razor
@@ -38,6 +38,9 @@
 
     void RemoveItem()
     {
-        _items.RemoveAt(0);
+        if (_items.Any())
+        {
+            _items.RemoveAt(0);
+        }
     }
 }


### PR DESCRIPTION
## Description
During interactions with the data grid examples, specifically the 'Observability' example, I encountered an issue. An error arises when all items from the data grid are removed, and a further attempt to remove an item is made. The root cause was identified as a missing verification to determine if the list of items is already empty before initiating item removal. This update rectifies this oversight, ensuring smooth item management.

## How Has This Been Tested?

To ensure the robustness of the implemented fix:

1. **Automated Testing:** All existing unit tests were executed, and they passed without any failures.
2. **Manual Testing:** I manually interacted with the 'Observability' example, adding and removing items multiple times, ensuring that no errors are produced under different scenarios.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Visual Demonstrations

To better understand the issue and its subsequent resolution, please refer to the GIFs below:

### Before the Fix:
![Before Fix GIF](https://github.com/MudBlazor/MudBlazor/assets/92410596/8dec6aeb-af83-455e-884e-779498660ba4)

### After the Fix:
![After Fix GIF](https://github.com/MudBlazor/MudBlazor/assets/92410596/048c028c-ee46-4249-8132-aa577de8fa69)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.