### PR TITLE
MudToggle: Make doc examples mobile ready

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
@@ -24,7 +24,7 @@
                 </MudToggleItem>
             </MudToggleGroup>
         </MudStack>
-
+        <MudSpacer/>
         <MudToggleGroup T="string" Vertical  Outline="@_outline" Delimiters="@_delimiters" Dense="@_dense" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent">
                 <MudToggleItem Value="@("left")">
                     <MudIcon Icon="@Icons.Material.Filled.FormatAlignLeft"/>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudStack>
-    <div class="d-flex justify-space-between">
+    <MudStack Row Class="flex-wrap">
         <MudStack Spacing="16" AlignItems="@AlignItems.Start">
-            <MudToggleGroup T="string" Style="width: 360px;" Outline="@_outline" Delimiters="@_delimiters" Dense="@_dense" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent">
+            <MudToggleGroup T="string" Style="width: 300px;" Outline="@_outline" Delimiters="@_delimiters" Dense="@_dense" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent">
                 <MudToggleItem Value="@("One")"/>
                 <MudToggleItem Value="@("Two")"/>
                 <MudToggleItem Value="@("Three")"/>
@@ -39,9 +39,9 @@
                     <MudIcon Icon="@Icons.Material.Filled.FormatAlignJustify"/>                
                 </MudToggleItem>
         </MudToggleGroup>
-    </div>
+    </MudStack>
 
-    <MudStack Row>
+    <MudStack Row Class="flex-wrap">
         <MudCheckBox @bind-Checked="@_dense" Label="Dense"/>
         <MudCheckBox @bind-Checked="@_rounded" Label="Rounded"/>
         <MudCheckBox @bind-Checked="@_checkMark" Label="CheckMark"/>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
@@ -34,7 +34,6 @@
     .ellipsis {
         overflow: hidden;
         white-space: nowrap;
-        text-wrap: nowrap;
         text-overflow: ellipsis
     }
 </style>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
@@ -1,33 +1,40 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudStack Class="mud-width-full">
-    <MudToggleGroup T="string" SelectedClass="black white-text">
-        <MudToggleItem Value="@("Basic Edition")">
-            <div class="mud-width-full mud-height-full">
-                <div class="d-flex align-center justify-space-between">
-                    <MudText>Indie Developer</MudText>
-                    <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Basic</MudChip>
-                </div>
-                <MudText Typo="Typo.subtitle2">Perfect for lone wolves</MudText>
+<MudToggleGroup  Class="mud-width-full" T="string" SelectedClass="black white-text">
+    <MudToggleItem Value="@("Basic Edition")">
+        <div class="mud-width-full mud-height-full">
+            <div class="d-flex align-center justify-space-between flex-wrap">
+                <MudText Class="ellipsis">Indie Developer</MudText>
+                <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Basic</MudChip>
             </div>
-        </MudToggleItem>
-        <MudToggleItem Value="@("Pro Edition")">
-            <div class="mud-width-full mud-height-full">
-                <div class="d-flex align-center justify-space-between">
-                    <MudText>Small Team</MudText>
-                    <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Pro</MudChip>
-                </div>
-                <MudText Typo="Typo.subtitle2">Up to five devs and two interns</MudText>
+            <MudText Typo="Typo.subtitle2">Perfect for lone wolves</MudText>
+        </div>
+    </MudToggleItem>
+    <MudToggleItem Value="@("Pro Edition")">
+        <div class="mud-width-full mud-height-full">
+            <div class="d-flex align-center justify-space-between flex-wrap">
+                <MudText Class="ellipsis">Small Team</MudText>
+                <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Pro</MudChip>
             </div>
-        </MudToggleItem>
-        <MudToggleItem Value="@("Enterprise Edition")">
-            <div class="mud-width-full mud-height-full">
-                <div class="d-flex align-center justify-space-between">
-                    <MudText>Corporation</MudText>
-                    <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Enterprise</MudChip>
-                </div>
-                <MudText Typo="Typo.subtitle2">Unlimited edition</MudText>
+            <MudText Typo="Typo.subtitle2">Up to five devs and two interns</MudText>
+        </div>
+    </MudToggleItem>
+    <MudToggleItem Value="@("Enterprise Edition")">
+        <div class="mud-width-full mud-height-full">
+            <div class="d-flex align-center justify-space-between flex-wrap">
+                <MudText Class="ellipsis">Corporation</MudText>
+                <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Enterprise</MudChip>
             </div>
-        </MudToggleItem>
-    </MudToggleGroup>
-</MudStack>
+            <MudText Typo="Typo.subtitle2">Unlimited edition</MudText>
+        </div>
+    </MudToggleItem>
+</MudToggleGroup>
+
+<style>
+    .ellipsis {
+        overflow: hidden;
+        white-space: nowrap;
+        text-wrap: nowrap;
+        text-overflow: ellipsis
+    }
+</style>


### PR DESCRIPTION
## Description

The examples in the MudToggle docs were not responsive and looked catastrophically bad on small screens. Added flex-wrap to make them adjust to screen sizes down to 340px in width.

### before
![image](https://github.com/MudBlazor/MudBlazor/assets/44090/1e099a12-b11e-47fc-8117-68bc55641078)

### after
![image](https://github.com/MudBlazor/MudBlazor/assets/44090/308983fd-436f-4494-bdc6-1be86d7e848f)

### before
![image](https://github.com/MudBlazor/MudBlazor/assets/44090/11e1d096-78b7-46fe-925a-9aa9b35eec21)

### after
![image](https://github.com/MudBlazor/MudBlazor/assets/44090/335b2a23-a388-4a3e-a6e4-dffd27ee411a)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant screenshots.
