### PR TITLE
DataGrid: Add IsOpened property to CellContext (#7432)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3401,8 +3401,10 @@ namespace MudBlazor.UnitTests.Components
 
             await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().Contain(item);
+            cell._cellContext.IsOpened.Should().Be(true);
             await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().NotContain(item);
+            cell._cellContext.IsOpened.Should().Be(false);
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -27,6 +27,14 @@ namespace MudBlazor
             }
         }
 
+        public bool IsOpened
+        {
+            get
+            {
+                return OpenHierarchies.Contains(Item);
+            }
+        }
+
         public CellContext(MudDataGrid<T> dataGrid, T item)
         {
             _selection = dataGrid.Selection;


### PR DESCRIPTION
## Description
We want to open/close the row detail view for certain elements in code behind. Currently there is no public way to know if a detail view is already opened or still closed. 
Internally this functionality is already possible via the access to the internal visible field OpenHierarchies. With the new public property in this PR, this functionality is available for external code.
Closes #7432

## How Has This Been Tested?
The existing unit tests for the internal functionality was extended with tests for the new public property.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
