### PR TITLE
BrowserViewportService: Fix when the circuit has disconnected in BSS

### DIFF
--- a/src/MudBlazor/Interop/ResizeListenerInterop.cs
+++ b/src/MudBlazor/Interop/ResizeListenerInterop.cs
@@ -20,9 +20,11 @@ internal class ResizeListenerInterop
         _jsRuntime = jsRuntime;
     }
 
-    public ValueTask<bool> MatchMedia(string mediaQuery)
+    public async ValueTask<bool> MatchMedia(string mediaQuery)
     {
-        return _jsRuntime.InvokeAsync<bool>("mudResizeListener.matchMedia", mediaQuery);
+        var matchMedia = await _jsRuntime.InvokeAsyncWithErrorHandling(false, "mudResizeListener.matchMedia", mediaQuery);
+
+        return matchMedia.value;
     }
 
     public ValueTask<bool> ListenForResize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotNetObjectReference, ResizeOptions options, Guid javaScriptListerId) where T : class
@@ -40,8 +42,10 @@ internal class ResizeListenerInterop
         return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListeners", jsListenerIds);
     }
 
-    public ValueTask<BrowserWindowSize> GetBrowserWindowSize()
+    public async ValueTask<BrowserWindowSize> GetBrowserWindowSize()
     {
-        return _jsRuntime.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize");
+        var size = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize");
+
+        return size.value;
     }
 }

--- a/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
@@ -115,7 +115,7 @@ namespace MudBlazor
             // catch prerending errors since there is no browser at this point.
             catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
             {
-                return (false, fallbackValue);;
+                return (false, fallbackValue);
             }
             catch (JSDisconnectedException)
             {


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/8070
Did not know that there is `InvokeVoidAsyncWithErrorHandling` overload for generics and with fallback value.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
