### PR TITLE
Inputs: Consistent Naming of the Value Parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxBasicExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@Basic_CheckBox1"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox2" Color="Color.Primary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox3" Color="Color.Secondary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox4" Disabled="true"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox1"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox2" Color="Color.Primary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox3" Color="Color.Secondary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox4" Disabled="true"></MudCheckBox>
 
 @code {
     public bool Basic_CheckBox1 { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxColorExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@Basic_CheckBox1" UnCheckedColor="Color.Error"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox2" Color="Color.Primary" UnCheckedColor="Color.Default"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox3" Color="Color.Secondary" UnCheckedColor="Color.Default"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Basic_CheckBox4" Disabled="true" UnCheckedColor="Color.Success"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox1" UnCheckedColor="Color.Error"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox2" Color="Color.Primary" UnCheckedColor="Color.Default"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox3" Color="Color.Secondary" UnCheckedColor="Color.Default"></MudCheckBox>
+<MudCheckBox @bind-Value="@Basic_CheckBox4" Disabled="true" UnCheckedColor="Color.Success"></MudCheckBox>
 
 @code {
     public bool Basic_CheckBox1 { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxConversionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxConversionExample.razor
@@ -1,11 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="boolean">bool: @boolean</MudCheckBox>
-<MudCheckBox @bind-Checked="nullable" Color="Color.Primary">bool?: @nullable</MudCheckBox>
-<MudCheckBox @bind-Checked="integer" Color="Color.Secondary">int: @integer</MudCheckBox>
-<MudCheckBox @bind-Checked="str" Color="Color.Tertiary">string: "@(str)"</MudCheckBox>
-<MudCheckBox @bind-Checked="customstr" Converter="@(new CustomStringToBoolConverter())"> custom string: "@(customstr)"</MudCheckBox>
-<MudCheckBox @bind-Checked="obj" Converter="@(new ObjectToBoolConverter())">boxed bool: "@(obj.ToString())"</MudCheckBox>
+<MudCheckBox @bind-Value="boolean">bool: @boolean</MudCheckBox>
+<MudCheckBox @bind-Value="nullable" Color="Color.Primary">bool?: @nullable</MudCheckBox>
+<MudCheckBox @bind-Value="integer" Color="Color.Secondary">int: @integer</MudCheckBox>
+<MudCheckBox @bind-Value="str" Color="Color.Tertiary">string: "@(str)"</MudCheckBox>
+<MudCheckBox @bind-Value="customstr" Converter="@(new CustomStringToBoolConverter())"> custom string: "@(customstr)"</MudCheckBox>
+<MudCheckBox @bind-Value="obj" Converter="@(new ObjectToBoolConverter())">boxed bool: "@(obj.ToString())"</MudCheckBox>
 
 @code{ 
     public bool boolean { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxDenseExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@Dense_CheckBox" Dense="true" Color="Color.Success"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Dense_CheckBox" Dense="false" Color="Color.Primary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Dense_CheckBox" Dense="true" Color="Color.Success"></MudCheckBox>
+<MudCheckBox @bind-Value="@Dense_CheckBox" Dense="false" Color="Color.Primary"></MudCheckBox>
 
 @code {
     public bool Dense_CheckBox { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxIconExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@CheckBox1" Color="Color.Secondary" CheckedIcon="@Icons.Material.Filled.Favorite" UncheckedIcon="@Icons.Material.Filled.FavoriteBorder"></MudCheckBox>
-<MudCheckBox @bind-Checked="@CheckBox2" Color="Color.Tertiary" CheckedIcon="@Icons.Material.Filled.Bookmark" UncheckedIcon="@Icons.Material.Filled.BookmarkBorder"></MudCheckBox>
-<MudCheckBox @bind-Checked="@CheckBox3" Color="Color.Warning" CheckedIcon="@Icons.Material.Filled.Star" UncheckedIcon="@Icons.Material.Filled.StarOutline"></MudCheckBox>
+<MudCheckBox @bind-Value="@CheckBox1" Color="Color.Secondary" CheckedIcon="@Icons.Material.Filled.Favorite" UncheckedIcon="@Icons.Material.Filled.FavoriteBorder"></MudCheckBox>
+<MudCheckBox @bind-Value="@CheckBox2" Color="Color.Tertiary" CheckedIcon="@Icons.Material.Filled.Bookmark" UncheckedIcon="@Icons.Material.Filled.BookmarkBorder"></MudCheckBox>
+<MudCheckBox @bind-Value="@CheckBox3" Color="Color.Warning" CheckedIcon="@Icons.Material.Filled.Star" UncheckedIcon="@Icons.Material.Filled.StarOutline"></MudCheckBox>
 
 
 

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxIndeterminateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxIndeterminateExample.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="value" Color="@Color.Primary">
+<MudCheckBox @bind-Value="value" Color="@Color.Primary">
     Value: @(value == null ? "null" : value.ToString())
 </MudCheckBox>
 <MudButton OnClick="@(()=>value=null)">Reset</MudButton>
-<MudCheckBox @bind-Checked="anotherValue" Color="@Color.Secondary" TriState="true">Checkbox with TriState. Value: @(anotherValue == null ? "null" : anotherValue.ToString())</MudCheckBox>
+<MudCheckBox @bind-Value="anotherValue" Color="@Color.Secondary" TriState="true">Checkbox with TriState. Value: @(anotherValue == null ? "null" : anotherValue.ToString())</MudCheckBox>
 
 @code {
     public bool? value { get; set; } = null;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxKeyboardNavigationExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@CheckBox1" Color="Color.Primary" Label="Basic"></MudCheckBox>
-<MudCheckBox @bind-Checked="@CheckBox2" Color="Color.Primary" Label="TriState" TriState="true"></MudCheckBox>
+<MudCheckBox @bind-Value="@CheckBox1" Color="Color.Primary" Label="Basic"></MudCheckBox>
+<MudCheckBox @bind-Value="@CheckBox2" Color="Color.Primary" Label="TriState" TriState="true"></MudCheckBox>
 
 @code {
     public bool CheckBox1 { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxLabelExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@Label_CheckBox1" Label="Default"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Label_CheckBox2" Label="Primary" Color="Color.Primary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Label_CheckBox3" Label="Secondary" LabelPosition="LabelPosition.Start" Color="Color.Secondary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Label_CheckBox1" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start"></MudCheckBox>
+<MudCheckBox @bind-Value="@Label_CheckBox1" Label="Default"></MudCheckBox>
+<MudCheckBox @bind-Value="@Label_CheckBox2" Label="Primary" Color="Color.Primary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Label_CheckBox3" Label="Secondary" LabelPosition="LabelPosition.Start" Color="Color.Secondary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Label_CheckBox1" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start"></MudCheckBox>
 
 @code {
     public bool Label_CheckBox1 { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxReadOnlyExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div>
-    <MudCheckBox ReadOnly="@ReadOnly" @bind-Checked="@Label_Checkbox1" Label="@(ReadOnly ? "ReadOnly Checkbox 1" : "EditMode Checkbox 1")"/>
-    <MudCheckBox ReadOnly="@ReadOnly" @bind-Checked="@Label_Checkbox2" Label="@(ReadOnly ? "ReadOnly Checkbox 2" : "EditMode Checkbox 2")"/>
+    <MudCheckBox ReadOnly="@ReadOnly" @bind-Value="@Label_Checkbox1" Label="@(ReadOnly ? "ReadOnly Checkbox 1" : "EditMode Checkbox 1")"/>
+    <MudCheckBox ReadOnly="@ReadOnly" @bind-Value="@Label_Checkbox2" Label="@(ReadOnly ? "ReadOnly Checkbox 2" : "EditMode Checkbox 2")"/>
 </div>
 <MudSelect  @bind-Value="@Label_Checkbox1" Label="Checkbox 1">
     <MudSelectItem Value="@(false)">False</MudSelectItem>
@@ -13,7 +13,7 @@
     <MudSelectItem Value="@(true)">True</MudSelectItem>
 </MudSelect>
 
-<MudSwitch @bind-Checked="@ReadOnly" Label="@(ReadOnly ? "ReadOnly Mode" : "Edit Mode")"/>
+<MudSwitch @bind-Value="@ReadOnly" Label="@(ReadOnly ? "ReadOnly Mode" : "Edit Mode")"/>
 
 @code {
     public bool Label_Checkbox1 { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxSizeExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCheckBox @bind-Checked="@Size_CheckBox1" Size="Size.Small" Color="Color.Primary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Size_CheckBox2" Size="Size.Medium" Color="Color.Secondary"></MudCheckBox>
-<MudCheckBox @bind-Checked="@Size_CheckBox3" Size="Size.Large" Color="Color.Tertiary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Size_CheckBox1" Size="Size.Small" Color="Color.Primary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Size_CheckBox2" Size="Size.Medium" Color="Color.Secondary"></MudCheckBox>
+<MudCheckBox @bind-Value="@Size_CheckBox3" Size="Size.Large" Color="Color.Tertiary"></MudCheckBox>
 @code {
     public bool Size_CheckBox1 { get; set; } = true;
     public bool Size_CheckBox2 { get; set; } = false;

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioContentPlacementExample.razor
@@ -2,13 +2,13 @@
 
 <MudGrid>
     <MudItem xs="12" md="1">
-        <MudRadioGroup @bind-SelectedOption="@Placement">
-            <MudRadio Color="Color.Primary" Option="@(Placement.Top)">Top</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Bottom)">Bottom</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Start)">Start</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.End)">End</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Left)">Left</MudRadio>
-            <MudRadio Color="Color.Primary" Option="@(Placement.Right)">Right</MudRadio>
+        <MudRadioGroup @bind-Value="@Placement">
+            <MudRadio Color="Color.Primary" Value="@(Placement.Top)">Top</MudRadio>
+            <MudRadio Color="Color.Primary" Value="@(Placement.Bottom)">Bottom</MudRadio>
+            <MudRadio Color="Color.Primary" Value="@(Placement.Start)">Start</MudRadio>
+            <MudRadio Color="Color.Primary" Value="@(Placement.End)">End</MudRadio>
+            <MudRadio Color="Color.Primary" Value="@(Placement.Left)">Left</MudRadio>
+            <MudRadio Color="Color.Primary" Value="@(Placement.Right)">Right</MudRadio>
         </MudRadioGroup>
     </MudItem>
     <MudItem xs="12" md="9" Class="d-flex justify-center align-center my-auto">

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioDenseExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudRadioGroup @bind-SelectedOption="Dense_Radio">
-    <MudRadio Option="true" Color="Color.Primary" Dense="true">Dense</MudRadio>
-    <MudRadio Option="false" Color="Color.Secondary" Dense="false">Normal</MudRadio>
+<MudRadioGroup @bind-Value="Dense_Radio">
+    <MudRadio Value="true" Color="Color.Primary" Dense="true">Dense</MudRadio>
+    <MudRadio Value="false" Color="Color.Secondary" Dense="false">Normal</MudRadio>
 </MudRadioGroup>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupColorExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudRadioGroup T="int">
-    <MudRadio Option="1" Color="Color.Primary" UnCheckedColor="Color.Default">One</MudRadio>
-    <MudRadio Option="2" Color="Color.Secondary" UnCheckedColor="Color.Default">Two</MudRadio>
-    <MudRadio Option="3" Color="Color.Success" UnCheckedColor="Color.Error">Three</MudRadio>
-    <MudRadio Option="4" Color="Color.Primary" Disabled="true">Four</MudRadio>
+    <MudRadio Value="1" Color="Color.Primary" UnCheckedColor="Color.Default">One</MudRadio>
+    <MudRadio Value="2" Color="Color.Secondary" UnCheckedColor="Color.Default">Two</MudRadio>
+    <MudRadio Value="3" Color="Color.Success" UnCheckedColor="Color.Error">Three</MudRadio>
+    <MudRadio Value="4" Color="Color.Primary" Disabled="true">Four</MudRadio>
 </MudRadioGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioGroupExample.razor
@@ -1,11 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudForm>
-    <MudRadioGroup @bind-SelectedOption="@SelectedOption">
-        <MudRadio Option="@("Radio 1")" Color="Color.Primary">Primary</MudRadio>
-        <MudRadio Option="@("Radio 2")" Color="Color.Secondary">Secondary</MudRadio>
-        <MudRadio Option="@("Radio 3")">Default</MudRadio>
-        <MudRadio Option="@("Radio 4")" Color="Color.Primary" Disabled="true">Disabled</MudRadio>
+    <MudRadioGroup @bind-Value="@SelectedOption">
+        <MudRadio Value="@("Radio 1")" Color="Color.Primary">Primary</MudRadio>
+        <MudRadio Value="@("Radio 2")" Color="Color.Secondary">Secondary</MudRadio>
+        <MudRadio Value="@("Radio 3")">Default</MudRadio>
+        <MudRadio Value="@("Radio 4")" Color="Color.Primary" Disabled="true">Disabled</MudRadio>
     </MudRadioGroup>
 </MudForm>
 

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioKeyboardNavigationExample.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudForm>
-    <MudRadioGroup @bind-SelectedOption="@SelectedOption">
-        <MudRadio Option="@("Radio 1")" Color="Color.Primary">Primary</MudRadio>
-        <MudRadio Option="@("Radio 2")" Color="Color.Secondary">Secondary</MudRadio>
-        <MudRadio Option="@("Radio 3")" Color="Color.Tertiary">Tertiary</MudRadio>
-        <MudRadio Option="@("Radio 4")">Default</MudRadio>
-        <MudRadio Option="@("Radio 4")" Color="Color.Primary" Disabled="true">Disabled</MudRadio>
+    <MudRadioGroup @bind-Value="@SelectedOption">
+        <MudRadio Value="@("Radio 1")" Color="Color.Primary">Primary</MudRadio>
+        <MudRadio Value="@("Radio 2")" Color="Color.Secondary">Secondary</MudRadio>
+        <MudRadio Value="@("Radio 3")" Color="Color.Tertiary">Tertiary</MudRadio>
+        <MudRadio Value="@("Radio 4")">Default</MudRadio>
+        <MudRadio Value="@("Radio 4")" Color="Color.Primary" Disabled="true">Disabled</MudRadio>
     </MudRadioGroup>
 </MudForm>
 

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioReadOnlyDisabledExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioReadOnlyDisabledExample.razor
@@ -2,23 +2,23 @@
 
 <MudGrid>
     <MudItem sm="12" md="6">
-        <MudRadioGroup @bind-SelectedOption="@SelectedOption1" ReadOnly="ReadOnly">
-            <MudRadio Option="@("Radio 1")">Radio 1</MudRadio>
-            <MudRadio Option="@("Radio 2")">Radio 2</MudRadio>
-            <MudRadio Option="@("Radio 3")">Radio 3</MudRadio>
-            <MudRadio Option="@("Radio 4")">Radio 4</MudRadio>
+        <MudRadioGroup @bind-Value="@SelectedOption1" ReadOnly="ReadOnly">
+            <MudRadio Value="@("Radio 1")">Radio 1</MudRadio>
+            <MudRadio Value="@("Radio 2")">Radio 2</MudRadio>
+            <MudRadio Value="@("Radio 3")">Radio 3</MudRadio>
+            <MudRadio Value="@("Radio 4")">Radio 4</MudRadio>
         </MudRadioGroup>
-        <MudSwitch @bind-Checked="ReadOnly" Color="Color.Primary" Label="ReadOnly" />
+        <MudSwitch @bind-Value="ReadOnly" Color="Color.Primary" Label="ReadOnly" />
         <MudText>Selected Option 1: @SelectedOption1</MudText>
     </MudItem>
     <MudItem sm="12" md="6">
-        <MudRadioGroup @bind-SelectedOption="@SelectedOption2" Disabled="Disabled">
-            <MudRadio Option="@("Radio 1")">Radio 1</MudRadio>
-            <MudRadio Option="@("Radio 2")">Radio 2</MudRadio>
-            <MudRadio Option="@("Radio 3")">Radio 3</MudRadio>
-            <MudRadio Option="@("Radio 4")">Radio 4</MudRadio>
+        <MudRadioGroup @bind-Value="@SelectedOption2" Disabled="Disabled">
+            <MudRadio Value="@("Radio 1")">Radio 1</MudRadio>
+            <MudRadio Value="@("Radio 2")">Radio 2</MudRadio>
+            <MudRadio Value="@("Radio 3")">Radio 3</MudRadio>
+            <MudRadio Value="@("Radio 4")">Radio 4</MudRadio>
         </MudRadioGroup>
-        <MudSwitch @bind-Checked="Disabled" Color="Color.Primary" Label="Disabled" />
+        <MudSwitch @bind-Value="Disabled" Color="Color.Primary" Label="Disabled" />
         <MudText>Selected Option 2: @SelectedOption2</MudText>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/Examples/RadioSizeExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudRadioGroup @bind-SelectedOption="Radio_Size">
-    <MudRadio Option="1" Color="Color.Primary" Size="Size.Small">Small</MudRadio>
-    <MudRadio Option="2" Color="Color.Secondary" Size="Size.Medium">Medium</MudRadio>
-    <MudRadio Option="3" Color="Color.Tertiary" Size="Size.Large">Large</MudRadio>
+<MudRadioGroup @bind-Value="Radio_Size">
+    <MudRadio Value="1" Color="Color.Primary" Size="Size.Small">Small</MudRadio>
+    <MudRadio Value="2" Color="Color.Secondary" Size="Size.Medium">Medium</MudRadio>
+    <MudRadio Value="3" Color="Color.Tertiary" Size="Size.Large">Large</MudRadio>
 </MudRadioGroup>
 
 @code { 

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchBasicExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="@Basic_Switch1" />
-<MudSwitch @bind-Checked="@Basic_Switch2" Color="Color.Primary" />
-<MudSwitch @bind-Checked="@Basic_Switch3" Color="Color.Secondary" />
+<MudSwitch @bind-Value="@Basic_Switch1" />
+<MudSwitch @bind-Value="@Basic_Switch2" Color="Color.Primary" />
+<MudSwitch @bind-Value="@Basic_Switch3" Color="Color.Secondary" />
 <MudSwitch T="bool" Disabled="true" />
 
 @code{

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchColorExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="@Basic_Switch1" Color="Color.Success" UnCheckedColor="Color.Error" />
-<MudSwitch @bind-Checked="@Basic_Switch2" Color="Color.Primary" UnCheckedColor="Color.Secondary" />
-<MudSwitch @bind-Checked="@Basic_Switch3" Color="Color.Info" UnCheckedColor="Color.Warning" />
+<MudSwitch @bind-Value="@Basic_Switch1" Color="Color.Success" UnCheckedColor="Color.Error" />
+<MudSwitch @bind-Value="@Basic_Switch2" Color="Color.Primary" UnCheckedColor="Color.Secondary" />
+<MudSwitch @bind-Value="@Basic_Switch3" Color="Color.Info" UnCheckedColor="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" UnCheckedColor="Color.Dark" />
 
 @code{

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchConversionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchConversionExample.razor
@@ -1,11 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="boolean">bool: @boolean</MudSwitch>
-<MudSwitch @bind-Checked="nullable" Color="Color.Primary">bool?: @nullable</MudSwitch>
-<MudSwitch @bind-Checked="integer" Color="Color.Secondary">int: @integer</MudSwitch>
-<MudSwitch @bind-Checked="str" Color="Color.Tertiary">string: "@(str)"</MudSwitch>
-<MudSwitch @bind-Checked="customstr" Color="Color.Error" Converter="@(new CustomStringToBoolConverter())"> custom string: "@(customstr)"</MudSwitch>
-<MudSwitch @bind-Checked="customobj" Color="Color.Dark" Converter="@(new ObjectToBoolConverter())">object: "@(customobj.ToString())"</MudSwitch>
+<MudSwitch @bind-Value="boolean">bool: @boolean</MudSwitch>
+<MudSwitch @bind-Value="nullable" Color="Color.Primary">bool?: @nullable</MudSwitch>
+<MudSwitch @bind-Value="integer" Color="Color.Secondary">int: @integer</MudSwitch>
+<MudSwitch @bind-Value="str" Color="Color.Tertiary">string: "@(str)"</MudSwitch>
+<MudSwitch @bind-Value="customstr" Color="Color.Error" Converter="@(new CustomStringToBoolConverter())"> custom string: "@(customstr)"</MudSwitch>
+<MudSwitch @bind-Value="customobj" Color="Color.Dark" Converter="@(new ObjectToBoolConverter())">object: "@(customobj.ToString())"</MudSwitch>
 
 @code{
     public bool boolean { get; set; } = true;

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchKeyboardNavigationExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="@Label_Switch1" Label="Switch With Key Navigation" />
+<MudSwitch @bind-Value="@Label_Switch1" Label="Switch With Key Navigation" />
 
 @code{
     bool Label_Switch1 = false;

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchReadOnlyExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div class="d-flex flex-column align-center">
-    <MudSwitch ReadOnly="@ReadOnly" @bind-Checked="@SwitchValue" Color="Color.Primary" Class="mr-n2 mb-6"/>
+    <MudSwitch ReadOnly="@ReadOnly" @bind-Value="@SwitchValue" Color="Color.Primary" Class="mr-n2 mb-6"/>
     <MudButton OnClick="@ToggleValue" Variant="Variant.Filled" DisableElevation="true">Toggle Value</MudButton>
-    <MudCheckBox @bind-Checked="@ReadOnly" Label="@(ReadOnly ? "readonly-mode" : "edit-mode")" />
+    <MudCheckBox @bind-Value="@ReadOnly" Label="@(ReadOnly ? "readonly-mode" : "edit-mode")" />
 </div>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchSizeExample.razor
@@ -3,7 +3,7 @@
 <MudSwitch T="bool" Label="Small" Size="Size.Small"/>
 <MudSwitch T="bool" Label="Medium"/>
 <MudSwitch T="bool" Label="Large" Size="Size.Large"/>
-<MudSwitch @bind-Checked="@Label_Switch" T="bool" Label="Switches from small to large" Size="@(Label_Switch ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
+<MudSwitch @bind-Value="@Label_Switch" T="bool" Label="Switches from small to large" Size="@(Label_Switch ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
 
 @code{
     public bool Label_Switch { get; set; } = false;

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithIconExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="@_checked1" ThumbIcon="@Icons.Custom.Brands.MudBlazor">Basic</MudSwitch>
-<MudSwitch @bind-Checked="@_checked2" ThumbIcon="@Icons.Custom.Brands.MudBlazor" ThumbIconColor="Color.Info">Colored</MudSwitch>
-<MudSwitch @bind-Checked="@_checked3" ThumbIcon="@(_checked3==true ? Icons.Material.Filled.Done : Icons.Material.Filled.Close)" ThumbIconColor="@(_checked3==true ? Color.Success : Color.Error)">Changing</MudSwitch>
+<MudSwitch @bind-Value="@_checked1" ThumbIcon="@Icons.Custom.Brands.MudBlazor">Basic</MudSwitch>
+<MudSwitch @bind-Value="@_checked2" ThumbIcon="@Icons.Custom.Brands.MudBlazor" ThumbIconColor="Color.Info">Colored</MudSwitch>
+<MudSwitch @bind-Value="@_checked3" ThumbIcon="@(_checked3==true ? Icons.Material.Filled.Done : Icons.Material.Filled.Close)" ThumbIconColor="@(_checked3==true ? Color.Success : Color.Error)">Changing</MudSwitch>
 
 @code{
     bool _checked1 = false;

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchWithLabelExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwitch @bind-Checked="@Label_Switch1" Label="Info" Color="Color.Info" />
-<MudSwitch @bind-Checked="@Label_Switch2" Label="Success" Color="Color.Success" />
-<MudSwitch @bind-Checked="@Label_Switch3" Label="Warning!" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
+<MudSwitch @bind-Value="@Label_Switch1" Label="Info" Color="Color.Info" />
+<MudSwitch @bind-Value="@Label_Switch2" Label="Success" Color="Color.Success" />
+<MudSwitch @bind-Value="@Label_Switch3" Label="Warning!" LabelPosition="LabelPosition.Start" Color="Color.Warning" />
 <MudSwitch T="bool" Disabled="true" Label="Disabled" LabelPosition="LabelPosition.Start" />
 
 @code{

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxTest3.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudCheckBox  @bind-Checked="is_checked">Synced</MudCheckBox>
-<MudCheckBox @bind-Checked="is_checked">Synced</MudCheckBox>
+<MudCheckBox  @bind-Value="is_checked">Synced</MudCheckBox>
+<MudCheckBox @bind-Value="is_checked">Synced</MudCheckBox>
 
 @code {
     public static string __description__ = "Clicking any checkbox should toggle both.";

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxesBindAgainstArrayTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxesBindAgainstArrayTest.razor
@@ -5,7 +5,7 @@
     {
         var local = i;
         <MudItem xs="6" md="6">
-            <MudCheckBox @bind-Checked="@values[local]" Color="Color.Tertiary">@amenities[local]</MudCheckBox>
+            <MudCheckBox @bind-Value="@values[local]" Color="Color.Tertiary">@amenities[local]</MudCheckBox>
         </MudItem>
     }
     <p>@selected</p>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupExceptionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupExceptionTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup T="char">
-    <MudRadio T="string" Option="@("10")" Dense="true" />
+    <MudRadio T="string" Value="@("10")" Dense="true" />
 </MudRadioGroup>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup T="string" Class="some-main-class" InputClass="some-input-class">
-    <MudRadio Option="@("1")" Placement="Placement.Left" />
-    <MudRadio Option="@("2")" Placement="Placement.Top" />
-    <MudRadio Option="@("3")" />
+    <MudRadio Value="@("1")" Placement="Placement.Left" />
+    <MudRadio Value="@("2")" Placement="Placement.Top" />
+    <MudRadio Value="@("3")" />
 </MudRadioGroup>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest2.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup @bind-SelectedOption="@option">
-    <MudRadio Option="@("1")" />
-    <MudRadio Option="@("2")" />
-    <MudRadio Option="@("3")" />
+<MudRadioGroup @bind-Value="@option">
+    <MudRadio Value="@("1")" />
+    <MudRadio Value="@("2")" />
+    <MudRadio Value="@("3")" />
 </MudRadioGroup>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest3.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup @bind-SelectedOption="@option">
-    <MudRadio Option="@("1")" />
-    <MudRadio Option="@("2")" />
+<MudRadioGroup @bind-Value="@option">
+    <MudRadio Value="@("1")" />
+    <MudRadio Value="@("2")" />
 </MudRadioGroup>
 
-<MudRadioGroup @bind-SelectedOption="@option">
-    <MudRadio Option="@("1")" />
-    <MudRadio Option="@("2")" />
+<MudRadioGroup @bind-Value="@option">
+    <MudRadio Value="@("1")" />
+    <MudRadio Value="@("2")" />
 </MudRadioGroup>
 
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest4.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup T="string" >
-    <MudRadio Option="@("1")" />
-    <MudRadio Option="@("2")" />
+    <MudRadio Value="@("1")" />
+    <MudRadio Value="@("2")" />
 </MudRadioGroup>
 
 <MudRadioGroup T="string" >
-    <MudRadio Option="@("x")" />
-    <MudRadio Option="@("y")" />
+    <MudRadio Value="@("x")" />
+    <MudRadio Value="@("y")" />
 </MudRadioGroup>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup @bind-SelectedOption="@option">
-    <MudRadio Option="@("1")" />
-    <MudRadio Option="@("2")" />
-    <MudRadio Option="@("3")" />
+<MudRadioGroup @bind-Value="@option">
+    <MudRadio Value="@("1")" />
+    <MudRadio Value="@("2")" />
+    <MudRadio Value="@("3")" />
 </MudRadioGroup>
 
 <MudButton OnClick="OnClick" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest6.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup @bind-SelectedOption="@option">
-    <MudRadio Option="@("1")" Dense="true" />
-    <MudRadio Option="@("2")" Size="Size.Small" />
-    <MudRadio Option="@("3")" />
-    <MudRadio Option="@("4")" Size="Size.Large" />
+<MudRadioGroup @bind-Value="@option">
+    <MudRadio Value="@("1")" Dense="true" />
+    <MudRadio Value="@("2")" Size="Size.Small" />
+    <MudRadio Value="@("3")" />
+    <MudRadio Value="@("4")" Size="Size.Large" />
 </MudRadioGroup>
 
 <MudButton OnClick="OnClick" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/MudSwitchTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/MudSwitchTest.razor
@@ -1,11 +1,11 @@
-﻿<MudSwitch @bind-Checked="@Label_Switch2"  T="bool" Disabled="true" Label="Disabled" />
-<MudSwitch @bind-Checked="@Label_Switch2"  T="bool" ReadOnly="true" Label="ReadOnly"  Color="Color.Success"  />
-<MudSwitch @bind-Checked="@Label_Switch2"  T="bool" DisableRipple="true" Label="Disabled Ripple" />
-<MudSwitch @bind-Checked="@Label_Switch2"  T="bool"  Label="Test" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Small" Size="Size.Small" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Medium" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Large" Size="Size.Large" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" Color="Color.Info" />
-<MudSwitch @bind-Checked="@Label_Switch2" T="bool" Label="Switches from small to large" Size="@(Label_Switch2 ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
+﻿<MudSwitch @bind-Value="@Label_Switch2"  T="bool" Disabled="true" Label="Disabled" />
+<MudSwitch @bind-Value="@Label_Switch2"  T="bool" ReadOnly="true" Label="ReadOnly"  Color="Color.Success"  />
+<MudSwitch @bind-Value="@Label_Switch2"  T="bool" DisableRipple="true" Label="Disabled Ripple" />
+<MudSwitch @bind-Value="@Label_Switch2"  T="bool"  Label="Test" />
+<MudSwitch @bind-Value="@Label_Switch2" T="bool" Label="Small" Size="Size.Small" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
+<MudSwitch @bind-Value="@Label_Switch2" T="bool" Label="Medium" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
+<MudSwitch @bind-Value="@Label_Switch2" T="bool" Label="Large" Size="Size.Large" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" Color="Color.Info" />
+<MudSwitch @bind-Value="@Label_Switch2" T="bool" Label="Switches from small to large" Size="@(Label_Switch2 ? Size.Small : Size.Large)" ThumbIcon="@Icons.Material.Filled.Favorite" ThumbIconColor="Color.Error" />
 
 
 @code{

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -26,12 +26,12 @@ namespace MudBlazor.UnitTests.Components
             var box = comp.Instance;
             var input = comp.Find("input");
             // check initial state
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
             // click and check if it has toggled
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
             input.Change(false);
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
         }
 
         /// <summary>
@@ -40,17 +40,17 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTest2()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>(ComponentParameter.CreateParameter("Checked", true));
+            var comp = Context.RenderComponent<MudCheckBox<bool>>(ComponentParameter.CreateParameter("Value", true));
             // select elements needed for the test
             var box = comp.Instance;
             var input = comp.Find("input");
             // check initial state
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
             // click and check if it has toggled
             input.Change(false);
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
         }
 
         /// <summary>
@@ -64,24 +64,24 @@ namespace MudBlazor.UnitTests.Components
             var boxes = comp.FindComponents<MudCheckBox<bool>>();
             var inputs = comp.FindAll("input");
             // check initial state
-            boxes[0].Instance.Checked.Should().Be(true);
-            boxes[1].Instance.Checked.Should().Be(true);
+            boxes[0].Instance.Value.Should().Be(true);
+            boxes[1].Instance.Value.Should().Be(true);
             // click and check if it has toggled
             inputs[0].Change(false);
-            boxes[0].Instance.Checked.Should().Be(false);
-            boxes[1].Instance.Checked.Should().Be(false);
+            boxes[0].Instance.Value.Should().Be(false);
+            boxes[1].Instance.Value.Should().Be(false);
             inputs = comp.FindAll("input");
             inputs[0].Change(true);
-            boxes[0].Instance.Checked.Should().Be(true);
-            boxes[1].Instance.Checked.Should().Be(true);
+            boxes[0].Instance.Value.Should().Be(true);
+            boxes[1].Instance.Value.Should().Be(true);
             inputs = comp.FindAll("input");
             inputs[1].Change(false);
-            boxes[0].Instance.Checked.Should().Be(false);
-            boxes[1].Instance.Checked.Should().Be(false);
+            boxes[0].Instance.Value.Should().Be(false);
+            boxes[1].Instance.Value.Should().Be(false);
             inputs = comp.FindAll("input");
             inputs[1].Change(true);
-            boxes[0].Instance.Checked.Should().Be(true);
-            boxes[1].Instance.Checked.Should().Be(true);
+            boxes[0].Instance.Value.Should().Be(true);
+            boxes[1].Instance.Value.Should().Be(true);
         }
 
         /// <summary>
@@ -119,18 +119,18 @@ namespace MudBlazor.UnitTests.Components
             var box = comp.Instance;
             var input = comp.Find("input");
             // check initial state
-            box.Checked.Should().Be(default);
+            box.Value.Should().Be(default);
             // click and check if it has toggled
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
             input.Change(false);
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
             // click and check if this is the indeterminate value
             input.Change(false);
-            box.Checked.Should().Be(default);
+            box.Value.Should().Be(default);
             // click and check if this is the true value
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
         }
 
         /// <summary>
@@ -194,43 +194,43 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var checkbox = comp.Instance;
-            checkbox.Checked.Should().Be(null);
+            checkbox.Value.Should().Be(null);
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
 
             //Backspace should not change state on non-tristate checkbox
             comp.SetParam(x => x.TriState, false);
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
             //Check tristate space key
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
 
             comp.SetParam("Disabled", true);
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(true));
         }
         /// <summary>
         /// Test if the keyboard-disabling switch works
@@ -244,43 +244,43 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var checkbox = comp.Instance;
-            checkbox.Checked.Should().Be(null);
+            checkbox.Value.Should().Be(null);
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             //Backspace should not change state on non-tristate checkbox
             comp.SetParam(x => x.TriState, null);
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
             //Check tristate space key
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
 
             comp.SetParam("Disabled", true);
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            comp.WaitForAssertion(() => checkbox.Checked.Should().Be(null));
+            comp.WaitForAssertion(() => checkbox.Value.Should().Be(null));
         }
 
         [Test]
@@ -302,12 +302,12 @@ namespace MudBlazor.UnitTests.Components
 
             var checkboxClasses = comp.Find(".mud-button-root.mud-icon-button");
             // check initial state
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
 
             // click and check if it has new color
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3127,22 +3127,22 @@ namespace MudBlazor.UnitTests.Components
             var switches = dataGrid.FindComponents<MudSwitch<bool>>();
             switches.Count.Should().Be(2);
 
-            switches[0].Instance.Checked.Should().BeFalse();
-            switches[1].Instance.Checked.Should().BeTrue();
+            switches[0].Instance.Value.Should().BeFalse();
+            switches[1].Instance.Value.Should().BeTrue();
 
             var buttons = dataGrid.FindComponents<MudButton>();
 
             // this is the hide all button
             buttons[0].Find("button").Click();
-            switches[0].Instance.Checked.Should().BeTrue();
-            switches[1].Instance.Checked.Should().BeTrue();
+            switches[0].Instance.Value.Should().BeTrue();
+            switches[1].Instance.Value.Should().BeTrue();
             // 2 columns, 2 hidden
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(0);
 
             // this is the show all button
             buttons[1].Find("button").Click();
-            switches[0].Instance.Checked.Should().BeFalse();
-            switches[1].Instance.Checked.Should().BeFalse();
+            switches[0].Instance.Value.Should().BeFalse();
+            switches[1].Instance.Value.Should().BeFalse();
             // 2 columns, 0 hidden
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(2);
         }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -92,13 +92,13 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should be invalid due to having a required field that is not filled
             form.IsValid.Should().Be(false);
             form.IsTouched.Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>()[0].Instance.Checked.Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>()[1].Instance.Checked.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>()[0].Instance.Value.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>()[1].Instance.Value.Should().Be(false);
             // filling in the required field
             textFields[1].Find("input").Change("Fill in the required field to make this form valid");
             form.IsValid.Should().Be(true);
-            comp.FindComponents<MudSwitch<bool>>()[0].Instance.Checked.Should().Be(true);
-            comp.FindComponents<MudSwitch<bool>>()[1].Instance.Checked.Should().Be(true);
+            comp.FindComponents<MudSwitch<bool>>()[0].Instance.Value.Should().Be(true);
+            comp.FindComponents<MudSwitch<bool>>()[1].Instance.Value.Should().Be(true);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace MudBlazor.UnitTests.Components
             var form = comp.FindComponent<MudForm>().Instance;
             // check initial state: form should be valid due to having no required field, but the user's two-way binding did override that value to false
             comp.WaitForAssertion(() => form.IsValid.Should().Be(true));
-            comp.WaitForAssertion(() => comp.FindComponent<MudSwitch<bool>>().Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.FindComponent<MudSwitch<bool>>().Instance.Value.Should().Be(true));
         }
 
         /// <summary>
@@ -459,9 +459,9 @@ namespace MudBlazor.UnitTests.Components
                 tf.Instance.Text.Should().NotBeNullOrEmpty();
             comp.FindComponent<MudTextField<int>>().Instance.Value.Should().Be(17);
             // then click the checkbox
-            comp.FindComponent<MudCheckBox<bool>>().Instance.Checked.Should().Be(true);
+            comp.FindComponent<MudCheckBox<bool>>().Instance.Value.Should().Be(true);
             comp.FindAll("input")[3].Change(false); // it was on before
-            comp.FindComponent<MudCheckBox<bool>>().Instance.Checked.Should().Be(false);
+            comp.FindComponent<MudCheckBox<bool>>().Instance.Value.Should().Be(false);
             // the text fields should be unchanged
             foreach (var tf in comp.FindComponents<MudTextField<string>>())
                 tf.Instance.Text.Should().NotBeNullOrEmpty();
@@ -569,7 +569,7 @@ namespace MudBlazor.UnitTests.Components
             textfields[2].Instance.Text.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => checkbox.Instance.HasErrors.Should().BeFalse());
             checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
-            comp.WaitForAssertion(() => checkbox.Instance.Checked.Should().BeFalse());
+            comp.WaitForAssertion(() => checkbox.Instance.Value.Should().BeFalse());
             // TODO: fill out the form with errors, field after field, check how fields get validation errors after blur
         }
 
@@ -1615,10 +1615,10 @@ namespace MudBlazor.UnitTests.Components
 
             var inputs = comp.FindAll("input").ToArray();
             // check initial state
-            radioGroup.SelectedOption.Should().Be(null);
+            radioGroup.Value.Should().Be(null);
             // click radio 1
             inputs[2].Click();
-            radioGroup.SelectedOption.Should().Be("1");
+            radioGroup.Value.Should().Be("1");
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("1");
             Assert.AreEqual(comp.Instance.FormFieldChangedEventArgs.Field, radioGroup);
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -42,34 +42,34 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input").ToArray();
             var spans = comp.FindAll("span.mud-radio-icons").ToArray();
             // check initial state
-            group.Instance.SelectedOption.Should().Be(null);
+            group.Instance.Value.Should().Be(null);
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
             // click radio 1
             inputs[0].Click();
-            group.Instance.SelectedOption.Should().Be("1");
+            group.Instance.Value.Should().Be("1");
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().Contain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
             // click radio 2
             inputs[1].Click();
-            group.Instance.SelectedOption.Should().Be("2");
+            group.Instance.Value.Should().Be("2");
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().Contain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
             // click radio 3
             inputs[2].Click();
-            group.Instance.SelectedOption.Should().Be("3");
+            group.Instance.Value.Should().Be("3");
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().Contain("mud-checked");
             // click radio 1
             inputs[0].Click();
-            group.Instance.SelectedOption.Should().Be("1");
+            group.Instance.Value.Should().Be("1");
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().Contain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
@@ -84,7 +84,7 @@ namespace MudBlazor.UnitTests.Components
             var group = comp.FindComponent<MudRadioGroup<string>>();
             var spans = comp.FindAll("span.mud-radio-icons").ToArray();
             // check initial state, should be initialized to second radio by default
-            group.Instance.SelectedOption.Should().Be("2");
+            group.Instance.Value.Should().Be("2");
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().Contain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
@@ -99,8 +99,8 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input").ToArray();
             var spans = comp.FindAll("span.mud-radio-icons").ToArray();
             // check initial state, should be initialized to second radio by default for both groups
-            groups[0].Instance.SelectedOption.Should().Be("2");
-            groups[1].Instance.SelectedOption.Should().Be("2");
+            groups[0].Instance.Value.Should().Be("2");
+            groups[1].Instance.Value.Should().Be("2");
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().Contain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
@@ -108,8 +108,8 @@ namespace MudBlazor.UnitTests.Components
             // click first radio of second group - they should both switch to L1
             inputs[2].Click();
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
-            groups[0].Instance.SelectedOption.Should().Be("1");
-            groups[1].Instance.SelectedOption.Should().Be("1");
+            groups[0].Instance.Value.Should().Be("1");
+            groups[1].Instance.Value.Should().Be("1");
             spans[0].ClassList.Should().Contain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().Contain("mud-checked");
@@ -117,8 +117,8 @@ namespace MudBlazor.UnitTests.Components
             // click second radio of first group - they should both switch to L1
             inputs[1].Click();
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
-            groups[0].Instance.SelectedOption.Should().Be("2");
-            groups[1].Instance.SelectedOption.Should().Be("2");
+            groups[0].Instance.Value.Should().Be("2");
+            groups[1].Instance.Value.Should().Be("2");
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().Contain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
@@ -134,8 +134,8 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input").ToArray();
             var spans = comp.FindAll("span.mud-radio-icons").ToArray();
             // check initial state, should be uninitialized
-            groups[0].Instance.SelectedOption.Should().Be(null);
-            groups[1].Instance.SelectedOption.Should().Be(null);
+            groups[0].Instance.Value.Should().Be(null);
+            groups[1].Instance.Value.Should().Be(null);
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
@@ -143,8 +143,8 @@ namespace MudBlazor.UnitTests.Components
             // click first radio of second group - only second group should switch to L1
             inputs[2].Click();
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
-            groups[0].Instance.SelectedOption.Should().Be(null);
-            groups[1].Instance.SelectedOption.Should().Be("x");
+            groups[0].Instance.Value.Should().Be(null);
+            groups[1].Instance.Value.Should().Be("x");
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().Contain("mud-checked");
@@ -152,8 +152,8 @@ namespace MudBlazor.UnitTests.Components
             // click second radio of first group - only first group should switch to L1
             inputs[1].Click();
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
-            groups[0].Instance.SelectedOption.Should().Be("2");
-            groups[1].Instance.SelectedOption.Should().Be("x");
+            groups[0].Instance.Value.Should().Be("2");
+            groups[1].Instance.Value.Should().Be("x");
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().Contain("mud-checked");
             spans[2].ClassList.Should().Contain("mud-checked");
@@ -169,20 +169,20 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input").ToArray();
             var spans = comp.FindAll("span.mud-radio-icons").ToArray();
             // check initial state
-            group.Instance.SelectedOption.Should().Be(null);
+            group.Instance.Value.Should().Be(null);
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
             // click radio 1
             inputs[0].Click();
-            group.Instance.SelectedOption.Should().Be("1");
+            group.Instance.Value.Should().Be("1");
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().Contain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
             spans[2].ClassList.Should().NotContain("mud-checked");
             // click reset button
             comp.Find("button").Click();
-            group.Instance.SelectedOption.Should().Be(null);
+            group.Instance.Value.Should().Be(null);
             spans = comp.FindAll("span.mud-radio-icons").ToArray();
             spans[0].ClassList.Should().NotContain("mud-checked");
             spans[1].ClassList.Should().NotContain("mud-checked");
@@ -220,13 +220,13 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var radio = comp.FindComponent<MudRadioGroup<string>>();
-            radio.Instance.SelectedOption.Should().Be(null);
+            radio.Instance.Value.Should().Be(null);
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            comp.WaitForAssertion(() => radio.Instance.SelectedOption.Should().Be("1"));
+            comp.WaitForAssertion(() => radio.Instance.Value.Should().Be("1"));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            comp.WaitForAssertion(() => radio.Instance.SelectedOption.Should().Be(null));
+            comp.WaitForAssertion(() => radio.Instance.Value.Should().Be(null));
 
             //Can't tabbed around the radios in test.
         }
@@ -242,10 +242,10 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => radio.Instance.OnClickAsync());
 #pragma warning disable BL0005
             await comp.InvokeAsync(() => radio.Instance.Disabled = true);
-            comp.WaitForAssertion(() => group.Instance.SelectedOption.Should().Be(null));
+            comp.WaitForAssertion(() => group.Instance.Value.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            comp.WaitForAssertion(() => group.Instance.SelectedOption.Should().Be(null));
+            comp.WaitForAssertion(() => group.Instance.Value.Should().Be(null));
         }
 
 
@@ -302,7 +302,7 @@ namespace MudBlazor.UnitTests.Components
         /// Tests the Readonly property of the MudRadioGroup
         /// </summary>
         [Test]
-        public async Task RadioGroupReadOnlyTest()
+        public void RadioGroupReadOnlyTest()
         {
             var comp = Context.RenderComponent<RadioReadOnlyDisabledExample>();
             var radioGroup = comp.FindComponents<MudRadioGroup<string>>()[0];

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -90,9 +90,9 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("1"));
             //Check user on blur implementation works
             var @switch = comp.FindComponent<MudSwitch<bool>>();
-            @switch.Instance.Checked = true;
+            @switch.Instance.Value = true;
             await comp.InvokeAsync(() => select.Instance.OnBlurAsync(new FocusEventArgs()));
-            comp.WaitForAssertion(() => @switch.Instance.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => @switch.Instance.Value.Should().Be(false));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -20,29 +20,29 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudSwitch<bool>>();
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(false));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
 
             comp.SetParam("Disabled", true);
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            comp.WaitForAssertion(() => comp.Instance.Checked.Should().Be(true));
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
         }
 
         [Test]
@@ -64,12 +64,12 @@ namespace MudBlazor.UnitTests.Components
 
             var checkboxClasses = comp.Find(".mud-button-root.mud-icon-button.mud-switch-base");
             // check initial state
-            box.Checked.Should().Be(false);
+            box.Value.Should().Be(false);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
 
             // click and check if it has new color
             input.Change(true);
-            box.Checked.Should().Be(true);
+            box.Value.Should().Be(true);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -654,12 +654,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -687,12 +687,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -710,15 +710,15 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(1); // selected items should be empty
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(1);
-            checkboxes[0].Checked.Should().Be(false);
-            checkboxes[1].Checked.Should().Be(true);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(1);
+            checkboxes[0].Value.Should().Be(false);
+            checkboxes[1].Value.Should().Be(true);
             // uncheck it
             checkboxRendered[1].Find("input").Change(false);
             // check result
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -736,13 +736,13 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             // uncheck only row 1 => header checkbox should be off then
             checkboxRendered[2].Find("input").Change(false);
-            checkboxes[0].Checked.Should().Be(true); // header checkbox should be on
+            checkboxes[0].Value.Should().Be(true); // header checkbox should be on
             table.SelectedItems.Count.Should().Be(2);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(2);
         }
 
         /// <summary>
@@ -760,15 +760,15 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(4);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(2);
             // uncheck a row then switch to page 2 and both checkboxes on page 2 should be checked
             checkboxRendered[1].Find("input").Change(false);
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(1);
             // switch page 
             await comp.InvokeAsync(() => table.CurrentPage = 1);
             // now two checkboxes should be checked on page 2
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(2);
         }
 
         /// <summary>
@@ -796,12 +796,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[4].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[4].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -829,12 +829,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[4].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[4].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -864,7 +864,7 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(1);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }"); // only "1" should be present
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(1);
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
@@ -876,11 +876,11 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }"); // we reset search, so all three numbers should be searched
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3);
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -899,7 +899,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Change(true);
             table.SelectedItems.Count.Should().Be(5);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3, 4 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(5);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(5);
 
             // click delete button
             var buttons = comp.FindAll("button");
@@ -918,9 +918,9 @@ namespace MudBlazor.UnitTests.Components
             //verify selection
             table.SelectedItems.Count.Should().Be(4);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 3, 4 }");
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(4);
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(4);
 
-            checkboxes[0].Checked.Should().BeTrue(); //manually verify header is checked after deleting item
+            checkboxes[0].Value.Should().BeTrue(); //manually verify header is checked after deleting item
         }
 
         /// <summary>
@@ -2057,7 +2057,7 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
 
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3); //there should be 3 items
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3); //there should be 3 items
             comp.Find("p").TextContent.Should().Be("Elements { A, B, C }");
 
             // Click on the second row
