### PR TITLE
MudTreeView: Fix selection issues

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DelegateEqualityComparer.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DelegateEqualityComparer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace MudBlazor.UnitTests.TestComponents;
+
+public class DelegateEqualityComparer<T> : IEqualityComparer<T>
+{
+    private readonly Func<T, T, bool> _equals;
+    private readonly Func<T, int> _getHashCode;
+
+    public DelegateEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode)
+    {
+        _equals = equals ?? throw new ArgumentNullException(nameof(equals));
+        _getHashCode = getHashCode ?? throw new ArgumentNullException(nameof(getHashCode));
+    }
+
+    public bool Equals(T x, T y)
+    {
+        return _equals(x, y);
+    }
+
+    public int GetHashCode(T obj)
+    {
+        return _getHashCode(obj);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewCompareMultiSelectTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewCompareMultiSelectTest.razor
@@ -1,0 +1,41 @@
+﻿@using System.Collections
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" MultiSelection="false" @bind-SelectedValue="SelectedValue"
+             Comparer="Compare">
+    <MudTreeViewItem Value='"AA"' @bind-Activated="Item1Selected" 
+                     @bind-Selected="Item1Selected" @ref="Item1"/>
+    <MudTreeViewItem Value='"AC"' @bind-Activated="Item2Selected" 
+                     @bind-Selected="Item2Selected" @ref="Item2"/>
+    
+</MudTreeView>
+
+@code{
+    [Parameter]
+    public string SelectedValue { get; set; }
+
+    public bool Item1Selected { get; set; }
+
+    public bool Item2Selected { get; set; }
+    
+    public MudTreeViewItem<string> Item1 { get; set; }
+    
+    public MudTreeViewItem<string> Item2 { get; set; }
+
+    [Parameter]
+    public IEqualityComparer<string> Compare { get; set; } = new DelegateEqualityComparer<string>(
+            (x, y) => 
+            {
+                if (x == null && y == null) return true;
+                if (x == null || y == null) return false;
+                return x.Equals(y);
+            },
+            obj => 
+            {
+                if (obj == null) return 0;
+                return obj.GetHashCode();
+            }
+        );
+
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewCompareTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewCompareTest.razor
@@ -1,0 +1,39 @@
+﻿@using System.Collections
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" MultiSelection="false" @bind-SelectedValue="SelectedValue"
+             Comparer="Compare">
+    <MudTreeViewItem Value='"Ax"' @bind-Activated="Item1Activated" @bind-Selected="ParentItemSelected">
+        <MudTreeViewItem Value='"Bx"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"Cx"' @bind-Activated="Item2Activated">
+        <MudTreeViewItem Value='"Dx"' />
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code{
+    [Parameter]
+    public string SelectedValue { get; set; }
+    public bool SubItemSelected { get; set; }
+
+    public bool ParentItemSelected { get; set; }
+
+    public bool Item1Activated { get; set; }
+
+    public bool Item2Activated { get; set; }
+
+    [Parameter]
+    public IEqualityComparer<string> Compare { get; set; } = new DelegateEqualityComparer<string>(
+            (x, y) => 
+            {
+                if (x == null && y == null) return true;
+                if (x == null || y == null) return false;
+                return x.Equals(y);
+            },
+            obj => 
+            {
+                if (obj == null) return 0;
+                return obj.GetHashCode();
+            }
+        );
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest6.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" @bind-SelectedValue="SelectedValue" @ref="Tree">
+    <MudTreeViewItem Value='"content"'>
+        <MudTreeViewItem Value='"logo.png"' />
+        <MudTreeViewItem Value='"MudBlazor.svg"' />
+        <MudTreeViewItem Value='"Nuget.png"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"src"'>
+        <MudTreeViewItem Value='"MudBlazor"' />
+        <MudTreeViewItem Value='"MudBlazor.Docs"'>
+            <MudTreeViewItem Value='"wwwroot"'>
+                <MudTreeViewItem Value='"MudAppbarCorner.svg"' />
+                <MudTreeViewItem Value='"MudBlazorDocs.min.css"' />
+            </MudTreeViewItem>
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code {
+    [Parameter] public string SelectedValue { get; set; }
+    public MudTreeView<string> Tree { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest7.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest7.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" MultiSelection="false" @bind-SelectedValue="SelectedValue">
+    <MudTreeViewItem Value='"content"' @bind-Activated="Item1Activated" @bind-Selected="ParentItemSelected">
+        <MudTreeViewItem Value='"logo.png"' />
+        <MudTreeViewItem Value='"MudBlazor.svg"' @bind-Selected="SubItemSelected" />
+        <MudTreeViewItem Value='"Nuget.png"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"src"' @bind-Activated="Item2Activated">
+        <MudTreeViewItem Value='"MudBlazor"' />
+        <MudTreeViewItem Value='"MudBlazor.Docs"'>
+            <MudTreeViewItem Value='"wwwroot"'>
+                <MudTreeViewItem Value='"MudAppbarCorner.svg"' />
+                <MudTreeViewItem Value='"MudBlazorDocs.min.css"' />
+            </MudTreeViewItem>
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code{
+    public string SelectedValue { get; set; }
+    public bool SubItemSelected { get; set; }
+
+    public bool ParentItemSelected { get; set; }
+
+    public bool Item1Activated { get; set; }
+
+    public bool Item2Activated { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -380,5 +380,24 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Item1Selected.Should().BeTrue();
             comp.Instance.Item2Selected.Should().BeFalse();
         }
+        
+        [Test]
+        public void MudTreeViewItemComparer_ShouldReturnTrueWhenBothNull()
+        {
+            var comparer = new MudTreeViewItemComparer<string>(EqualityComparer<string>.Default);
+            
+            comparer.Equals(null, null).Should().BeTrue();
+        }
+        
+        [Test]
+        public void MudTreeViewItemComparer_ShouldReturnFalseWhenOneNull()
+        {
+            var comparer = new MudTreeViewItemComparer<string>(EqualityComparer<string>.Default);
+
+            var treeItem = new MudTreeViewItem<string> { Value = "value" };
+
+            comparer.Equals(treeItem, null).Should().BeFalse();
+            comparer.Equals(null, treeItem).Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-treeview-item-content").DoubleClick();
             comp.Instance.SelectedValue.Should().BeNull();
         }
-
+        
         [Test]
         public void TreeView_ClickWhileActive_DoesChangeSelection()
         {
@@ -254,5 +254,61 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("p.mud-typography")[4].InnerHtml.MarkupMatches("This is item 5");
         }
         
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_SetsSelectedValue()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            await comp.Instance.Tree.SetSelectedValue("logo.png");
+            comp.Instance.SelectedValue.Should().Be("logo.png");
+        }
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenChanged()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
+            results.Should().BeTrue();
+        }
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_ReturnsFalseWhenNoMatched()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
+            results.Should().BeFalse();
+        }
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenNoMatched()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
+            results.Should().BeFalse();
+        }
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenItemAlreadySelected()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            await comp.Instance.Tree.SetSelectedValue("logo.png");
+            var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
+            results.Should().BeTrue();
+        }
+        
+        [Test]
+        public async Task TreeView_SetSelectedValue_WillUnselectValueWhenSetToNull()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            await comp.Instance.Tree.SetSelectedValue("logo.png");
+            await comp.Instance.Tree.SetSelectedValue(null);
+            comp.Instance.SelectedValue.Should().Be(null);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -100,6 +100,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Item2Activated.Should().BeTrue();
             comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(2);
         }
