### PR TITLE
MudTextInput: Add AutoGrow feature (#7631)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAutoGrowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAutoGrowExample.razor
@@ -1,0 +1,10 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTextField T="string" Label="AutoGrow" Variant="Variant.Text" Text="@sampleText" AutoGrow HelperText="This field grows when you enter new lines" />
+<MudTextField T="string" Label="AutoGrow with Lines" Variant="Variant.Text" Text="@sampleText" AutoGrow Lines="3" HelperText="This field has always at least 3 lines" />
+<MudTextField T="string" Label="AutoGrow with MaxLines" Variant="Variant.Text" Text="@sampleText" AutoGrow MaxLines="4" HelperText="This field grows to a maximum of 4 lines" />
+
+@code
+{
+    string sampleText = "Lorem ipsum dolor sit amet.";
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -153,6 +153,11 @@
     <SectionContent Code="TextFieldMultilineExample" ShowCode="false">
         <TextFieldMultilineExample/>
     </SectionContent>
+    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+        If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
+        you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
+        For more details see <MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
+    </MudAlert>
     <SectionSubGroups>
         <DocsPageSection>
             <SectionHeader Title="Auto Grow">

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -153,6 +153,20 @@
     <SectionContent Code="TextFieldMultilineExample" ShowCode="false">
         <TextFieldMultilineExample/>
     </SectionContent>
+    <SectionSubGroups>
+        <DocsPageSection>
+            <SectionHeader Title="Auto Grow">
+                <Description>
+                    With the <CodeInline>AutoGrow</CodeInline> property set to true, the height of the text field automatically changes with the number of lines of text.
+                    The text field will not get smaller than the number of lines specified with the <CodeInline>Lines</CodeInline> property.
+                    You can limit the maximum height of the text field with the <CodeInline>MaxLines</CodeInline> property.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="TextFieldAutoGrowExample" ShowCode="false">
+                <TextFieldAutoGrowExample />
+            </SectionContent>
+        </DocsPageSection>
+    </SectionSubGroups>
 </DocsPageSection>
 
 <DocsPageSection>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -393,6 +393,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task AutoGrowTextField_Should_InvokeJavaScriptInitOnRender()
+        {
+            var comp = Context.RenderComponent<MudTextField<string>>(
+                Parameter(nameof(MudTextField<string>.AutoGrow), true),
+                Parameter(nameof(MudTextField<string>.MaxLines), 5));
+
+            Context.JSInterop.VerifyInvoke("mudInputAutoGrow.initAutoGrow", 1);
+            Context.JSInterop.Invocations["mudInputAutoGrow.initAutoGrow"].Single()
+                .Arguments
+                .Should()
+                .HaveCount(2)
+                .And
+                .HaveElementAt(1, 5); // MaxLines
+
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "A"));
+
+            Context.JSInterop.Invocations["mudInputAutoGrow.adjustHeight"].Single()
+               .Arguments
+               .Should()
+               .HaveCount(1);
+        }
+
+        [Test]
         public async Task TextFieldClearableTest()
         {
             var comp = Context.RenderComponent<TextFieldClearableTest>();

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -17,7 +17,7 @@
         />
 	}
 
-	@if (Lines > 1)
+	@if (AutoGrow || Lines > 1)
 	{
 	    <textarea class="@InputClassname"
                 @ref="ElementReference" 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -155,7 +155,8 @@ namespace MudBlazor
         [Parameter] public bool AutoGrow { get; set; }
 
         /// <summary>
-        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines.
+        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines. If MaxLines is set to 0
+        /// or less, the property will be ignored.
         /// </summary>
         [Parameter] public int MaxLines { get; set; }
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -148,6 +149,16 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string NumericDownIcon { get; set; } = Icons.Material.Filled.KeyboardArrowDown;
 
+        /// <summary>
+        /// If true the input element will grow automatically with the text.
+        /// </summary>
+        [Parameter] public bool AutoGrow { get; set; }
+
+        /// <summary>
+        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines.
+        /// </summary>
+        [Parameter] public int MaxLines { get; set; }
+
         private Size GetButtonSize() => Margin == Margin.Dense ? Size.Small : Size.Medium;
 
         /// <summary>
@@ -183,6 +194,26 @@ namespace MudBlazor
             }
         }
 
