### PR TITLE
MudToggleGroup: Rename SelectedValues and warn if misconfigured

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleSelectionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleSelectionsExample.razor
@@ -16,7 +16,7 @@
     <MudStack>
         <MudText>Multi Selection</MudText>
         <MudText>Values: @string.Join(", ", _value2 ?? new List<string>())</MudText>
-        <MudToggleGroup T="string" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="_value2" Color="Color.Secondary" CheckMark>
+        <MudToggleGroup T="string" SelectionMode="SelectionMode.MultiSelection" @bind-Values="_value2" Color="Color.Secondary" CheckMark>
             <MudToggleItem Value="@("Extra Bag")" UnselectedIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" SelectedIcon="@Icons.Material.Filled.CheckBox"/>
             <MudToggleItem Value="@("Vegan Menu")" UnselectedIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" SelectedIcon="@Icons.Material.Filled.CheckBox" />
             <MudToggleItem Value="@("Carbon Offset")" UnselectedIcon="@Icons.Material.Filled.CheckBoxOutlineBlank" SelectedIcon="@Icons.Material.Filled.CheckBox" />

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
@@ -49,7 +49,10 @@
                         You must set the <CodeInline>Value</CodeInline> property of each item to a unique value or the selection
                         won't work. Also, the type of the item's value must match the group's <CodeInline>T</CodeInline> parameter.
                     </MudAlert>
-
+                    <MudAlert Severity="Severity.Info" Class="mt-3">
+                        Make sure to bind the toggle group's <CodeInline>Value</CodeInline> property in single- and toggle-selection mode 
+                        and <CodeInline>SelectedValues</CodeInline> with multi-selection.
+                    </MudAlert>
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(ToggleSelectionsExample)" ShowCode="false">

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
@@ -28,7 +28,7 @@
                     the <CodeInline>FixedContent</CodeInline> parameter to counterbalance the checkmark with padding on the right.
                     <MudAlert Severity="Severity.Info" Class="mt-3">
                         If you don't set the <CodeInline>Text</CodeInline> property the items will simply show the 
-                        <CodeInline>Value</CodeInline> if <CodeInline>ShowText</CodeInline> is <CodeInline>true</CodeInline>.
+                        <CodeInline>Value</CodeInline> if you didn't define the child content of a <CodeInline>MudToggleItem</CodeInline>.
                     </MudAlert>
                 </Description>
             </SectionHeader>
@@ -51,7 +51,7 @@
                     </MudAlert>
                     <MudAlert Severity="Severity.Info" Class="mt-3">
                         Make sure to bind the toggle group's <CodeInline>Value</CodeInline> property in single- and toggle-selection mode 
-                        and <CodeInline>SelectedValues</CodeInline> with multi-selection.
+                        and <CodeInline>Values</CodeInline> with multi-selection.
                     </MudAlert>
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Toggle/ToggleBindMultiSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Toggle/ToggleBindMultiSelectionTest.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudToggleGroup @bind-SelectedValues="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
+<MudToggleGroup @bind-Values="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
     <MudToggleItem T="string" Value="@("Item One")" Text="Item One" />
     <MudToggleItem T="string" Value="@("Item Two")" Text="Item Two" />
     <MudToggleItem T="string" Value="@("Item Three")" Text="Item Three" />
 </MudToggleGroup>
 
-<MudToggleGroup @bind-SelectedValues="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
+<MudToggleGroup @bind-Values="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
     <MudToggleItem T="string" Value="@("Item One")" Text="Item One" />
     <MudToggleItem T="string" Value="@("Item Two")" Text="Item Two" />
     <MudToggleItem T="string" Value="@("Item Three")" Text="Item Three" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Toggle/ToggleInitializeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Toggle/ToggleInitializeTest.razor
@@ -6,7 +6,7 @@
     <MudToggleItem T="string" Value="@("Item Three")" Text="Item Three" />
 </MudToggleGroup>
 
