### PR TITLE
DataGrid: Make RowsPerPage two-way bindable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRowsPerPageBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRowsPerPageBindingTest.razor
@@ -10,9 +10,9 @@
 </MudDataGrid>
 
 @code {
-	private List<Item> _items = new List<Item>();
+    private List<Item> _items = new List<Item>();
 
-	public int BoundRowsPerPage = 5;
+    public int BoundRowsPerPage = 5;
 
     protected override void OnInitialized()
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRowsPerPageBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridRowsPerPageBindingTest.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items" @bind-RowsPerPage="BoundRowsPerPage">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+	private List<Item> _items = new List<Item>();
+
+	public int BoundRowsPerPage = 5;
+
+    protected override void OnInitialized()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            _items.Add(new Item(i.ToString()));
+        }
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public Item(string name)
+        {
+            Name = name;
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -471,6 +471,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridRowsPerPageTwoWayBindingTest()
+        {
+            var comp = Context.RenderComponent<DataGridRowsPerPageBindingTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridRowsPerPageBindingTest.Item>>();
+
+            // confirm that BoundRowsPerPage is equal to the initial value of 5 (See DataGridRowsPerPageBindingTest)
+            comp.Instance.BoundRowsPerPage.Should().Be(5);
+
+            // programmatically set the datagrid rowsPerPage to 10
+            await dataGrid.InvokeAsync(() => dataGrid.Instance.SetRowsPerPageAsync(10));
+
+            // confirm that BoundRowsPerPage changes when rowsPerPage is set to 10
+            comp.Instance.BoundRowsPerPage.Should().Be(10);
+        }
+
+        [Test]
         public async Task DataGridInlineEditTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -601,6 +601,11 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Rows Per Page two-way bindable parameter
+        /// </summary>
+        [Parameter] public EventCallback<int> RowsPerPageChanged { get; set; }
+
+        /// <summary>
         /// The page index of the currently displayed page (Zero based). Usually called by MudTablePager.
         /// Note: requires a MudTablePager in PagerContent.
         /// </summary>
@@ -1192,6 +1197,8 @@ namespace MudBlazor
                 CurrentPage = 0;
 
             StateHasChanged();
+
+            await RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
 
             if (_isFirstRendered)
                 await InvokeAsync(InvokeServerLoadFunc);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1196,9 +1196,9 @@ namespace MudBlazor
             if (resetPage)
                 CurrentPage = 0;
 
-            StateHasChanged();
-
             await RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
+
+            StateHasChanged();
 
             if (_isFirstRendered)
                 await InvokeAsync(InvokeServerLoadFunc);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
For some reason, the RowsPerPageChanged EventCallback parameter was not included in the MudDataGrid component. This is required to allow for two-way binding. This issue is related to a discussion from last year (#7677).

To resolve the issue I have included the RowsPerPageChanged EventCallback parameter in the DataGrid component. I have also included a line to invoke the callback when the RowsPerPage value is changed.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I tested this change using the MudBlazor.Docs.Server project. I quickly altered one example to use two-way binding (@bind-RowsPerPage). Everything worked as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
