### PR TITLE
MudTable: Optimize event handling for OnRowMouseEnter/Leave

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -199,6 +199,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseEnter { get; set; }
 
+        internal override bool HasRowMouseEnterEventHandler => OnRowMouseEnter.HasDelegate;
+
         internal override async Task FireRowMouseEnterEventAsync(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);
@@ -219,7 +221,9 @@ namespace MudBlazor
         /// Row hover stop event.
         /// </summary>
         [Parameter] public EventCallback<TableRowHoverEventArgs<T>> OnRowMouseLeave { get; set; }
-
+        
+        internal override bool HasRowMouseLeaveEventHandler => OnRowMouseLeave.HasDelegate;
+        
         internal override async Task FireRowMouseLeaveEventAsync(MouseEventArgs args, MudTr row, object o)
         {
             var item = default(T);

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -561,7 +561,8 @@ namespace MudBlazor
         internal abstract Task FireRowMouseLeaveEventAsync(MouseEventArgs args, MudTr mudTr, object item);
 
         internal abstract void OnHeaderCheckboxClicked(bool checkedState);
-
+        internal abstract bool HasRowMouseEnterEventHandler { get; }
+        internal abstract bool HasRowMouseLeaveEventHandler { get; }
         internal abstract bool IsEditable { get; }
 
         public abstract bool ContainsItem(object item);

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -2,7 +2,7 @@
 @implements IDisposable
 @inherits MudComponentBase
 
-<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@OnRowMouseEnterAsync" @onmouseleave="@OnRowMouseLeaveAsync" style="@Style" @attributes="@UserAttributes">
+<tr class="@Classname" @onclick="@OnRowClicked" @onmouseenter="@RowMouseEnterEventCallback" @onmouseleave="@RowMouseLeaveEventCallback" style="@Style" @attributes="@UserAttributes">
     @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -83,6 +83,32 @@ namespace MudBlazor
             await table.FireRowMouseLeaveEventAsync(args, this, Item);
         }
 
+        private EventCallback<MouseEventArgs> RowMouseEnterEventCallback
+        {
+            get
+            {
+                var hasEventHandler = Context?.Table?.HasRowMouseEnterEventHandler ?? false;
+
+                if (hasEventHandler)
+                    return EventCallback.Factory.Create<MouseEventArgs>(this, OnRowMouseEnterAsync);
+
+                return default;
+            }
+        }
+        
+        private EventCallback<MouseEventArgs> RowMouseLeaveEventCallback
+        {
+            get
+            {
+                var hasEventHandler = Context?.Table?.HasRowMouseLeaveEventHandler ?? false;
+
+                if (hasEventHandler)
+                    return EventCallback.Factory.Create<MouseEventArgs>(this, OnRowMouseLeaveAsync);
+
+                return default;
+            }
+        }
+        
         private void StartEditingItem() => StartEditingItem(buttonClicked: true);
 
         private void StartEditingItem(bool buttonClicked)


### PR DESCRIPTION
## Description
This is a fix for #8014.
It optimizes event handling of OnRowMouseEnter/OnRowMouseLeave to reduce SignalR messages in Blazor ServerSide.

## How Has This Been Tested?
manually using Docs app + browser tools

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
