### PR TITLE
MudTextField: Fix double triggering of validation on blur (#7034)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -947,6 +947,23 @@ namespace MudBlazor.UnitTests.Components
             text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
         }
 
+        /// <summary>
+        /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
+        /// </summary>
+        [Test]
+        public async Task OnBlurWithModifiedValueTriggerValidationOnce()
+        {
+            var callCounter = 0;
+            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Validation, (string value) => { callCounter++; return true; })
+            );
+
+            comp.Find("input").Change("A");
+            callCounter.Should().Be(1);
+            comp.Find("input").Blur();
+            callCounter.Should().Be(1);
+        }
+
         [Test]
         public async Task OnKeyDownErrorContentCaughtException()
         {

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -951,13 +951,29 @@ namespace MudBlazor.UnitTests.Components
         /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
         /// </summary>
         [Test]
-        public async Task OnBlurWithModifiedValueTriggerValidationOnce()
+        public async Task OnBlurWithModifiedValueTriggerValidationOnce1()
         {
             var callCounter = 0;
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Validation, (string value) => { callCounter++; return true; })
             );
-
+            comp.Find("input").Change("A");
+            callCounter.Should().Be(1);
+            comp.Find("input").Blur();
+            callCounter.Should().Be(1);
+        }
+        
+        /// <summary>
+        /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
+        /// </summary>
+        [Test]
+        public async Task OnBlurWithModifiedValueTriggerValidationOnce2()
+        {
+            var callCounter = 0;
+            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+                .Add(p => p.OnlyValidateIfDirty, true)
+                .Add(p => p.Validation, (string value) => { callCounter++; return true; })
+            );
             comp.Find("input").Change("A");
             callCounter.Should().Be(1);
             comp.Find("input").Blur();

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -13,7 +13,12 @@ namespace MudBlazor
     public abstract class MudBaseInput<T> : MudFormComponent<T, string>
     {
         private bool _isDirty;
-
+        /// <summary>
+        /// this flag is set to true by validation in order to prevent multiple invocations of validation after a single
+        /// value change. When the value changes _validated is set back to false.
+        /// </summary>
+        private bool _validated; 
+        
         protected MudBaseInput() : base(new DefaultConverter<T>()) { }
 
         /// <summary>
@@ -222,6 +227,7 @@ namespace MudBlazor
             if (Text != text)
             {
                 Text = text;
+                _validated = false;
                 if (!string.IsNullOrWhiteSpace(Text))
                     Touched = true;
                 if (updateValue)
@@ -273,11 +279,14 @@ namespace MudBlazor
             if (ReadOnly)
                 return;
             _isFocused = false;
-
+            
             if (!OnlyValidateIfDirty || _isDirty)
             {
                 Touched = true;
-                await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
+                if (_validated)
+                    await OnBlur.InvokeAsync(obj);
+                else
+                    await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
             }
         }
 
@@ -395,6 +404,7 @@ namespace MudBlazor
             if (!EqualityComparer<T>.Default.Equals(Value, value) || force == true)
             {
                 _isDirty = true;
+                _validated = false;
                 Value = value;
                 await ValueChanged.InvokeAsync(Value);
                 if (updateText)
@@ -461,12 +471,12 @@ namespace MudBlazor
             return changed;
         }
 
-        protected override Task ValidateValue()
+        protected override async Task ValidateValue()
         {
-            if (SubscribeToParentForm)
-                return base.ValidateValue();
-
-            return Task.CompletedTask;
+            if (SubscribeToParentForm) {
+                await base.ValidateValue();
+                _validated = true;
+            }
         }
 
         protected override async Task OnInitializedAsync()
@@ -542,6 +552,7 @@ namespace MudBlazor
         {
             SetTextAsync(null, updateValue: true).AndForget();
             this._isDirty = false;
+            this._validated = false;
             base.ResetValue();
         }
 
@@ -549,6 +560,7 @@ namespace MudBlazor
         {
             await SetTextAsync(null, updateValue: true);
             this._isDirty = false;
+            this._validated = false;
             await base.ResetValueAsync();
         }
     }


### PR DESCRIPTION
## Description

The validation is triggered when :
* The value is updated
* The component lost the focus

But with some components (like MudTextField), when it lost the focus the value is update... that trigger two times the validation and the same value is validated two times.

Furthermore, the validation trigger the event `OnFieldChanged `.

Resolves #7034

## How Has This Been Tested?

I added a unit test that fail when the bug is reproduced.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.