+        
+        [Test]
+        public void TreeView_WillUnselectItems_WhenNotMultiSelect()
+        {
+            var comp = Context.RenderComponent<TreeViewTest7>();
+            comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(0);
+            comp.Find("div.mud-treeview-item-content").Click();
+            comp.Instance.Item1Activated.Should().BeTrue();
+            comp.Instance.Item2Activated.Should().BeFalse();
+            comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(1);
+            comp.FindAll("div.mud-treeview-item-content")[4].Click();
+            comp.Instance.Item1Activated.Should().BeFalse();
+            comp.Instance.Item2Activated.Should().BeTrue();
+            comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(1);
+        }
 
         [Test]
         public void Normal_Activate_CheckActivated_Deactivate_Check()

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -85,7 +85,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.SubItemSelected.Should().BeFalse();
             comp.Instance.ParentItemSelected.Should().BeTrue();
         }
-
+        
         [Test]
         public void Normal_Activate_CheckActivated_ActivateAnother_CheckBoth()
         {
@@ -96,9 +96,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Item2Activated.Should().BeFalse();
             comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(1);
             comp.FindAll("div.mud-treeview-item-content")[4].Click();
-            comp.Instance.Item1Activated.Should().BeFalse();
+            comp.Instance.Item1Activated.Should().BeTrue();
             comp.Instance.Item2Activated.Should().BeTrue();
-            comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(1);
+            comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(2);
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
         
         
         [Test]
-        public async Task TreeView_SetSelectedValue_SetsSelectedValue()
+        public void TreeView_SetSelectedValue_SetsSelectedValue()
         {
             var comp = Context.RenderComponent<TreeViewTest6>();
 
@@ -265,53 +265,28 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.SelectedValue.Should().Be("logo.png");
         }
         
-        // [Test]
-        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenChanged()
-        // {
-        //     var comp = Context.RenderComponent<TreeViewTest6>();
-        //     
-        //     var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
-        //     results.Should().BeTrue();
-        // }
-        //
-        // [Test]
-        // public async Task TreeView_SetSelectedValue_ReturnsFalseWhenNoMatched()
-        // {
-        //     var comp = Context.RenderComponent<TreeViewTest6>();
-        //     
-        //     
-        //     comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
-        //     var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
-        //     results.Should().BeFalse();
-        // }
-        //
-        // [Test]
-        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenNoMatched()
-        // {
-        //     var comp = Context.RenderComponent<TreeViewTest6>();
-        //     
-        //     var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
-        //     results.Should().BeFalse();
-        // }
-        //
-        // [Test]
-        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenItemAlreadySelected()
-        // {
-        //     var comp = Context.RenderComponent<TreeViewTest6>();
-        //     
-        //     await comp.Instance.Tree.SetSelectedValue("logo.png");
-        //     var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
-        //     results.Should().BeTrue();
-        // }
-        //
-        // [Test]
-        // public async Task TreeView_SetSelectedValue_WillUnselectValueWhenSetToNull()
-        // {
-        //     var comp = Context.RenderComponent<TreeViewTest6>();
-        //     
-        //     await comp.Instance.Tree.SetSelectedValue("logo.png");
-        //     await comp.Instance.Tree.SetSelectedValue(null);
-        //     comp.Instance.SelectedValue.Should().Be(null);
-        // }
+        [Test]
+        public void TreeView_SetSelectedValue_IsSetNullWhenNotFound()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
+            
+            comp.Instance.SelectedValue.Should().Be("logo.png");
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "xxxxxx"));
+            
+            comp.Instance.SelectedValue.Should().Be(default);
+        }
+        
+        [Test]
+        public void TreeView_SetSelectedValue_IsSetNullWhenInitialValueIsInvalid()
+        {
+            var comp = Context.RenderComponent<TreeViewTest6>();
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "xxxxxx"));
+            
+            comp.Instance.SelectedValue.Should().Be(default);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -341,5 +341,44 @@ namespace MudBlazor.UnitTests.Components
             
             comp.Instance.SelectedValue.Should().Be("Ax");
         }
