### PR TITLE
Build: Suppress IL2075 trimming warning

### DIFF
--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -652,7 +652,12 @@ namespace MudBlazor
                 // Sourced from https://stackoverflow.com/a/43076222/4839162
                 // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
                 var expression = (MemberExpression)For.Body;
+
+                // Currently we have no solution for this which is trimming incompatible
+                // A possible solution is to use source gen
+#pragma warning disable IL2075
                 var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);
+#pragma warning restore IL2075                
                 _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
                 _fieldIdentifier = FieldIdentifier.Create(For);

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -33,8 +33,12 @@ namespace MudBlazor
         public static string GetLabelString<T>(this Expression<Func<T>> expression)
         {
             var memberExpression = (MemberExpression)expression.Body;
-            var propertyInfo = memberExpression.Expression?.Type.GetProperty(memberExpression.Member.Name);
 
+            // Currently we have no solution for this which is trimming incompatible
+            // A possible solution is to use source gen
+#pragma warning disable IL2075
+            var propertyInfo = memberExpression.Expression?.Type.GetProperty(memberExpression.Member.Name);
+#pragma warning restore IL2075
             return propertyInfo?.GetCustomAttributes(typeof(LabelAttribute), true).Cast<LabelAttribute>().FirstOrDefault()?.Name ?? string.Empty;
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Suppress trimming warning.
`IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.`
Currently we don't have a solution for this and we want to turn `TreatWarningsAsErrors` back on so we have to `#pragma`

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Build to check warnings gone.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
