### PR TITLE
MudPopoverProvider: Don't static render

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor.Docs.Examples;
+using MudBlazor.Services;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Popover;
 using NUnit.Framework;
@@ -1070,6 +1072,15 @@ namespace MudBlazor.UnitTests.Components
         public void MudPopoverProvider_NoRenderWhenIsEnabledIsFalse()
         {
             var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderIsEnabled, false));
+            Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void MudPopoverProvider_NoRenderWhenStaticRendering(bool providerIsEnabled)
+        {
+            Context.Services.AddScoped<IRenderContext, MockStaticRenderContext>();
+            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderIsEnabled, providerIsEnabled));
             Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
         }
 

--- a/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
@@ -18,6 +18,7 @@ namespace MudBlazor.UnitTests
                 options.SnackbarConfiguration.ShowTransitionDuration = 0;
                 options.SnackbarConfiguration.HideTransitionDuration = 0;
             });
+            ctx.Services.AddScoped<IRenderContext, MockRenderContext>();
             ctx.Services.AddScoped(sp => new HttpClient());
             ctx.Services.AddOptions();
         }

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -50,6 +50,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
             ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddTransient<InternalMudLocalizer>();
+            ctx.Services.AddScoped<IRenderContext, MockRenderContext>();
             ctx.Services.AddScoped(sp => new HttpClient());
         }
 

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -48,6 +48,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IPopoverService, MockPopoverServiceV2>();
             ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddTransient<InternalMudLocalizer>();
+            ctx.Services.AddScoped<IRenderContext, MockRenderContext>();
             ctx.Services.AddOptions();
             ctx.Services.AddScoped(sp =>
                 new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });

--- a/src/MudBlazor.UnitTests/Mocks/MockRenderContext.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockRenderContext.cs
@@ -8,6 +8,6 @@ public class MockRenderContext : IRenderContext
 
     public bool IsInteractiveServer() => true;
 
-    public bool IsStatic() => false;
+    public bool IsStaticServer() => false;
 }
 

--- a/src/MudBlazor.UnitTests/Mocks/MockRenderContext.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockRenderContext.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace MudBlazor.Services;
+
+public class MockRenderContext : IRenderContext
+{
+    public bool IsInteractiveWebAssembly() => false;
+
+    public bool IsInteractiveServer() => true;
+
+    public bool IsStatic() => false;
+}
+

--- a/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
@@ -8,6 +8,6 @@ public class MockStaticRenderContext : IRenderContext
 
     public bool IsInteractiveServer() => false;
 
-    public bool IsStatic() => true;
+    public bool IsStaticServer() => true;
 }
 

--- a/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace MudBlazor.Services;
+
+public class MockStaticRenderContext : IRenderContext
+{
+    public bool IsInteractiveWebAssembly() => false;
+
+    public bool IsInteractiveServer() => true;
+
+    public bool IsStatic() => true;
+}
+

--- a/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockStaticRenderContext.cs
@@ -6,7 +6,7 @@ public class MockStaticRenderContext : IRenderContext
 {
     public bool IsInteractiveWebAssembly() => false;
 
-    public bool IsInteractiveServer() => true;
+    public bool IsInteractiveServer() => false;
 
     public bool IsStatic() => true;
 }