-<MudToggleGroup @bind-SelectedValues="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
+<MudToggleGroup @bind-Values="_values" T="string" Color="Color.Primary" SelectionMode="SelectionMode.MultiSelection">
     <MudToggleItem T="string" Value="@("Item One")" Text="Item One" />
     <MudToggleItem T="string" Value="@("Item Two")" Text="Item Two" />
     <MudToggleItem T="string" Value="@("Item Three")" Text="Item Three" />

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AngleSharp.Common;
@@ -101,9 +102,9 @@ namespace MudBlazor.UnitTests.Components
             toggleItem.Click();
             toggle.Instance.Value.Should().BeNull();
         }
-        
+
         [Test]
-        public  async Task ToggleGroup_HorizontalItemPadding_Test()
+        public async Task ToggleGroup_HorizontalItemPadding_Test()
         {
             var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
             {
@@ -153,9 +154,9 @@ namespace MudBlazor.UnitTests.Components
             // (_|_|x)
             item3.ClassList.Should().Contain("pe-3");
             item3.ClassList.Should().Contain("ps-2");
-            item3.ClassList.Should().Contain("py-2");            
+            item3.ClassList.Should().Contain("py-2");
         }
-        
+
         [Test]
         public async Task ToggleGroup_VerticalItemPadding_Test()
         {
@@ -210,7 +211,7 @@ namespace MudBlazor.UnitTests.Components
             item3.ClassList.Should().Contain("pt-2");
             item3.ClassList.Should().Contain("px-2");
         }
-        
+
         [Test]
         public void ToggleGroup_CustomClasses_Test()
         {
@@ -219,7 +220,7 @@ namespace MudBlazor.UnitTests.Components
                 builder.Add(x => x.CheckMarkClass, "c69");
                 builder.Add(x => x.TextClass, "c42");
                 builder.Add(x => x.CheckMark, true);
-                builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a").Add(x=>x.UnselectedIcon, @Icons.Material.Filled.Coronavirus));
+                builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a").Add(x => x.UnselectedIcon, @Icons.Material.Filled.Coronavirus));
             });
             var icon = comp.Find("svg");
             icon.ClassList.Should().Contain("c69");
@@ -227,7 +228,7 @@ namespace MudBlazor.UnitTests.Components
             var text = comp.Find(".mud-typography");
             text.ClassList.Should().Contain("c42");
         }
-                
+
         [Test]
         public void ToggleItem_IsEmpty_Test()
         {
@@ -238,7 +239,7 @@ namespace MudBlazor.UnitTests.Components
             new MudToggleItem<string>() { Text = null, Value = "a" }.IsEmpty.Should().Be(false);
 #pragma warning restore BL0005
         }
