### PR TITLE
MudFormComponent: Fix bad test causing invalid operation exception

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -897,7 +897,7 @@ namespace MudBlazor.UnitTests.Components
                 var colorElement = collectionView.Children[i];
                 colorElement.ClassList.Should().Contain("mud-picker-color-dot");
 
-                colorElement.Click();
+                comp.InvokeAsync(() => colorElement.Click());
                 comp.Instance.ColorValue.Should().Be(expectedColor);
 
                 comp.Find(".mud-picker-color-grid").Children[i].ClassList.Should().BeEquivalentTo("mud-picker-color-dot", "selected");

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -782,7 +782,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
 
-        
+
         [Test]
         //mud-button-root added for greying out and making buttons not clickable if month is disabled
         public void MonthButtons_ButtonRootClassPresent()
@@ -799,7 +799,7 @@ namespace MudBlazor.UnitTests.Components
         public void AdditionalDateClassesFunc_ClassIsAdded()
         {
             Func<DateTime, string> additionalDateClassesFunc = date => "__addedtestclass__";
-            
+
             var comp = OpenPicker(Parameter(nameof(MudDatePicker.AdditionalDateClassesFunc), additionalDateClassesFunc));
 
             var daysCount = comp.FindAll("button.mud-picker-calendar-day")
@@ -1105,7 +1105,7 @@ namespace MudBlazor.UnitTests.Components
 
             datePicker.MinDate = DateTime.Now.AddDays(-1);
             datePicker.MaxDate = DateTime.Now.AddDays(1);
-            
+
 
             // Open the datepicker
             await comp.InvokeAsync(datePicker.Open);

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1196,11 +1196,12 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             var oldDate = DateTime.Now;
             var newDate = oldDate.AddDays(1);
-            picker.Date = oldDate;
+            comp.SetParam(p => p.Date, oldDate);
 
             comp.SetParam(p => p.Text, newDate.ToShortDateString());
 
-            picker.Date.Value.Kind.Should().Be(oldDate.Kind);
+            picker.Date.Should().NotBeNull();
+            picker.Date!.Value.Kind.Should().Be(oldDate.Kind);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1,5 +1,4 @@
-﻿
-#pragma warning disable CS1998 // async without await
+﻿#pragma warning disable CS1998 // async without await
 
 using System;
 using System.Collections.Generic;
@@ -7,7 +6,6 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -345,7 +345,7 @@ namespace MudBlazor
                     ErrorText = errors.FirstOrDefault();
                     ErrorId = HasErrors ? Guid.NewGuid().ToString() : null;
                     Form?.Update(this);
-                    await InvokeAsync(StateHasChanged);
+                    StateHasChanged();
                 }
             }
         }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -345,7 +345,7 @@ namespace MudBlazor
                     ErrorText = errors.FirstOrDefault();
                     ErrorId = HasErrors ? Guid.NewGuid().ToString() : null;
                     Form?.Update(this);
-                    StateHasChanged();
+                    await InvokeAsync(StateHasChanged);
                 }
             }
         }
@@ -645,7 +645,7 @@ namespace MudBlazor
             if (For is not null && For != _currentFor)
             {
                 // Extract validation attributes
-                // Sourced from https://stackoverflow.com/a/43076222/4839162 
+                // Sourced from https://stackoverflow.com/a/43076222/4839162
                 // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
                 var expression = (MemberExpression)For.Body;
                 var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);


### PR DESCRIPTION
## Description
Fixes an issue causing an `InvalidOperationException`.

I am not sure what kind of impact this change can have on an application, never needed to wrap a `StateHasChanged` call with `InvokeAsync`.

Stacktrace (#7578):

```
System.InvalidOperationException: The current thread is not associated with the Dispatcher. Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.
   at Microsoft.AspNetCore.Components.Dispatcher.AssertAccess()
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.AddToRenderQueue(Int32 componentId, RenderFragment renderFragment)
   at Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged()
   at MudBlazor.MudFormComponent`2.ValidateValue() in /_/src/MudBlazor/Base/MudFormComponent.cs:line 348
   at MudBlazor.MudFormComponent`2.<BeginValidateAsync>b__62_0() in /_/src/MudBlazor/Base/MudFormComponent.cs:line 243
   at MudBlazor.MudDatePicker.SetDateAsync(Nullable`1 date, Boolean updateValue) in /_/src/MudBlazor/Components/DatePicker/MudDatePicker.cs:line 54
   at MudBlazor.TaskExtensions.AndForget(Task task, Boolean ignoreExceptions) in /_/src/MudBlazor/Extensions/TaskExtensions.cs:line 33
```
   
Previously this test would pass but threw an exception:
   
![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/99a636e4-0104-4a4f-9442-5f9a47e73a89)

Now it passes without exception:

![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/6152327f-8e10-4fe2-bfc8-3f267f36ca3d)
   
## How Has This Been Tested?
Re-ran all unit tests. Had to adapt one `ColorPicker` test for flakiness.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
