### PR TITLE
DataGridRowValidator : Mark the Model property as virtual

### DIFF
--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
 
 #nullable enable
         [ExcludeFromCodeCoverage]
-        public object? Model { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public virtual object? Model { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
 #nullable disable
 
         protected HashSet<string> _errors = new HashSet<string>();


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7794

Marked the Model property on the DataGridRowValidator as virtual so, that it can be overriden. Existing DatagridRowValidator.Model throws the NotImplementedexception when accessed. See open discussion for more details: https://github.com/MudBlazor/MudBlazor/discussions/7767

## Description
I would like to use the built in mudblazor validation (For) in the MudDataGrid in combination with the FluentValidator. That could potentially be done quite nicely in a similar clean way as it's already possible with other controls like MudTextField. 

Here is **the problem**:
MudDataGrid.razor.cs contains the validator property:
`public Interfaces.IForm Validator { get; set; } = new DataGridRowValidator();`

There is currently no working implementation in place for the DataGrid and trying to use the mentioned validator leads to a crash because of the following implementation in the _DataGridRowValidator_ :
`public object? Model { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }`

The _MudFormComponent_ would start the validation using "For" and crashes because of **Form?.Model**
```
protected virtual async Task ValidateModelWithFullPathOfMember(Func<object, string, Task<IEnumerable<string?>>> func, List<string> errors)
{
    try
    {
        if (Form?.Model is null)
        {
            return;
        }
```
The implementation is just not in place yet, which is perfectly fine. 
Unfortunately it is currently impossible to extend or override the functionality because of the Model Property implementation (or rather the fact that it's missing and throws an exception) on the _DataGridRowValidator_. It's also impossible to provide a completely new implementation for the _IForm_ since some of te properties are marked as internal. 
```
    public interface IForm
    {
        public bool IsValid { get; }
        public string[] Errors { get; }
#nullable enable
        public object? Model { get; set; }
        public void FieldChanged(IFormComponent formControl, object? newValue);
#nullable disable
        internal void Add(IFormComponent formControl);
        internal void Remove(IFormComponent formControl);
        internal void Update(IFormComponent formControl);
    }
```

**The easiest solution** would probably be to mark the _Model_ property on the _DataGridRowValidator_ as **virtual**
The alternative would be to allow setting of Model on _DataGridRowValidator_. If you would prefer that let me know and I'll provide a new PR.

## How Has This Been Tested?
I've created a small application to check whether the change would suffice for what I was intending to do. (override model and provide my own implementation. Honestly a normal get/set instead of an exception would have probably already be enough but I just wanted to have as little of an impact as possible. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
