### PR TITLE
MudTextField: Add option to suppress validation and use custom Error/ErrorText

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -765,6 +765,26 @@ namespace MudBlazor.UnitTests.Components
         }
         
         [Test]
+        public async Task TextField_ShouldCallOnValidValueSet_WithValidValue()
+        {
+            var validValue = "";
+            var comp = Context.RenderComponent<MudTextField<string>>(
+                ComponentParameter.CreateParameter("Value", ""),
+                ComponentParameter.CreateParameter("Required", true),
+                EventCallback<string>("OnValidValueSet", x => validValue = x));
+            
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Text", "A"));
+            await comp.InvokeAsync(() => { comp.Instance.Validate(); });
+            comp.Instance.Error.Should().BeFalse();
+            validValue.Should().BeEquivalentTo("A");
+
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Text", ""));
+            await comp.InvokeAsync(() => { comp.Instance.Validate(); });
+            comp.Instance.Error.Should().BeTrue();
+            validValue.Should().BeEquivalentTo("A");
+        }
+        
+        [Test]
         public async Task TextField_ShouldSetErrorText_WhenManualOverRideTrue()
         {
             var errorText = Guid.NewGuid().ToString();

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -763,6 +763,36 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await comp.Instance.SelectRangeAsync(0, 1));
             comp.WaitForAssertion(() => comp.Instance.ValidationErrors.Should().HaveCount(0));
         }
+        
+        [Test]
+        public async Task TextField_ShouldSetErrorText_WhenManualOverRideTrue()
+        {
+            var errorText = Guid.NewGuid().ToString();
+            
+            var comp = Context.RenderComponent<MudTextField<string>>(
+                ComponentParameter.CreateParameter("UseManualErrorMessage", true),
+                ComponentParameter.CreateParameter("Error", true),
+                ComponentParameter.CreateParameter("ErrorText", errorText));
+
+            await comp.InvokeAsync(() => comp.Instance.Validate());
+            
+            comp.Instance.ErrorText.Should().Be(errorText);
+        }
+        
+        [Test]
+        public async Task TextField_ShouldNotSetErrorText_WhenManualOverRideFalse()
+        {
+            var errorText = Guid.NewGuid().ToString();
+            
+            var comp = Context.RenderComponent<MudTextField<string>>(
+                ComponentParameter.CreateParameter("UseManualErrorMessage", false),
+                ComponentParameter.CreateParameter("Error", true),
+                ComponentParameter.CreateParameter("ErrorText", errorText));
+
+            await comp.InvokeAsync(() => comp.Instance.Validate());
+            
+            comp.Instance.ErrorText.Should().BeNullOrEmpty();
+        }
 
         [Test]
         public async Task InputMode_DefaultValue_IsText()

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -55,6 +55,14 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Validation)]
         public string? ErrorText { get; set; }
 
+
+        /// <summary>
+        /// If true, all validation will be overridden with the given ErrorText, still requires error to be set true.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Validation)]
+        public bool UseManualErrorMessage { get; set; } = false;
+
         /// <summary>
         /// If true, the label will be displayed in an error state.
         /// </summary>
@@ -286,9 +294,18 @@ namespace MudBlazor
             var errors = new List<string>();
             try
             {
+                if (UseManualErrorMessage)
+                {
+                    if (Error && !string.IsNullOrWhiteSpace(ErrorText))
+                        errors.Add(ErrorText);
+                    
+                    return;
+                }
+                
                 // conversion error
                 if (ConversionError)
                     errors.Add(ConversionErrorMessage);
+                
                 // validation errors
                 if (Validation is ValidationAttribute validationAttribute)
                     ValidateWithAttribute(validationAttribute, _value, errors);

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -62,7 +62,14 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool UseManualErrorMessage { get; set; } = false;
-
+        
+        /// <summary>
+        /// Callback method that will be called when the value is set and is valid
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Validation)]
+        public EventCallback<T> OnValidValueSet { get; set; }
+        
         /// <summary>
         /// If true, the label will be displayed in an error state.
         /// </summary>
@@ -362,6 +369,9 @@ namespace MudBlazor
                     ErrorText = errors.FirstOrDefault();
                     ErrorId = HasErrors ? Guid.NewGuid().ToString() : null;
                     Form?.Update(this);
+
+                    if (!Error) await OnValidValueSet.InvokeAsync(_value);
+
                     StateHasChanged();
                 }
             }

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -58,6 +58,12 @@ namespace MudBlazor
         public bool Error { get; set; }
 
         /// <summary>
+        /// If true, all validation will be overridden with the given ErrorText, still requires error to be set true.
+        /// </summary>
+        [Parameter]
+        public bool UseManualErrorMessage { get; set; } = false;
+        
+        /// <summary>
         /// The ErrorText that will be displayed if Error true
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -12,6 +12,7 @@
                      Class="@Classname"
                      Error="@HasErrors"
                      ErrorText="@GetErrorText()"
+                     UseManualErrorMessage="@UseManualErrorMessage"
                      ErrorId="@ErrorId"
                      Disabled="@GetDisabledState()"
                      Margin="@Margin"


### PR DESCRIPTION
## Description

The current behavior around Error and ErrorText is misleading, when setting Error and ErrorText manually the values will be overridden by internal validation even if validation is not set.

I've added a new parameter that when set will always use ErrorText and Error values for validation. I original tried to automate this by checking the user has set any of the validation parameter, but that approach is more prone to breaking existing code.

There might be more issues but I found #3543

The changes are only intended for MudTextField but MudInputControl was altered so this could affect other components?

---

Edit 1:

I also added a callback method that gets used when a valid value is set, this is useful when you are want to write up date directly to a DB whenever a value is changed.

## How Has This Been Tested?
I added in a test that set the flag then checks the error is overwritten, then checks the same thing with the flag not set.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Example of how I think people are trying to use error:
https://try.mudblazor.com/snippet/camHvQOTeuoiewvV

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
