### PR TITLE
MudAutoComplete: Add ListItemClass

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1291,5 +1291,19 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("div.mud-popover").InnerHtml.Should().BeEmpty();
         }
+
+        [Test]
+        public async Task Autocomplete_Should_ApplyListItemClass()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var listItemClassTest = "list-item-class-test";
+
+            autocompletecomp.SetParam(a => a.ListItemClass, listItemClassTest);
+            var inputControl = comp.Find("div.mud-input-control");
+            inputControl.Click();
+
+            comp.WaitForAssertion(() => comp.Find("div.mud-list-item").ClassList.Should().Contain(listItemClassTest));
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -57,7 +57,7 @@
                                 bool isSelected = index == _selectedListItemIndex;
                                 bool isDisabled = !_enabledItemIndices.Contains(index);
                                 var captureIndex = index;
-                                <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async () => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@(isSelected ? "mud-selected-item mud-primary-text mud-primary-hover" : "")">
+                                <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async () => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@GetListItemClassname(isSelected)">
                                     @if (ItemTemplate == null)
                                     {
                                         @GetItemString(item)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -56,6 +56,12 @@ namespace MudBlazor
             .AddClass("progress-indicator-circular--with-adornment", Adornment == Adornment.End)
             .Build();
 
+        protected string GetListItemClassname(bool isSelected) =>
+            new CssBuilder()
+            .AddClass("mud-selected-item mud-primary-text mud-primary-hover", isSelected)
+            .AddClass(ListItemClass)
+            .Build();
+
         /// <summary>
         /// User class names for the popover, separated by space
         /// </summary>
@@ -69,6 +75,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
         public string ListClass { get; set; }
+
+        /// <summary>
+        /// User class names for the internal list item, separated by space.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public string ListItemClass { get; set; }
 
         /// <summary>
         /// Set the anchor origin point to determen where the popover will open from.


### PR DESCRIPTION
Added ListItemClass to AutoComplete to allow stylistic control over the appearance of autocomplete list items.

## Description
Fixes #7716

## How Has This Been Tested?
unit, visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![image](https://github.com/MudBlazor/MudBlazor/assets/57046415/60362b8a-7cc2-4286-a14d-5799360ac289)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