--- a/src/MudBlazor.UnitTests/Services/RenderContextTests.cs
+++ b/src/MudBlazor.UnitTests/Services/RenderContextTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using Microsoft.JSInterop;
+using Moq;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services;
+
+[TestFixture]
+public class RenderContextTests
+{
+    // This test just clarifies the behaviour of the Mocked IJSRuntime with RenderContext
+    // This is why we need to use MockRenderContext and MockPreRenderContext to get sane test results
+    // We add the Mocks here for clarity
+    [Test]
+    public void CheckValuesWithMockJSRuntime()
+    {
+        var jsruntimeMock = new Mock<IJSRuntime>();
+        var renderContext = new RenderContext(jsruntimeMock.Object);
+        renderContext.IsInteractiveWebAssembly().Should().BeFalse();
+        renderContext.IsInteractiveServer().Should().BeFalse();
+        renderContext.IsStatic().Should().BeTrue();
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/RenderContextTests.cs
+++ b/src/MudBlazor.UnitTests/Services/RenderContextTests.cs
@@ -23,6 +23,6 @@ public class RenderContextTests
         var renderContext = new RenderContext(jsruntimeMock.Object);
         renderContext.IsInteractiveWebAssembly().Should().BeFalse();
         renderContext.IsInteractiveServer().Should().BeFalse();
-        renderContext.IsStatic().Should().BeTrue();
+        renderContext.IsStaticServer().Should().BeTrue();
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Services;
 
 namespace MudBlazor
 {
@@ -21,6 +22,9 @@ namespace MudBlazor
 
         [Inject]
         internal IPopoverService PopoverService { get; set; } = null!;
+
+        [Inject]
+        internal IRenderContext RenderContext { get; set; } = null!;
 
         /// <summary>
         /// In some scenarios we need more than one ThemeProvider but we must not have more than one
@@ -40,6 +44,11 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
+            if (RenderContext.IsStatic())
+            {
+                IsEnabled = false;
+            }
+
             if (IsEnabled == false)
             {
                 return;

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            if (RenderContext.IsStatic())
+            if (RenderContext.IsStaticServer())
             {
                 IsEnabled = false;
             }

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -362,6 +362,17 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        /// Adds the services required for detecting render context.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        public static IServiceCollection AddMudRenderContext(this IServiceCollection services)
+        {
+            services.TryAddScoped<IRenderContext, RenderContext>();
+
+            return services;
+        }
+
+        /// <summary>
         /// Adds common services required by MudBlazor components
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -384,7 +395,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorScrollSpy()
                 .AddMudPopoverService(configuration.PopoverOptions)
                 .AddMudEventManager()
-                .AddMudLocalization();
+                .AddMudLocalization()
+                .AddMudRenderContext();
         }
 
         /// <summary>
@@ -408,7 +420,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorScrollSpy()
                 .AddMudPopoverService()
                 .AddMudEventManager()
-                .AddMudLocalization();
+                .AddMudLocalization()
+                .AddMudRenderContext();
         }
 
         /// <summary>
@@ -475,7 +488,8 @@ namespace MudBlazor.Services
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()
-                .AddMudLocalization();
+                .AddMudLocalization()
+                .AddMudRenderContext();
         }
     }
 }

--- a/src/MudBlazor/Services/RenderContext/IRenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/IRenderContext.cs
@@ -2,12 +2,29 @@
 
 namespace MudBlazor.Services;
 
+/// <summary>
+/// Service to return the current render mode
+/// </summary>
 public interface IRenderContext
 {
+
+    /// <summary>
+    /// WebAssembly interctive mode
+    /// </summary>
+    /// <returns>true if the mode is active else false</returns>
     bool IsInteractiveWebAssembly();
 
+    /// <summary>
+    /// Server Side interctive mode
+    /// </summary>
+    /// <returns>true if the mode is active else false</returns>
     bool IsInteractiveServer();
 
+    /// <summary>
+    /// The server is statically rendering the page for SSR or PreRendering.
+    /// No interactivity is available.
+    /// </summary>
+    /// <returns>true if the mode is active else false</returns>
     bool IsStaticServer();
 }
 

--- a/src/MudBlazor/Services/RenderContext/IRenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/IRenderContext.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace MudBlazor.Services;
+
+public interface IRenderContext
+{
+    bool IsInteractiveWebAssembly();
+
+    bool IsInteractiveServer();
+
+    bool IsStatic();
+}
+

--- a/src/MudBlazor/Services/RenderContext/IRenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/IRenderContext.cs
@@ -8,6 +8,6 @@ public interface IRenderContext
 
     bool IsInteractiveServer();
 
-    bool IsStatic();
+    bool IsStaticServer();
 }
 

