### PR TITLE
MudDynamicTabs: Fix disappearing slider with key attribute (#2816)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsWithKeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsWithKeyTest.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDynamicTabs KeepPanelsAlive MinimumTabWidth="100px"
+ AddIconClass="custom-add-button" CloseIconClass="custom-close-button" CloseTab="@OnCloseTab" @bind-ActivePanelIndex="@_activePanel">
+     @foreach (var item in _tabs)
+    {
+        <MudTabPanel ID="@item.Id" Text="@($"tab {item.Id}")" ShowCloseIcon @key="@item"/>
+    }
+</MudDynamicTabs>
+
+@code {
+    private int _activePanel = 3;
+    private List<Item> _tabs =
+        Enumerable.Range(0, 4).Select(x => new Item { Id = x }).ToList();
+
+    public static string __description__ = "Slider needs to be visible while popping tabs from the front";
+
+    private void OnCloseTab(MudTabPanel panel)
+    {
+        var itemId = panel.Text;
+        var idx = _tabs.FindIndex(x => x.Id.Equals(panel.ID));
+        _tabs.RemoveAt(idx);
+    }
+
+    private class Item
+    {
+        internal int Id { get; init; }
+    }
+}

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -23,7 +23,7 @@
                         {
                             @if (panel.TabContent == null && panel.TabWrapperContent == null)
                             {
-                                <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
+                                <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip" @key="@panel">
                                     @RenderTab(panel)
                                 </MudTooltip>
                             }
@@ -31,13 +31,13 @@
                             {
                                 if (panel.TabWrapperContent == null)
                                 {
-                                    <div class="d-inline-block" style="width: fit-content;">
+                                    <div class="d-inline-block" style="width: fit-content;" @key="@panel">
                                         @RenderTab(panel)
                                     </div>
                                 }
                                 else
                                 {
-                                    <div class="d-inline-block" style="width: fit-content;">
+                                    <div class="d-inline-block" style="width: fit-content;" @key="@panel">
                                         @panel.TabWrapperContent(RenderTab(panel))
                                     </div>
                                 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -29,18 +29,16 @@
                             }
                             else
                             {
-                                if (panel.TabWrapperContent == null)
-                                {
-                                    <div class="d-inline-block" style="width: fit-content;" @key="@panel">
+                                <div class="d-inline-block" style="width: fit-content;" @key="@panel">
+                                    @if (panel.TabWrapperContent is null) 
+                                    {
                                         @RenderTab(panel)
-                                    </div>
-                                }
-                                else
-                                {
-                                    <div class="d-inline-block" style="width: fit-content;" @key="@panel">
+                                    }
+                                    else
+                                    {
                                         @panel.TabWrapperContent(RenderTab(panel))
-                                    </div>
-                                }
+                                    }
+                                </div>
                             }
                         }
                         @if (!HideSlider && IsSliderPositionDetermined)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Fixes #2816, fixes #8017
I've added `key` attribute to elements inside the loop responsible for adding panels.
After that slider stays always visible.


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
visually
I've tried to write some unit tests, but I couldn't reproduce the issue using code. Seems like `key` attribute isn't respected at all in test's context.
I've added example to `UnitTests.Viewer` just for testing visually.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
### Before

https://github.com/MudBlazor/MudBlazor/assets/50521366/36bca7a1-72de-4d81-850d-057145b13177

### After

https://github.com/MudBlazor/MudBlazor/assets/50521366/d7133437-c594-488a-b895-3427b306dde4


<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
