### PR TITLE
MudTable: add OnRowMouseEnter and OnRowMouseLeave events

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowMouseEnterAsync="RowMouseEnterEvent" OnRowMouseLeaveAsync="RowMouseLeaveEvent" Breakpoint="Breakpoint.Sm">
+<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowMouseEnter="RowMouseEnterEvent" OnRowMouseLeave="RowMouseLeaveEvent" Breakpoint="Breakpoint.Sm">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowHoverStart="RowHoverStartEvent" OnRowHoverStop="RowHoverStopEvent" Breakpoint="Breakpoint.Sm">
+<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowMouseEnter="RowMouseEnterEvent" OnRowMouseLeave="RowMouseLeaveEvent" Breakpoint="Breakpoint.Sm">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -34,12 +34,12 @@
         elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
     }
 
-    private void RowHoverStartEvent(TableRowHoverEventArgs<Element> eventArgs)
+    private void RowMouseEnterEvent(TableRowHoverEventArgs<Element> eventArgs)
     {
         currentlyHoveredElement = eventArgs.Item.Name;
     }
 
-    private void RowHoverStopEvent(TableRowHoverEventArgs<Element> eventArgs)
+    private void RowMouseLeaveEvent(TableRowHoverEventArgs<Element> eventArgs)
     {
         currentlyHoveredElement = "";
         lastHoveredElement = eventArgs.Item.Name;

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
@@ -1,0 +1,47 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowHoverStart="RowHoverStartEvent" OnRowHoverStop="RowHoverStopEvent" Breakpoint="Breakpoint.Sm">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+</MudTable>
+
+<MudText>Currently hovered: @(currentlyHoveredElement)</MudText>
+<MudText>Last hovered: @(lastHoveredElement)</MudText>
+
+@code {
+    private IEnumerable<Element> elements = new List<Element>();
+
+    private string currentlyHoveredElement;
+    private string lastHoveredElement;
+
+    protected override async Task OnInitializedAsync()
+    {
+        elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+
+    private void RowHoverStartEvent(TableRowHoverEventArgs<Element> eventArgs)
+    {
+        currentlyHoveredElement = eventArgs.Item.Name;
+    }
+
+    private void RowHoverStopEvent(TableRowHoverEventArgs<Element> eventArgs)
+    {
+        currentlyHoveredElement = "";
+        lastHoveredElement = eventArgs.Item.Name;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRowHoverEventsExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowMouseEnter="RowMouseEnterEvent" OnRowMouseLeave="RowMouseLeaveEvent" Breakpoint="Breakpoint.Sm">
+<MudTable T="Element" Items="@elements.Take(3)" Hover="true" OnRowMouseEnterAsync="RowMouseEnterEvent" OnRowMouseLeaveAsync="RowMouseLeaveEvent" Breakpoint="Breakpoint.Sm">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -32,8 +32,8 @@
         <DocsPageSection>
             <SectionHeader Title="Hover Events">
                 <Description>
-                    <CodeInline>OnRowMouseEnterAsync</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
-                    <CodeInline>OnRowMouseLeaveAsync</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
+                    <CodeInline>OnRowMouseEnter</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
+                    <CodeInline>OnRowMouseLeave</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableRowHoverEventsExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -30,6 +30,18 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Hover Events">
+                <Description>
+                    <CodeInline>OnRowHoverStart</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
+                    <CodeInline>OnRowHoverStop</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(TableRowHoverEventsExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TableRowHoverEventsExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Table with pagination and filtering">
                 <Description>
                     The <CodeInline>&lt;MudTable></CodeInline> component supports pagination, sorting and filtering of rows, as well as single and multiple row selection. To tell the table how to render your data, define a <CodeInline>&lt;RowTemplate></CodeInline>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -32,8 +32,8 @@
         <DocsPageSection>
             <SectionHeader Title="Hover Events">
                 <Description>
-                    <CodeInline>OnRowMouseEnter</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
-                    <CodeInline>OnRowMouseLeave</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
+                    <CodeInline>OnRowMouseEnterAsync</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
+                    <CodeInline>OnRowMouseLeaveAsync</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableRowHoverEventsExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -32,8 +32,8 @@
         <DocsPageSection>
             <SectionHeader Title="Hover Events">
                 <Description>
-                    <CodeInline>OnRowHoverStart</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
-                    <CodeInline>OnRowHoverStop</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
+                    <CodeInline>OnRowMouseEnter</CodeInline> is triggered when the row starts being hovered (onmouseenter event).
+                    <CodeInline>OnRowMouseLeave</CodeInline> is triggered when the row stops being hovered (onmouseleave event).
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableRowHoverEventsExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable T="string" Items="items" OnRowHoverStart="@(args => OnRowHoverStart(args))" OnRowHoverStop="@(args => OnRowHoverStop(args))">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+<p>
+    Current: '@(currentlyHoveredItem)', last: '@(lastHoveredItem)'
+</p>
+
+@code {
+    public static string __description__ = @"
+        OnRowHoverStart should be called whenever a row (<tr>) starts being hovered (onmouseenter).
+        OnRowHoverStop should be called whenever a row (<tr>) stops being hovered (onmouseleave).
+        The paragraph (<p>) should be refreshed with the current and last hovered element.
+        ";
+
+    string[] items = new string[] { "A", "B" };
+
+    string currentlyHoveredItem = string.Empty;
+    string lastHoveredItem = string.Empty;
+
+    private void OnRowHoverStart(TableRowHoverEventArgs<string> args)
+    {
+        currentlyHoveredItem = args.Item;
+    }
+
+    private void OnRowHoverStop(TableRowHoverEventArgs<string> args)
+    {
+        currentlyHoveredItem = string.Empty;
+        lastHoveredItem = args.Item;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable T="string" Items="items" OnRowMouseEnterAsync="@(args => OnRowMouseEnterAsync(args))" OnRowMouseLeaveAsync="@(args => OnRowMouseLeaveAsync(args))">
+<MudTable T="string" Items="items" OnRowMouseEnter="@(args => OnRowMouseEnter(args))" OnRowMouseLeave="@(args => OnRowMouseLeave(args))">
     <RowTemplate>
         <MudTd>@context</MudTd>
     </RowTemplate>
@@ -12,8 +12,8 @@
 
 @code {
     public static string __description__ = @"
-        OnRowMouseEnterAsync should be called whenever a row (<tr>) starts being hovered (onmouseenter).
-        OnRowMouseLeaveAsync should be called whenever a row (<tr>) stops being hovered (onmouseleave).
+        OnRowMouseEnter should be called whenever a row (<tr>) starts being hovered (onmouseenter).
+        OnRowMouseLeave should be called whenever a row (<tr>) stops being hovered (onmouseleave).
         The paragraph (<p>) should be refreshed with the current and last hovered element.
         ";
 
@@ -22,12 +22,12 @@
     string currentlyHoveredItem = string.Empty;
     string lastHoveredItem = string.Empty;
 
-    private void OnRowMouseEnterAsync(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseEnter(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = args.Item;
     }
 
-    private void OnRowMouseLeaveAsync(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseLeave(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = string.Empty;
         lastHoveredItem = args.Item;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable T="string" Items="items" OnRowHoverStart="@(args => OnRowHoverStart(args))" OnRowHoverStop="@(args => OnRowHoverStop(args))">
+<MudTable T="string" Items="items" OnRowMouseEnter="@(args => OnRowMouseEnter(args))" OnRowMouseLeave="@(args => OnRowMouseLeave(args))">
     <RowTemplate>
         <MudTd>@context</MudTd>
     </RowTemplate>
@@ -12,8 +12,8 @@
 
 @code {
     public static string __description__ = @"
-        OnRowHoverStart should be called whenever a row (<tr>) starts being hovered (onmouseenter).
-        OnRowHoverStop should be called whenever a row (<tr>) stops being hovered (onmouseleave).
+        OnRowMouseEnter should be called whenever a row (<tr>) starts being hovered (onmouseenter).
+        OnRowMouseLeave should be called whenever a row (<tr>) stops being hovered (onmouseleave).
         The paragraph (<p>) should be refreshed with the current and last hovered element.
         ";
 
@@ -22,12 +22,12 @@
     string currentlyHoveredItem = string.Empty;
     string lastHoveredItem = string.Empty;
 
-    private void OnRowHoverStart(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseEnter(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = args.Item;
     }
 
-    private void OnRowHoverStop(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseLeave(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = string.Empty;
         lastHoveredItem = args.Item;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowHoverTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable T="string" Items="items" OnRowMouseEnter="@(args => OnRowMouseEnter(args))" OnRowMouseLeave="@(args => OnRowMouseLeave(args))">
+<MudTable T="string" Items="items" OnRowMouseEnterAsync="@(args => OnRowMouseEnterAsync(args))" OnRowMouseLeaveAsync="@(args => OnRowMouseLeaveAsync(args))">
     <RowTemplate>
         <MudTd>@context</MudTd>
     </RowTemplate>
@@ -12,8 +12,8 @@
 
 @code {
     public static string __description__ = @"
-        OnRowMouseEnter should be called whenever a row (<tr>) starts being hovered (onmouseenter).
-        OnRowMouseLeave should be called whenever a row (<tr>) stops being hovered (onmouseleave).
+        OnRowMouseEnterAsync should be called whenever a row (<tr>) starts being hovered (onmouseenter).
+        OnRowMouseLeaveAsync should be called whenever a row (<tr>) stops being hovered (onmouseleave).
         The paragraph (<p>) should be refreshed with the current and last hovered element.
         ";
 
@@ -22,12 +22,12 @@
     string currentlyHoveredItem = string.Empty;
     string lastHoveredItem = string.Empty;
 
-    private void OnRowMouseEnter(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseEnterAsync(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = args.Item;
     }
 
-    private void OnRowMouseLeave(TableRowHoverEventArgs<string> args)
+    private void OnRowMouseLeaveAsync(TableRowHoverEventArgs<string> args)
     {
         currentlyHoveredItem = string.Empty;
         lastHoveredItem = args.Item;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if the OnRowMouseEnter and OnRowMouseLeave event callbacks are fired as intended
+        /// Check if the OnRowMouseEnterAsync and OnRowMouseLeaveAsync event callbacks are fired as intended
         /// </summary>
         [Test]
         public void TableRowHover()

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if the OnRowHoverStart and OnRowHoverStop event callbacks are fired as intended
+        /// Check if the OnRowMouseEnter and OnRowMouseLeave event callbacks are fired as intended
         /// </summary>
         [Test]
         public void TableRowHover()

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if the OnRowMouseEnterAsync and OnRowMouseLeaveAsync event callbacks are fired as intended
+        /// Check if the OnRowMouseEnter and OnRowMouseLeave event callbacks are fired as intended
         /// </summary>
         [Test]
         public void TableRowHover()

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -8,6 +8,7 @@ using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Moq;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
@@ -37,6 +38,36 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1");
             trs[4].Click(); // clicking the header should add 100
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1,100");
+        }
+
+        /// <summary>
+        /// Check if the OnRowHoverStart and OnRowHoverStop event callbacks are fired as intended
+        /// </summary>
+        [Test]
+        public void TableRowHover()
+        {
+            var comp = Context.RenderComponent<TableRowHoverTest>();
+            comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: ''");
+
+            var trs = comp.FindAll("tr");
+
+            trs[0].TriggerEvent("onmouseenter", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: ''");
+
+            trs[0].TriggerEvent("onmouseleave", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
+
+            trs[1].TriggerEvent("onmouseenter", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: 'B', last: 'A'");
+
+            trs[1].TriggerEvent("onmouseleave", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'B'");
+
+            trs[0].TriggerEvent("onmouseenter", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: 'B'");
+
+            trs[0].TriggerEvent("onmouseleave", new MouseEventArgs());
+            comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -197,7 +197,7 @@ namespace MudBlazor
         /// <summary>
         /// Row hover start event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnterAsync { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnter { get; set; }
 
         internal override async Task FireRowMouseEnterEventAsync(MouseEventArgs args, MudTr row, object o)
         {
@@ -207,7 +207,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            await OnRowMouseEnterAsync.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseEnter.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,
@@ -218,7 +218,7 @@ namespace MudBlazor
         /// <summary>
         /// Row hover stop event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeaveAsync { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeave { get; set; }
 
         internal override async Task FireRowMouseLeaveEventAsync(MouseEventArgs args, MudTr row, object o)
         {
@@ -228,7 +228,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            await OnRowMouseLeaveAsync.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseLeave.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -195,6 +195,48 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Row hover start event.
+        /// </summary>
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowHoverStart { get; set; }
+
+        internal override void FireRowHoverStartEvent(MouseEventArgs args, MudTr row, object o)
+        {
+            var item = default(T);
+            try
+            {
+                item = (T)o;
+            }
+            catch (Exception) { /*ignore*/}
+            OnRowHoverStart.InvokeAsync(new TableRowHoverEventArgs<T>()
+            {
+                MouseEventArgs = args,
+                Row = row,
+                Item = item,
+            });
+        }
+
+        /// <summary>
+        /// Row hover stop event.
+        /// </summary>
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowHoverStop { get; set; }
+
+        internal override void FireRowHoverStopEvent(MouseEventArgs args, MudTr row, object o)
+        {
+            var item = default(T);
+            try
+            {
+                item = (T)o;
+            }
+            catch (Exception) { /*ignore*/}
+            OnRowHoverStop.InvokeAsync(new TableRowHoverEventArgs<T>()
+            {
+                MouseEventArgs = args,
+                Row = row,
+                Item = item,
+            });
+        }
+
+        /// <summary>
         /// Returns the class that will get joined with RowClass. Takes the current item and row index.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -197,9 +197,9 @@ namespace MudBlazor
         /// <summary>
         /// Row hover start event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowHoverStart { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnter { get; set; }
 
-        internal override void FireRowHoverStartEvent(MouseEventArgs args, MudTr row, object o)
+        internal override async Task FireRowMouseEnterEvent(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);
             try
@@ -207,7 +207,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            OnRowHoverStart.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseEnter.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,
@@ -218,9 +218,9 @@ namespace MudBlazor
         /// <summary>
         /// Row hover stop event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowHoverStop { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeave { get; set; }
 
-        internal override void FireRowHoverStopEvent(MouseEventArgs args, MudTr row, object o)
+        internal override async Task FireRowMouseLeaveEvent(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);
             try
@@ -228,7 +228,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            OnRowHoverStop.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseLeave.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -197,9 +197,9 @@ namespace MudBlazor
         /// <summary>
         /// Row hover start event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnter { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnterAsync { get; set; }
 
-        internal override async Task FireRowMouseEnterEvent(MouseEventArgs args, MudTr row, object o)
+        internal override async Task FireRowMouseEnterEventAsync(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);
             try
@@ -207,7 +207,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            await OnRowMouseEnter.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseEnterAsync.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,
@@ -218,9 +218,9 @@ namespace MudBlazor
         /// <summary>
         /// Row hover stop event.
         /// </summary>
-        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeave { get; set; }
+        [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeaveAsync { get; set; }
 
-        internal override async Task FireRowMouseLeaveEvent(MouseEventArgs args, MudTr row, object o)
+        internal override async Task FireRowMouseLeaveEventAsync(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);
             try
@@ -228,7 +228,7 @@ namespace MudBlazor
                 item = (T)o;
             }
             catch (Exception) { /*ignore*/}
-            await OnRowMouseLeave.InvokeAsync(new TableRowHoverEventArgs<T>()
+            await OnRowMouseLeaveAsync.InvokeAsync(new TableRowHoverEventArgs<T>()
             {
                 MouseEventArgs = args,
                 Row = row,

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -556,9 +556,9 @@ namespace MudBlazor
 
         internal abstract void FireRowClickEvent(MouseEventArgs args, MudTr mudTr, object item);
 
-        internal abstract void FireRowHoverStartEvent(MouseEventArgs args, MudTr mudTr, object item);
+        internal abstract Task FireRowMouseEnterEvent(MouseEventArgs args, MudTr mudTr, object item);
 
-        internal abstract void FireRowHoverStopEvent(MouseEventArgs args, MudTr mudTr, object item);
+        internal abstract Task FireRowMouseLeaveEvent(MouseEventArgs args, MudTr mudTr, object item);
 
         internal abstract void OnHeaderCheckboxClicked(bool checkedState);
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -556,6 +556,10 @@ namespace MudBlazor
 
         internal abstract void FireRowClickEvent(MouseEventArgs args, MudTr mudTr, object item);
 
+        internal abstract void FireRowHoverStartEvent(MouseEventArgs args, MudTr mudTr, object item);
+
+        internal abstract void FireRowHoverStopEvent(MouseEventArgs args, MudTr mudTr, object item);
+
         internal abstract void OnHeaderCheckboxClicked(bool checkedState);
 
         internal abstract bool IsEditable { get; }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -556,9 +556,9 @@ namespace MudBlazor
 
         internal abstract void FireRowClickEvent(MouseEventArgs args, MudTr mudTr, object item);
 
-        internal abstract Task FireRowMouseEnterEvent(MouseEventArgs args, MudTr mudTr, object item);
+        internal abstract Task FireRowMouseEnterEventAsync(MouseEventArgs args, MudTr mudTr, object item);
 
-        internal abstract Task FireRowMouseLeaveEvent(MouseEventArgs args, MudTr mudTr, object item);
+        internal abstract Task FireRowMouseLeaveEventAsync(MouseEventArgs args, MudTr mudTr, object item);
 
         internal abstract void OnHeaderCheckboxClicked(bool checkedState);
 

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -2,7 +2,7 @@
 @implements IDisposable
 @inherits MudComponentBase
 
-<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowHoverStart" @onmouseleave="@OnRowHoverStop" style="@Style" @attributes="@UserAttributes">
+<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowMouseEnter" @onmouseleave="@OnRowMouseLeave" style="@Style" @attributes="@UserAttributes">
     @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -2,7 +2,7 @@
 @implements IDisposable
 @inherits MudComponentBase
 
-<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowMouseEnter" @onmouseleave="@OnRowMouseLeave" style="@Style" @attributes="@UserAttributes">
+<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowMouseEnterAsync" @onmouseleave="@OnRowMouseLeaveAsync" style="@Style" @attributes="@UserAttributes">
     @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -2,7 +2,7 @@
 @implements IDisposable
 @inherits MudComponentBase
 
-<tr class="@Classname" @onclick="@OnRowClicked" style="@Style" @attributes="@UserAttributes">
+<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowHoverStart" @onmouseleave="@OnRowHoverStop" style="@Style" @attributes="@UserAttributes">
     @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -67,20 +67,20 @@ namespace MudBlazor
             table.FireRowClickEvent(args, this, Item);
         }
 
-        public void OnRowHoverStart(MouseEventArgs args)
+        public async Task OnRowMouseEnter(MouseEventArgs args)
         {
             var table = Context?.Table;
             if (table is null)
                 return;
-            table.FireRowHoverStartEvent(args, this, Item);
+            await table.FireRowMouseEnterEvent(args, this, Item);
         }
 
-        public void OnRowHoverStop(MouseEventArgs args)
+        public async Task OnRowMouseLeave(MouseEventArgs args)
         {
             var table = Context?.Table;
             if (table is null)
                 return;
-            table.FireRowHoverStopEvent(args, this, Item);
+            await table.FireRowMouseLeaveEvent(args, this, Item);
         }
 
         private void StartEditingItem() => StartEditingItem(buttonClicked: true);

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -67,20 +67,20 @@ namespace MudBlazor
             table.FireRowClickEvent(args, this, Item);
         }
 
-        public async Task OnRowMouseEnter(MouseEventArgs args)
+        public async Task OnRowMouseEnterAsync(MouseEventArgs args)
         {
             var table = Context?.Table;
             if (table is null)
                 return;
-            await table.FireRowMouseEnterEvent(args, this, Item);
+            await table.FireRowMouseEnterEventAsync(args, this, Item);
         }
 
-        public async Task OnRowMouseLeave(MouseEventArgs args)
+        public async Task OnRowMouseLeaveAsync(MouseEventArgs args)
         {
             var table = Context?.Table;
             if (table is null)
                 return;
-            await table.FireRowMouseLeaveEvent(args, this, Item);
+            await table.FireRowMouseLeaveEventAsync(args, this, Item);
         }
 
         private void StartEditingItem() => StartEditingItem(buttonClicked: true);

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -67,6 +67,22 @@ namespace MudBlazor
             table.FireRowClickEvent(args, this, Item);
         }
 
+        public void OnRowHoverStart(MouseEventArgs args)
+        {
+            var table = Context?.Table;
+            if (table is null)
+                return;
+            table.FireRowHoverStartEvent(args, this, Item);
+        }
+
+        public void OnRowHoverStop(MouseEventArgs args)
+        {
+            var table = Context?.Table;
+            if (table is null)
+                return;
+            table.FireRowHoverStopEvent(args, this, Item);
+        }
+
         private void StartEditingItem() => StartEditingItem(buttonClicked: true);
 
         private void StartEditingItem(bool buttonClicked)

--- a/src/MudBlazor/Components/Table/TableRowHoverEventArgs.cs
+++ b/src/MudBlazor/Components/Table/TableRowHoverEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor
+{
+    public class TableRowHoverEventArgs<T> : EventArgs
+    {
+        public MouseEventArgs MouseEventArgs { get; set; }
+        public T Item { get; set; }
+        public MudTr Row { get; set; }
+    }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
The `MudTable` component doesn't provide any way of attaching to its rows "hover" events. This PR adds that.
Previously, we had to attach callbacks to each `MudTd` for this, which was not optimal as the events were triggered when going from one cell to another in the same row.
These new events can be useful for interactions between the table and another component (in my case, a chart or a map, for example).

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
- Created a `TableRowHover` unit test using a new `TableRowHoverTest` testing component
- Added an example in the MudTable docs. Allows for visually testing the PR

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![MudTable hover events](https://github.com/MudBlazor/MudBlazor/assets/43544490/f9c5bc8f-1a21-414d-ade5-08357a8eef84)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
