### PR TITLE
MudDatePicker DisplayMonths issue #6270

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -161,6 +161,15 @@
                 <DateRangePickerUsageExample/>
             </SectionContent>
         </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Display Months Usage">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Code="DatePickerMultipleMonthsExample" ShowCode="false">
+                <DatePickerMultipleMonthsExample/>
+            </SectionContent>
+        </DocsPageSection>
 
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMultipleMonthsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMultipleMonthsExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDatePicker Label="Display Months Usage" DisplayMonths="3" @bind-Date="date"/>
+
+@code {
+    DateTime? date = DateTime.Today;
+}

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -8,148 +8,152 @@
 @code {
 
     protected override RenderFragment PickerContent =>
-    @<CascadingValue Value="@this" IsFixed="true">
-        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
-            <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
-            <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
-        </MudPickerToolbar>
-        <MudPickerContent>
-            <div id="@_mudPickerCalendarContentElementId" class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
-                @{
-                    int dayId = 0;
-                    @if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
-                    {
-                        dayId = -1;
+        @<CascadingValue Value="@this" IsFixed="true">
+            <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
+                <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="OnYearClick">@GetFormattedYearString()</MudButton>
+                <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
+            </MudPickerToolbar>
+            <MudPickerContent>
+                <div id="@_mudPickerCalendarContentElementId" class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
+                    @{
+                            int dayId = 0;
+                        @if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+                        {
+                            dayId = -1;
+                        }
                     }
-                }
-                @for (int displayMonth = 0; displayMonth < DisplayMonths; ++displayMonth)
-                {
-                    int tempMonth = displayMonth; //without local variable month names are wrong
+                    @for (int displayMonth = 0; displayMonth < DisplayMonths; ++displayMonth)
+                    {
+                        int tempMonth = displayMonth; //without local variable month names are wrong
 
-                    <div class="mud-picker-calendar-container">
-                        @if (tempMonth == 0 && CurrentView == OpenTo.Year)
-                        {
-                            <div id="pickerYears" class="mud-picker-year-container">
-                                @for (int i = GetMinYear(); i <= GetMaxYear(); i++)
+                        <div class="mud-picker-calendar-container">
+                            @if (tempMonth == _monthPickerIndex)
+                            {
+                                if (CurrentView == OpenTo.Year)
                                 {
-                                    var year = i;
-                                    <div class="mud-picker-year" id="@(_componentId + year)" @onclick="(() => OnYearClicked(year))" @onclick:stopPropagation="true">
-                                        <MudText Typo="@GetYearTypo(year)" Class="@GetYearClasses(year)">@GetCalendarYear(year)</MudText>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        else if (tempMonth == 0 && CurrentView == OpenTo.Month)
-                        {
-                            var calendarYear = GetCalendarYear(PickerMonth?.Year ?? DateTime.Today.Year);
-                            var prevLabel = $"Go to previous year {calendarYear - 1}";
-                            var nextLabel = $"Go to next year {calendarYear + 1}";
-
-                            <div class="mud-picker-calendar-header">
-                                <div class="mud-picker-calendar-header-switch">
-                                    @if (!FixYear.HasValue)
-                                    {
-                                        <MudIconButton aria-label="@prevLabel" Icon="@PreviousIcon" OnClick="OnPreviousYearClick" Class="mud-flip-x-rtl" />
-                                        <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition" @onclick="OnYearClick" @onclick:stopPropagation="true">
-                                            <MudText Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
-                                        </button>
-                                        <MudIconButton aria-label="@nextLabel" Icon="@NextIcon" OnClick="OnNextYearClick" Class="mud-flip-x-rtl" />
-                                    }
-                                    else
-                                    {
-                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
-                                    }
-                                </div>
-                            </div>
-                            <div class="mud-picker-month-container">
-                                @foreach (var month in GetAllMonths())
-                                {
-                                    <button type="button" aria-label="@GetMonthName(month)" disabled="@IsMonthDisabled(month)"
-                                    class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
-                                        <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
-                                    </button>
-                                }
-                            </div>
-                        }
-                        else if (CurrentView == OpenTo.Date || tempMonth > 0)
-                        {
-                            var prevLabel = $"Go to previous month {GetMonthName((tempMonth - 1) % 12)}";
-                            var nextLabel = $"Go to next month {GetMonthName((tempMonth + 1) % 12)}";
-
-                            <div class="@GetCalendarHeaderClasses(tempMonth)">
-                                <div class="mud-picker-calendar-header-switch">
-                                    @if (!FixMonth.HasValue)
-                                    {
-                                        <MudIconButton aria-label="@prevLabel" Class="mud-picker-nav-button-prev mud-flip-x-rtl" Icon="@PreviousIcon" OnClick="OnPreviousMonthClick" />
-                                        <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition mud-button-month" @onclick="(() => OnMonthClicked(tempMonth))" @onclick:stopPropagation="true">
-                                            <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
-                                        </button>
-                                        <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" />
-                                    }
-                                    else
-                                    {
-                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
-                                    }
-                                </div>
-                                <div class="mud-picker-calendar-header-day">
-                                    @if (ShowWeekNumbers)
-                                    {
-                                        <div class="mud-picker-calendar-week">
-                                            <MudText Typo="Typo.caption" Class="mud-picker-calendar-week-text"></MudText>
-                                        </div>
-                                    }
-                                    @foreach (var dayname in GetAbbreviatedDayNames())
-                                    {
-                                        <MudText Typo="Typo.caption" Class="mud-day-label">@dayname</MudText>
-                                    }
-                                </div>
-                            </div>
-                            <div class="mud-picker-calendar-transition mud-picker-slide-transition">
-                                <div class="mud-picker-calendar">
-                                    @for (int week = 0; week < 6; week++)
-                                    {
-                                        int tempWeek = week;
-                                        var firstMonthFirstYear = _picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1;
-
-                                        @if (ShowWeekNumbers)
+                                    <div id="pickerYears" class="mud-picker-year-container">
+                                        @for (int i = GetMinYear(); i <= GetMaxYear(); i++)
                                         {
-                                            <div class="mud-picker-calendar-week">
-                                                <MudText class="mud-picker-calendar-week-text" Typo="Typo.caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
+                                            var year = i;
+                                            <div class="mud-picker-year" id="@(_componentId + year)" @onclick="(() => OnYearClicked(year))" @onclick:stopPropagation="true">
+                                                <MudText Typo="@GetYearTypo(year)" Class="@GetYearClasses(year)">@GetCalendarYear(year)</MudText>
                                             </div>
                                         }
-                                        @foreach (var day in GetWeek(tempMonth, tempWeek))
-                                        {
-                                            var tempId = ++dayId;
+                                    </div>
+                                }
+                                if (CurrentView == OpenTo.Month)
+                                {
+                                    var calendarYear = GetCalendarYear(PickerMonth?.Year ?? DateTime.Today.Year);
+                                    var prevLabel = $"Go to previous year {calendarYear - 1}";
+                                    var nextLabel = $"Go to next year {calendarYear + 1}";
 
-                                            @if (tempId != 0 || !firstMonthFirstYear)
+                                    <div class="mud-picker-calendar-header">
+                                        <div class="mud-picker-calendar-header-switch">
+                                            @if (!FixYear.HasValue)
                                             {
-                                                var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
-                                                <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
-                                                        @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
-                                                        @onclick:stopPropagation="true"
-                                                        aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
-                                                        onmouseover="@(async () => await HandleMouseoverOnPickerCalendarDayButton(!firstMonthFirstYear ? tempId : tempId + 1))"
-                                                        disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
-                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(selectedDay)</p>
+                                                <MudIconButton aria-label="@prevLabel" Icon="@PreviousIcon" OnClick="OnPreviousYearClick" Class="mud-flip-x-rtl"/>
+                                                <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition" @onclick="OnYearClick" @onclick:stopPropagation="true">
+                                                    <MudText Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
                                                 </button>
+                                                <MudIconButton aria-label="@nextLabel" Icon="@NextIcon" OnClick="OnNextYearClick" Class="mud-flip-x-rtl"/>
                                             }
                                             else
                                             {
-                                                <button @key="0" type="button" style="--day-id: 1;"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
-                                                        aria-label='' disabled>
-                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
-                                                </button>
+                                                <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
+                                            }
+                                        </div>
+                                    </div>
+                                    <div class="mud-picker-month-container">
+                                        @foreach (var month in GetAllMonths())
+                                        {
+                                            <button type="button" aria-label="@GetMonthName(month)" disabled="@IsMonthDisabled(month)"
+                                                    class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                                <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
+                                            </button>
+                                        }
+                                    </div>
+                                }
+                            }
+                            @if (CurrentView == OpenTo.Date || tempMonth != _monthPickerIndex)
+                            {
+                                var prevLabel = $"Go to previous month {GetMonthName((tempMonth - 1) % 12)}";
+                                var nextLabel = $"Go to next month {GetMonthName((tempMonth + 1) % 12)}";
+
+                                <div class="@GetCalendarHeaderClasses(tempMonth)">
+                                    <div class="mud-picker-calendar-header-switch">
+                                        @if (!FixMonth.HasValue)
+                                        {
+                                            <MudIconButton aria-label="@prevLabel" Class="mud-picker-nav-button-prev mud-flip-x-rtl" Icon="@PreviousIcon" OnClick="OnPreviousMonthClick"/>
+                                            <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition mud-button-month" @onclick="(() => OnMonthInHeaderClicked(tempMonth))" @onclick:stopPropagation="true">
+                                                <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
+                                            </button>
+                                            <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick"/>
+                                        }
+                                        else
+                                        {
+                                            <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
+                                        }
+                                    </div>
+                                    <div class="mud-picker-calendar-header-day">
+                                        @if (ShowWeekNumbers)
+                                        {
+                                            <div class="mud-picker-calendar-week">
+                                                <MudText Typo="Typo.caption" Class="mud-picker-calendar-week-text"></MudText>
+                                            </div>
+                                        }
+                                        @foreach (var dayname in GetAbbreviatedDayNames())
+                                        {
+                                            <MudText Typo="Typo.caption" Class="mud-day-label">@dayname</MudText>
+                                        }
+                                    </div>
+                                </div>
+                                <div class="mud-picker-calendar-transition mud-picker-slide-transition">
+                                    <div class="mud-picker-calendar">
+                                        @for (int week = 0; week < 6; week++)
+                                        {
+                                            int tempWeek = week;
+                                            var firstMonthFirstYear = _picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1;
+
+                                            @if (ShowWeekNumbers)
+                                            {
+                                                <div class="mud-picker-calendar-week">
+                                                    <MudText class="mud-picker-calendar-week-text" Typo="Typo.caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
+                                                </div>
+                                            }
+                                            @foreach (var day in GetWeek(tempMonth, tempWeek))
+                                            {
+                                                var tempId = ++dayId;
+
+                                                @if (tempId != 0 || !firstMonthFirstYear)
+                                                {
+                                                    var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
+                                                    <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId : tempId + 1);"
+                                                            class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day ? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
+                                                            @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
+                                                            @onclick:stopPropagation="true"
+                                                            aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
+                                                            onmouseover="@(async () => await HandleMouseoverOnPickerCalendarDayButton(!firstMonthFirstYear ? tempId : tempId + 1))"
+                                                            disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
+                                                        <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(selectedDay)</p>
+                                                    </button>
+                                                }
+                                                else
+                                                {
+                                                    <button @key="0" type="button" style="--day-id: 1;"
+                                                            class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
+                                                            aria-label='' disabled>
+                                                        <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
+                                                    </button>
+                                                }
                                             }
                                         }
-                                    }
+                                    </div>
                                 </div>
-                            </div>
-                        }
-                    </div>
-                }
-            </div>
-        </MudPickerContent>
-    </CascadingValue>;
+                            }
+                        </div>
+                    }
+                </div>
+            </MudPickerContent>
+        </CascadingValue>;
+
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -12,6 +12,11 @@ namespace MudBlazor
     {
         private readonly string _mudPickerCalendarContentElementId;
         private bool _dateFormatTouched;
+        
+        /// <summary>
+        /// When DisplayMonths is greater than 1 and user clicks on header of date view calendar, this variable stores index of date view calendar
+        /// </summary>
+        private int _monthPickerIndex = -1;
 
         protected MudBaseDatePicker() : base(new DefaultConverter<DateTime?>
         {
@@ -393,6 +398,17 @@ namespace MudBlazor
             _picker_month = _picker_month?.AddMonths(month);
             StateHasChanged();
         }
+        
+        /// <summary>
+        /// user clicked on a month in header, when in date view.
+        /// method opens month view in corresponding mud-picker-calendar-container
+        /// </summary>
+        protected virtual void OnMonthInHeaderClicked(int monthPickerIndex)
+        {
+            CurrentView = OpenTo.Month;
+            _monthPickerIndex = monthPickerIndex;
+            StateHasChanged();
+        }
 
         /// <summary>
         /// Check if month is disabled
@@ -518,7 +534,7 @@ namespace MudBlazor
                 return MaxDate.Value.Year;
             return DateTime.Today.Year + 100;
         }
-
+        
         private string GetYearClasses(int year)
         {
             if (year == GetMonthStart(0).Year)

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -105,6 +105,7 @@ namespace MudBlazor
         protected override async void OnDayClicked(DateTime dateTime)
         {
             _selectedDate = dateTime;
+            
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
                 Submit();


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 --> 
* MudBlazor.Docs: Added DatePickerMultipleMonthsExample.razor on DatePickerPage.razor.
 * MudBlazor: DatePicker: Changed DatePicker behavior, when DisplayMonths is greater than 1. Now months/years view opens not in first calendar, but in one which header was clicked (#6270)
 
![image](https://github.com/MudBlazor/MudBlazor/assets/75577256/25b01548-ab57-4174-afb6-7fc25150a7a8)
![image](https://github.com/MudBlazor/MudBlazor/assets/75577256/8a381452-2b73-4bfc-a3a7-e53bbc6b4fd5)

 Closes #6270
 
 I'm new to open-source project development. Hope i didn't miss anything and this helps.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I've tested it visually on local server.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