--- a/src/MudBlazor/Services/RenderContext/IRenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/IRenderContext.cs
@@ -9,20 +9,20 @@ public interface IRenderContext
 {
 
     /// <summary>
-    /// WebAssembly interctive mode
+    /// Is the rendering in Interactive WebAssembly mode
     /// </summary>
     /// <returns>true if the mode is active else false</returns>
     bool IsInteractiveWebAssembly();
 
     /// <summary>
-    /// Server Side interctive mode
+    /// Is the rendering in Interactive Server mode
     /// </summary>
     /// <returns>true if the mode is active else false</returns>
     bool IsInteractiveServer();
 
     /// <summary>
-    /// The server is statically rendering the page for SSR or PreRendering.
-    /// No interactivity is available.
+    /// Is the rendering in Static mode (SSR or PreRendering)
+    /// Note: No interactivity is available.
     /// </summary>
     /// <returns>true if the mode is active else false</returns>
     bool IsStaticServer();

--- a/src/MudBlazor/Services/RenderContext/RenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/RenderContext.cs
@@ -1,0 +1,29 @@
+#nullable enable
+
+using System;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services;
+
+public class RenderContext : IRenderContext
+{
+
+    private readonly IJSRuntime _jsRuntime;
+
+    public RenderContext(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public bool IsInteractiveWebAssembly() => OperatingSystem.IsBrowser();
+
+    public bool IsInteractiveServer() => !IsInteractiveWebAssembly() && IsInitialized();
+
+    public bool IsStatic() => !IsInteractiveWebAssembly() && !IsInitialized();
+
+    private bool IsInitialized()
+    {
+        return (bool)(_jsRuntime?.GetType()?.GetProperty("IsInitialized")?.GetValue(_jsRuntime) ?? false);
+    }
+}
+

--- a/src/MudBlazor/Services/RenderContext/RenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/RenderContext.cs
@@ -5,20 +5,31 @@ using Microsoft.JSInterop;
 
 namespace MudBlazor.Services;
 
+/// <summary>
+/// This service returns the current render mode
+/// Note it uses a private property of the IJSRuntime that is unsupported
+/// At the time of writing MS don't provide a supported equivalent method
+/// </summary>
 public class RenderContext : IRenderContext
 {
-
     private readonly IJSRuntime _jsRuntime;
 
+    /// <summary>
+    /// Constructor
+    /// IJSRuntime is injected for detection method IsInitialised
+    /// </summary>
     public RenderContext(IJSRuntime jsRuntime)
     {
         _jsRuntime = jsRuntime;
     }
 
+    /// <inhertidoc />
     public bool IsInteractiveWebAssembly() => OperatingSystem.IsBrowser();
 
+    /// <inhertidoc />
     public bool IsInteractiveServer() => !IsInteractiveWebAssembly() && IsInitialized();
 
+    /// <inhertidoc />
     public bool IsStaticServer() => !IsInteractiveWebAssembly() && !IsInitialized();
 
     private bool IsInitialized()

--- a/src/MudBlazor/Services/RenderContext/RenderContext.cs
+++ b/src/MudBlazor/Services/RenderContext/RenderContext.cs
@@ -19,7 +19,7 @@ public class RenderContext : IRenderContext
 
     public bool IsInteractiveServer() => !IsInteractiveWebAssembly() && IsInitialized();
 
-    public bool IsStatic() => !IsInteractiveWebAssembly() && !IsInitialized();
+    public bool IsStaticServer() => !IsInteractiveWebAssembly() && !IsInitialized();
 
     private bool IsInitialized()
     {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
- Added `RenderContext` to our services to enable detection of Static Server-Side Rendering (SSR) or prerendering
- Use `RenderContext` to avoid rendering `MudPopoverProvider` when prerendering or when in SSR mode.
- `MudPopoverProvider` is non-functional in Static Server-Side Rendering (SSR) or prerendering so not rendering also saves on resources/page size.
- Another side benefit is when using `MudThemeProvider` in SSR we don't have to use a parameter to remove the `MudPopoverProvider` making our boilerplate setup code simpler for some of the new net8.0 Templates

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Running BSS and Hosted Wasm Docs and debuging the `OnInitialized()` lifecycle method.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
