### PR TITLE
MudLineChart: remove Integrate() call because the return not used

### DIFF
--- a/src/MudBlazor/Components/Chart/Interpolation/EndSlopeSpline.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/EndSlopeSpline.cs
@@ -23,7 +23,6 @@ namespace MudBlazor.Components.Chart
             h = new double[n];
 
             CalcParameters(firstSlopeDegrees, lastSlopeDegrees);
-            Integrate();
             Interpolate();
         }
 

--- a/src/MudBlazor/Components/Chart/Interpolation/PeriodicSpline.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/PeriodicSpline.cs
@@ -21,7 +21,6 @@ namespace MudBlazor.Components.Chart
             h = new double[n];
 
             CalcParameters();
-            Integrate();
             Interpolate();
         }
 


### PR DESCRIPTION
## Description
follow up https://github.com/MudBlazor/MudBlazor/pull/1139#issuecomment-1605692059  this code obviously not used else where, even in UI

## How Has This Been Tested?
I never noticed used the return value in same class in all return/set variable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



## Checklist:
- [x] The PR is submitted to the correct branch (dev).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.