-        
+
         [Test]
         public void ToggleGroup_ItemRegistration_Test()
         {
@@ -254,6 +255,32 @@ namespace MudBlazor.UnitTests.Components
             // re-registering an item won't do nothing
             comp.Instance.Register(comp.Instance.GetItems().First());
             comp.Instance.GetItems().Count().Should().Be(3);
+        }
+
+        [Test]
+        public void ToggleGroup_Exception_Test()
+        {
+            foreach (var mode in new[] { SelectionMode.SingleSelection, SelectionMode.ToggleSelection })
+            {
+                Assert.Catch<ArgumentException>(() =>
+                    {
+                        Action<IEnumerable<string>> callback = _ => { };
+                        Context.RenderComponent<MudToggleGroup<string>>(builder =>
+                        {
+                            builder.Add(x => x.SelectionMode, mode);
+                            builder.Add(x => x.SelectedValuesChanged, callback);
+                        });
+                    }, $"For SelectionMode {mode} you should bind {nameof(MudToggleGroup<string>.Value)} instead of {nameof(MudToggleGroup<string>.SelectedValues)}");
+            }
+            Assert.Catch<ArgumentException>(() =>
+                {
+                    Action<string> callback = _ => { };
+                    Context.RenderComponent<MudToggleGroup<string>>(builder =>
+                    {
+                        builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
+                        builder.Add(x => x.ValueChanged, callback);
+                    });
+                }, $"For SelectionMode {SelectionMode.MultiSelection} you should bind {nameof(MudToggleGroup<string>.SelectedValues)} instead of {nameof(MudToggleGroup<string>.Value)}");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -261,7 +261,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ToggleGroup_Exception_Test()
+        public void ToggleGroup_SelectionModeWarning_Test()
         {
             var provider = new MockLoggerProvider();
             var logger = provider.CreateLogger(GetType().FullName!) as MockLogger;

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -60,17 +60,17 @@ namespace MudBlazor.UnitTests.Components
             var toggleItemSecond = comp.FindAll("div.mud-toggle-item").GetItemByIndex(1);
             var toggleItemThird = comp.FindAll("div.mud-toggle-item").GetItemByIndex(2);
 
-            group1.Instance.SelectedValues.Should().BeNull();
-            group2.Instance.SelectedValues.Should().BeNull();
+            group1.Instance.Values.Should().BeNull();
+            group2.Instance.Values.Should().BeNull();
             toggleItemSecond.Click();
-            group1.Instance.SelectedValues.Should().Contain("Item Two");
-            group2.Instance.SelectedValues.Should().Contain("Item Two");
+            group1.Instance.Values.Should().Contain("Item Two");
+            group2.Instance.Values.Should().Contain("Item Two");
             toggleItemThird.Click();
-            group1.Instance.SelectedValues.Should().BeEquivalentTo("Item Two", "Item Three");
-            group2.Instance.SelectedValues.Should().Contain("Item Three");
+            group1.Instance.Values.Should().BeEquivalentTo("Item Two", "Item Three");
+            group2.Instance.Values.Should().Contain("Item Three");
             toggleItemSecond.Click();
-            group1.Instance.SelectedValues.Should().BeEquivalentTo("Item Three");
-            group2.Instance.SelectedValues.Should().Contain("Item Three");
+            group1.Instance.Values.Should().BeEquivalentTo("Item Three");
+            group2.Instance.Values.Should().Contain("Item Three");
         }
 
         [Test]
@@ -83,13 +83,13 @@ namespace MudBlazor.UnitTests.Components
             var buttonTwo = comp.FindAll("button").Last();
 
             toggleFirst.Instance.Value.Should().Be("Item Two");
-            toggleSecond.Instance.SelectedValues.Should().BeEquivalentTo("Item One", "Item Three");
+            toggleSecond.Instance.Values.Should().BeEquivalentTo("Item One", "Item Three");
 
             buttonOne.Click();
             toggleFirst.Instance.Value.Should().Be("Item One");
 
             buttonTwo.Click();
-            toggleSecond.Instance.SelectedValues.Should().BeEquivalentTo("Item Two", "Item Three");
+            toggleSecond.Instance.Values.Should().BeEquivalentTo("Item Two", "Item Three");
         }
 
         [Test]
@@ -263,15 +263,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_SelectionModeWarning_Test()
         {
-            // fight partial coverage
-            Assert.DoesNotThrow(() =>
-            {
-                Context.RenderComponent<MudToggleGroup<string>>(builder =>
-                {
-                    builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
-                    builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
-                });
-            });
             var provider = new MockLoggerProvider();
             var logger = provider.CreateLogger(GetType().FullName!) as MockLogger;
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider
@@ -280,10 +271,10 @@ namespace MudBlazor.UnitTests.Components
                 Context.RenderComponent<MudToggleGroup<string>>(builder =>
                 {
                     builder.Add(x => x.SelectionMode, mode);
-                    builder.Add(x => x.SelectedValuesChanged, new Action<IEnumerable<string>>(_ => { }));
+                    builder.Add(x => x.ValuesChanged, new Action<IEnumerable<string>>(_ => { }));
                 });
                 logger!.GetEntries().Last().Level.Should().Be(LogLevel.Warning);
-                logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {mode} you should bind {nameof(MudToggleGroup<string>.Value)} instead of {nameof(MudToggleGroup<string>.SelectedValues)}");
+                logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {mode} you should bind {nameof(MudToggleGroup<string>.Value)} instead of {nameof(MudToggleGroup<string>.Values)}");
             }
             Context.RenderComponent<MudToggleGroup<string>>(builder =>
             {
@@ -291,14 +282,14 @@ namespace MudBlazor.UnitTests.Components
                 builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
             });
             logger!.GetEntries().Last().Level.Should().Be(LogLevel.Warning);