+        
+        /// <summary>
+        /// This test checks that when multiple values are selected and the compare parameter is updated,
+        /// selected values are updated correctly. 
+        /// </summary>
+        [Test]
+        public async Task TreeView_SelectedValues_ShouldUseCompareParameter()
+        {
+            // tree containing two children with values AA and AB
+            var comp = Context.RenderComponent<TreeViewCompareMultiSelectTest>();
+
+            await comp.InvokeAsync(() => comp.Instance.Item1.SelectedChanged.InvokeAsync(true));
+            await comp.InvokeAsync(() => comp.Instance.Item2.SelectedChanged.InvokeAsync(true));
+            
+            comp.Instance.Item1Selected.Should().BeTrue();
+            comp.Instance.Item2Selected.Should().BeTrue();
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.Compare, 
+                new DelegateEqualityComparer<string>(
+                    (x, y) => 
+                    {
+                        if (string.IsNullOrEmpty(x) && string.IsNullOrEmpty(y))
+                            return true;
+                        if (string.IsNullOrEmpty(x) || string.IsNullOrEmpty(y))
+                            return false;
+                        return x[0] == y[0];
+                    },
+                    obj => 
+                    {
+                        if (string.IsNullOrEmpty(obj))
+                            return 0;
+                        return obj[0].GetHashCode();
+                    }
+                )
+            ));
+            
+            comp.Instance.Item1Selected.Should().BeTrue();
+            comp.Instance.Item2Selected.Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -259,56 +259,59 @@ namespace MudBlazor.UnitTests.Components
         public async Task TreeView_SetSelectedValue_SetsSelectedValue()
         {
             var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            await comp.Instance.Tree.SetSelectedValue("logo.png");
+
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
+
             comp.Instance.SelectedValue.Should().Be("logo.png");
         }
         
