### PR TITLE
Docs: Remove MudHidden for perf and prerendering

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,4 +1,4 @@
-﻿<MudHidden Breakpoint="Breakpoint.MdAndUp">
+﻿<div class="d-flex flex-grow-1 d-md-none">
     <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start"/>
     <MudSpacer/>
     <NavLink ActiveClass="d-flex" href="/">
@@ -14,8 +14,8 @@
     {
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" Href="https://github.com/MudBlazor/MudBlazor/"/>
     }
-</MudHidden>
-<MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
+</div>
+<div class="d-none d-md-flex flex-grow-1">
     <NavLink ActiveClass="d-flex me-4" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo"/>
         <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
@@ -96,7 +96,7 @@
     <MudTooltip Duration="1000" Text="GitHub Repository" ShowOnFocus="false">
         <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End"/>
     </MudTooltip>
-</MudHidden>
+</div>
 
 
 <MudDialog @bind-IsVisible="_searchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,9 +1,9 @@
-﻿<div class="d-flex flex-grow-1 d-md-none">
+﻿<div class="d-flex align-center flex-grow-1 d-md-none">
     <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start"/>
     <MudSpacer/>
     <NavLink ActiveClass="d-flex" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo"/>
-        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
+        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text mt-1">MudBlazor</MudText>
     </NavLink>
     <MudSpacer/>
     @if (DisplaySearchBar)
@@ -15,10 +15,10 @@
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" Href="https://github.com/MudBlazor/MudBlazor/"/>
     }
 </div>
-<div class="d-none d-md-flex flex-grow-1">
+<div class="d-none d-md-flex align-center flex-grow-1">
     <NavLink ActiveClass="d-flex me-4" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo"/>
-        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
+        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text mt-1">MudBlazor</MudText>
     </NavLink>
     <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
     <MudButton Href="/getting-started/installation" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.GettingStarted)">Getting Started</MudButton>

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -7,7 +7,7 @@
         <Appbar DrawerToggleCallback="ToggleDrawer" DisplaySearchBar="true" />
     </MudAppBar>
     <MudDrawer Open="@_drawerOpen" OpenChanged="OnDrawerOpenChanged" ClipMode="DrawerClipMode.Docked" Elevation="0" Breakpoint="Breakpoint.Md">
-        <MudHidden Breakpoint="Breakpoint.MdAndUp">
+        <div class="d-block d-md-none">
             <MudToolBar Dense="true" DisableGutters="true" Class="docs-gray-bg">
                 @if (_topMenuOpen == false)
                 {
@@ -39,8 +39,8 @@
                     </MudNavGroup>
                 </MudNavMenu>
             }
-        </MudHidden>
-         <MudNavMenu Color="Color.Primary" Rounded="true" Dense="true" Margin="Margin.Dense" Class="pa-2 overflow-auto mb-3">
+        </div>
+        <MudNavMenu Color="Color.Primary" Rounded="true" Dense="true" Margin="Margin.Dense" Class="pa-2 overflow-auto mb-3">
             @if (!_topMenuOpen && LayoutService.GetDocsBasePage(NavigationManager.Uri) == DocsBasePage.Docs)
             {
                 <NavMenu @ref="@_navMenuRef"/>

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Services;
 
@@ -12,7 +11,7 @@ public partial class DocsLayout : LayoutComponentBase
 {
     [Inject] private LayoutService LayoutService { get; set; }
     [Inject] private NavigationManager NavigationManager { get; set; }
-    
+
     private NavMenu _navMenuRef;
     private bool _drawerOpen = true;
     private bool _topMenuOpen = false;
@@ -20,7 +19,7 @@ public partial class DocsLayout : LayoutComponentBase
     {
         LayoutService.SetBaseTheme(Theme.DocsTheme());
     }
-    
+
     protected override void OnAfterRender(bool firstRender)
     {
         //refresh nav menu because no parameters change in nav menu but internal data does


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Docs were using MudHidden which has to wait for javascript to be loaded.
This means prerendering doesn't show the app bar which is an important part of the page.
It also causes flashiness which google doesn't like.
Users see the menu loading delay.

Despite the app rendering more elements when using the CSS method the result is a more responsive and SEO friendly UI.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually by running the docs.
https://mudblazor-test.azurewebsites.net/
ATM there are no tests for the docs navigation.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
