### PR TITLE
MudFileUpload: Fix validation in MudForm (#7577)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudForm ValidationDelay="0">
@@ -12,8 +11,7 @@
 </MudForm>
 
 @code {
-    #nullable enable
-
+#nullable enable
     public static string __description__ = "Form should validate file uploader's file.";
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
@@ -4,8 +4,7 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudForm ValidationDelay="0">
-    <MudFileUpload @ref="_fileUploaderRef"
-                   T="IBrowserFile"
+    <MudFileUpload T="IBrowserFile"
                    @bind-Files="File"
                    Required="@Required"
                    Validation="@Validation">
@@ -25,6 +24,4 @@
 
     [Parameter]
     public Func<IBrowserFile, string?>? Validation { get; set; }
-
-    private MudFileUpload<IBrowserFile>? _fileUploaderRef;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadTest.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudForm ValidationDelay="0">
+    <MudFileUpload @ref="_fileUploaderRef"
+                   T="IBrowserFile"
+                   @bind-Files="File"
+                   Required="@Required"
+                   Validation="@Validation">
+    </MudFileUpload>
+</MudForm>
+
+@code {
+    #nullable enable
+
+    public static string __description__ = "Form should validate file uploader's file.";
+
+    [Parameter]
+    public IBrowserFile? File { get; set; }
+
+    [Parameter]
+    public bool Required { get; set; } = true;
+
+    [Parameter]
+    public Func<IBrowserFile, string?>? Validation { get; set; }
+
+    private MudFileUpload<IBrowserFile>? _fileUploaderRef;
+}

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -4,11 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
@@ -19,7 +15,6 @@ using Microsoft.Extensions.Logging;
 using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -13,6 +13,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.Docs.Examples;
+using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.Utilities;
@@ -946,7 +947,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(0);
 
             // clear selection, form should now be invalid
-            input.ClearFiles();
+            await input.ClearFiles();
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
@@ -978,7 +979,7 @@ namespace MudBlazor.UnitTests.Components
             fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
 
             // clear files
-            input.ClearFiles();
+            await input.ClearFiles();
             fileUploadInstance.Files.Should().BeNull();
 
             // form should now be invalid because a file is required

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -947,7 +947,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(0);
 
             // clear selection, form should now be invalid
-            await input.ClearFiles();
+            await input.ClearFilesAsync();
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
@@ -979,7 +979,7 @@ namespace MudBlazor.UnitTests.Components
             fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
 
             // clear files
-            await input.ClearFiles();
+            await input.ClearFilesAsync();
             fileUploadInstance.Files.Should().BeNull();
 
             // form should now be invalid because a file is required

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -916,29 +916,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// FileUploader should be validated like every other form component when a file is added
+        /// FileUpload should be validated like every other form component when a file is added
         /// </summary>
         [Test]
-        public async Task Form_Should_Validate_FileUploader_When_FileAdded()
+        public async Task Form_Should_Validate_FileUpload_When_FileAdded()
         {
             var comp = Context.RenderComponent<FormWithFileUploadTest>();
             var form = comp.FindComponent<MudForm>().Instance;
-            var fileUploaderComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
-            var fileUploaderInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
-            var input = fileUploaderComp.FindComponent<InputFile>();
+            var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
+            var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
+            var input = fileUploadComp.FindComponent<InputFile>();
             var fileName = "cat.jpg";
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", fileName);
 
-            // check initial state: form should not be valid because fileUploaderInstance is required
+            // check initial state: form should not be valid because fileUploadInstance is required
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeFalse();
-            fileUploaderInstance.Error.Should().BeFalse();
-            fileUploaderInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.Error.Should().BeFalse();
+            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
 
             // add a file
             input.UploadFiles(fileToUpload);
-            fileUploaderInstance.Files.Should().NotBeNull();
-            fileUploaderInstance.Files.Name.Should().Be(fileName);
+            fileUploadInstance.Files.Should().NotBeNull();
+            fileUploadInstance.Files.Name.Should().Be(fileName);
 
             // form should now be valid and touched
             form.IsValid.Should().BeTrue();
@@ -951,15 +951,15 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
-            fileUploaderInstance.Error.Should().BeTrue();
-            fileUploaderInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.Error.Should().BeTrue();
+            fileUploadInstance.ErrorText.Should().Be("Required");
         }
 
         /// <summary>
-        /// FileUploader should be validated like every other form component when a file is cleared
+        /// FileUpload should be validated like every other form component when a file is cleared
         /// </summary>
         [Test]
-        public async Task Form_Should_Validate_FileUploader_When_FileCleared()
+        public async Task Form_Should_Validate_FileUpload_When_FileCleared()
         {
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
@@ -967,35 +967,35 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<FormWithFileUploadTest>(
                 ComponentParameterFactory.Parameter(nameof(FormWithFileUploadTest.File), defaultFile));
             var form = comp.FindComponent<MudForm>().Instance;
-            var fileUploaderComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
-            var fileUploaderInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
-            var input = fileUploaderComp.FindComponent<InputFile>();
+            var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
+            var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
+            var input = fileUploadComp.FindComponent<InputFile>();
 
             // check initial state: form should not be valid because form is untouched
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeFalse();
-            fileUploaderInstance.Error.Should().BeFalse();
-            fileUploaderInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.Error.Should().BeFalse();
+            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
 
             // clear files
             input.ClearFiles();
-            fileUploaderInstance.Files.Should().BeNull();
+            fileUploadInstance.Files.Should().BeNull();
 
             // form should now be invalid because a file is required
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
-            fileUploaderInstance.Error.Should().BeTrue();
-            fileUploaderInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.Error.Should().BeTrue();
+            fileUploadInstance.ErrorText.Should().Be("Required");
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
             form.IsValid.Should().BeTrue();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(0);
-            fileUploaderInstance.Error.Should().BeFalse();
-            fileUploaderInstance.Files.Name.Should().Be(fileName);
+            fileUploadInstance.Error.Should().BeFalse();
+            fileUploadInstance.Files.Name.Should().Be(fileName);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -127,7 +127,7 @@ namespace MudBlazor.UnitTests.Components
             var textField = textFieldcomp.Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             var dateField = dateComp.Instance;
-            // check initial state: form should not be touched 
+            // check initial state: form should not be touched
             form.IsTouched.Should().Be(false);
             // input a date, istouched should be true
             dateComp.Find("input").Change("2001-01-31");
@@ -147,7 +147,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Changing the nested form fields value should set IsTouched 
+        /// Changing the nested form fields value should set IsTouched
         /// </summary>
         [Test]
         public async Task FormIsTouchedAndNestedFormIsNotTouchedWhenParentFormFieldIsTouchedTest()
@@ -163,7 +163,7 @@ namespace MudBlazor.UnitTests.Components
             var nestedFormTextField = textCompFields[1].Instance;
             var nestedFormDateField = dateCompFields[1].Instance;
 
-            // check initial state: form should not be touched 
+            // check initial state: form should not be touched
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(false);
             // input a date, istouched should be true
@@ -204,7 +204,7 @@ namespace MudBlazor.UnitTests.Components
             var nestedFormTextField = textCompFields[1].Instance;
             var nestedFormDateField = dateCompFields[1].Instance;
 
-            // check initial state: form should not be touched 
+            // check initial state: form should not be touched
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(false);
             // input a date, istouched should be true
@@ -388,12 +388,12 @@ namespace MudBlazor.UnitTests.Components
                 await Task.Delay(delay);
                 elapsedTime += delay;
             }
-            // after the final debounce, the value should be updated without swallowing any user input 
+            // after the final debounce, the value should be updated without swallowing any user input
             await Task.Delay(comp.Instance.DebounceInterval);
             textField.Value.Should().Be(currentText);
             textField.Text.Should().Be(currentText);
         }
-        
+
         /// <summary>
         /// After changing any of the textfields with a For expression the corresponding chip should show a change message after the textfield blurred.
         /// </summary>
@@ -591,7 +591,7 @@ namespace MudBlazor.UnitTests.Components
             radioGroup.Error.Should().BeTrue();
             radioGroup.ErrorText.Should().Be("Required");
         }