-            logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {SelectionMode.MultiSelection} you should bind {nameof(MudToggleGroup<string>.SelectedValues)} instead of {nameof(MudToggleGroup<string>.Value)}");
+            logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {SelectionMode.MultiSelection} you should bind {nameof(MudToggleGroup<string>.Values)} instead of {nameof(MudToggleGroup<string>.Value)}");
             logger.GetEntries().Count.Should().Be(3);
             // no warning if both are bound
             Context.RenderComponent<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
                 builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
-                builder.Add(x => x.SelectedValuesChanged, new Action<IEnumerable<string>>(_ => { }));
+                builder.Add(x => x.ValuesChanged, new Action<IEnumerable<string>>(_ => { }));
             });
             logger.GetEntries().Count.Should().Be(3);
             // no warning if none are bound

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -268,11 +268,10 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider
             foreach (var mode in new[] { SelectionMode.SingleSelection, SelectionMode.ToggleSelection })
             {
-                Action<IEnumerable<string>> callback = _ => { };
                 Context.RenderComponent<MudToggleGroup<string>>(builder =>
                 {
                     builder.Add(x => x.SelectionMode, mode);
-                    builder.Add(x => x.SelectedValuesChanged, callback);
+                    builder.Add(x => x.SelectedValuesChanged, new Action<IEnumerable<string>>(_ => { }));
                 });
                 logger!.GetEntries().Last().Level.Should().Be(LogLevel.Warning);
                 logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {mode} you should bind {nameof(MudToggleGroup<string>.Value)} instead of {nameof(MudToggleGroup<string>.SelectedValues)}");
@@ -284,6 +283,20 @@ namespace MudBlazor.UnitTests.Components
             });
             logger!.GetEntries().Last().Level.Should().Be(LogLevel.Warning);
             logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {SelectionMode.MultiSelection} you should bind {nameof(MudToggleGroup<string>.SelectedValues)} instead of {nameof(MudToggleGroup<string>.Value)}");
+            logger.GetEntries().Count.Should().Be(3);
+            // no warning if both are bound
+            Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            {
+                builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
+                builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
+                builder.Add(x => x.SelectedValuesChanged, new Action<IEnumerable<string>>(_ => { }));
+            });
+            logger.GetEntries().Count.Should().Be(3);
+            // no warning if none are bound
+            Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            {
+                builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
+            });
             logger.GetEntries().Count.Should().Be(3);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -263,6 +263,15 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_SelectionModeWarning_Test()
         {
+            // fight partial coverage
+            Assert.DoesNotThrow(() =>
+            {
+                Context.RenderComponent<MudToggleGroup<string>>(builder =>
+                {
+                    builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
+                    builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
+                });
+            });
             var provider = new MockLoggerProvider();
             var logger = provider.CreateLogger(GetType().FullName!) as MockLogger;
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -46,63 +46,63 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// The generic value for the component.
+        /// The selected value in single- and toggle-selection mode.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Behavior)]
         public T? Value { get; set; }
 
         /// <summary>
-        /// Fires when value changed.
+        /// Fires when Value changes.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Behavior)]
         public EventCallback<T?> ValueChanged { get; set; }
 
         /// <summary>
-        /// Selected values that stored for multiselection mode.
+        /// The selected values for multi-selection mode.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Behavior)]
-        public IEnumerable<T?>? SelectedValues { get; set; }
+        public IEnumerable<T?>? Values { get; set; }
 
         /// <summary>
-        /// Fires when SelectedValues changed.
+        /// Fires when Values change.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Behavior)]
-        public EventCallback<IEnumerable<T?>> SelectedValuesChanged { get; set; }
+        public EventCallback<IEnumerable<T?>> ValuesChanged { get; set; }
 
         /// <summary>
-        /// Classnames only applied selected item, sepereated by space.
+        /// Classes (separated by space) to be applied to the selected items only.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? SelectedClass { get; set; }
 
         /// <summary>
-        /// Class for toggle item text.
+        /// Classes (separated by space) to be applied to the text of all toggle items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? TextClass { get; set; }
-        
+
         /// <summary>
-        /// Class for toggle item icon.
+        /// Classes (separated by space) to be applied to SelectedIcon/UnselectedIcon of the items (if CheckMark is true).
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? CheckMarkClass { get; set; }
-        
+
         /// <summary>
-        /// If true, items ordered vertically.
+        /// If true, use vertical layout.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public bool Vertical { get; set; }
 
         /// <summary>
-        /// If true, first and last item will be rounded.
+        /// If true, the first and last item will be rounded.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
@@ -112,14 +112,14 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// If true, outline border will show. Default is true.
+        /// If true, show an outline border. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public bool Outline { get; set; } = true;
 
         /// <summary>
-        /// If true, the line delimiter between items will show. Default is true.
+        /// If true, show a line delimiter between items. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
@@ -133,7 +133,7 @@ namespace MudBlazor
         public bool DisableRipple { get; set; }
 
         /// <summary>
-        /// If true, component's margin and padding will reduce.
+        /// If true, the component's padding is reduced so it takes up less space.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
@@ -149,7 +149,7 @@ namespace MudBlazor
         public SelectionMode SelectionMode { get; set; }
 
         /// <summary>
-        /// The color of the component. Affect borders and selection color. Default is primary.
+        /// The color of the component. Affects borders and selection color. Default is Colors.Primary.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
@@ -188,18 +188,18 @@ namespace MudBlazor
         {
             base.OnInitialized();
             var isValueBound = ValueChanged.HasDelegate;
-            var isSelectedValuesBound = SelectedValuesChanged.HasDelegate;
+            var isSelectedValuesBound = ValuesChanged.HasDelegate;
             switch (SelectionMode)
             {
                 default:
                 case SelectionMode.SingleSelection:
                 case SelectionMode.ToggleSelection:
                     if (!isValueBound && isSelectedValuesBound)
-                        Logger?.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(Value)} instead of {nameof(SelectedValues)}");
+                        Logger.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(Value)} instead of {nameof(Values)}");
                     break;
                 case SelectionMode.MultiSelection:
                     if (isValueBound && !isSelectedValuesBound)
-                        Logger?.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(SelectedValues)} instead of {nameof(Value)}");
+                        Logger.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(Values)} instead of {nameof(Value)}");
                     break;
             }
         }