-        [Test]
-        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenChanged()
-        {
-            var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
-            results.Should().BeTrue();
-        }
-        
-        [Test]
-        public async Task TreeView_SetSelectedValue_ReturnsFalseWhenNoMatched()
-        {
-            var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
-            results.Should().BeFalse();
-        }
-        
-        [Test]
-        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenNoMatched()
-        {
-            var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
-            results.Should().BeFalse();
-        }
-        
-        [Test]
-        public async Task TreeView_SetSelectedValue_ReturnsTrueWhenItemAlreadySelected()
-        {
-            var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            await comp.Instance.Tree.SetSelectedValue("logo.png");
-            var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
-            results.Should().BeTrue();
-        }
-        
-        [Test]
-        public async Task TreeView_SetSelectedValue_WillUnselectValueWhenSetToNull()
-        {
-            var comp = Context.RenderComponent<TreeViewTest6>();
-            
-            await comp.Instance.Tree.SetSelectedValue("logo.png");
-            await comp.Instance.Tree.SetSelectedValue(null);
-            comp.Instance.SelectedValue.Should().Be(null);
-        }
+        // [Test]
+        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenChanged()
+        // {
+        //     var comp = Context.RenderComponent<TreeViewTest6>();
+        //     
+        //     var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
+        //     results.Should().BeTrue();
+        // }
+        //
+        // [Test]
+        // public async Task TreeView_SetSelectedValue_ReturnsFalseWhenNoMatched()
+        // {
+        //     var comp = Context.RenderComponent<TreeViewTest6>();
+        //     
+        //     
+        //     comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
+        //     var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
+        //     results.Should().BeFalse();
+        // }
+        //
+        // [Test]
+        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenNoMatched()
+        // {
+        //     var comp = Context.RenderComponent<TreeViewTest6>();
+        //     
+        //     var results = await comp.Instance.Tree.SetSelectedValue("xxxxxx");
+        //     results.Should().BeFalse();
+        // }
+        //
+        // [Test]
+        // public async Task TreeView_SetSelectedValue_ReturnsTrueWhenItemAlreadySelected()
+        // {
+        //     var comp = Context.RenderComponent<TreeViewTest6>();
+        //     
+        //     await comp.Instance.Tree.SetSelectedValue("logo.png");
+        //     var results = await comp.Instance.Tree.SetSelectedValue("logo.png");
+        //     results.Should().BeTrue();
+        // }
+        //
+        // [Test]
+        // public async Task TreeView_SetSelectedValue_WillUnselectValueWhenSetToNull()
+        // {
+        //     var comp = Context.RenderComponent<TreeViewTest6>();
+        //     
+        //     await comp.Instance.Tree.SetSelectedValue("logo.png");
+        //     await comp.Instance.Tree.SetSelectedValue(null);
+        //     comp.Instance.SelectedValue.Should().Be(null);
+        // }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -303,5 +303,43 @@ namespace MudBlazor.UnitTests.Components
             
             comp.Instance.SelectedValue.Should().Be(default);
         }
