### PR TITLE
DataGrid: Introduce hover feedback for SelectOnRowClick feature

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7128;http://localhost:5128",
-      "launchUrl": "components/tooltip",
+      "launchUrl": "docs/overview",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
@@ -4,7 +4,7 @@
 @inject HttpClient httpClient
 
 <MudDataGrid T="Element" MultiSelection="true" Items="@Elements" SortMode="SortMode.Multiple" Filterable="true" QuickFilter="@_quickFilter"
-    Hideable="true" RowClick="@RowClicked" SelectedItemsChanged="@SelectedItemsChanged">
+    Hideable="true" RowClick="@RowClicked" SelectedItemsChanged="@SelectedItemsChanged" SelectOnRowClick="true">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudSpacer />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDataGrid Items=@_items ReadOnly=false EditMode=DataGridEditMode.Cell Dense FixedHeader=true MultiSelection="true">
+<MudDataGrid Items=@_items ReadOnly=false EditMode=DataGridEditMode.Cell Dense FixedHeader=true MultiSelection="true" SelectOnRowClick="true">
     <Columns>
         <SelectColumn/>        
         <PropertyColumn Property="x => x.Name" IsEditable=false/>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
                .AddClass("mud-lg-table", Breakpoint == Breakpoint.Lg || Breakpoint == Breakpoint.Always)
                .AddClass("mud-xl-table", Breakpoint == Breakpoint.Xl || Breakpoint == Breakpoint.Always)
                .AddClass("mud-table-dense", Dense)
-               .AddClass("mud-table-hover", Hover)
+               .AddClass("mud-table-hover", Hover || SelectOnRowClick)
                .AddClass("mud-table-bordered", Bordered)
                .AddClass("mud-table-striped", Striped)
                .AddClass("mud-table-outlined", Outlined)
@@ -414,7 +414,7 @@ namespace MudBlazor
         /// <summary>
         /// When true, row-click also toggles the checkbox state
         /// </summary>
-        [Parameter] public bool SelectOnRowClick { get; set; } = true;
+        [Parameter] public bool SelectOnRowClick { get; set; }
 
         /// <summary>
         /// When the grid is not read only, you can specify what type of editing mode to use.


### PR DESCRIPTION
## Description
In the current design of the `MudDataGrid` component, while `SelectOnRowClick` provides functionality to select rows on click, it lacks intuitive visual feedback. This makes it difficult for users to understand the clickable nature of the rows, especially in instances where the grid doesn't use selection checkboxes.

To address this, I've introduced a hover effect on rows when `SelectOnRowClick` is activated. This has been achieved through the CSS builder:

```csharp
.AddClass("mud-table-hover", Hover || SelectOnRowClick)
```
To ensure clearer and more purposeful behavior, I've set the default value of `SelectOnRowClick` to `false`. This way, developers can consciously activate it, and the hover effect will only be applied when this feature is intentionally enabled.

Furthermore, to enhance the local development experience, I've updated the default `launchUrl` in `launchSettings.json` from `"components/tooltip"` to `"docs/overview"`. This adjustment ensures developers are greeted with an overview of all components upon launching the localhost.

## How Has This Been Tested?
1. **Automated Testing:** All related unit tests have been executed and passed successfully.
2. **Manual Testing:** Inspected the hover feedback on `MudDataGrid` rows with the `SelectOnRowClick` feature turned on and confirmed its intuitiveness.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Visual Demonstrations
To better elucidate the enhancements introduced:

### Before the Enhancements:
![GIF showing behavior before enhancements](https://github.com/MudBlazor/MudBlazor/assets/92410596/4f747ce7-2e0d-4783-b976-bbdfac6c6293)

### After the Enhancements:
![GIF showing behavior after enhancements](https://github.com/MudBlazor/MudBlazor/assets/92410596/e96cc52e-66e1-416a-b01a-eea770497c2c)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
