### PR TITLE
Autocomplete: Navigation with keyboard allows to select disabled items #7819

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteKeyboardTopBottomNavigationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteKeyboardTopBottomNavigationTest.razor
@@ -1,0 +1,27 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete @bind-Value="value" SearchFunc="@Search"  Label="Navigate with keyboard arrows">
+    <ItemTemplate>
+        @context
+    </ItemTemplate>
+</MudAutocomplete>
+
+@code
+{
+    public static string __description__ = "User should be able to navigate top to bottom and bottom to top with keyboard arrow keys.";
+
+    string value = null;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa"
+    };
+
+    private Task<IEnumerable<string>> Search(string value)
+    {
+        var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+        return Task.FromResult(result);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsKeyArrowTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsKeyArrowTest.razor
@@ -1,0 +1,32 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete @bind-Value="value" SearchFunc="@Search" ItemDisabledFunc="@(s => s?.ToLower().Contains("m") == true)" Label="DisabledItemsTest" MaxItems="25">
+    <ItemTemplate>
+        @context
+    </ItemTemplate>
+    <ItemDisabledTemplate>
+        @context
+        <MudText Typo="Typo.subtitle2">Disabled as the state contains the letter 'o'</MudText>
+    </ItemDisabledTemplate>
+</MudAutocomplete>
+
+@code
+{
+    public static string __description__ = "The Autocomplete should show states containing 'm' as disabled. They should not be selectable.";
+
+    string value = null;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "Arizona",
+        "Delaware", "District of Columbia"
+    };
+
+    private Task<IEnumerable<string>> Search(string value)
+    {
+        var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+        return Task.FromResult(result);
+    }
+}

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -55,7 +55,7 @@
                             {
                                 var item = _items[index];
                                 bool isSelected = index == _selectedListItemIndex;
-                                bool isDisabled = !_enabledItemIndices.Contains(index);
+                                bool isDisabled = !_enabledItemIndicesLinkedList.Contains(index);
                                 var captureIndex = index;
                                 <MudListItem @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async () => await ListItemOnClick(item))" OnClickHandlerPreventDefault="true" Class="@GetListItemClassname(isSelected)">
                                     @if (ItemTemplate == null)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
         private Task _currentSearchTask;
         private Timer _timer;
         private T[] _items;
-        private IList<int> _enabledItemIndices = new List<int>();
+        private LinkedList<int> _enabledItemIndicesLinkedList = new();
         private Func<T, string> _toStringFunc;
 
         [Inject]
@@ -549,15 +549,16 @@ namespace MudBlazor
             }
             _items = searchedItems;
 
-            var enabledItems = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true).ToList();
-            _enabledItemIndices = enabledItems.Select(tuple => tuple.idx).ToList();
+            var enabledItems = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true);
+            _enabledItemIndicesLinkedList = new LinkedList<int>(enabledItems.Select(tuple => tuple.idx));
+
             if (searchingWhileSelected) //compute the index of the currently select value, if it exists
             {
                 _selectedListItemIndex = Array.IndexOf(_items, Value);
             }
             else
             {
-                _selectedListItemIndex = _enabledItemIndices.Any() ? _enabledItemIndices.First() : -1;
+                _selectedListItemIndex = _enabledItemIndicesLinkedList.Any() ? _enabledItemIndicesLinkedList.First!.Value : -1;
             }
 
             IsOpen = true;
@@ -658,8 +659,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        var increment = _enabledItemIndices.ElementAtOrDefault(_enabledItemIndices.IndexOf(_selectedListItemIndex) + 1) - _selectedListItemIndex;
-                        await SelectNextItem(increment < 0 ? 1 : increment);
+                        await SelectNextItem();
                     }
                     break;
                 case "ArrowUp":
@@ -673,8 +673,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        var decrement = _selectedListItemIndex - _enabledItemIndices.ElementAtOrDefault(_enabledItemIndices.IndexOf(_selectedListItemIndex) - 1);
-                        await SelectNextItem(-(decrement < 0 ? 1 : decrement));
+                        await SelectNextItem(moveBackwards: true);
                     }
                     break;
                 case "Escape":
@@ -699,12 +698,24 @@ namespace MudBlazor
             await base.InvokeKeyUpAsync(args);
         }
 
-        private ValueTask SelectNextItem(int increment)
+        private ValueTask SelectNextItem(bool moveBackwards = false)
         {
-            if (increment == 0 || _items == null || _items.Length == 0 || !_enabledItemIndices.Any())
+            var curr = _enabledItemIndicesLinkedList.Find(_selectedListItemIndex);
+
+            if (curr == null || _items == null || _items.Length == 0 || _enabledItemIndicesLinkedList == null || !_enabledItemIndicesLinkedList.Any())
+            {
                 return ValueTask.CompletedTask;
-            // if we are at the end, or the beginning we just do an rollover
-            _selectedListItemIndex = Math.Clamp(value: (10 * _items.Length + _selectedListItemIndex + increment) % _items.Length, min: 0, max: _items.Length - 1);
+            }
+
+            if (moveBackwards)
+            {
+                _selectedListItemIndex = curr.Previous?.Value ?? _enabledItemIndicesLinkedList.Last();
+            }
+            else
+            {
+               _selectedListItemIndex = curr.Next?.Value ?? _enabledItemIndicesLinkedList.First();
+            }
+
             return ScrollToListItem(_selectedListItemIndex);
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves #7819 

* Refactored selecting next item logic with using `LinkedList<int>` instead of `List<int>`
    - This way code is more human readable and easy to navigate next/previous
* Removed unnecessary allocation with `ToList()` method in the `enabledItems`
* Refactored **SelectNextItem** method with an optional `moveBackwards` named argument, which default value is **false**

* Before, you couldn't navigate first index(top) to last(bottom) when you press `Up Arrow`,  but you could navigate from bottom to top with `Down Arrow`. We can jump both-way now.
* Used **null-forgiving** operator "!" couple of times after null checking first to be able to make compiler happy.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

- All unit tests passed
- Created 2 new unit tests
- Visually tested functionality with couple of edge cases like, one item, zero items, zero enabled items etc.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
(Modified `AutocompleteDisabledItemsTest` view)
Before
![before](https://github.com/MudBlazor/MudBlazor/assets/59802077/e521974f-4a85-44fd-b57e-2dbc85ccf47d)

After
![after](https://github.com/MudBlazor/MudBlazor/assets/59802077/5a57aa95-29a5-4889-806e-f72fc89246ff)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