+
+        [Test] public void TreeView_SelectedValue_ShouldUseCompareParameter()
+        {
+            // test tree with items ("Ax", "Bx", "Cx", "Dx")
+            var comp = Context.RenderComponent<TreeViewCompareTest>();
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "Ax"));
+            
+            comp.Instance.SelectedValue.Should().Be("Ax");
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "A"));
+            
+            comp.Instance.SelectedValue.Should().Be(default);
+            
+            // set the comparer to a value that will only check the first character of the string
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.Compare, 
+                new DelegateEqualityComparer<string>(
+                    (x, y) => 
+                    {
+                        if (string.IsNullOrEmpty(x) && string.IsNullOrEmpty(y))
+                            return true;
+                        if (string.IsNullOrEmpty(x) || string.IsNullOrEmpty(y))
+                            return false;
+                        return x[0] == y[0];
+                    },
+                    obj => 
+                    {
+                        if (string.IsNullOrEmpty(obj))
+                            return 0;
+                        return obj[0].GetHashCode();
+                    }
+                )
+            ));
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.SelectedValue, "A"));
+            
+            comp.Instance.SelectedValue.Should().Be("Ax");
+        }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -154,7 +154,7 @@ namespace MudBlazor
         /// Called whenever the selected value changed.
         /// </summary>
         [Parameter] public EventCallback<T> SelectedValueChanged { get; set; }
-
+        
         /// <summary>
         /// Called whenever the selectedvalues changed.
         /// </summary>
@@ -249,5 +249,50 @@ namespace MudBlazor
 
         internal void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
 
+        public async Task SetSelectedValue(T value)
+        {
+            if (_selectedValue?.Value?.Equals(value) ?? false)
+            {
+                return;
+            }
+
+            if (_selectedValue != null)
+            {
+                await _selectedValue.Select(false);
+                _selectedValue = null;
+            }
+
+            if (value != null)
+            {
+                var item = FindItemByValue(value);
+                if (item != null)
+                {
+                    await item.Select(true);
+                    _selectedValue = item;
+                }
+            }
+        }
+
+        internal MudTreeViewItem<T>? FindItemByValue(T value, List<MudTreeViewItem<T>>? children = null)
+        {
+            children ??= _childItems;
+
+            foreach (var item in children)
+            {
+                if (Equals(item.Value, value))
+                {
+                    return item;
+                }
+
+                var foundChild = FindItemByValue(value, item.ChildItems);
+                if (foundChild != null)
+                {
+                    return foundChild;
+                }
+            }
+
+            return null;
+        }
+        
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -17,7 +17,6 @@ namespace MudBlazor
             : null;
         private HashSet<MudTreeViewItem<T>>? _selectedValues;
         private List<MudTreeViewItem<T>> _childItems = new();
-        private T? _selectedValue;
 
         protected string Classname =>
         new CssBuilder("mud-treeview")
@@ -155,20 +154,8 @@ namespace MudBlazor
         }
 
         [Parameter]
-        public T? SelectedValue
-        {
-            get => _selectedValue;
-            set
-            {
-                if (value is not null && FindItemByValue(value) is not null )
-                {
-                    _selectedValue = value;
-                    return;
-                }
-
-                _selectedValue = default;
-            }
-        }
+        [Category(CategoryTypes.TreeView.Selecting)]
+        public T? SelectedValue { get; set; }
 
         /// <summary>
         /// Called whenever the selected value changed.
@@ -273,21 +260,14 @@ namespace MudBlazor
             await base.SetParametersAsync(parameters);
         }
 