-        
+
         /// <summary>
         /// ColorPicker should be validated like every other form component when color is changed via inputs
         /// </summary>
@@ -640,13 +640,13 @@ namespace MudBlazor.UnitTests.Components
             // initial form state
             form.IsTouched.Should().BeFalse();
             form.IsValid.Should().BeFalse();
-            
+
             await comp.InvokeAsync(() => comp.Find("input").Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             // open color collection view
             await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-dot-current").Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
-            
+
             // set valid color
             await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").Skip(1).First().Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(0));
@@ -655,10 +655,10 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(0);
             colorPicker.Error.Should().BeFalse();
             colorPicker.ErrorText.Should().BeNullOrEmpty();
-            
+
             await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-dot-current").Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
-            
+
             // set invalid color
             await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").First().Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(0));
@@ -913,6 +913,89 @@ namespace MudBlazor.UnitTests.Components
             form.Errors[0].Should().Be("Only full hours allowed");
             timePicker.Error.Should().BeTrue();
             timePicker.ErrorText.Should().Be("Only full hours allowed");
+        }
+
+        /// <summary>
+        /// FileUploader should be validated like every other form component when a file is added
+        /// </summary>
+        [Test]
+        public async Task Form_Should_Validate_FileUploader_When_FileAdded()
+        {
+            var comp = Context.RenderComponent<FormWithFileUploadTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var fileUploaderComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
+            var fileUploaderInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
+            var input = fileUploaderComp.FindComponent<InputFile>();
+            var fileName = "cat.jpg";
+            var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", fileName);
+
+            // check initial state: form should not be valid because fileUploaderInstance is required
+            form.IsValid.Should().BeFalse();
+            form.IsTouched.Should().BeFalse();
+            fileUploaderInstance.Error.Should().BeFalse();
+            fileUploaderInstance.ErrorText.Should().BeNullOrEmpty();
+
+            // add a file
+            input.UploadFiles(fileToUpload);
+            fileUploaderInstance.Files.Should().NotBeNull();
+            fileUploaderInstance.Files.Name.Should().Be(fileName);
+
+            // form should now be valid and touched
+            form.IsValid.Should().BeTrue();
+            form.IsTouched.Should().BeTrue();
+            form.Errors.Length.Should().Be(0);
+
+            // clear selection, form should now be invalid
+            input.ClearFiles();
+            form.IsValid.Should().BeFalse();
+            form.IsTouched.Should().BeTrue();
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Required");
+            fileUploaderInstance.Error.Should().BeTrue();
+            fileUploaderInstance.ErrorText.Should().Be("Required");
+        }
+
+        /// <summary>
+        /// FileUploader should be validated like every other form component when a file is cleared
+        /// </summary>
+        [Test]
+        public async Task Form_Should_Validate_FileUploader_When_FileCleared()
+        {
+            var fileName = "cat.jpg";
+            var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
+            var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
+            var comp = Context.RenderComponent<FormWithFileUploadTest>(
+                ComponentParameterFactory.Parameter(nameof(FormWithFileUploadTest.File), defaultFile));
+            var form = comp.FindComponent<MudForm>().Instance;
+            var fileUploaderComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
+            var fileUploaderInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
+            var input = fileUploaderComp.FindComponent<InputFile>();
+
+            // check initial state: form should not be valid because form is untouched
+            form.IsValid.Should().BeFalse();
+            form.IsTouched.Should().BeFalse();
+            fileUploaderInstance.Error.Should().BeFalse();
+            fileUploaderInstance.ErrorText.Should().BeNullOrEmpty();
+
+            // clear files
+            input.ClearFiles();
+            fileUploaderInstance.Files.Should().BeNull();
+
+            // form should now be invalid because a file is required
+            form.IsValid.Should().BeFalse();
+            form.IsTouched.Should().BeTrue();
+            form.Errors.Length.Should().Be(1);
+            form.Errors[0].Should().Be("Required");
+            fileUploaderInstance.Error.Should().BeTrue();
+            fileUploaderInstance.ErrorText.Should().Be("Required");
+
+            // re-add a file, form should now be valid and touched
+            input.UploadFiles(fileToUpload);
+            form.IsValid.Should().BeTrue();
+            form.IsTouched.Should().BeTrue();
+            form.Errors.Length.Should().Be(0);
+            fileUploaderInstance.Error.Should().BeFalse();
+            fileUploaderInstance.Files.Name.Should().Be(fileName);
         }
 
         /// <summary>
