### PR TITLE
 MudFormComponent: Update ValidationMessages on EditContext state change

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormComponentUpdateValidationMessagesOnEditContextChangedTest.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormComponentUpdateValidationMessagesOnEditContextChangedTest.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2023
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.UnitTests.TestComponents.Form
+{
+    public class FormComponentUpdateValidationMessagesModel
+    {
+        public string Name;
+    }
+
+    public class FormComponentUpdateValidationMessagesValidator : ComponentBase
+    {
+        private ValidationMessageStore messageStore;
+
+        [CascadingParameter]
+        private EditContext CurrentEditContext { get; set; }
+
+        protected override void OnInitialized()
+        {
+            messageStore = new(CurrentEditContext);
+        }
+
+        public void AddError(string @field, string error)
+        {
+            messageStore.Add(CurrentEditContext.Field(@field), error);
+            CurrentEditContext?.NotifyValidationStateChanged();
+        }
+
+        public void ClearErrors()
+        {
+            messageStore?.Clear();
+            CurrentEditContext?.NotifyValidationStateChanged();
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormComponentUpdateValidationMessagesOnEditContextChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormComponentUpdateValidationMessagesOnEditContextChangedTest.razor
@@ -1,0 +1,10 @@
+﻿<EditForm Model="@model">
+    <FormComponentUpdateValidationMessagesValidator />
+    <MudTextField Label="Name" @bind-Value="model.Name" For="@(() => model.Name)" />
+</EditForm>
+
+@code {
+    public static string __description__ = "Form should update its validation messages when the state of the edit context changes.";
+
+    private FormComponentUpdateValidationMessagesModel model { get; set; } = new();
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1819,5 +1819,22 @@ namespace MudBlazor.UnitTests.Components
             forms.Count.Should().Be(1);
             parentForm.IsValid.Should().BeTrue();
         }
+
+        [Test]
+        public async Task FormComponent_Should_UpdateValidationMessagesOnEditContextChanged()
+        {
+            var comp = Context.RenderComponent<FormComponentUpdateValidationMessagesOnEditContextChangedTest>();
+            var validator = comp.FindComponent<FormComponentUpdateValidationMessagesValidator>();
+            var errorMessage = "some error";
+
+            await validator.InvokeAsync(() => validator.Instance.AddError(nameof(FormComponentUpdateValidationMessagesModel.Name), errorMessage));
+
+            var tf = comp.FindComponent<MudTextField<string>>();
+            tf.Instance.ValidationErrors.Should().HaveCount(1).And.Contain(new[] { errorMessage });
+
+            await validator.InvokeAsync(() => validator.Instance.ClearErrors());
+
+            tf.Instance.ValidationErrors.Should().HaveCount(0);
+        }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -621,6 +621,10 @@ namespace MudBlazor
                 var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
                 Error = errorMessages.Length > 0;
                 ErrorText = Error ? errorMessages[0] : null;
+
+                ValidationErrors.Clear();
+                ValidationErrors.AddRange(errorMessages);
+
                 StateHasChanged();
             }
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
Resolves #7647 
The ValidationMessages property of the MudFormComponent was not updated when the validation state of the cascaded EditContext changes. This PR updates the ValidationMessages after a validation state change.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
