### PR TITLE
MudRipple: Show ripple effect based on click position (#157)

### DIFF
--- a/src/MudBlazor/Styles/core/_ripple.scss
+++ b/src/MudBlazor/Styles/core/_ripple.scss
@@ -1,4 +1,7 @@
 ﻿.mud-ripple {
+    --mud-ripple-offset-x: 0;
+    --mud-ripple-offset-y: 0;
+
     position: relative;
     overflow: hidden;
 
@@ -8,15 +11,15 @@
         position: absolute;
         width: 100%;
         height: 100%;
-        top: 0;
-        left: 0;
+        top: var(--mud-ripple-offset-y);
+        left: var(--mud-ripple-offset-x);
         pointer-events: none;
         background-image: radial-gradient(circle, #000 10%, transparent 10.01%);
         background-repeat: no-repeat;
         background-position: 50%;
-        transform: scale(10,10);
+        transform: scale(20,20);
         opacity: 0;
-        transition: transform .3s, opacity 1s;
+        transition: transform .6s, opacity 1s;
     }
 
     &:active:after {
@@ -28,7 +31,7 @@
 
 .mud-ripple-icon, .mud-ripple-checkbox, .mud-ripple-switch, .mud-ripple-radio {
     &:after {
-        transform: scale(7,7);
+        transform: scale(14,14);
     }
 }
 

--- a/src/MudBlazor/TScripts/mudRipple.js
+++ b/src/MudBlazor/TScripts/mudRipple.js
@@ -1,0 +1,17 @@
+function setRippleOffset(event, target) {
+    // calculate click position relative to the center of the target element
+    const rect = target.getBoundingClientRect();
+    const x = event.clientX - rect.left - rect.width / 2;
+    const y = event.clientY - rect.top - rect.height / 2;
+    
+    target.style.setProperty("--mud-ripple-offset-x", `${x}px`);
+    target.style.setProperty("--mud-ripple-offset-y", `${y}px`);
+}
+
+document.addEventListener("click", function (event) {
+    const target = event.target.closest(".mud-ripple");
+
+    if (target) {
+        setRippleOffset(event, target);
+    }
+});


### PR DESCRIPTION
## Description

This solution uses JavaScript to calculate an offset based on the click position. The offset is then applied to the ripple pseudo-element using css variables.

I've tried to make the ripple look the same as before. Because I had to double the size of the pseudo-element `transform: scale(10,10)` -> `transform: scale(20,20)` a minor visual difference may be noticeable. This could possibly be mitigated by calculating a scaling factor based on the distance between the click position and the center of the clicked element:

```css
/* --mud-ripple-scale would need to be calculated in js */
transform: scale(calc(10 * var(--mud-ripple-scale)), calc(10 * var(--mud-ripple-scale)));
```

I'm not sure if the added complexity is worth it but I'd be happy to implement that as well if wanted.

**Note:** This does not have the same issue as the reverted `ripple.js` implementation, the ripple _"stays with the button when it moves"_, see: https://github.com/MudBlazor/MudBlazor/issues/157#issuecomment-980543275

resolves #157

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Before

https://github.com/MudBlazor/MudBlazor/assets/22305878/740381d1-322f-4fe9-9cfc-278ccbb1d710

### After

https://github.com/MudBlazor/MudBlazor/assets/22305878/8d78320b-0c48-478b-be78-995351a71ad0

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
