### PR TITLE
DataGrid: Fix ignored update of ".Hidden" property for Columns

### DIFF
--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -77,7 +77,18 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool? Hideable { get; set; }
 
-        [Parameter] public bool Hidden { get; set; }
+        [Parameter] public bool Hidden 
+        {
+            get => hidden;
+            set
+            {
+                if (hidden != value)
+                {
+                    hidden = value;
+                    HiddenChanged.InvokeAsync(hidden);
+                }
+            }
+        }
         [Parameter] public EventCallback<bool> HiddenChanged { get; set; }
 
         /// <summary>
@@ -303,7 +314,6 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            hidden = Hidden;
             groupBy = GroupBy;
 
             if (groupable && Grouping)


### PR DESCRIPTION
## Description
`Hidden` public property was only used for first Initialization in method `OnInitialized()` of abstract `Column` class.

##Changes
Following line was removed from `OnInitialized()`:
`hidden = Hidden;`

Following property:

`[Parameter] public bool Hidden { get; set; }`

was replaced to
```
        [Parameter] public bool Hidden 
        {
            get => hidden;
            set
            {
                if (hidden != value)
                {
                    hidden = value;
                    HiddenChanged.InvokeAsync(hidden);
                }
            }
        }
```

## How Has This Been Tested?
Existing test "DataGridColumnHiddenTest" passed.
With binding `<MudSwitch>` to `Hidden` property.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
