### PR TITLE
MudDataGrid: Fix HierarchyColumn button not clickable on glyph

### DIFF
--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -5,13 +5,12 @@
 <TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
     Filterable="false" IsEditable="false">
     <CellTemplate>
-        <label class="ma-n3">
-            <MudIconButton
+         <MudIconButton 
+            Class="ma-n3 pa-1"
             Icon="@(context.OpenHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
             OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
             Size="@IconSize"
             Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>
-        </label>
     </CellTemplate>
 </TemplateColumn>
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
The button for display the detail row was not clickable if the mouse was exactly on the glyph (it seems it didn't work only on webassembly).

I have fixed the html and now the button is always clickable.

Fixes #5796
Fixes #6821
Fixes #7671

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
For testing I have manually checked that the button is always clickable.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
