### PR TITLE
MudTextField: Fix initial height if AutoGrow is enabled (#7839)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAutoGrowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldAutoGrowExample.razor
@@ -4,7 +4,12 @@
 <MudTextField T="string" Label="AutoGrow with Lines" Variant="Variant.Text" Text="@sampleText" AutoGrow Lines="3" HelperText="This field has always at least 3 lines" />
 <MudTextField T="string" Label="AutoGrow with MaxLines" Variant="Variant.Text" Text="@sampleText" AutoGrow MaxLines="4" HelperText="This field grows to a maximum of 4 lines" />
 
-@code
-{
-    string sampleText = "Lorem ipsum dolor sit amet.";
+ @code
+ {
+    string sampleText;
+
+    protected override void OnInitialized()
+    {
+        sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.";
+    }
 }

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -30,6 +30,8 @@ window.mudInputAutoGrow = {
         elem.addEventListener('input', () => {
             elem.adjustAutoGrowHeight();
         });
+
+        elem.adjustAutoGrowHeight();
     },
     adjustHeight: (elem) => {
         if (typeof elem.adjustAutoGrowHeight === 'function') {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
Resolves #7839

I did test it visually and with the example code given in the associated issue. When I implemented this feature initially I did only check the scenario when the text changes after initialization but missed the case that the text might span multiple lines after initialization. The issue has been fixed with a change to the javascript file. In this case no unit test is possible.

@henon @ScarletKuro 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. Unit tests are not possible is this case.