-        /// <summary>
-        /// Sets the selected value of the tree view.
-        /// If the value is found, the corresponding item is selected; 
-        /// otherwise, no changes are made.
-        /// </summary>
-        /// <param name="value">The value to be set as the selected value.</param>
-        ///<returns>
-        /// Returns true if the value is found and the corresponding item is selected; 
-        /// otherwise, returns false.
-        /// </returns>
-        /// <remarks>
-        /// This method updates the internal state to reflect the new selection and 
-        /// triggers the necessary UI updates and events.
-        /// </remarks>
-        internal async Task<bool> SetSelectedValue(T? value)
+        ///  <summary>
+        ///  Sets the selected value of the tree view.
+        ///  If the value is found, the corresponding item is selected; 
+        ///  otherwise, selected value is set null.
+        ///  If the selected item is valid it sets the corresponding tree item to selected.
+        ///  </summary>
+        ///  <param name="value">The value to be set as the selected value.</param>
+        internal async Task SetSelectedValue(T? value)
         {
             try
             {
@@ -298,16 +278,15 @@ namespace MudBlazor
                 {
                     if (SelectedValue == null)
                     {
-                        return false;
+                        return;
                     }
 
                     SelectedValue = default;
-                    return true;
+                    return;
                 }
 
                 SelectedValue = value;
                 await item.Select(true);
-                return true;
             }
             finally
             {

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -255,15 +255,19 @@ namespace MudBlazor
         /// otherwise, no changes are made.
         /// </summary>
         /// <param name="value">The value to be set as the selected value.</param>
+        ///<returns>
+        /// Returns true if the value is found and the corresponding item is selected; 
+        /// otherwise, returns false.
+        /// </returns>
         /// <remarks>
         /// This method updates the internal state to reflect the new selection and 
         /// triggers the necessary UI updates and events.
         /// </remarks>
-        public async Task SetSelectedValue(T value)
+        public async Task<bool> SetSelectedValue(T value)
         {
             if (_selectedValue?.Value?.Equals(value) ?? false)
             {
-                return;
+                return true;
             }
 
             if (value != null)
@@ -271,10 +275,19 @@ namespace MudBlazor
                 var item = FindItemByValue(value);
                 if (item != null)
                 {
-                    await UpdateSelected(item, true);
+                   await InvokeAsync(async () => await UpdateSelected(item, true));
+                   return true;
                 }
-                return;
+
+                return false;
             }
+
+            if (_selectedValue != null)
+            {
+                await InvokeAsync(async () => await UpdateSelected(_selectedValue, false));
+            }
+            
+            return true;
         }
 
         internal MudTreeViewItem<T>? FindItemByValue(T value, List<MudTreeViewItem<T>>? children = null)

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -249,6 +249,16 @@ namespace MudBlazor
 
         internal void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
 
+        /// <summary>
+        /// Sets the selected value of the tree view.
+        /// If the value is found, the corresponding item is selected; 
+        /// otherwise, no changes are made.
+        /// </summary>
+        /// <param name="value">The value to be set as the selected value.</param>
+        /// <remarks>
+        /// This method updates the internal state to reflect the new selection and 
+        /// triggers the necessary UI updates and events.
+        /// </remarks>
         public async Task SetSelectedValue(T value)
         {
             if (_selectedValue?.Value?.Equals(value) ?? false)

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -256,20 +256,14 @@ namespace MudBlazor
                 return;
             }
 
-            if (_selectedValue != null)
-            {
-                await _selectedValue.Select(false);
-                _selectedValue = null;
-            }
-
             if (value != null)
             {
                 var item = FindItemByValue(value);
                 if (item != null)
                 {
-                    await item.Select(true);
-                    _selectedValue = item;
+                    await UpdateSelected(item, true);
                 }
+                return;
             }
         }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -12,7 +12,9 @@ namespace MudBlazor
 {
     public partial class MudTreeView<T> : MudComponentBase
     {
-        private MudTreeViewItem<T>? _selectedTreeItem => FindItemByValue(SelectedValue);
+        private MudTreeViewItem<T>? _selectedTreeItem => SelectedValue is not null 
+            ? FindItemByValue(SelectedValue)
+            : null;
         private HashSet<MudTreeViewItem<T>>? _selectedValues;
         private List<MudTreeViewItem<T>> _childItems = new();
         private T? _selectedValue;
@@ -116,7 +118,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public string Height { get; set; }
+        public string? Height { get; set; }
 
         /// <summary>
         /// Setting a maximum height will allow to scroll the treeview. If not set, it will try to grow in height.
@@ -124,14 +126,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public string MaxHeight { get; set; }
+        public string? MaxHeight { get; set; }
 
         /// <summary>
         /// Setting a width the treeview. You can set this to any CSS value that the attribute 'height' accepts, i.e. 500px.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public string Width { get; set; }
+        public string? Width { get; set; }
 
         /// <summary>
         /// If true, treeview will be disabled and all its childitems.
@@ -142,11 +144,11 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public HashSet<T> Items { get; set; }
+        public HashSet<T> Items { get; set; } = new();
 
         [ExcludeFromCodeCoverage]
         [Obsolete("Use SelectedValueChanged instead.", true)]
-        [Parameter] public EventCallback<T> ActivatedValueChanged
+        [Parameter] public EventCallback<T?> ActivatedValueChanged
         {
             get => SelectedValueChanged;
             set => SelectedValueChanged = value;
@@ -183,20 +185,20 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// ItemTemplate for rendering children.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public RenderFragment<T> ItemTemplate { get; set; }
+        public RenderFragment<T>? ItemTemplate { get; set; }
 
         [CascadingParameter] MudTreeView<T> MudTreeRoot { get; set; }
 
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public Func<T, Task<HashSet<T>>> ServerData { get; set; }
+        public Func<T, Task<HashSet<T>>>? ServerData { get; set; }
 
         public MudTreeView()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -266,7 +266,7 @@ namespace MudBlazor
             if (parameters.TryGetValue(nameof(Comparer), out IEqualityComparer<T?>? comparer) && 
                 !Equals(comparer, Comparer))
             {
-                UpdateSelectedValueCompare(comparer!);
+                await UpdateSelectedValueCompare(comparer!);
             }
             
             await base.SetParametersAsync(parameters);
@@ -296,8 +296,10 @@ namespace MudBlazor
             await item.Select(true);
         }
 
-        private void UpdateSelectedValueCompare(IEqualityComparer<T?> comparer)
+        private async ValueTask UpdateSelectedValueCompare(IEqualityComparer<T?> comparer)
         {
+            List<MudTreeViewItem<T>> unselectedItem;
+            
             lock (_selectedUpdateLock)
             {
                 if (_selectedValues is null)
@@ -313,7 +315,15 @@ namespace MudBlazor
                     newSelected.Add(item);
                 }
 
+                unselectedItem = _selectedValues.Except(newSelected).ToList();
+
                 _selectedValues = newSelected;
+            }
+            
+            
+            foreach (var unselectedItems in unselectedItem)
+            {
+                await unselectedItems.SelectedChanged.InvokeAsync(false);
             }
         }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -233,7 +233,9 @@ namespace MudBlazor
             return SelectedValuesChanged.InvokeAsync(SelectedValues);
         }
 
