### PR TITLE
MudMenuItem: Add OnAction for either click or touch but invoked only once

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemActionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemActionTest.razor
@@ -1,0 +1,43 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudText>Priority: Href > (OnClick and OnTouch) > OnAction</MudText>
+<MudText>OnAction is a fallback for OnClick and for OnTouch.</MudText>
+<MudText>@Count Invokes</MudText>
+<MudText>Callers: @Callers</MudText>
+
+<MudMenu Label="Menu">
+    <MudMenuItem OnAction="IncrementByAction" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction</MudMenuItem>
+    <MudMenuItem OnClick="IncrementByClick" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnClick</MudMenuItem>
+    <MudMenuItem OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnTouch</MudMenuItem>
+    <MudMenuItem OnClick="IncrementByClick" OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnClick + OnTouch</MudMenuItem>
+    <MudMenuItem OnAction="IncrementByAction" OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnTouch</MudMenuItem>
+    <MudMenuItem OnAction="IncrementByAction" OnClick="IncrementByClick" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnClick</MudMenuItem>
+</MudMenu>
+
+@code
+{
+    public static string __description__ = "Test OnAction behavior on MudMenuItem.";
+
+    private int Count = 0;
+    private string Callers = "";
+
+    private void IncrementByAction()
+    {
+        Callers += "A";
+        Count++;
+    }
+
+    private void IncrementByTouch()
+    {
+        Callers += "T";
+        Count++;
+    }
+
+    private void IncrementByClick()
+    {
+        Callers += "C";
+        Count++;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemActionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemActionTest.razor
@@ -8,20 +8,20 @@
 <MudText>Callers: @Callers</MudText>
 
 <MudMenu Label="Menu">
-    <MudMenuItem OnAction="IncrementByAction" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction</MudMenuItem>
+    <MudMenuItem id="id_on_action" OnAction="IncrementByAction" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction</MudMenuItem>
     <MudMenuItem OnClick="IncrementByClick" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnClick</MudMenuItem>
     <MudMenuItem OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnTouch</MudMenuItem>
     <MudMenuItem OnClick="IncrementByClick" OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnClick + OnTouch</MudMenuItem>
-    <MudMenuItem OnAction="IncrementByAction" OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnTouch</MudMenuItem>
-    <MudMenuItem OnAction="IncrementByAction" OnClick="IncrementByClick" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnClick</MudMenuItem>
+    <MudMenuItem id="id_on_action_on_touch" OnAction="IncrementByAction" OnTouch="IncrementByTouch" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnTouch</MudMenuItem>
+    <MudMenuItem id="id_on_action_on_click" OnAction="IncrementByAction" OnClick="IncrementByClick" AutoClose="false" IconSize="Size.Large" IconColor="Color.Secondary">OnAction + OnClick</MudMenuItem>
 </MudMenu>
 
 @code
 {
     public static string __description__ = "Test OnAction behavior on MudMenuItem.";
 
-    private int Count = 0;
-    private string Callers = "";
+    public int Count { get; set; } = 0;
+    public string Callers { get; set; } = "";
 
     private void IncrementByAction()
     {

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -278,5 +278,36 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.TrueInvocationCount.Should().Be(1);
             comp.Instance.FalseInvocationCount.Should().Be(1);
         }
+
+        [Test]
+        public void OnAction_WhenClick_OnActionInvoked()
+        {
+            var comp = Context.RenderComponent<MenuItemActionTest>();
+            comp.Find("button.mud-button-root").Click();
+            comp.Find("#id_on_action").Click();
+            comp.Instance.Count.Should().Be(1);
+            comp.Instance.Callers.Should().Be("A");
+        }
+
+        [Test]
+        public void OnActionAndOnClick_WhenClick_JustOnClickInvoked()
+        {
+            var comp = Context.RenderComponent<MenuItemActionTest>();
+            comp.Find("button.mud-button-root").Click();
+            comp.Find("#id_on_action_on_click").Click();
+            comp.Instance.Count.Should().Be(1);
+            comp.Instance.Callers.Should().Be("C");
+        }
+
+        [Test]
+        public void OnActionAndOnTouch_WhenTouch_JustOnTouchInvoked()
+        {
+            var comp = Context.RenderComponent<MenuItemActionTest>();
+            comp.Find("button.mud-button-root").Click();
+            var item = comp.Find("#id_on_action_on_touch");
+            item.TouchEnd();
+            comp.Instance.Count.Should().Be(1);
+            comp.Instance.Callers.Should().Be("T");
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -74,6 +74,16 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
         [Parameter] public EventCallback<TouchEventArgs> OnTouch { get; set; }
 
+        /// <summary>
+        /// Minimum time between OnAction calls
+        /// </summary>
+        /// <remarks>
+        /// The OnAction event will not be fired again if it has already been fired less than SilenceTime ago.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Menu.Behavior)]
+        public TimeSpan SilenceTime { get; set; } = TimeSpan.FromMilliseconds(100);
+
         protected async Task OnClickHandler(MouseEventArgs ev)
         {
             if (Disabled)
@@ -131,7 +141,6 @@ namespace MudBlazor
         }
 
         private DateTime _lastCall = DateTime.MinValue;
-        private readonly TimeSpan _silenceTime = TimeSpan.FromMilliseconds(100);
         protected internal async Task OnActionHandlerAsync(EventArgs ev)
         {
             var now = DateTime.UtcNow;
@@ -140,7 +149,7 @@ namespace MudBlazor
 
             lock (this)
             {
-                if (now - _lastCall <= _silenceTime) return;
+                if (now - _lastCall <= SilenceTime) return;
                 _lastCall = now;
             }
 

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -130,19 +130,21 @@ namespace MudBlazor
             }
         }
 
-        private EventArgs _lastActionHandled = EventArgs.Empty;
+        private DateTime _lastCall = DateTime.MinValue;
+        private readonly TimeSpan _silenceTime = TimeSpan.FromMilliseconds(100);
         protected internal async Task OnActionHandlerAsync(EventArgs ev)
         {
+            var now = DateTime.UtcNow;
+
             if (!OnAction.HasDelegate) return;
 
-            var needInvoke = false;
-            lock (_lastActionHandled)
+            lock (this)
             {
-                needInvoke = _lastActionHandled != ev;
-                _lastActionHandled = ev;
+                if (now - _lastCall <= _silenceTime) return;
+                _lastCall = now;
             }
-            if (needInvoke)
-                await OnAction.InvokeAsync(ev);
+
+            await OnAction.InvokeAsync(ev);
         }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -92,7 +92,7 @@ namespace MudBlazor
                 if(OnClick.HasDelegate)
                     await OnClick.InvokeAsync(ev);
                 else 
-                    await OnActionHandler(ev);
+                    await OnActionHandlerAsync(ev);
 #pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
@@ -120,7 +120,7 @@ namespace MudBlazor
                 if(OnTouch.HasDelegate)
                     await OnTouch.InvokeAsync(ev);
                 else 
-                    await OnActionHandler(ev);
+                    await OnActionHandlerAsync(ev);
 #pragma warning disable CS0618
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
@@ -130,8 +130,8 @@ namespace MudBlazor
             }
         }
 
-        protected EventArgs _lastActionHandled = new EventArgs();
-        protected internal async Task OnActionHandler(EventArgs ev)
+        private EventArgs _lastActionHandled = new EventArgs();
+        protected internal async Task OnActionHandlerAsync(EventArgs ev)
         {
             if (!OnAction.HasDelegate) return;
 

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -130,7 +130,7 @@ namespace MudBlazor
             }
         }
 
