### PR TITLE
MudDataGrid: Adjust simple filter width for consistency (#7538)

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -417,13 +417,13 @@
                         <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="@Localizer["MudDataGrid.Operator"]" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-operator">
                             @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(fieldType))
-                        {
-                            <MudSelectItem Value="@fieldOperator">@Localizer[$"MudDataGrid.{fieldOperator}"]</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
+                            {
+                                <MudSelectItem Value="@fieldOperator">@Localizer[$"MudDataGrid.{fieldOperator}"]</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
                     <MudItem xs="4">
-                    @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
                                           Immediate="true" Class="filter-input" />
@@ -431,7 +431,7 @@
                         else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
+                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                         }
                         else if (fieldType.IsEnum)
                         {
@@ -457,17 +457,17 @@
                         {
                             <MudGrid Spacing="0">
                                 <MudItem xs="7">
-                                    <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
+                                    <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
                                 </MudItem>
                                 <MudItem xs="5">
-                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
+                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
                                 </MudItem>
                             </MudGrid>
                         }
                         else if (fieldType.IsGuid)
                         {
                             <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                          Immediate="true" Class="filter-input" />
+                                          Immediate="true" Class="filter-input"/>
                         }
                     </MudItem>
                 </MudGrid>
@@ -475,65 +475,65 @@
             }
             else
             {
-            <MudGrid Spacing="0">
-                <MudItem xs="12">
-                    <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                               Class="filter-operator">
-                        @foreach (var o in FilterOperator.GetOperatorByDataType(fieldType))
-                    {
-                        <MudSelectItem Value="@o">@Localizer[$"MudDataGrid.{o}"]</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudItem>
-                <MudItem xs="12">
-                @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input" />
-                    }
-                    else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
-                    }
-                    else if (fieldType.IsEnum)
-                    {
-                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                            @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
+                <MudGrid Spacing="0">
+                    <MudItem xs="12">
+                        <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-operator">
+                            @foreach (var o in FilterOperator.GetOperatorByDataType(fieldType))
                             {
-                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
+                                <MudSelectItem Value="@o">@Localizer[$"MudDataGrid.{o}"]</MudSelectItem>
                             }
                         </MudSelect>
-                    }
-                    else if (fieldType.IsBoolean)
-                    {
-                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(true)">@Localizer["MudDataGrid.True"]</MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(false)">@Localizer["MudDataGrid.False"]</MudSelectItem>
-                        </MudSelect>
-                    }
-                    else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudGrid Spacing="0">
-                            <MudItem xs="7">
-                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
-                            </MudItem>
-                            <MudItem xs="5">
-                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
-                            </MudItem>
-                        </MudGrid>
-                    }
-                    else if (fieldType.IsGuid)
-                    {
-                        <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input" />
-                    }
-                </MudItem>
-            </MudGrid>
+                    </MudItem>
+                    <MudItem xs="12">
+                        @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        {
+                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                          Immediate="true" Class="filter-input"/>
+                        }
+                        else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        {
+                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
+                        }
+                        else if (fieldType.IsEnum)
+                        {
+                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                       Class="filter-input">
+                                <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
+                                @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
+                                {
+                                    <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
+                                }
+                            </MudSelect>
+                        }
+                        else if (fieldType.IsBoolean)
+                        {
+                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                       Class="filter-input">
+                                <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+                                <MudSelectItem T="bool?" Value="@(true)">@Localizer["MudDataGrid.True"]</MudSelectItem>
+                                <MudSelectItem T="bool?" Value="@(false)">@Localizer["MudDataGrid.False"]</MudSelectItem>
+                            </MudSelect>
+                        }
+                        else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        {
+                            <MudGrid Spacing="0">
+                                <MudItem xs="7">
+                                    <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                </MudItem>
+                                <MudItem xs="5">
+                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
+                                </MudItem>
+                            </MudGrid>
+                        }
+                        else if (fieldType.IsGuid)
+                        {
+                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                          Immediate="true" Class="filter-input"/>
+                        }
+                    </MudItem>
+                </MudGrid>
             }
          </text>;
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -63,12 +63,12 @@
                             <MudPaper Class="pa-2 filters-panel" Style="position:absolute;width:auto;min-width:700px;z-index:var(--mud-zindex-drawer)" Elevation="4">
                                 @if (FilterTemplate == null)
                                 {
-                                    <MudGrid Spacing="0">
+                                    <MudStack>
                                         @foreach (var f in FilterDefinitions)
                                         {
                                             @Filter(f, null)
                                         }
-                                    </MudGrid>
+                                    </MudStack>
                                     <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">@Localizer["MudDataGrid.AddFilter"]</MudButton>
                                     @if (ServerData != null)
                                     {
@@ -400,97 +400,101 @@
             }
             @if (column is null)
             {
-                <MudItem xs="1" Class="d-flex">
-                    <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
-                </MudItem>
-                <MudItem xs="4">
-                    <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Column"]" Dense="true" Margin="@Margin.Dense"
-                               Class="filter-field">
-                    @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false) ?? Enumerable.Empty<Column<T>>())
-                        {
-                            <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="3">
-                    <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="@Localizer["MudDataGrid.Operator"]" Dense="true" Margin="@Margin.Dense"
-                               Class="filter-operator">
-                        @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(fieldType))
+                <MudGrid Spacing="0">
+                    <MudItem xs="1" Class="d-flex">
+                        <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
+                    </MudItem>
+                    <MudItem xs="4">
+                        <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Column"]" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-field">
+                            @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false) ?? Enumerable.Empty<Column<T>>())
+                            {
+                                <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="3">
+                        <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="@Localizer["MudDataGrid.Operator"]" Dense="true" Margin="@Margin.Dense"
+                                   Class="filter-operator">
+                            @foreach (var fieldOperator in FilterOperator.GetOperatorByDataType(fieldType))
                         {
                             <MudSelectItem Value="@fieldOperator">@Localizer[$"MudDataGrid.{fieldOperator}"]</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
-                <MudItem xs="4">
+                    <MudItem xs="4">
                     @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
-                    }
-                    else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
-                    }
-                    else if (fieldType.IsEnum)
-                    {
-                        <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
-                            @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
-                            {
-                                <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
-                            }
-                        </MudSelect>
-                    }
-                    else if (fieldType.IsBoolean)
-                    {
-                        <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-input">
-                            <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(true)">@Localizer["MudDataGrid.True"]</MudSelectItem>
-                            <MudSelectItem T="bool?" Value="@(false)">@Localizer["MudDataGrid.False"]</MudSelectItem>
-                        </MudSelect>
-                    }
-                    else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
-                    {
-                        <MudGrid Spacing="0">
-                            <MudItem xs="7">
-                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
-                            </MudItem>
-                            <MudItem xs="5">
-                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
-                            </MudItem>
-                        </MudGrid>
-                    }
-                    else if (fieldType.IsGuid)
-                    {
-                        <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
-                    }
-                </MudItem>
+                        {
+                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                          Immediate="true" Class="filter-input" />
+                        }
+                        else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        {
+                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
+                        }
+                        else if (fieldType.IsEnum)
+                        {
+                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                       Class="filter-input">
+                                <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
+                                @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
+                                {
+                                    <MudSelectItem T="Enum" Value="@((Enum)item)">@item</MudSelectItem>
+                                }
+                            </MudSelect>
+                        }
+                        else if (fieldType.IsBoolean)
+                        {
+                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Dense="true" Margin="@Margin.Dense"
+                                       Class="filter-input">
+                                <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+                                <MudSelectItem T="bool?" Value="@(true)">@Localizer["MudDataGrid.True"]</MudSelectItem>
+                                <MudSelectItem T="bool?" Value="@(false)">@Localizer["MudDataGrid.False"]</MudSelectItem>
+                            </MudSelect>
+                        }
+                        else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                        {
+                            <MudGrid Spacing="0">
+                                <MudItem xs="7">
+                                    <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
+                                </MudItem>
+                                <MudItem xs="5">
+                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
+                                </MudItem>
+                            </MudGrid>
+                        }
+                        else if (fieldType.IsGuid)
+                        {
+                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
+                                          Immediate="true" Class="filter-input" />
+                        }
+                    </MudItem>
+                </MudGrid>
+
             }
             else
             {
+            <MudGrid Spacing="0">
                 <MudItem xs="12">
                     <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Dense="true" Margin="@Margin.Dense"
                                Class="filter-operator">
                         @foreach (var o in FilterOperator.GetOperatorByDataType(fieldType))
-                        {
-                            <MudSelectItem Value="@o">@Localizer[$"MudDataGrid.{o}"]</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
+                    {
+                        <MudSelectItem Value="@o">@Localizer[$"MudDataGrid.{o}"]</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
                 <MudItem xs="12">
-                    @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
+                @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
+                                      Immediate="true" Class="filter-input" />
                     }
                     else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                     {
                         <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
+                                         Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" />
                     }
                     else if (fieldType.IsEnum)
                     {
@@ -516,19 +520,20 @@
                     {
                         <MudGrid Spacing="0">
                             <MudItem xs="7">
-                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                <MudDatePicker Date="@filter._valueDate" DateChanged="@filter.DateValueChanged" Margin="@Margin.Dense" Class="filter-input-date" />
                             </MudItem>
                             <MudItem xs="5">
-                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time"/>
+                                <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Margin="@Margin.Dense" Class="filter-input-time" />
                             </MudItem>
                         </MudGrid>
                     }
                     else if (fieldType.IsGuid)
                     {
                         <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer["MudDataGrid.Value"]" Placeholder="@Localizer["MudDataGrid.FilterValue"]" Margin="@Margin.Dense"
-                                      Immediate="true" Class="filter-input"/>
+                                      Immediate="true" Class="filter-input" />
                     }
                 </MudItem>
+            </MudGrid>
             }
          </text>;
 }


### PR DESCRIPTION
## Description
This pull request addresses a visual bug in the ***'MudDataGrid'*** component where the width of the simple filter overlay extends unexpectedly on pressing the "ADD FILTER" button multiple times. The change ensures that the overlay width remains consistent and within the width of the table.

**Issue:** 
- resolves #7538

## How Has This Been Tested?

To ensure the robustness of the implemented fix:

1. **Automated Testing:** All existing unit tests were executed, and they passed without any failures.
2. **Manual Testing:** I manually interacted with the ***'Filtering'*** functionality in the ***`MudDataGrid`***, clicking on the filter, pressed "ADD FILTER" multiple times, and observed the width behavior, ensuring the width remains consistent and does not exceed the table width.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Visual Demonstrations

To better understand the issue and its subsequent resolution, please refer to the GIFs below:

### Before the Fix:
![Before Fix GIF](https://github.com/MudBlazor/MudBlazor/assets/92410596/412e312a-6472-48e9-b26d-5fbec0168e46)

### After the Fix:
![After Fix GIF](https://github.com/MudBlazor/MudBlazor/assets/92410596/b39a8fb0-02ba-4541-b6d9-7e71eb0a031f)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
