### PR TITLE
MudDatePicker: Setting date null doesn't clear invalid text

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -199,6 +199,66 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataPicker_ShouldClearText_WhenDateSetNull()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+
+            string invalid = "INVALID_DATE";
+            comp.SetParam(p => p.Text, "INVALID_DATE");
+            
+            picker.Date.Should().Be(null);
+            picker.Text.Should().Be(invalid);
+
+            await Task.Delay(150);
+            
+            comp.SetParam(p => p.Date, null);
+            
+            picker.Date.Should().Be(null);
+            picker.Text.Should().Be(null);
+        }
+        
+        
+        [Test]
+        public async Task DataPicker_ShouldDeBounceSetDate_WhenDateSetToTheSameValueQuickly()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+
+            string invalid = "INVALID_DATE";
+            comp.SetParam(p => p.Text, "INVALID_DATE");
+            
+            picker.Date.Should().Be(null);
+            picker.Text.Should().Be(invalid);
+            
+            comp.SetParam(p => p.Date, null);
+            
+            picker.Date.Should().Be(null);
+            picker.Text.Should().Be(invalid);
+        }
+        
+        [Test]
+        public async Task DataPicker_ShouldDisplayError_WhenTextSetToInvalidValue()
+        {
+            var comp = Context.RenderComponent<MudDatePicker>();
+
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+
+            string invalid = "INVALID_DATE";
+            comp.SetParam(p => p.Text, "INVALID_DATE");
+
+            picker.Error.Should().BeTrue();
+        }
+        
+        [Test]
         public void Check_Intial_Date_Format()
         {
             DateTime? date = new DateTime(2021, 1, 13);

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
@@ -26,15 +27,27 @@ namespace MudBlazor
             get => _value;
             set => SetDateAsync(value, true).AndForget();
         }
-
+        
+        private DateTime _lastSetTime = DateTime.MinValue;
+        private const int DebounceTimeoutMs = 100;
+        
         protected async Task SetDateAsync(DateTime? date, bool updateValue)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {
                 date = DateTime.SpecifyKind(date.Value, _value.Value.Kind);
             }
+ 
+            var now = DateTime.UtcNow;
+            
+            if (_value == date && (now - _lastSetTime).TotalMilliseconds < DebounceTimeoutMs)
+            {
+                return;
+            }
 
-            if (_value != date)
+            _lastSetTime = now;
+            
+            if (_value != date || (date is null && Text != null))
             {
                 Touched = true;
 


### PR DESCRIPTION
## Description

This pull request addresses an issue with the date picker component. When the Data value is null and the user inputs an invalid string (updating the Text value), the error is not properly detected. Furthermore, attempting to clear the Data value under these circumstances does not remove the text from the box. This issue is somewhat related to issue #6768, but the following snippet more accurately demonstrates the problem:

https://try.mudblazor.com/snippet/GkGRlGEAeMhsPXSx

To replicate the issue, set the text to an invalid string, then click the clear button. The error text does not display for an invalid string, and the button fails to clear the text.

The underlying issue arises from a conditional check in the code. If the newly set value for Data is equal to the current value, the component takes no action. Since the initial Data value is null and the user is setting an invalid value (text = "ERROR"), the set method receives a null value, resulting in no change. The proposed fix involves checking if the incoming value is null and if the Text is not null, then executing specific code.

However, there's a complication: the Date property is "noisy." This means that in the UI, when you click on a box, set the input to "ERROR," and click off, the Data property is set multiple times. This behavior causes the workaround for the text issue to interfere with other functionalities, like error checking. To mitigate this, I've implemented a debouncer to ensure SetData isn't called rapidly with the same value. Although not ideal, this solution seems to be effective.

I'm not entirely satisfied with this solution and believe there could be a better approach involving some kind of flag, but I haven't been able to pinpoint it yet.

## How Has This Been Tested?
Added some unit tests to check for error and text is set null at the correct times.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![date-picker](https://github.com/MudBlazor/MudBlazor/assets/9060893/08b6788d-7e05-40c9-854e-54c5475c44ea)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
