### PR TITLE
WebCompiler: update to 3.5.79 version

### DIFF
--- a/src/MudBlazor/.config/dotnet-tools.json
+++ b/src/MudBlazor/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "3.5.44",
+      "version": "3.5.79",
       "commands": [
         "webcompiler"
       ]


### PR DESCRIPTION
## Description
Updating Excubo.WebCompiler to the latest 3.5.79 version.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