@@ -1396,7 +1479,7 @@ namespace MudBlazor.UnitTests.Components
 
         /// <summary>
         /// When the field is initialised from cache, the value can be set before the cascading parameter "Form",
-        /// triggering validation. Validations requiring "Form" or "For" properties should not crash. 
+        /// triggering validation. Validations requiring "Form" or "For" properties should not crash.
         /// </summary>
         [Test]
         public async Task FieldValidationWithoutRequiredForm_ShouldNot_Validate()
@@ -1730,7 +1813,7 @@ namespace MudBlazor.UnitTests.Components
             var childForm = forms[1];
             childForm.Instance.IsValid.Should().BeFalse();
             parentForm.IsValid.Should().Be(false);
-            
+
             // remove the child form
             childFormSwitch.Change(false);
             forms = comp.FindComponents<MudForm>();

--- a/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
+++ b/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
@@ -10,11 +10,15 @@ namespace MudBlazor.UnitTests.Dummy;
 
 public class DummyBrowserFile : IBrowserFile
 {
-    public string Name { get; set;  }
-    public DateTimeOffset LastModified { get; set; }
-    public long Size { get; set; }
-    public string ContentType { get; set; }
-    public byte[] Content { get; set; }
+    public string Name { get; }
+
+    public DateTimeOffset LastModified { get; }
+
+    public long Size { get; }
+
+    public string ContentType { get; }
+
+    public byte[] Content { get; }
 
     public DummyBrowserFile(string name, DateTimeOffset lastModified, long size, string contentType, byte[] content)
     {
@@ -25,6 +29,5 @@ public class DummyBrowserFile : IBrowserFile
         Content = content;
     }
 
-    public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = new())
-        => new MemoryStream(Content);
+    public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream(Content);
 }