-        private EventArgs _lastActionHandled = new EventArgs();
+        private EventArgs _lastActionHandled = EventArgs.Empty;
         protected internal async Task OnActionHandlerAsync(EventArgs ev)
         {
             if (!OnAction.HasDelegate) return;

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -75,16 +75,6 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
         [Parameter] public EventCallback<TouchEventArgs> OnTouch { get; set; }
 
-        /// <summary>
-        /// Minimum time between OnAction calls
-        /// </summary>
-        /// <remarks>
-        /// The OnAction event will not be fired again if it has already been fired less than SilenceTime ago.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Menu.Behavior)]
-        public TimeSpan DebounceInterval { get; set; } = TimeSpan.FromMilliseconds(100);
-
         protected async Task OnClickHandler(MouseEventArgs ev)
         {
             if (Disabled)
@@ -150,12 +140,13 @@ namespace MudBlazor
             if (!OnAction.HasDelegate) return;
 
             await _semaphoreLastCall.WaitAsync();
-            var needCall = now - _lastCall > DebounceInterval;
-            _lastCall = now;
+            var needCall = now - _lastCall > MudGlobal.MenuItemDebounceInterval;
+            if (needCall) _lastCall = now;
             _semaphoreLastCall.Release();
 
             if (needCall)
                 await OnAction.InvokeAsync(ev);
+
         }
     }
 }

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -14,6 +14,14 @@ namespace MudBlazor
     public static class MudGlobal
     {
         /// <summary>
+        /// Minimum time between OnAction calls for MenuItem
+        /// </summary>
+        /// <remarks>
+        /// The OnAction event will not be fired again if it has already been fired less than this TimeSpan ago.
+        /// </remarks>
+        public static TimeSpan MenuItemDebounceInterval { get; set; } = TimeSpan.FromMilliseconds(100);
+
+        /// <summary>
         /// Global unhandled exception handler for such exceptions which can not be bubbled up. Note: this is not a global catch-all.
         /// It just allows the user to handle such exceptions which were suppressed inside MudBlazor using Task.AndForget() in places
         /// where it is impossible to await the task. Exceptions in user code or in razor files will still crash your app if you are not carefully


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
OnAction will only be invoked once, when the user clicks or touch the menu item.
If OnClick is set, OnAction is not called on user clicks.
If OnTouch is set, OnAction is not called on user touch.
Thus maintaining backwards compatibility.

Example:
```<MudMenuItem OnAction="MyAction">My Item</MudMenuItem>```

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tests in MenuItemActionTest.cs
**I don't have an Apple, could someone test it for me?**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

## See
Discussion: https://github.com/MudBlazor/MudBlazor/discussions/6954