-        private HashSet<T> SelectedValues => new(_selectedValues.Select(i => i.Value));
+        private HashSet<T> SelectedValues => _selectedValues is not null
+            ? new(_selectedValues.Select(i => i.Value))
+            : new();
         
         public async Task Select(MudTreeViewItem<T> item, bool isSelected = true)
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -180,7 +180,7 @@ namespace MudBlazor
         public RenderFragment<T>? ItemTemplate { get; set; }
         
         /// <summary>
-        /// Comparer is used to check if tow tree items are equal
+        /// Comparer is used to check if two tree items are equal
         /// </summary>
         [Parameter] 
         [Category(CategoryTypes.TreeView.Selecting)]

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -205,7 +205,7 @@ namespace MudBlazor
                     return;
 
                 _isChecked = value;
-                MudTreeRoot?.UpdateSelectedItems();
+                MudTreeRoot?.SetSelectedItemsCompare();
                 SelectedChanged.InvokeAsync(_isChecked);
             }
         }
@@ -452,7 +452,7 @@ namespace MudBlazor
             {
                 if (MudTreeRoot != null)
                 {
-                    await MudTreeRoot.UpdateSelectedItems();
+                    await MudTreeRoot.SetSelectedItemsCompare();
                 }
             }
         }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -186,7 +186,12 @@ namespace MudBlazor
         public bool Activated
         {
             get => _isSelected;
-            set { }
+            set
+            {
+                if(_isSelected.Equals(value)) return;
+
+                _isSelected = value;
+            }
         }
 
         [Parameter]
@@ -424,7 +429,7 @@ namespace MudBlazor
             if (_isSelected == value)
                 return Task.CompletedTask;
 
-            _isSelected = value;
+            Activated = value;
 
             StateHasChanged();
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -186,10 +186,7 @@ namespace MudBlazor
         public bool Activated
         {
             get => _isSelected;
-            set
-            {
-                _ = MudTreeRoot?.UpdateSelected(this, value);
-            }
+            set { }
         }
 
         [Parameter]