--- a/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
+++ b/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.IO;
+using System.Threading;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace MudBlazor.UnitTests.Dummy;
+
+public class DummyBrowserFile : IBrowserFile
+{
+    public string Name { get; set;  }
+    public DateTimeOffset LastModified { get; set; }
+    public long Size { get; set; }
+    public string ContentType { get; set; }
+    public byte[] Content { get; set; }
+
+    public DummyBrowserFile(string name, DateTimeOffset lastModified, long size, string contentType, byte[] content)
+    {
+        Name = name;
+        LastModified = lastModified;
+        Size = size;
+        ContentType = contentType;
+        Content = content;
+    }
+
+    public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = new())
+        => new MemoryStream(Content);
+}

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -17,8 +17,9 @@ namespace MudBlazor.UnitTests
         /// <returns></returns>
         public static async Task<string> GetFileContents(this IBrowserFile file)
         {
-            var memoryStream = new MemoryStream();
-            await file.OpenReadStream().CopyToAsync(memoryStream);
+            using var fileStream = file.OpenReadStream();
+            using var memoryStream = new MemoryStream();
+            await fileStream.CopyToAsync(memoryStream);
             return Encoding.ASCII.GetString(memoryStream.ToArray());
         }
     }

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -3,10 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Forms;
 
@@ -25,5 +24,26 @@ namespace MudBlazor.UnitTests
             await file.OpenReadStream().CopyToAsync(memoryStream);
             return Encoding.ASCII.GetString(memoryStream.ToArray());
         }
+    }
+
+    public class DummyBrowserFile : IBrowserFile
+    {
+        public string Name { get; set;  }
+        public DateTimeOffset LastModified { get; set; }
+        public long Size { get; set; }
+        public string ContentType { get; set; }
+        public byte[] Content { get; set; }
+
+        public DummyBrowserFile(string name, DateTimeOffset lastModified, long size, string contentType, byte[] content)
+        {
+            Name = name;
+            LastModified = lastModified;
+            Size = size;
+            ContentType = contentType;
+            Content = content;
+        }
+
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = new())
+            => new MemoryStream(Content);
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-using System;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Forms;
 
@@ -24,26 +21,5 @@ namespace MudBlazor.UnitTests
             await file.OpenReadStream().CopyToAsync(memoryStream);
             return Encoding.ASCII.GetString(memoryStream.ToArray());
         }
