### PR TITLE
ButtonGroupExamples: Fix alignment in split button section

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
@@ -2,7 +2,7 @@
 
 <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
     <MudButton>@_buttonText</MudButton>
-    <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown">
+    <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown" Style="align-self: auto;">
         <MudMenuItem OnClick="() => SetButtonText(0)">Reply</MudMenuItem>
         <MudMenuItem OnClick="() => SetButtonText(1)">Reply All</MudMenuItem>
         <MudMenuItem OnClick="() => SetButtonText(2)">Forward</MudMenuItem>


### PR DESCRIPTION
## Description
During my interactions with the Button Group page, I observed a slight height misalignment in the Split button section. Specifically, the `MudMenu` button was slightly misaligned compared to its adjacent `MudButton`, by approximately 1px. Notably, this misalignment's visibility varied based on the page's zoom level. To address this, I introduced a style adjustment to the `MudMenu` to ensure consistent alignment.

## How Has This Been Tested?
To ensure the robustness of the implemented fix:

1. **Automated Testing:** All existing unit tests were executed, and they passed without any failures.
2. **Manual Testing:** I manually examined the Split button functionality at various zoom levels on the Button Group page, ensuring the `MudMenu` button is consistently aligned with the adjacent `MudButton`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Visual Demonstrations
To better understand the issue and its subsequent resolution, please refer to the images below:

### Before the Fix:
![Before Fix Image](https://github.com/MudBlazor/MudBlazor/assets/92410596/c24819e4-d830-466a-b4c3-9234124a48c6)

### After the Fix:
![After Fix Image](https://github.com/MudBlazor/MudBlazor/assets/92410596/cc125096-7360-443d-be11-c77dd66e1f5d)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.