+        [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
+
+        private string _oldText = null;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (AutoGrow && firstRender)
+            {
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.initAutoGrow", ElementReference, MaxLines);
+                _oldText = _internalText;
+            }
+            else if(AutoGrow && _oldText != _internalText)
+            {
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.adjustHeight", ElementReference);
+                _oldText = _internalText;
+            }
+
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
         /// <summary>
         /// Sets the input text from outside programmatically
         /// </summary>
@@ -193,7 +224,6 @@ namespace MudBlazor
             _internalText = text;
             return SetTextAsync(text);
         }
-
 
         // Certain HTML5 inputs (dates and color) have a native placeholder
         private bool HasNativeHtmlPlaceholder()

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -27,6 +27,8 @@
                               InputType="@InputType"
                               InputMode="@InputMode"
                               Lines="@Lines"
+                              MaxLines="@MaxLines"
+                              AutoGrow="@AutoGrow"
                               Style="@Style"
                               Variant="@Variant"
                               TextUpdateSuppression="@TextUpdateSuppression"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -174,7 +174,8 @@ namespace MudBlazor
         public bool AutoGrow { get; set; }
 
         /// <summary>
-        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines.
+        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines. If MaxLines is set to 0
+        /// or less, the property will be ignored.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Behavior)]

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -165,6 +165,20 @@ namespace MudBlazor
         {
             await SetTextAsync(s);
         }
+
+        /// <summary>
+        /// If true the input element will grow automatically with the text.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.General.Behavior)]
+        public bool AutoGrow { get; set; }
+
+        /// <summary>
+        /// If AutoGrow is set to true, the input element will not grow bigger than MaxLines lines.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.General.Behavior)]
+        public int MaxLines { get; set; }
     }
 
     [Obsolete("MudTextFieldString is no longer available.", true)]

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2023
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+window.mudInputAutoGrow = {
+
+    initAutoGrow: (elem, maxLines) => {
+        const compStyles = getComputedStyle(elem);
+        const lineHeight = parseFloat(compStyles.getPropertyValue('line-height'));
+
+        let minHeight = lineHeight * elem.rows;
+
+        let maxHeight = 0;
+        if (maxLines > 0) {
+            maxHeight = lineHeight * maxLines;
+        }
+
+        // Capture min and max height in closure to trigger height adjustment on element in MudTextField.
+        elem.adjustAutoGrowHeight = function () {
+            elem.style.height = 0;
+
+            let newHeight = Math.max(minHeight, elem.scrollHeight);
+            if (maxHeight > 0) {
+                newHeight = Math.min(newHeight, maxHeight);
+            }
+
+            elem.style.height = newHeight + "px";
+        }
+
+        elem.addEventListener('input', () => {
+            elem.adjustAutoGrowHeight();
+        });
+    },
+    adjustHeight: (elem) => {
+        if (typeof elem.adjustAutoGrowHeight === 'function') {
+            elem.adjustAutoGrowHeight();
+        }
+    }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Resolves #7631 
By implementing an AutoGrow and MaxLines property on the MudTextField. This feature allows for the input field to grow and shrink automatically when the number of lines changes. This feature can even be seen here on github when trying to create new comments. I have update the documentation to showcase this new feature.

![image](https://github.com/MudBlazor/MudBlazor/assets/4333991/3524130d-efd0-4765-aa8e-3291873dda10)

<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
Unit tests did not seem feasible in this case. The changes do not alter any logic and merely invoke JavaScript functions that alter the height of the textarea using the elements scroll offset. Although I could probably create a Unit Test that checks if the JavaScript method is invoked after the component has been rendered when the AutoGrow property is set to true. But I am not sure if thats on overkill.

I did execute the tests manually on the latest version of Microsoft Edge. I tested both the server and web assembly version. I temporarily altered the example to update the bound text value with a button click to check if the autogrow feature works too in this scenario.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
