### PR TITLE
DataGrid: Fix FilterDefinition.Title not updating when selected field is changed

### DIFF
--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -62,6 +62,7 @@ namespace MudBlazor
             _filterDefinition.Column = column;
             var operators = FilterOperator.GetOperatorByDataType(column.PropertyType);
             _filterDefinition.Operator = operators.FirstOrDefault();
+            _filterDefinition.Title = column.Title;
             _filterDefinition.Value = null;
         }
 


### PR DESCRIPTION
## Description
`Title` Property of `FilterDefinition` doesn't get updated when the user changes the filter field in DataGrid when `FilterMode` is `DataGridFilterMode.Simple`.

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