@@ -2070,13 +2070,13 @@ namespace MudBlazor.UnitTests.Components
 
             table.SelectedItems.Count.Should().Be(3);
 
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3); //there should be 3 items
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(3); //there should be 3 items
             comp.Find("p").TextContent.Should().Be("Elements { A, Change, C }");
 
             // Uncheck and verify that all items are removed
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
-            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0); //there should be 4 items
+            checkboxes.Sum(x => x.Value ? 1 : 0).Should().Be(0); //there should be 4 items
             comp.Find("p").TextContent.Should().Be("Elements {  }");
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -36,12 +37,28 @@ namespace MudBlazor
         /// <summary>
         /// The state of the component
         /// </summary>
+        [Obsolete("Use Value instead.")]
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
         public T? Checked
         {
             get => _value;
             set => _value = value;
+        }
+
+        /// <summary>
+        /// The state of the component
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Data)]
+        public T? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                
+            }
         }
 
         /// <summary>
@@ -52,12 +69,19 @@ namespace MudBlazor
         public bool StopClickPropagation { get; set; } = true;
 
         /// <summary>
+        /// Fired when Value changes.
+        /// </summary>
+        [Parameter]
+        public EventCallback<T?> ValueChanged { get; set; }
+
+        /// <summary>
         /// Fired when Checked changes.
         /// </summary>
