### PR TITLE
MudDataGrid: Remove redundant column menu (#7566)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRedundantMenuTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRedundantMenuTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="Model" Items="@_items" FilterMode="DataGridFilterMode.ColumnFilterRow" SortMode="SortMode.None" Filterable>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.Amount" />
+        <PropertyColumn Property="x => x.Total" />
+        <PropertyColumn Property="x => x.Distance" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, 3.5, 5.2, 2.1),
+        new Model("Alicia", 54, 3.6, 4.8, 2.2),
+        new Model("Ira", 27, 3.9, 6.2, 2.3),
+        new Model("John", 32, 4.2, 3.2, 2.4)
+    };
+
+    public record Model(string Name, int? Age, double? Amount, double? Total, double? Distance);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4104,5 +4104,24 @@ namespace MudBlazor.UnitTests.Components
             newHeaderValues[3].InnerHtml.Should().Be("Hired");
             newHeaderValues[4].InnerHtml.Should().Be("HiredOn");
         }
+
+        [Test]
+        public void DataGridRedundantMenuTest()
+        {
+            var comp = Context.RenderComponent<DataGridRedundantMenuTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridRedundantMenuTest.Model>>();
+
+            dataGrid.Instance.FilterMode = DataGridFilterMode.ColumnFilterRow;
+            dataGrid.Instance.SortMode = SortMode.None;
+
+            // Render after applying conditions
+            comp.Render();
+
+            // Assert that the `column-options` span is present but empty
+            var columnOptionsSpan = comp.Find(".column-options");
+            columnOptionsSpan.Should().NotBeNull();
+            columnOptionsSpan.TextContent.Trim().Should().BeEmpty();
+        }
+
     }
 }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Docs.Server", "MudBlazor.Docs.Server\MudBlazor.Docs.Server.csproj", "{90B6D51A-133A-4744-A5FE-FF398F0D6BAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Docs.Server", "MudBlazor.Docs.Server\MudBlazor.Docs.Server.csproj", "{90B6D51A-133A-4744-A5FE-FF398F0D6BAA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.SourceCodeGenerator", "MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj", "{CDE02174-96AB-4E97-AFA8-391C0FF98225}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -149,6 +149,8 @@ namespace MudBlazor
             {
                 if (!sortable && !filterable && !groupable)
                     return false;
+                if (!sortable && DataGrid.FilterMode == DataGridFilterMode.ColumnFilterRow)
+                    return false;
 
                 return Column?.ShowColumnOptions ?? DataGrid?.ShowColumnOptions ?? true;
             }


### PR DESCRIPTION
## Description
In the `MudDataGrid` component, I observed a redundant "⋮" menu being rendered when `FilterMode` is set to `DataGridFilterMode.ColumnFilterRow` and `SortMode` is set to `SortMode.None`.

This update rectifies this oversight by ensuring the column menu is not rendered with the aforementioned combination of properties.

**Linked Issue:** 
- Fixes [#7566](https://github.com/MudBlazor/MudBlazor/issues/7566)

## How Has This Been Tested?

1. **Automated Testing:** 
    - Executed all relevant unit tests, all of which passed successfully.
    - Introduced tests within `DataGridRedundantMenuTest.razor` to validate the removal of the redundant menu based on specific `FilterMode` and `SortMode` combinations.

2. **Manual Testing:** 
    - Interacted with the `MudDataGrid` on the `DataGridRedundantMenuTest.razor` page, confirming the removal of the redundant menu with the specified conditions.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Visual Demonstrations
To visually highlight the addressed issue and its resolution:

### Before the Fix:
![GIF showing the redundant menu before the fix](https://github.com/MudBlazor/MudBlazor/assets/92410596/376e78f5-8e99-4140-8fd7-f16bf71db8d8)

### After the Fix:
![GIF showing the grid without the redundant menu after the fix](https://github.com/MudBlazor/MudBlazor/assets/92410596/88294f0a-9130-490f-953b-cf28a2510116)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
