### PR TITLE
WebCompiler: Update to the latest version

### DIFF
--- a/src/MudBlazor.Docs/.config/dotnet-tools.json
+++ b/src/MudBlazor.Docs/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "3.5.44",
+      "version": "3.5.79",
       "commands": [
         "webcompiler"
       ]

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -91,7 +91,7 @@
 
   <!--Excubo  webcompiler -  used for scss and js compilation-->
   <Target Name="ToolRestore">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
+    <Exec Command="dotnet tool restore --no-cache" StandardOutputImportance="high" />
   </Target>
 
   <Target Name="WebCompiler" DependsOnTargets="ToolRestore">

--- a/src/MudBlazor/.config/dotnet-tools.json
+++ b/src/MudBlazor/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "3.5.44",
+      "version": "3.5.79",
       "commands": [
         "webcompiler"
       ]

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -70,7 +70,7 @@
   </ItemGroup>
 
   <Target Name="ToolRestore">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
+    <Exec Command="dotnet tool restore --no-cache" StandardOutputImportance="high" />
   </Target>
 
   <!--combine js files-->


### PR DESCRIPTION
As discussed in the discord channel, this PR updates the Excubo.WebCompiler tool to the latest version and solves the [process cannot access the file](https://github.com/MudBlazor/MudBlazor/actions/runs/6945037712/job/18928404863#step:7:9) error during build.