### PR TITLE
MudChipSet: Fix unable to select same item after reset (#7841)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetClearSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetClearSelectionTest.razor
@@ -1,0 +1,37 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudChipSet @bind-SelectedChips="selected" MultiSelection="true">
+    <MudChip Text="Milk"></MudChip>
+    <MudChip Text="Eggs"></MudChip>
+    <MudChip Text="Soap"></MudChip>
+    <MudChip Text="Corn flakes"></MudChip>
+    <MudChip Text="Salad"></MudChip>
+    <MudChip Text="Apples"></MudChip>
+    <MudChip Text="Red wine"></MudChip>
+</MudChipSet>
+
+
+@if (selected != null && selected.Length>0)
+{
+    <MudText>@string.Join(", ", selected.Select(chip=>chip.Text).OrderBy(x => x))</MudText>
+}
+else
+{
+    <MudText>Nothing selected.</MudText>
+}
+<MudButton OnClick="SetNull">Set Null</MudButton>
+<MudButton OnClick="SetEmpty">Set Empty</MudButton>
+@code
+{
+    MudChip[] selected;
+
+    void SetNull()
+    {
+        selected = null;
+    }
+    
+    void SetEmpty()
+    {
+        selected = new MudChip[]{};
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -280,6 +280,56 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => chipSet.Instance.SetSelectedValuesAsync(null));
             comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(0));
         }
+        
+        [Test]
+        public async Task ChipSet_MultiSelection_AfterChipArraySetNull_ShouldBeAbleToSelectSameChip()
+        {
+            var comp = Context.RenderComponent<ChipSetClearSelectionTest>();
+            var chipSet = comp.FindComponent<MudChipSet>();
+            
+            // Select one chip
+            comp.FindAll("div.mud-chip")[0].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(1));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Milk");
+            
+            // Set chip array to null
+            comp.FindAll("button")[0].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(0));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Nothing selected.");
+            
+            // Select same chip again
+            comp.FindAll("div.mud-chip")[0].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(1));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Milk");
+        }
+        
+        [Test]
+        public async Task ChipSet_MultiSelection_AfterChipArraySetEmpty_ShouldBeAbleToSelectSameChip()
+        {
+            var comp = Context.RenderComponent<ChipSetClearSelectionTest>();
+            var chipSet = comp.FindComponent<MudChipSet>();
+    
+            // Select one chip
+            comp.FindAll("div.mud-chip")[0].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(1));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Milk");
+
+            // Set chip array to empty
+            comp.FindAll("button")[1].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(0));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Nothing selected.");
+    
+            // Select same chip again
+            comp.FindAll("div.mud-chip")[0].Click();
+            
+            comp.WaitForAssertion(() => chipSet.Instance.SelectedChips.Length.Should().Be(1));
+            comp.FindAll("p")[0].TrimmedText().Should().Be("Milk");
+        }
     }
 
 }

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -119,6 +119,7 @@ namespace MudBlazor
                     {
                         chip.IsSelected = false;
                     }
+                    _lastSelectedValues = null;
                 }
                 else
                 {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fix for #7841 
Set `_lastSelectedValues` back to null again when collection set to null or empty. This was failing at this bit;

https://github.com/MudBlazor/MudBlazor/blob/544fa8f77744fed5c22bdff9469a064ea7e0abc0/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs#L295-L301

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

- All unit tests passed
- Visually tested for both multi selection and single selection modes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![849b7ab8-945d-4919-85d9-0313513ab0db](https://github.com/MudBlazor/MudBlazor/assets/59802077/05d22381-832d-432b-a337-24477d666017)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
