### PR TITLE
DataGrid: Support for sub properties editing

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditComplexPropertyExpressionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditComplexPropertyExpressionTest.razor
@@ -2,29 +2,29 @@
 
 <MudDataGrid T="Item" Items="Items" EditMode="@DataGridEditMode.Cell" ReadOnly="false">
     <Columns>
-		<PropertyColumn Property="x => x.Name" />
-		<PropertyColumn Property="x => x.SubItem.SubProperty" />
-		<PropertyColumn Property="x => x.SubItem.SubItem2.SubProperty2" />
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.SubItem.SubProperty" />
+        <PropertyColumn Property="x => x.SubItem.SubItem2.SubProperty2" />
     </Columns>
 </MudDataGrid>
 
 @code {
-	public List<Item> Items = new List<Item>()
+    public List<Item> Items = new List<Item>()
     {
         new Item("A", "A-D", "A-D-E"), 
         new Item("B", "B-D", "B-D-E"), 
         new Item("C", "C-D", "C-D-E")
     };
 
-	public class SubItem
-	{
-		public SubItem(string subProperty, string subProperty2)
-		{
-			SubProperty = subProperty;
-			SubItem2 = new SubItem2(subProperty2);
-		}
+    public class SubItem
+    {
+        public SubItem(string subProperty, string subProperty2)
+        {
+            SubProperty = subProperty;
+            SubItem2 = new SubItem2(subProperty2);
+        }
 
-		public SubItem2 SubItem2 { get; set; }
+        public SubItem2 SubItem2 { get; set; }
 
         public string SubProperty { get; set; }
     }
@@ -37,16 +37,16 @@
 
         public string SubProperty2 { get; set; }
     }
-	public class Item
+    public class Item
     {
         public string Name { get; set; }
 
-		public SubItem SubItem { get; set; }
+        public SubItem SubItem { get; set; }
 
-		public Item(string name, string subProperty, string subProperty2)
+        public Item(string name, string subProperty, string subProperty2)
         {
             Name = name;
-			SubItem = new SubItem(subProperty, subProperty2);
+            SubItem = new SubItem(subProperty, subProperty2);
         }
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditComplexPropertyExpressionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditComplexPropertyExpressionTest.razor
@@ -1,0 +1,53 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="Item" Items="Items" EditMode="@DataGridEditMode.Cell" ReadOnly="false">
+    <Columns>
+		<PropertyColumn Property="x => x.Name" />
+		<PropertyColumn Property="x => x.SubItem.SubProperty" />
+		<PropertyColumn Property="x => x.SubItem.SubItem2.SubProperty2" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+	public List<Item> Items = new List<Item>()
+    {
+        new Item("A", "A-D", "A-D-E"), 
+        new Item("B", "B-D", "B-D-E"), 
+        new Item("C", "C-D", "C-D-E")
+    };
+
+	public class SubItem
+	{
+		public SubItem(string subProperty, string subProperty2)
+		{
+			SubProperty = subProperty;
+			SubItem2 = new SubItem2(subProperty2);
+		}
+
+		public SubItem2 SubItem2 { get; set; }
+
+        public string SubProperty { get; set; }
+    }
+    public class SubItem2
+    {
+        public SubItem2(string subProperty)
+        {
+            SubProperty2 = subProperty;
+        }
+
+        public string SubProperty2 { get; set; }
+    }
+	public class Item
+    {
+        public string Name { get; set; }
+
+		public SubItem SubItem { get; set; }
+
+		public Item(string name, string subProperty, string subProperty2)
+        {
+            Name = name;
+			SubItem = new SubItem(subProperty, subProperty2);
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -705,7 +705,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Fire RowClick, SelectedItemChanged, SelectedItemsChanged, and StartedEditingItem callbacks.
             dataGrid.FindAll(".mud-table-body tr")[0].Click();
-            
+
             // Fire RowContextMenuClick
             dataGrid.FindAll(".mud-table-body tr")[0].ContextMenu();
 
@@ -723,6 +723,33 @@ namespace MudBlazor.UnitTests.Components
             // but we can brute force it by directly calling the CancelEditingItemAsync method on the datagrid
             await dataGrid.InvokeAsync(dataGrid.Instance.CancelEditingItemAsync);
             comp.Instance.CanceledEditingItem.Should().Be(true);
+        }
+
+        [Test]
+        public async Task DataGridEditComplexPropertyExpressionTest()
+        {
+            var comp = Context.RenderComponent<DataGridEditComplexPropertyExpressionTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditComplexPropertyExpressionTest.Item>>();
+
+
+            dataGrid.Render();
+
+            // Make sure that the value is as expected before we try to change it
+            comp.Instance.Items[0].Name.Should().Be("A");
+            comp.Instance.Items[0].SubItem.SubProperty.Should().Be("A-D");
+            comp.Instance.Items[0].SubItem.SubItem2.SubProperty2.Should().Be("A-D-E");
+
+            // Edit an item 'normally'
+            dataGrid.FindAll(".mud-table-body tr td input")[0].Change("Test 1");
+            comp.Instance.Items[0].Name.Should().Be("Test 1");
+
+            // Edit an item that has a sub property like x.Something.SomethingElse
+            dataGrid.FindAll(".mud-table-body tr td input")[1].Change("Test 2");
+            comp.Instance.Items[0].SubItem.SubProperty.Should().Be("Test 2");
+
+            // Edit an item that has a sub property like x.Something.SomethingElse.SomethingElseAgain
+            dataGrid.FindAll(".mud-table-body tr td input")[2].Change("Test 3");
+            comp.Instance.Items[0].SubItem.SubItem2.SubProperty2.Should().Be("Test 3");
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -11,108 +11,108 @@ using MudBlazor.Utilities.Expressions;
 namespace MudBlazor
 {
 #nullable enable
-	/// <typeparam name="T">The type of data represented by each row in the data grid.</typeparam>
-	/// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
-	public partial class PropertyColumn<T, TProperty> : Column<T>
-	{
-		private readonly Guid _id = Guid.NewGuid();
+    /// <typeparam name="T">The type of data represented by each row in the data grid.</typeparam>
+    /// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
+    public partial class PropertyColumn<T, TProperty> : Column<T>
+    {
+        private readonly Guid _id = Guid.NewGuid();
 
-		private string? _propertyName;
-		private Func<T, object?>? _cellContentFunc;
-		private Func<T, TProperty>? _compiledPropertyFunc;
-		private Expression<Func<T, TProperty>>? _lastAssignedProperty;
-		private Expression<Func<T, TProperty>>? _compiledPropertyFuncFor;
+        private string? _propertyName;
+        private Func<T, object?>? _cellContentFunc;
+        private Func<T, TProperty>? _compiledPropertyFunc;
+        private Expression<Func<T, TProperty>>? _lastAssignedProperty;
+        private Expression<Func<T, TProperty>>? _compiledPropertyFuncFor;
 
-		[Parameter]
-		[EditorRequired]
-		public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
+        [Parameter]
+        [EditorRequired]
+        public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
 
-		[Parameter]
-		public string? Format { get; set; }
+        [Parameter]
+        public string? Format { get; set; }
 
-		protected override void OnParametersSet()
-		{
-			// We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
-			if (_lastAssignedProperty != Property)
-			{
-				_lastAssignedProperty = Property;
-				var compiledPropertyExpression = Property.Compile();
-				_cellContentFunc = item => compiledPropertyExpression(item);
-			}
+        protected override void OnParametersSet()
+        {
+            // We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
+            if (_lastAssignedProperty != Property)
+            {
+                _lastAssignedProperty = Property;
+                var compiledPropertyExpression = Property.Compile();
+                _cellContentFunc = item => compiledPropertyExpression(item);
+            }
 
-			var property = PropertyPath.Visit(Property);
-			if (property.IsBodyMemberExpression)
-			{
-				_propertyName = property.GetPath();
-			}
-			else
-			{
-				// Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
-				// We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
-				_propertyName = _id.ToString();
-			}
-			Title ??= property.GetLastMemberName();
+            var property = PropertyPath.Visit(Property);
+            if (property.IsBodyMemberExpression)
+            {
+                _propertyName = property.GetPath();
+            }
+            else
+            {
+                // Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
+                // We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
+                _propertyName = _id.ToString();
+            }
+            Title ??= property.GetLastMemberName();
 
-			CompileGroupBy();
-		}
+            CompileGroupBy();
+        }
 
-		protected internal override LambdaExpression? PropertyExpression
-			=> Property;
+        protected internal override LambdaExpression? PropertyExpression
+            => Property;
 
-		public override string? PropertyName
-			=> _propertyName;
+        public override string? PropertyName
+            => _propertyName;
 
-		protected internal override string? ContentFormat
-			=> Format;
+        protected internal override string? ContentFormat
+            => Format;
 
-		protected internal override object? CellContent(T item)
-			=> _cellContentFunc!(item);
+        protected internal override object? CellContent(T item)
+            => _cellContentFunc!(item);
 
-		protected internal override object? PropertyFunc(T item)
-		{
-			if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
-			{
-				_compiledPropertyFunc = Property.Compile();
-				_compiledPropertyFuncFor = Property;
-			}
+        protected internal override object? PropertyFunc(T item)
+        {
+            if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
+            {
+                _compiledPropertyFunc = Property.Compile();
+                _compiledPropertyFuncFor = Property;
+            }
 
-			return _compiledPropertyFunc(item);
-		}
+            return _compiledPropertyFunc(item);
+        }
 
-		protected internal override Type PropertyType
-			=> typeof(TProperty);
+        protected internal override Type PropertyType
+            => typeof(TProperty);
 
-		/// <summary>
-		/// If the Property expression looks like 'x => x.y.z', to set the value of 'z' we need to find the value of 'y', we can dig recursively until we find it.
-		/// </summary>
-		/// <exception cref="NullReferenceException"></exception>
-		private object RecursiveGetSubProperties(MemberExpression memberExpression, object item)
-		{
-			if (memberExpression.Expression is MemberExpression subMemberExpress && subMemberExpress.Member is PropertyInfo propertyInfo)
-			{
-				var subObject = RecursiveGetSubProperties(subMemberExpress, item);
+        /// <summary>
+        /// If the Property expression looks like 'x => x.y.z', to set the value of 'z' we need to find the value of 'y', we can dig recursively until we find it.
+        /// </summary>
+        /// <exception cref="NullReferenceException"></exception>
+        private object RecursiveGetSubProperties(MemberExpression memberExpression, object item)
+        {
+            if (memberExpression.Expression is MemberExpression subMemberExpress && subMemberExpress.Member is PropertyInfo propertyInfo)
+            {
+                var subObject = RecursiveGetSubProperties(subMemberExpress, item);
 
-				return propertyInfo.GetValue(subObject) ?? throw new NullReferenceException($"Unable to get property value, value of '{propertyInfo.Name}' is null in '{Property}'");
-			}
+                return propertyInfo.GetValue(subObject) ?? throw new NullReferenceException($"Unable to get property value, value of '{propertyInfo.Name}' is null in '{Property}'");
+            }
 
-			return item;
-		}
+            return item;
+        }
 
-		protected internal override void SetProperty(object item, object value)
-		{
-			var expression = Property.Body;
+        protected internal override void SetProperty(object item, object value)
+        {
+            var expression = Property.Body;
 
-			// Only MemberExpression is supported, MemberExpression access members like 'x.y' is accessing the member 'y'
-			if (expression is MemberExpression memberExpression)
-			{
-				item = RecursiveGetSubProperties(memberExpression, item);
+            // Only MemberExpression is supported, MemberExpression access members like 'x.y' is accessing the member 'y'
+            if (expression is MemberExpression memberExpression)
+            {
+                item = RecursiveGetSubProperties(memberExpression, item);
 
                 if (memberExpression.Member is PropertyInfo propertyInfo)
                 {
                     var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
                     propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
                 }
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -11,108 +11,105 @@ using MudBlazor.Utilities.Expressions;
 namespace MudBlazor
 {
 #nullable enable
-    /// <typeparam name="T">The type of data represented by each row in the data grid.</typeparam>
-    /// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
-    public partial class PropertyColumn<T, TProperty> : Column<T>
-    {
-        private readonly Guid _id = Guid.NewGuid();
+	/// <typeparam name="T">The type of data represented by each row in the data grid.</typeparam>
+	/// <typeparam name="TProperty">The type of the value being displayed in the column's cells.</typeparam>
+	public partial class PropertyColumn<T, TProperty> : Column<T>
+	{
+		private readonly Guid _id = Guid.NewGuid();
 
-        private string? _propertyName;
-        private Func<T, object?>? _cellContentFunc;
-        private Func<T, TProperty>? _compiledPropertyFunc;
-        private Expression<Func<T, TProperty>>? _lastAssignedProperty;
-        private Expression<Func<T, TProperty>>? _compiledPropertyFuncFor;
+		private string? _propertyName;
+		private Func<T, object?>? _cellContentFunc;
+		private Func<T, TProperty>? _compiledPropertyFunc;
+		private Expression<Func<T, TProperty>>? _lastAssignedProperty;
+		private Expression<Func<T, TProperty>>? _compiledPropertyFuncFor;
 
-        [Parameter]
-        [EditorRequired]
-        public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
+		[Parameter]
+		[EditorRequired]
+		public Expression<Func<T, TProperty>> Property { get; set; } = Expression.Lambda<Func<T, TProperty>>(Expression.Default(typeof(TProperty)), Expression.Parameter(typeof(T)));
 
-        [Parameter]
-        public string? Format { get; set; }
+		[Parameter]
+		public string? Format { get; set; }
 
-        protected override void OnParametersSet()
-        {
-            // We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
-            if (_lastAssignedProperty != Property)
-            {
-                _lastAssignedProperty = Property;
-                var compiledPropertyExpression = Property.Compile();
-                _cellContentFunc = item => compiledPropertyExpression(item);
-            }
+		protected override void OnParametersSet()
+		{
+			// We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
+			if (_lastAssignedProperty != Property)
+			{
+				_lastAssignedProperty = Property;
+				var compiledPropertyExpression = Property.Compile();
+				_cellContentFunc = item => compiledPropertyExpression(item);
+			}
 
-            var property = PropertyPath.Visit(Property);
-            if (property.IsBodyMemberExpression)
-            {
-                _propertyName = property.GetPath();
-            }
-            else
-            {
-                // Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
-                // We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
-                _propertyName = _id.ToString();
-            }
-            Title ??= property.GetLastMemberName();
+			var property = PropertyPath.Visit(Property);
+			if (property.IsBodyMemberExpression)
+			{
+				_propertyName = property.GetPath();
+			}
+			else
+			{
+				// Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
+				// We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
+				_propertyName = _id.ToString();
+			}
+			Title ??= property.GetLastMemberName();
 
-            CompileGroupBy();
-        }
+			CompileGroupBy();
+		}
 
-        protected internal override LambdaExpression? PropertyExpression
-            => Property;
+		protected internal override LambdaExpression? PropertyExpression
+			=> Property;
 
-        public override string? PropertyName
-            => _propertyName;
+		public override string? PropertyName
+			=> _propertyName;
 
-        protected internal override string? ContentFormat
-            => Format;
+		protected internal override string? ContentFormat
+			=> Format;
 
-        protected internal override object? CellContent(T item)
-            => _cellContentFunc!(item);
+		protected internal override object? CellContent(T item)
+			=> _cellContentFunc!(item);
 
-        protected internal override object? PropertyFunc(T item)
-        {
-            if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
-            {
-                _compiledPropertyFunc = Property.Compile();
-                _compiledPropertyFuncFor = Property;
-            }
+		protected internal override object? PropertyFunc(T item)
+		{
+			if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
+			{
+				_compiledPropertyFunc = Property.Compile();
+				_compiledPropertyFuncFor = Property;
+			}
 
-            return _compiledPropertyFunc(item);
-        }
+			return _compiledPropertyFunc(item);
+		}
 
-        protected internal override Type PropertyType
-            => typeof(TProperty);
+		protected internal override Type PropertyType
+			=> typeof(TProperty);
 
-        /// <summary>
-        /// If the Property expression looks like 'x => x.y.z', to set the value of 'z' we need to find the value of 'y', we can dig recursively until we find it.
-        /// </summary>
-        /// <exception cref="NullReferenceException"></exception>
-        private object RecursiveGetSubProperties(MemberExpression memberExpression, object item)
-        {
-            if (memberExpression.Expression is MemberExpression subMemberExpress && subMemberExpress.Member is PropertyInfo propertyInfo) 
-            {
-                var subObject = RecursiveGetSubProperties(subMemberExpress, item);
+		/// <summary>
+		/// If the Property expression looks like 'x => x.y.z', to set the value of 'z' we need to find the value of 'y', we can dig recursively until we find it.
+		/// </summary>
+		/// <exception cref="NullReferenceException"></exception>
+		private object RecursiveGetSubProperties(MemberExpression memberExpression, object item)
+		{
+			if (memberExpression.Expression is MemberExpression subMemberExpress && subMemberExpress.Member is PropertyInfo propertyInfo)
+			{
+				var subObject = RecursiveGetSubProperties(subMemberExpress, item);
 
-                return propertyInfo.GetValue(subObject) ?? throw new NullReferenceException($"Unable to get property value, value of '{propertyInfo.Name}' is null in '{Property}'");
-            }
+				return propertyInfo.GetValue(subObject) ?? throw new NullReferenceException($"Unable to get property value, value of '{propertyInfo.Name}' is null in '{Property}'");
+			}
 
-            return item;
-        }
+			return item;
+		}
 
-        protected internal override void SetProperty(object item, object value)
-        {
-            var expression = Property.Body;
+		protected internal override void SetProperty(object item, object value)
+		{
+			var expression = Property.Body;
 
-            // Only MemberExpression is supported, MemberExpression access members like 'x.y' is accessing the member 'y'
-            if(expression is MemberExpression memberExpression)
-            {
-                item = RecursiveGetSubProperties(memberExpression, item);
+			// Only MemberExpression is supported, MemberExpression access members like 'x.y' is accessing the member 'y'
+			if (expression is MemberExpression memberExpression)
+			{
+				item = RecursiveGetSubProperties(memberExpression, item);
 
-                if(memberExpression.Member is PropertyInfo propertyInfo)
-                {
-                    propertyInfo.SetValue(item, value);
-                    return;
-                }
-            }
-        }
-    }
+				if (memberExpression.Member is PropertyInfo propertyInfo)
+					propertyInfo.SetValue(item, value);
+			}
+		}
+	}
 }

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -107,8 +107,11 @@ namespace MudBlazor
 			{
 				item = RecursiveGetSubProperties(memberExpression, item);
 
-				if (memberExpression.Member is PropertyInfo propertyInfo)
-					propertyInfo.SetValue(item, value);
+                if (memberExpression.Member is PropertyInfo propertyInfo)
+                {
+                    var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
+                    propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
+                }
 			}
 		}
 	}

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -82,12 +82,36 @@ namespace MudBlazor
         protected internal override Type PropertyType
             => typeof(TProperty);
 
+        /// <summary>
+        /// If the Property expression looks like 'x => x.y.z', to set the value of 'z' we need to find the value of 'y', we can dig recursively until we find it.
+        /// </summary>
+        /// <exception cref="NullReferenceException"></exception>
+        private object RecursiveGetSubProperties(MemberExpression memberExpression, object item)
+        {
+            if (memberExpression.Expression is MemberExpression subMemberExpress && subMemberExpress.Member is PropertyInfo propertyInfo) 
+            {
+                var subObject = RecursiveGetSubProperties(subMemberExpress, item);
+
+                return propertyInfo.GetValue(subObject) ?? throw new NullReferenceException($"Unable to get property value, value of '{propertyInfo.Name}' is null in '{Property}'");
+            }
+
+            return item;
+        }
+
         protected internal override void SetProperty(object item, object value)
         {
-            if (Property.Body is MemberExpression { Member: PropertyInfo propertyInfo })
+            var expression = Property.Body;
+
+            // Only MemberExpression is supported, MemberExpression access members like 'x.y' is accessing the member 'y'
+            if(expression is MemberExpression memberExpression)
             {
-                var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
-                propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
+                item = RecursiveGetSubProperties(memberExpression, item);
+
+                if(memberExpression.Member is PropertyInfo propertyInfo)
+                {
+                    propertyInfo.SetValue(item, value);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
Resolves; #6804
This allows the `PropertyColumn` of the DataGrid to be used with more complex expressions instead of just "property" expressions. We can now use sub properties such as `x => x.MyProperty.OtherProperty`.
Before this change, sub properties would work to display data but editing them would crash.
This will make it a lot easier to map existing objects to a DataGrid.
The only thing I had to change is the way the PropertyColumn 'set' the value. Let me know if I missed something, so far testing works without any issues.

## How Has This Been Tested?
Unit tests and an example DataGrid during tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
