### PR TITLE
Build:  CS1998 async lacks await fix warnings

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesWatchSystemPreferenceExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesWatchSystemPreferenceExample.razor
@@ -16,9 +16,10 @@
         }
     }
     
-    private async Task OnSystemPreferenceChanged(bool newValue)
+    private Task OnSystemPreferenceChanged(bool newValue)
     {
         _isDarkMode = newValue;
         StateHasChanged();
+        return Task.CompletedTask;
     }
 }

--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -59,7 +59,7 @@ public class LayoutService
         }
     }
 
-    public async Task OnSystemPreferenceChanged(bool newValue)
+    public Task OnSystemPreferenceChanged(bool newValue)
     {
         _systemPreferences = newValue;
         if (DarkModeToggle == DarkLightMode.System)
@@ -67,6 +67,7 @@ public class LayoutService
             IsDarkMode = newValue;
             OnMajorUpdateOccured();
         }
+        return Task.CompletedTask;
     }
 
     public event EventHandler MajorUpdateOccured;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
@@ -1,4 +1,5 @@
-﻿@namespace MudBlazor.UnitTests.TestComponents
+﻿@using System.Threading
+@namespace MudBlazor.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 <MudAutocomplete @ref="_selectAsync"
                  T="string"
@@ -27,9 +28,9 @@
         await _selectAsync.ResetAsync();
     }
 
-    private async Task SomeTask()
+    private Task SomeTask()
     {
-        //await Task.Delay(5);
+        return Task.CompletedTask;
     }
 
     private Task<IEnumerable<string>> Search(string value)

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -655,7 +655,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DateRangePicker_Should_Clear()
+        public void DateRangePicker_Should_Clear()
         {
             var comp = Context.RenderComponent<MudDateRangePicker>();
             // select elements needed for the test

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -314,10 +314,12 @@ namespace MudBlazor.UnitTests.Components
         }
 
         private bool _systemMockValue;
-        private async Task SystemChangedResult(bool newValue)
+        private Task SystemChangedResult(bool newValue)
         {
             _systemMockValue = newValue;
+            return Task.CompletedTask;
         }
+
         [Test]
         public async Task WatchSystemTest()
         {

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 namespace MudBlazor
 {
 #nullable enable
+#pragma warning disable CS1998
     [Obsolete("This will be removed in v7.")]
     public enum TaskOption
     {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
- I suppress all the `AndForget` extensions. I can't see a better option without bubbling up lack of awaits into user code.
- For examples I removed async but kept the method signature the same by returning `Task.Completed` task.
- `LayoutService.OnSystemPreferenceChanged`needs to conform to the method signature in `ThemeProvider` so even though its synchronous I used the same methodology there.

@ScarletKuro let me know if you think there's a better way.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Build to check warnings are gone.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
