### PR TITLE
mudHelpers.js: Add missing closing bracket

### DIFF
--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -13,7 +13,7 @@ window.getTabbableElements = (element) => {
         "iframe:not([tabindex='-1'])," +
         "details:not([tabindex='-1'])," +
         "[tabindex]:not([tabindex='-1'])," +
-        "[contentEditable=true]:not([tabindex='-1']"
+        "[contentEditable=true]:not([tabindex='-1'])"
     );
 };
 


### PR DESCRIPTION
A super simple fix adding a closing bracket in mudHelpers.js that cause an error on safari iPad

line 16 from:

`"[contentEditable=true]:not([tabindex='-1']"`

to

`"[contentEditable=true]:not([tabindex='-1'])"`



## Description
It's really strange that this is not causing errors on most other browsers (and that no one noticed it before), but it does cause an error on iPad. 
For the love of the code, no brackets should be left alone!

## How Has This Been Tested?
Tested on major browser on desktop, iPad, iPhone and Android

## Types of changes
Just added a bracket at the end of line n° 16

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
