### PR TITLE
Docs: fix typo in ColorsPage.razor

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
@@ -21,7 +21,7 @@
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="CSS and Theme colors">
-                        <Description>Here we add each class to the divs to change the background color, text color and both background and text color with one class only one class.</Description>
+                        <Description>Here we add each class to the divs to change the background color, text color and both background and text color with one class only.</Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" ShowCode="true" Code="ColorsMudBlazorExample">
                         <ColorsMudBlazorExample />
@@ -48,7 +48,7 @@
                 
                 <DocsPageSection>
                     <SectionHeader Title="CSS and Material colors">
-                        <Description>Here we add each class to the divs to change the background color, text color and both background and text color with one class only one class.</Description>
+                        <Description>Here we add each class to the divs to change the background color, text color and both background and text color with one class only.</Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" ShowCode="false" Code="ColorsMaterialExample">
                         <ColorsMaterialExample/>


### PR DESCRIPTION
Fix typos. 'one class' used multiple times.


<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
Small typo in Features/Color doc. Multiple use of 'one class' in two senteces.
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