@@ -223,17 +223,17 @@ namespace MudBlazor
             }
 
             // Handle multi-selection mode
-            if (((_values is null && SelectedValues is not null) || (_values is not null && !_values.Equals(SelectedValues))) && multiSelection)
+            if (((_values is null && Values is not null) || (_values is not null && !_values.Equals(Values))) && multiSelection)
             {
                 DeselectAllItems();
 
-                if (SelectedValues is not null)
+                if (Values is not null)
                 {
-                    var selectedItems = _items.Where(x => SelectedValues.Contains(x.Value)).ToList();
+                    var selectedItems = _items.Where(x => Values.Contains(x.Value)).ToList();
                     selectedItems.ForEach(x => x.SetSelected(true));
                 }
 
-                _values = SelectedValues;
+                _values = Values;
             }
         }
 
@@ -251,9 +251,9 @@ namespace MudBlazor
                 }
 
                 // Handle multi-selection mode
-                if (SelectedValues is not null && multiSelection)
+                if (Values is not null && multiSelection)
                 {
-                    var selectedItems = _items.Where(x => SelectedValues.Contains(x.Value)).ToList();
+                    var selectedItems = _items.Where(x => Values.Contains(x.Value)).ToList();
                     selectedItems.ForEach(x => x.SetSelected(true));
                 }
 
@@ -264,12 +264,12 @@ namespace MudBlazor
                 SelectedClass != _selectedClass ||
                 Outline != _outline ||
                 Delimiters != _delimiters ||
-                RightToLeft != _rtl || 
+                RightToLeft != _rtl ||
                 Dense != _dense ||
-                Rounded != _rounded || 
+                Rounded != _rounded ||
                 CheckMark != _checkMark ||
                 FixedContent != _fixedContent
