### PR TITLE
ObserverManager: Fix collection moddified.

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/ObserverManager/ObserverManagerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/ObserverManager/ObserverManagerTests.cs
@@ -275,4 +275,34 @@ public class ObserverManagerTests
             .VerifyLogging($"Adding entry for {DefunctObserverId}/{DefunctObserver}. 1 total observers after add.")
             .VerifyLogging($"Removing defunct entry for {DefunctObserverId}. 0 total observers after remove.");
     }
+
+    [Test]
+    public void CollectionModified()
+    {
+        // Arrange
+        var observerManager = new ObserverManager<int, int>(NullLogger.Instance);
+
+        for (var i = 0; i < 1000; i++)
+        {
+            observerManager.Subscribe(i, i);
+        }
+
+        bool Predicate(int id, int observer)
+        {
+            if (id == 500)
+            {
+                observerManager.Subscribe(1001, 1001);
+            }
+
+            return true;
+        }
+
+        Task NotificationAsync(int observer)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Act & Assert
+        Assert.DoesNotThrowAsync(() => observerManager.NotifyAsync(NotificationAsync, Predicate));
+    }
 }

--- a/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
+++ b/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
@@ -114,7 +114,7 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
     public async Task NotifyAsync(Func<TObserver, Task> notification, Func<TIdentity, TObserver, bool>? predicate = null)
     {
         var defunct = default(List<TIdentity>);
-        foreach (var observer in _observers)
+        foreach (var observer in _observers.ToArray())
         {
             // Skip observers which don't match the provided predicate.
             if (predicate != null && !predicate(observer.Key, observer.Value.Observer))


### PR DESCRIPTION
## Description
An issue that someone had in MAUI application.
Making a copy of collection is not ideal memory wise, considering that ObserverManager can have a high pressure if there hundreds of thousands components that use it, but for now this is easiest and fastest fix without increasing the code complexity. 

## How Has This Been Tested?
Unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