-    }
-
-    public class DummyBrowserFile : IBrowserFile
-    {
-        public string Name { get; set;  }
-        public DateTimeOffset LastModified { get; set; }
-        public long Size { get; set; }
-        public string ContentType { get; set; }
-        public byte[] Content { get; set; }
-
-        public DummyBrowserFile(string name, DateTimeOffset lastModified, long size, string contentType, byte[] content)
-        {
-            Name = name;
-            LastModified = lastModified;
-            Size = size;
-            ContentType = contentType;
-            Content = content;
-        }
-
-        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = new())
-            => new MemoryStream(Content);
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -17,10 +17,9 @@ namespace MudBlazor.UnitTests
         /// <returns></returns>
         public static async Task<string> GetFileContents(this IBrowserFile file)
         {
-            using var fileStream = file.OpenReadStream();
-            using var memoryStream = new MemoryStream();
-            await fileStream.CopyToAsync(memoryStream);
-            return Encoding.ASCII.GetString(memoryStream.ToArray());
+            await using var fileStream = file.OpenReadStream();
+            using var streamReader = new StreamReader(fileStream, Encoding.UTF8);
+            return await streamReader.ReadToEndAsync();
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -13,8 +13,6 @@ namespace MudBlazor.UnitTests
         /// <summary>
         /// Returns the string contents of an IBrowserFile
         /// </summary>
-        /// <param name="file"></param>
-        /// <returns></returns>
         public static async Task<string> GetFileContents(this IBrowserFile file)
         {
             await using var fileStream = file.OpenReadStream();

--- a/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
+using System.Threading.Tasks;
 using Bunit;
 using Microsoft.AspNetCore.Components.Forms;
 
@@ -9,16 +10,11 @@ namespace MudBlazor.UnitTests;
 
 public static class InputFileExtensions
 {
-    public static void ClearFiles(this IRenderedComponent<InputFile> inputFileComponent)
+    public static async Task ClearFiles(this IRenderedComponent<InputFile> inputFileComponent)
     {
-        if (inputFileComponent == null)
-            throw new ArgumentNullException(nameof(inputFileComponent));
+        ArgumentNullException.ThrowIfNull(inputFileComponent);
 
         var args = new InputFileChangeEventArgs(Array.Empty<IBrowserFile>());
-        var uploadTask = inputFileComponent.InvokeAsync(() => inputFileComponent.Instance.OnChange.InvokeAsync(args));
-        if (!uploadTask.IsCompleted)
-        {
-            uploadTask.GetAwaiter().GetResult();
-        }
+        await inputFileComponent.InvokeAsync(() => inputFileComponent.Instance.OnChange.InvokeAsync(args));
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace MudBlazor.UnitTests;
+
+public static class InputFileExtensions
+{
+    public static void ClearFiles(this IRenderedComponent<InputFile> inputFileComponent)
+    {
+        if (inputFileComponent == null)
+            throw new ArgumentNullException(nameof(inputFileComponent));
+
+        var args = new InputFileChangeEventArgs(Array.Empty<IBrowserFile>());
+        var uploadTask = inputFileComponent.InvokeAsync(() => inputFileComponent.Instance.OnChange.InvokeAsync(args));
+        if (!uploadTask.IsCompleted)
+        {
+            uploadTask.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.UnitTests;
 
 public static class InputFileExtensions
 {
-    public static async Task ClearFiles(this IRenderedComponent<InputFile> inputFileComponent)
+    public static async Task ClearFilesAsync(this IRenderedComponent<InputFile> inputFileComponent)
     {
         ArgumentNullException.ThrowIfNull(inputFileComponent);
 

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -119,7 +119,7 @@ namespace MudBlazor
         /// InputFileChangeEventArgs.GetMultipleFiles().
         /// It does not limit the total number of uploaded files
         /// when AppendMultipleFiles="true". A limit should be validated manually, for
-        /// example in the FilesChanged event callback. 
+        /// example in the FilesChanged event callback.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
@@ -158,10 +158,11 @@ namespace MudBlazor
             }
             else if (typeof(T) == typeof(IBrowserFile))
             {
-                _value = (T)args.File;
+                _value = args.FileCount == 1 ? (T)args.File : default;
             }
             else return;
 
+            Touched = true;
             await FilesChanged.InvokeAsync(_value);
             await BeginValidateAsync();
             FieldChanged(_value);


### PR DESCRIPTION
Fixes an issue where the `MudFileUpload` component would keep a `MudForm` invalid / untouched despite user interaction.

Fixes: #7577

## How Has This Been Tested?
Visually for regressions + unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