-                )
+               )
             {
                 _color = Color;
                 _selectedClass = SelectedClass;
@@ -295,14 +295,14 @@ namespace MudBlazor
             {
                 if (item.IsSelected)
                 {
-                    SelectedValues = SelectedValues?.Where(x => !Equals(x, item.Value));
-                    await SelectedValuesChanged.InvokeAsync(SelectedValues);
+                    Values = Values?.Where(x => !Equals(x, item.Value));
+                    await ValuesChanged.InvokeAsync(Values);
                 }
                 else
                 {
-                    SelectedValues ??= new HashSet<T>();
-                    SelectedValues = SelectedValues.Append(item.Value);
-                    await SelectedValuesChanged.InvokeAsync(SelectedValues);
+                    Values ??= new HashSet<T>();
+                    Values = Values.Append(item.Value);
+                    await ValuesChanged.InvokeAsync(Values);
                 }
                 item.SetSelected(!item.IsSelected);
             }
@@ -345,6 +345,5 @@ namespace MudBlazor
         protected internal bool IsFirstItem(MudToggleItem<T> item) => item.Equals(_items.FirstOrDefault());
 
         protected internal bool IsLastItem(MudToggleItem<T> item) => item.Equals(_items.LastOrDefault());
-        
     }
 }

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -179,10 +180,28 @@ namespace MudBlazor
             {
                 return;
             }
-
             _items.Add(item);
         }
-        
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            var isValueBound = ValueChanged.HasDelegate;
+            var isSelectedValuesBound = SelectedValuesChanged.HasDelegate;
+            switch (SelectionMode)
+            {
+                case SelectionMode.SingleSelection:
+                case SelectionMode.ToggleSelection:
+                    if (!isValueBound && isSelectedValuesBound)
+                        throw new ArgumentException($"For SelectionMode {SelectionMode} you should bind {nameof(Value)} instead of {nameof(SelectedValues)}");
+                    break;
+                case SelectionMode.MultiSelection:
+                    if (isValueBound && !isSelectedValuesBound)
+                        throw new ArgumentException($"For SelectionMode {SelectionMode} you should bind {nameof(SelectedValues)} instead of {nameof(Value)}");
+                    break;
+            }
+        }
+
         protected override void OnParametersSet()
         {
             base.OnParametersSet();

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
@@ -190,14 +191,15 @@ namespace MudBlazor
             var isSelectedValuesBound = SelectedValuesChanged.HasDelegate;
             switch (SelectionMode)
             {
+                default:
                 case SelectionMode.SingleSelection:
                 case SelectionMode.ToggleSelection:
                     if (!isValueBound && isSelectedValuesBound)
-                        throw new ArgumentException($"For SelectionMode {SelectionMode} you should bind {nameof(Value)} instead of {nameof(SelectedValues)}");
+                        Logger?.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(Value)} instead of {nameof(SelectedValues)}");
                     break;
                 case SelectionMode.MultiSelection:
                     if (isValueBound && !isSelectedValuesBound)
-                        throw new ArgumentException($"For SelectionMode {SelectionMode} you should bind {nameof(SelectedValues)} instead of {nameof(Value)}");
+                        Logger?.LogWarning($"For SelectionMode {SelectionMode} you should bind {nameof(SelectedValues)} instead of {nameof(Value)}");
                     break;
             }
         }

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -79,22 +79,35 @@ namespace MudBlazor
         [Category(CategoryTypes.List.Behavior)]
         public T? Value { get; set; }
 
+        /// <summary>
+        /// Icon to show if the item is not selected (if CheckMark is true on the parent group)
+        /// Leave null to show no check mark (default).
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? UnselectedIcon { get; set; }
 
+        /// <summary>
+        /// Icon to show if the item is selected (if CheckMark is true on the parent group)
+        /// By default this is set to a check mark icon.
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? SelectedIcon { get; set; } = Icons.Material.Filled.Check;
 
         private string? CurrentIcon => IsSelected ? SelectedIcon ?? UnselectedIcon : UnselectedIcon;
         
+        /// <summary>
+        /// The text to show. You need to set this only if you want a text that differs from the Value. If null,
+        /// show Value?.ToString().
+        /// Note: the Text is only shown if you haven't defined your own child content
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public string? Text { get; set; }
 
         /// <summary>
-        /// Define custom content. The boolean parameter conveys whether or not the item is selected. 
+        /// Custom child content which overrides the text. The boolean parameter conveys whether or not the item is selected. 
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]


### PR DESCRIPTION
## Description
Depending on the selection mode you need to bind either `Value` or `SelectedValues`. This tripped me up myself so I thought it good to check thie selection mode on component initialization and throw an exception if the wrong parameter is bound. Also added an info box relating this information to the docs for clarity.

## How Has This Been Tested?
unit

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