+        [Obsolete("Use ValueChanged instead.")]
         [Parameter]
         public EventCallback<T?> CheckedChanged { get; set; }
 
-        protected bool? BoolValue => Converter.Set(Checked);
+        protected bool? BoolValue => Converter.Set(Value);
 
         protected virtual Task OnChange(ChangeEventArgs args)
         {
@@ -74,12 +98,14 @@ namespace MudBlazor
         {
             if (GetDisabledState())
                 return;
-            if (!EqualityComparer<T>.Default.Equals(Checked, value))
+            if (!EqualityComparer<T>.Default.Equals(Value, value))
             {
+                Value = value;
+                await ValueChanged.InvokeAsync(value);
                 Checked = value;
                 await CheckedChanged.InvokeAsync(value);
                 await BeginValidateAsync();
-                FieldChanged(Checked);
+                FieldChanged(Value);
             }
         }
 
@@ -87,7 +113,7 @@ namespace MudBlazor
         {
             var changed = base.SetConverter(value);
             if (changed)
-                SetBoolValueAsync(Converter.Set(Checked)).AndForget();
+                SetBoolValueAsync(Converter.Set(Value)).AndForget();
 
             return changed;
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -90,7 +90,7 @@
                                     @foreach (var column in RenderedColumns)
                                     {
                                         <MudItem xs="12">
-                                            <MudSwitch T="bool" Disabled="@(!(column.Hideable ?? false))" Checked="@column.Hidden" CheckedChanged="@column.ToggleAsync" Converter="_oppositeBoolConverter" Color="Color.Primary" Label="@column.Title" />
+                                            <MudSwitch T="bool" Disabled="@(!(column.Hideable ?? false))" Value="@column.Hidden" ValueChanged="@column.ToggleAsync" Converter="_oppositeBoolConverter" Color="Color.Primary" Label="@column.Title" />
                                         </MudItem>
                                     }
                                     <MudItem xs="6">

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -6,16 +6,16 @@
     <HeaderTemplate>
         @if (ShowInHeader)
         {
-            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAllAsync" />
+            <MudCheckBox T="bool" Size="@Size" Value="@context.IsAllSelected" ValueChanged="@context.Actions.SetSelectAllAsync" />
         }
     </HeaderTemplate>
     <CellTemplate>
-        <MudCheckBox T="bool" Size="@Size" Checked="@context.IsSelected" CheckedChanged="@context.Actions.SetSelectedItemAsync" />
+        <MudCheckBox T="bool" Size="@Size" Value="@context.IsSelected" ValueChanged="@context.Actions.SetSelectedItemAsync" />
     </CellTemplate>
     <FooterTemplate>
         @if (ShowInFooter)
         {
-            <MudCheckBox T="bool" Size="@Size" Checked="@context.IsAllSelected" CheckedChanged="@context.Actions.SetSelectAllAsync" />
+            <MudCheckBox T="bool" Size="@Size" Value="@context.IsAllSelected" ValueChanged="@context.Actions.SetSelectAllAsync" />
         }
     </FooterTemplate>
 </TemplateColumn>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -100,7 +100,25 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Radio.Behavior)]
