### PR TITLE
MudMenuItem: Don't "click" when scrolling menu on touch devices (#7262)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -309,5 +309,31 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Count.Should().Be(1);
             comp.Instance.Callers.Should().Be("T");
         }
+
+        [Test]
+        public void OnActionAndOnTouch_WhenTouchMove_NoneInvoked()
+        {
+            var comp = Context.RenderComponent<MenuItemActionTest>();
+            comp.Find("button.mud-button-root").Click();
+            var item = comp.Find("#id_on_action_on_touch");
+            item.TouchStart();
+            item.TouchMove();
+            item.TouchEnd();
+            comp.Instance.Count.Should().Be(0);
+            comp.Instance.Callers.Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void OnActionAndOnClick_WhenTouchMove_NoneInvoked()
+        {
+            var comp = Context.RenderComponent<MenuItemActionTest>();
+            comp.Find("button.mud-button-root").Click();
+            var item = comp.Find("#id_on_action_on_click");
+            item.TouchStart();
+            item.TouchMove();
+            item.TouchEnd();
+            comp.Instance.Count.Should().Be(0);
+            comp.Instance.Callers.Should().Be(string.Empty);
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -1,8 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<MudListItem @attributes="UserAttributes" @onclick="OnClickHandler" @ontouchend="@OnTouchHandler" Disabled="@Disabled" Class="@Class" Style="@Style" Icon="@Icon" IconColor="@IconColor" IconSize="@IconSize">
+<MudListItem @attributes="UserAttributes" @ontouchstart="OnTouchStartHandler" @ontouchmove="OnTouchMoveHandler" @onclick="OnClickHandler" @ontouchend="@OnTouchHandler" Disabled="@Disabled" Class="@Class" Style="@Style" Icon="@Icon" IconColor="@IconColor" IconSize="@IconSize">
     @ChildContent
 </MudListItem>
-
-

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -103,9 +103,12 @@ namespace MudBlazor
             }
         }
 
+        private bool _isTouchMoved;
+        private void OnTouchStartHandler() => _isTouchMoved = false;
+        private void OnTouchMoveHandler() => _isTouchMoved = true;
         protected internal async Task OnTouchHandler(TouchEventArgs ev)
         {
-            if (Disabled)
+            if (Disabled || _isTouchMoved)
                 return;
             if (AutoClose) MudMenu.CloseMenu();
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This PR solves the issue which touchscreen users cannot scroll **MudMenu** without invoking **OnTouchHandler** 
Resolves #7262 

Added a private boolean "__isTouchMoved_" to the **MudMenuItem** which only **true** when `ontouchmove` for stopping **OnTouchHandler** invoke.

Touch events always start with `ontouchstart` so we're making "__isTouchMoved_" **false** back when `ontouchstart`.

**MudMenuItem**'s **OnTouchHandler** already binded to `ontouchend` event so it always works when the user just touches.

`ontouchstart` + `ontouchmove` + `ontouchend`(**OnTouchHandler** called) => ❌

`ontouchstart` + `ontouchend`(**OnTouchHandler** called) => ✅

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

- Added 2 unit tests. 
- All tests passed. 
- Tested the view(**MenuItemActionTest**) on mobile and browser's developer tool responsive view
- Locally tested scrolling on mobile, didn't add another testing view for it, since they have same functionality with `MenuItemActionTest` view

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

https://github.com/MudBlazor/MudBlazor/assets/59802077/9cbb4905-5ef0-4ee7-965a-44e0f0cc967b

https://github.com/MudBlazor/MudBlazor/assets/59802077/8fc113f1-a90f-4864-b7da-f5680c524a43

https://github.com/MudBlazor/MudBlazor/assets/59802077/d1a10beb-68c3-4528-956c-13466115cb2c



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
