### PR TITLE
MudOverlay: Update auto close to only close when the background is clicked

### DIFF
--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor
@@ -3,14 +3,14 @@
 
 @if (Visible)
 {
-    <div @attributes="UserAttributes" class="@Classname" style="@Styles" @onclick="OnClickHandlerAsync" @onclick:stopPropagation="true">
+    <div @attributes="UserAttributes" class="@Classname" style="@Styles" @onclick="OnClickBackgroundHandlerAsync" @onclick:stopPropagation="true">
         @if(LightBackground || DarkBackground)
         {
             <div class="@ScrimClassname"></div>
         }
         @if(ChildContent is not null)
         {
-            <div class="mud-overlay-content">
+            <div class="mud-overlay-content"  @onclick="OnClickOverlayHandlerAsync" @onclick:stopPropagation="true">
                 @ChildContent
             </div>
         }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -134,10 +134,15 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-        protected internal async Task OnClickHandlerAsync(MouseEventArgs ev)
+        protected internal async Task OnClickBackgroundHandlerAsync(MouseEventArgs ev)
         {
             if (AutoClose)
                 Visible = false;
+            await BaseOnClickHandlerAsync(ev);
+        }
+
+        private async Task BaseOnClickHandlerAsync(MouseEventArgs ev)
+        {
             await OnClick.InvokeAsync(ev);
 #pragma warning disable CS0618
             if (Command?.CanExecute(CommandParameter) ?? false)
@@ -145,6 +150,11 @@ namespace MudBlazor
                 Command.Execute(CommandParameter);
             }
 #pragma warning restore CS0618
+        }
+
+        protected internal async Task OnClickOverlayHandlerAsync(MouseEventArgs ev)
+        {
+            await BaseOnClickHandlerAsync(ev);
         }
 
         //if not visible or CSS `position:absolute`, don't lock scroll


### PR DESCRIPTION
## Description
I don't know if this is intended behavior but auto close, will close the overlay even if you click on the child component. I put in a dirty work around, could add a separate flag instead something like "AutoCloseOnBackground". Just want to chat about it before going either way.

This the functionality after this change:

![example-overlay](https://github.com/MudBlazor/MudBlazor/assets/9060893/ead12cb2-e579-4fab-bd89-f781fe663d87)

## How Has This Been Tested?
Will add tests after the design has been discussed

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Put as a bug but will change to feature depending on the discussion outcome.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