-        public T? Option { get; set; }
+        public T? Value { get; set; }
+
+        /// <summary>
+        /// The value to associate to the button.
+        /// </summary>
+        [Obsolete("Use Value instead.")]
+        [Parameter]
+        [Category(CategoryTypes.Radio.Behavior)]
+        public T? Option
+        {
+            get
+            {
+                return Option;
+            }
+            set
+            {
+                Value = value;
+            }
+        }
 
         /// <summary>
         /// If true, compact padding will be applied.

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -71,12 +71,25 @@ namespace MudBlazor
 
         [Parameter]
         [Category(CategoryTypes.Radio.Data)]
+        public T? Value
+        {
+            get => _value;
+            set => SetSelectedOptionAsync(value, true).AndForget();
+        }
+
+        [Parameter]
+        public EventCallback<T> ValueChanged { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.Radio.Data)]
+        [Obsolete("Use Value instead.")]
         public T? SelectedOption
         {
             get => _value;
             set => SetSelectedOptionAsync(value, true).AndForget();
         }
 
+        [Obsolete("Use ValueChanged instead.")]
         [Parameter]
         public EventCallback<T> SelectedOptionChanged { get; set; }
 
@@ -92,10 +105,11 @@ namespace MudBlazor
 
                 if (updateRadio)
                 {
-                    var radio = _radios.FirstOrDefault(r => OptionEquals(r.Option, _value));
+                    var radio = _radios.FirstOrDefault(r => OptionEquals(r.Value, _value));
                     await SetSelectedRadioAsync(radio, false);
                 }
 