@@ -325,10 +322,21 @@ namespace MudBlazor
         {
             if (firstRender && _isSelected)
             {
-                await MudTreeRoot.UpdateSelected(this, _isSelected);
+                await MudTreeRoot.Select(this);
             }
 
             await base.OnAfterRenderAsync(firstRender);
+        }
+
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            if (parameters.TryGetValue(nameof(Activated), out bool selected) &&
+                selected != Activated && MudTreeRoot is not null)
+            {
+                await MudTreeRoot.Select(this, Activated);
+            }
+            
+            await base.SetParametersAsync(parameters);
         }
 
         protected async Task OnItemClicked(MouseEventArgs ev)
@@ -347,7 +355,7 @@ namespace MudBlazor
 
             if (MudTreeRoot?.IsSelectable ?? false)
             {
-                await MudTreeRoot.UpdateSelected(this, !_isSelected);
+                await MudTreeRoot.Select(this, !_isSelected);
             }
 
             await OnClick.InvokeAsync(ev);
@@ -375,7 +383,7 @@ namespace MudBlazor
 
             if (MudTreeRoot?.IsSelectable ?? false)
             {
-                await MudTreeRoot.UpdateSelected(this, !_isSelected);
+                await MudTreeRoot.Select(this, !_isSelected);
             }
 
             await OnDoubleClick.InvokeAsync(ev);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
@@ -444,6 +445,7 @@ namespace MudBlazor
         }
 
         private void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
+        internal List<MudTreeViewItem<T>> ChildItems => _childItems.ToList();
 
         internal IEnumerable<MudTreeViewItem<T>> GetSelectedItems()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
@@ -9,14 +9,14 @@ namespace MudBlazor;
 
 public class MudTreeViewItemComparer<T> : IEqualityComparer<MudTreeViewItem<T>>
 {
-    private IEqualityComparer<T?> _valueComparer;
+    private readonly IEqualityComparer<T?> _valueComparer;
 
     public MudTreeViewItemComparer(IEqualityComparer<T?> valueComparer)
     {
         _valueComparer = valueComparer;
     }
 
-    public bool Equals(MudTreeViewItem<T> x, MudTreeViewItem<T> y)
+    public bool Equals(MudTreeViewItem<T>? x, MudTreeViewItem<T>? y)
     {
         if (x == null && y == null) return true;
         if (x == null || y == null) return false;

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using System.Collections.Generic;
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemComparer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace MudBlazor;
+
+public class MudTreeViewItemComparer<T> : IEqualityComparer<MudTreeViewItem<T>>
+{
+    private IEqualityComparer<T?> _valueComparer;
+
+    public MudTreeViewItemComparer(IEqualityComparer<T?> valueComparer)
+    {
+        _valueComparer = valueComparer;
+    }
+
+    public bool Equals(MudTreeViewItem<T> x, MudTreeViewItem<T> y)
+    {
+        if (x == null && y == null) return true;
+        if (x == null || y == null) return false;
+        return _valueComparer.Equals(x.Value, y.Value);
+    }
+
+    public int GetHashCode(MudTreeViewItem<T> obj)
+    {
+        return obj.Value != null ? _valueComparer.GetHashCode(obj.Value) : 0;
+    }
+}
+


### PR DESCRIPTION
## Description
closes #5704
closes #4492
closes #3394

This PR addresses issues #5704, #4492, #3394, and follows on from PR #5856. By tackling bind issues with IsSelected. Given the challenges of integrating async methods into property setters, I've introduced a new method:

```c#
public async Task SetSelectedValue(T value)
```

This method is designed to find a given value within the tree and execute the necessary selection logic. I'm seeking feedback on this approach, particularly regarding the following points:

Current usage of SelectedValue as an update event may be misleading due to the lack of a straightforward two-way bind. Would replacing this with a callback method and adding documentation for clarification be a best practice?

A new parameter `Comparer` was also added in the process. 

## How Has This Been Tested?

Unit tests are planned to cover these changes. I’m looking for feedback on the approach before proceeding with test implementation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The visual change is the same as in #5856.

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
