### PR TITLE
feat: Prevent multiple dotnet restore executions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.403",
+      "version": "8.0.100",
       "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": {
-      "version": "8.0.100",
-      "rollForward": "latestFeature"
-    }
-}

--- a/src/MudBlazor.Docs/.config/dotnet-tools.json
+++ b/src/MudBlazor.Docs/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "3.5.44",
+      "version": "3.5.79",
       "commands": [
         "webcompiler"
       ]

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -89,12 +89,7 @@
     <ProjectReference Include="..\MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <!--Excubo  webcompiler -  used for scss and js compilation-->
-  <Target Name="ToolRestore">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
-  </Target>
-
-  <Target Name="WebCompiler" DependsOnTargets="ToolRestore">
+  <Target Name="WebCompiler">
     <Exec Command="dotnet webcompiler ./Styles/MudBlazorDocs.scss -c excubowebcompiler.json" StandardOutputImportance="high" StandardErrorImportance="high" />
   </Target>
 

--- a/src/MudBlazor.SourceCodeGenerator/MudBlazor.SourceCodeGenerator.csproj
+++ b/src/MudBlazor.SourceCodeGenerator/MudBlazor.SourceCodeGenerator.csproj
@@ -17,4 +17,10 @@
     <InternalsVisibleTo Include="MudBlazor.UnitTests" />
   </ItemGroup>
 
+<!--  Run `dotnet tool restore` in a single target framework project to prevent multiple executions.-->
+  <Target Name="ToolRestore" BeforeTargets="PreBuildEvent">
+    <Exec Command="dotnet tool restore --tool-manifest ../MudBlazor/.config/dotnet-tools.json" StandardOutputImportance="high" />
+    <Exec Command="dotnet tool restore --tool-manifest ../MudBlazor.Docs/.config/dotnet-tools.json" StandardOutputImportance="high" />
+  </Target>
+  
 </Project>

--- a/src/MudBlazor/.config/dotnet-tools.json
+++ b/src/MudBlazor/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "3.5.44",
+      "version": "3.5.79",
       "commands": [
         "webcompiler"
       ]

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -69,10 +69,6 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.14" />
   </ItemGroup>
 
-  <Target Name="ToolRestore">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
-  </Target>
-
   <!--combine js files-->
   <Target Name="CombineJS">
     <CreateItem Include="./TScripts/*.js">
@@ -84,7 +80,7 @@
     <WriteLinesToFile File="./TScripts/combined/MudBlazor.js" Lines="@(jsLines)" Overwrite="true" />
   </Target>
 
-  <Target Name="WebCompiler" DependsOnTargets="ToolRestore;CombineJS">
+  <Target Name="WebCompiler" DependsOnTargets="CombineJS">
     <!--compile and minify scss-->
     <Exec Command="dotnet webcompiler ./Styles/MudBlazor.scss -c excubowebcompiler.json" StandardOutputImportance="high" StandardErrorImportance="high" />
     <!--minify js-->


### PR DESCRIPTION
This approach runs the `dotnet tool restore` command in the SourceGenerator project because it's a single-target-framework project. The command runs sequentially for MudBlazor and MudBlazor.Docs project.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