+                await ValueChanged.InvokeAsync(_value);
                 await SelectedOptionChanged.InvokeAsync(_value);
 
                 await BeginValidateAsync();
@@ -131,7 +145,7 @@ namespace MudBlazor
 
                 if (updateOption)
                 {
-                    await SetSelectedOptionAsync(GetOptionOrDefault(_selectedRadio), false);
+                    await SetSelectedOptionAsync(GetValueOrDefault(_selectedRadio), false);
                 }
             }
         }
@@ -142,7 +156,7 @@ namespace MudBlazor
 
             if (_selectedRadio is null)
             {
-                if (OptionEquals(radio.Option, _value))
+                if (OptionEquals(radio.Value, _value))
                 {
                     return SetSelectedRadioAsync(radio, false);
                 }
@@ -184,9 +198,9 @@ namespace MudBlazor
             return base.ResetValueAsync();
         }
 
-        private static T? GetOptionOrDefault(MudRadio<T>? radio)
+        private static T? GetValueOrDefault(MudRadio<T>? radio)
         {
-            return radio is not null ? radio.Option : default;
+            return radio is not null ? radio.Value : default;
         }
 
         private static bool OptionEquals(T? option1, T? option2)

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor
@@ -16,7 +16,7 @@
             }
             @if (IsCheckable)
             {
-                <MudCheckBox @bind-Checked="IsChecked" Class="mud-table-cell-checkbox"/>
+                <MudCheckBox @bind-Value="IsChecked" Class="mud-table-cell-checkbox"/>
             }
         </MudTd>
     }

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor
@@ -18,7 +18,7 @@
 			}
 			@if (IsCheckable)
 			{
-				<MudCheckBox @bind-Checked="IsChecked" Class="mud-table-cell-checkbox" />
+				<MudCheckBox @bind-Value="IsChecked" Class="mud-table-cell-checkbox" />
 			}
 		</MudTh>
 	}

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -24,7 +24,7 @@
                 }
                 @if (IsCheckable)
                 {
-                    <MudCheckBox T="bool?" @bind-Checked="IsChecked" Class="mud-table-cell-checkbox"/>
+                    <MudCheckBox T="bool?" @bind-Value="IsChecked" Class="mud-table-cell-checkbox"/>
                 }
             </div>
         </MudTd>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -40,7 +40,7 @@
             <div class="d-flex" style="@ActionsStylename">
                 @if (IsCheckable)
                 {
-                    <MudCheckBox @bind-Checked="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
+                    <MudCheckBox @bind-Value="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
                 }
             </div>
         </MudElement>


### PR DESCRIPTION
The boolean inputs (CheckBox and Switch) had `Checked` parameter.

And the RadioGroup had `SelectedOption` and the Radio had `Option` parameter.

Changed all parameter names to `Value` and obsolete the other ones.

Tested Both with old parameters and new parameters.

Test, testviewer and docs projects updated with new parameter.