### PR TITLE
MudAutocomplete: Fix doubling of the AfterItemsTemplate

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1262,10 +1262,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// BeforeItemsTemplate should render when there are no items
+        /// BeforeItemsTemplate should not render when there are no items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_LoadListStartWhenSet()
+        public async Task Autocomplete_Should_Not_LoadListStartWhenSet()
         {
             var comp = Context.RenderComponent<AutocompleteListStartRendersTest>();
 
@@ -1274,15 +1274,14 @@ namespace MudBlazor.UnitTests.Components
             inputControl.Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+            comp.Find("div.mud-popover").InnerHtml.Should().BeEmpty();
         }
 
         /// <summary>
-        /// AfterItemsTemplate should render when there are no items
+        /// AfterItemsTemplate should not render when there are no items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_LoadListEndWhenSet()
+        public async Task Autocomplete_Should_Not_LoadListEndWhenSet()
         {
             var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
 
@@ -1290,8 +1289,7 @@ namespace MudBlazor.UnitTests.Components
             inputControl.Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
-            var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
+            comp.Find("div.mud-popover").InnerHtml.Should().BeEmpty();
         }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -95,26 +95,8 @@
                     }
                     else if (NoItemsTemplate != null)
                     {
-                        @if (BeforeItemsTemplate != null)
-                        {
-                            <div class="pa-1">
-                                @BeforeItemsTemplate
-                            </div>
-                        }
                         <div class="pa-1">
                             @NoItemsTemplate
-                        </div>
-                    }
-                    else if (BeforeItemsTemplate != null && IsLoading is false)
-                    {
-                        <div class="pa-1">
-                            @BeforeItemsTemplate
-                        </div>
-                    }
-                    @if (AfterItemsTemplate != null && IsLoading is false)
-                    {
-                        <div class="pa-1">
-                            @AfterItemsTemplate
                         </div>
                     }
                 </MudPopover>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -265,14 +265,14 @@ namespace MudBlazor
 
 
         /// <summary>
-        /// Optional presentation template that is always shown at the top of the list
+        /// Optional presentation template that is shown at the top of the list. If no items are present, the fragment is hidden.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public RenderFragment BeforeItemsTemplate { get; set; }
 
         /// <summary>
-        /// Optional presentation template that is always shown at the bottom of the list
+        /// Optional presentation template that is shown at the bottom of the list. If no items are present, the fragment is hidden.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]


### PR DESCRIPTION

## Description
To fix this issue, the After and Before ItemsTemplate will be rendered only if any item is in the List. Otherwise, it will not be visible. After all, the names of the fragments imply that they are shown before and after items. For any rendering of custom content, there is the NoItemsTemplate

Fixes  #7612 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
