### PR TITLE
MudChart: Fix series coloring issue with more than 20 custom colors (#8099)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomColorsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomColorsTest.razor
@@ -1,0 +1,84 @@
+﻿<MudGrid>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Donut" InputData="@Data" InputLabels="@Labels" Width="300px" Height="300px" ChartOptions="@Options1"></MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Pie" InputData="@Data" InputLabels="@Labels" Width="300px" Height="300px" ChartOptions="@Options1"></MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Line" ChartSeries="@Series1" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="@Options1"></MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Bar" ChartSeries="@Series2" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="@Options1"></MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.StackedBar" ChartSeries="@Series1" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="@Options1"></MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.StackedBar" ChartSeries="@Series1" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="@Options2"></MudChart>
+    </MudItem>
+</MudGrid>
+
+
+@code {
+    public static string __description__ = "Charts with custom colors using ChartOptions.";
+
+    public double[] Data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
+
+    public string[] Labels = { "Deep Sea Blue", "Venetian Red", "Banana Yellow", "La Salle Green", "Rich Carmine", "Shiraz", "Cloud Burst",
+                               "Neon Pink", "Ocean", "Orangey Red", "Catalina Blue", "Fountain Blue", "Irish Green", "Wild Strawberry",
+                               "Geraldine", "Grey Teal", "Baby Pink", "Thunderbird", "Navy", "Aqua Marina", "Lavender Pinocchio", "Deep Sea Blue"
+
+    };
+
+    public List<ChartSeries> Series1 = new List<ChartSeries>()
+    {
+        new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 40, 20, 25, 27, 46 } },
+        new ChartSeries() { Name = "Venetian Red", Data = new double[] { 19, 24, 35, 13, 28 } },
+        new ChartSeries() { Name = "Banana Yellow", Data = new double[] { 8, 6, 11, 13, 4 } },
+        new ChartSeries() { Name = "La Salle Green", Data = new double[] { 18, 9, 7, 10, 7 } },
+        new ChartSeries() { Name = "Rich Carmine", Data = new double[] { 9, 14, 6, 15, 20 } },
+        new ChartSeries() { Name = "Shiraz", Data = new double[] { 9, 4, 11, 5, 19 } },
+        new ChartSeries() { Name = "Cloud Burst", Data = new double[] { 14, 9, 20, 16, 6 } },
+        new ChartSeries() { Name = "Neon Pink", Data = new double[] { 14, 8, 4, 14, 8 } },
+        new ChartSeries() { Name = "Ocean", Data = new double[] { 11, 20, 13, 5, 5 } },
+        new ChartSeries() { Name = "Orangey Red", Data = new double[] { 6, 6, 19, 20, 6 } },
+        new ChartSeries() { Name = "Catalina Blue", Data = new double[] { 3, 2, 20, 3, 10 } },
+        new ChartSeries() { Name = "Fountain Blue", Data = new double[] { 3, 18, 11, 12, 3 } },
+        new ChartSeries() { Name = "Irish Green", Data = new double[] { 20, 5, 15, 16, 13 } },
+        new ChartSeries() { Name = "Wild Strawberry", Data = new double[] { 15, 9, 12, 12, 1 } },
+        new ChartSeries() { Name = "Geraldine", Data = new double[] { 5, 13, 19, 15, 8 } },
+        new ChartSeries() { Name = "Grey Teal", Data = new double[] { 12, 16, 20, 16, 17 } },
+        new ChartSeries() { Name = "Baby Pink", Data = new double[] { 1, 18, 10, 19, 8 } },
+        new ChartSeries() { Name = "Thunderbird", Data = new double[] { 15, 16, 10, 8, 5 } },
+        new ChartSeries() { Name = "Navy", Data = new double[] { 16, 2, 3, 5, 5 } },
+        new ChartSeries() { Name = "Aqua Marina", Data = new double[] { 17, 6, 11, 19, 6 } },
+        new ChartSeries() { Name = "Lavender Pinocchio", Data = new double[] { 1, 11, 4, 18, 1 } },
+        new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
+    };
+
+    public List<ChartSeries> Series2 = new List<ChartSeries>()
+    {
+        new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 40, 20, 25, 27, 46 } },
+        new ChartSeries() { Name = "Venetian Red", Data = new double[] { 19, 24, 35, 13, 28 } },
+        new ChartSeries() { Name = "Banana Yellow", Data = new double[] { 8, 6, 11, 13, 4 } },
+    };
+
+    public string[] XAxisLabels = { "1", "2", "3", "4", "5" };
+
+
+    private ChartOptions Options1 = new ChartOptions()
+    {
+        ChartPalette = new string[] { "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+                                      "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+                                      "#01153E", "#2EE8BB", "#EBDDE2"
+        },
+    };
+
+    private ChartOptions Options2 = new ChartOptions()
+    {
+        ChartPalette = new string[] { "#5bdfeb" },
+        DisableLegend = true
+    };
+
+}

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -10,6 +10,7 @@ using MudBlazor.Charts;
 using NUnit.Framework;
 using Bunit;
 using MudBlazor.UnitTests.Utilities;
+using System;
 
 namespace MudBlazor.UnitTests.Charts
 {
@@ -25,6 +26,13 @@ namespace MudBlazor.UnitTests.Charts
         private readonly string[] _modifiedPalette =
         {
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"
+        };
+
+        private readonly string[] _customPalette =
+        {
+            "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+            "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+            "#01153E", "#2EE8BB", "#EBDDE2"
         };
 
         [SetUp]
@@ -99,6 +107,67 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _modifiedPalette }));
 
             comp.Markup.Should().Contain(_modifiedPalette[0]);
+        }
+
+        [Test]
+        public void BarChartColoring()
+        {
+            List<ChartSeries> chartSeries = new List<ChartSeries>()
+            {
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 40, 20, 25, 27, 46 } },
+                new ChartSeries() { Name = "Venetian Red", Data = new double[] { 19, 24, 35, 13, 28 } },
+                new ChartSeries() { Name = "Banana Yellow", Data = new double[] { 8, 6, 11, 13, 4 } },
+                new ChartSeries() { Name = "La Salle Green", Data = new double[] { 18, 9, 7, 10, 7 } },
+                new ChartSeries() { Name = "Rich Carmine", Data = new double[] { 9, 14, 6, 15, 20 } },
+                new ChartSeries() { Name = "Shiraz", Data = new double[] { 9, 4, 11, 5, 19 } },
+                new ChartSeries() { Name = "Cloud Burst", Data = new double[] { 14, 9, 20, 16, 6 } },
+                new ChartSeries() { Name = "Neon Pink", Data = new double[] { 14, 8, 4, 14, 8 } },
+                new ChartSeries() { Name = "Ocean", Data = new double[] { 11, 20, 13, 5, 5 } },
+                new ChartSeries() { Name = "Orangey Red", Data = new double[] { 6, 6, 19, 20, 6 } },
+                new ChartSeries() { Name = "Catalina Blue", Data = new double[] { 3, 2, 20, 3, 10 } },
+                new ChartSeries() { Name = "Fountain Blue", Data = new double[] { 3, 18, 11, 12, 3 } },
+                new ChartSeries() { Name = "Irish Green", Data = new double[] { 20, 5, 15, 16, 13 } },
+                new ChartSeries() { Name = "Wild Strawberry", Data = new double[] { 15, 9, 12, 12, 1 } },
+                new ChartSeries() { Name = "Geraldine", Data = new double[] { 5, 13, 19, 15, 8 } },
+                new ChartSeries() { Name = "Grey Teal", Data = new double[] { 12, 16, 20, 16, 17 } },
+                new ChartSeries() { Name = "Baby Pink", Data = new double[] { 1, 18, 10, 19, 8 } },
+                new ChartSeries() { Name = "Thunderbird", Data = new double[] { 15, 16, 10, 8, 5 } },
+                new ChartSeries() { Name = "Navy", Data = new double[] { 16, 2, 3, 5, 5 } },
+                new ChartSeries() { Name = "Aqua Marina", Data = new double[] { 17, 6, 11, 19, 6 } },
+                new ChartSeries() { Name = "Lavender Pinocchio", Data = new double[] { 1, 11, 4, 18, 1 } },
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
+            };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = new string[] { "#1E9AB0" } })
+                .Add(p => p.ChartSeries, chartSeries));
+
+            var paths1 = comp.FindAll("path");
+
+            int count;
+            count = paths1.Count(p => p.OuterHtml.Contains($"fill=\"{"#1E9AB0"}\"") && p.OuterHtml.Contains($"stroke=\"{"#1E9AB0"}\""));
+            count.Should().Be(5 * 22);
+
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _customPalette }));
+
+            var paths2 = comp.FindAll("path");
+
+            foreach (var color in _customPalette)
+            {
+                count = paths2.Count(p => p.OuterHtml.Contains($"fill=\"{color}\"") && p.OuterHtml.Contains($"stroke=\"{color}\""));
+                if (color == _customPalette[0])
+                {
+                    count.Should().Be(5 * 2, because: "the number of series defined exceeds the number of colors in the chart palette, thus, any new defined series takes the color from the chart palette in the same fashion as the previous series starting from the beginning");
+                }
+                else
+                {
+                    count.Should().Be(5);
+                }
+            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using MudBlazor.Charts;
 using NUnit.Framework;
 using Bunit;
+using System.Collections.Generic;
 
 namespace MudBlazor.UnitTests.Charts
 {
@@ -25,8 +26,16 @@ namespace MudBlazor.UnitTests.Charts
         {
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"
         };
-        
-         [SetUp]
+
+
+        private readonly string[] _customPalette =
+        {
+            "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+            "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+            "#01153E", "#2EE8BB", "#EBDDE2"
+        };
+
+        [SetUp]
         public void Init()
         {
             
@@ -120,6 +129,43 @@ namespace MudBlazor.UnitTests.Charts
                 cx.Should().Be(svgViewBox[2]/2);
 
                 cx.Should().Be(svgViewBox[3]/2);
+            }
+        }
+
+        [Test]
+        public void DonutChartColoring()
+        {
+            double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Donut)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = new string[] { "#1E9AB0" } })
+                .Add(p => p.InputData, data));
+
+            var circles1 = comp.FindAll("circle");
+
+            int count;
+            count = circles1.Count(p => p.OuterHtml.Contains($"stroke=\"{"#1E9AB0"}\""));
+            count.Should().Be(22);
+
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _customPalette }));
+
+            var circles2 = comp.FindAll("circle");
+
+            foreach (var color in _customPalette)
+            {
+                count = circles2.Count(p => p.OuterHtml.Contains($"stroke=\"{color}\""));
+                if (color == _customPalette[0])
+                {
+                    count.Should().Be(2, because: "the number of data points defined exceeds the number of colors in the chart palette, thus, any new defined data point takes the color from the chart palette in the same fashion as the previous data points starting from the beginning");
+                }
+                else
+                {
+                    count.Should().Be(1);
+                }
             }
         }
     }

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -27,7 +27,14 @@ namespace MudBlazor.UnitTests.Charts
         {
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"
         };
-        
+
+        private readonly string[] _customPalette =
+        {
+            "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+            "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+            "#01153E", "#2EE8BB", "#EBDDE2"
+        };
+
         private static Array GetInterpolationOptions()
         {
             return Enum.GetValues(typeof(InterpolationOption));
@@ -136,6 +143,67 @@ namespace MudBlazor.UnitTests.Charts
                 seriesCheckboxes[0].IsChecked().Should().BeFalse();
                 seriesCheckboxes[1].IsChecked().Should().BeTrue();
                 seriesCheckboxes[2].IsChecked().Should().BeTrue();
+            }
+        }
+
+        [Test]
+        public void LineChartColoring()
+        {
+            List<ChartSeries> chartSeries = new List<ChartSeries>()
+            {
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 40, 20, 25, 27, 46 } },
+                new ChartSeries() { Name = "Venetian Red", Data = new double[] { 19, 24, 35, 13, 28 } },
+                new ChartSeries() { Name = "Banana Yellow", Data = new double[] { 8, 6, 11, 13, 4 } },
+                new ChartSeries() { Name = "La Salle Green", Data = new double[] { 18, 9, 7, 10, 7 } },
+                new ChartSeries() { Name = "Rich Carmine", Data = new double[] { 9, 14, 6, 15, 20 } },
+                new ChartSeries() { Name = "Shiraz", Data = new double[] { 9, 4, 11, 5, 19 } },
+                new ChartSeries() { Name = "Cloud Burst", Data = new double[] { 14, 9, 20, 16, 6 } },
+                new ChartSeries() { Name = "Neon Pink", Data = new double[] { 14, 8, 4, 14, 8 } },
+                new ChartSeries() { Name = "Ocean", Data = new double[] { 11, 20, 13, 5, 5 } },
+                new ChartSeries() { Name = "Orangey Red", Data = new double[] { 6, 6, 19, 20, 6 } },
+                new ChartSeries() { Name = "Catalina Blue", Data = new double[] { 3, 2, 20, 3, 10 } },
+                new ChartSeries() { Name = "Fountain Blue", Data = new double[] { 3, 18, 11, 12, 3 } },
+                new ChartSeries() { Name = "Irish Green", Data = new double[] { 20, 5, 15, 16, 13 } },
+                new ChartSeries() { Name = "Wild Strawberry", Data = new double[] { 15, 9, 12, 12, 1 } },
+                new ChartSeries() { Name = "Geraldine", Data = new double[] { 5, 13, 19, 15, 8 } },
+                new ChartSeries() { Name = "Grey Teal", Data = new double[] { 12, 16, 20, 16, 17 } },
+                new ChartSeries() { Name = "Baby Pink", Data = new double[] { 1, 18, 10, 19, 8 } },
+                new ChartSeries() { Name = "Thunderbird", Data = new double[] { 15, 16, 10, 8, 5 } },
+                new ChartSeries() { Name = "Navy", Data = new double[] { 16, 2, 3, 5, 5 } },
+                new ChartSeries() { Name = "Aqua Marina", Data = new double[] { 17, 6, 11, 19, 6 } },
+                new ChartSeries() { Name = "Lavender Pinocchio", Data = new double[] { 1, 11, 4, 18, 1 } },
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
+            };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = new string[] { "#1E9AB0" } })
+                .Add(p => p.ChartSeries, chartSeries));
+
+            var paths1 = comp.FindAll("path");
+
+            int count;
+            count = paths1.Count(p => p.OuterHtml.Contains($"stroke=\"{"#1E9AB0"}\""));
+            count.Should().Be(22);
+
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _customPalette }));
+
+            var paths2 = comp.FindAll("path");
+
+            foreach (var color in _customPalette)
+            {
+                count = paths2.Count(p => p.OuterHtml.Contains($"stroke=\"{color}\""));
+                if (color == _customPalette[0])
+                {
+                    count.Should().Be(2, because: "the number of series defined exceeds the number of colors in the chart palette, thus, any new defined series takes the color from the chart palette in the same fashion as the previous series starting from the beginning");
+                }
+                else
+                {
+                    count.Should().Be(1);
+                }
             }
         }
     }

--- a/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
@@ -26,7 +26,14 @@ namespace MudBlazor.UnitTests.Charts
         {
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"
         };
-        
+
+        private readonly string[] _customPalette =
+        {
+            "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+            "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+            "#01153E", "#2EE8BB", "#EBDDE2"
+        };
+
         [SetUp]
         public void Init()
         { 
@@ -89,6 +96,43 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ChartOptions(){ChartPalette = _modifiedPalette}));
 
             comp.Markup.Should().Contain(_modifiedPalette[0]);
+        }
+
+        [Test]
+        public void PieChartColoring()
+        {
+            double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = new string[] { "#1E9AB0" } })
+                .Add(p => p.InputData, data));
+
+            var paths1 = comp.FindAll("path");
+
+            int count;
+            count = paths1.Count(p => p.OuterHtml.Contains($"fill=\"{"#1E9AB0"}\""));
+            count.Should().Be(22);
+
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _customPalette }));
+
+            var paths2 = comp.FindAll("path");
+
+            foreach (var color in _customPalette)
+            {
+                count = paths2.Count(p => p.OuterHtml.Contains($"fill=\"{color}\""));
+                if (color == _customPalette[0])
+                {
+                    count.Should().Be(2, because: "the number of data points defined exceeds the number of colors in the chart palette, thus, any new defined data point takes the color from the chart palette in the same fashion as the previous data points starting from the beginning");
+                }
+                else
+                {
+                    count.Should().Be(1);
+                }
+            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -27,6 +27,13 @@ namespace MudBlazor.UnitTests.Charts
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"
         };
 
+        private readonly string[] _customPalette =
+        {
+            "#015482", "#CC1512", "#FFE135", "#087830", "#D70040", "#B20931", "#202E54", "#F535AA", "#017B92",
+            "#FA4224", "#062A78", "#56B4BE", "#207000", "#FF43A4", "#FB8989", "#5E9B8A", "#FFB7CE", "#C02B18",
+            "#01153E", "#2EE8BB", "#EBDDE2"
+        };
+
         [SetUp]
         public void Init()
         {
@@ -100,6 +107,67 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _modifiedPalette }));
 
             comp.Markup.Should().Contain(_modifiedPalette[0]);
+        }
+
+        [Test]
+        public void StackedBarChartColoring()
+        {
+            List<ChartSeries> chartSeries = new List<ChartSeries>()
+            {
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 40, 20, 25, 27, 46 } },
+                new ChartSeries() { Name = "Venetian Red", Data = new double[] { 19, 24, 35, 13, 28 } },
+                new ChartSeries() { Name = "Banana Yellow", Data = new double[] { 8, 6, 11, 13, 4 } },
+                new ChartSeries() { Name = "La Salle Green", Data = new double[] { 18, 9, 7, 10, 7 } },
+                new ChartSeries() { Name = "Rich Carmine", Data = new double[] { 9, 14, 6, 15, 20 } },
+                new ChartSeries() { Name = "Shiraz", Data = new double[] { 9, 4, 11, 5, 19 } },
+                new ChartSeries() { Name = "Cloud Burst", Data = new double[] { 14, 9, 20, 16, 6 } },
+                new ChartSeries() { Name = "Neon Pink", Data = new double[] { 14, 8, 4, 14, 8 } },
+                new ChartSeries() { Name = "Ocean", Data = new double[] { 11, 20, 13, 5, 5 } },
+                new ChartSeries() { Name = "Orangey Red", Data = new double[] { 6, 6, 19, 20, 6 } },
+                new ChartSeries() { Name = "Catalina Blue", Data = new double[] { 3, 2, 20, 3, 10 } },
+                new ChartSeries() { Name = "Fountain Blue", Data = new double[] { 3, 18, 11, 12, 3 } },
+                new ChartSeries() { Name = "Irish Green", Data = new double[] { 20, 5, 15, 16, 13 } },
+                new ChartSeries() { Name = "Wild Strawberry", Data = new double[] { 15, 9, 12, 12, 1 } },
+                new ChartSeries() { Name = "Geraldine", Data = new double[] { 5, 13, 19, 15, 8 } },
+                new ChartSeries() { Name = "Grey Teal", Data = new double[] { 12, 16, 20, 16, 17 } },
+                new ChartSeries() { Name = "Baby Pink", Data = new double[] { 1, 18, 10, 19, 8 } },
+                new ChartSeries() { Name = "Thunderbird", Data = new double[] { 15, 16, 10, 8, 5 } },
+                new ChartSeries() { Name = "Navy", Data = new double[] { 16, 2, 3, 5, 5 } },
+                new ChartSeries() { Name = "Aqua Marina", Data = new double[] { 17, 6, 11, 19, 6 } },
+                new ChartSeries() { Name = "Lavender Pinocchio", Data = new double[] { 1, 11, 4, 18, 1 } },
+                new ChartSeries() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
+            };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = new string[] { "#1E9AB0" } })
+                .Add(p => p.ChartSeries, chartSeries));
+
+            var paths1 = comp.FindAll("path");
+
+            int count;
+            count = paths1.Count(p => p.OuterHtml.Contains($"fill=\"{"#1E9AB0"}\"") && p.OuterHtml.Contains($"stroke=\"{"#1E9AB0"}\""));
+            count.Should().Be(5 * 22);
+
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _customPalette }));
+
+            var paths2 = comp.FindAll("path");
+
+            foreach (var color in _customPalette)
+            {
+                count = paths2.Count(p => p.OuterHtml.Contains($"fill=\"{color}\"") && p.OuterHtml.Contains($"stroke=\"{color}\""));
+                if (color == _customPalette[0])
+                {
+                    count.Should().Be(5 * 2, because: "the number of series defined exceeds the number of colors in the chart palette, thus, any new defined series takes the color from the chart palette in the same fashion as the previous series starting from the beginning");
+                }
+                else
+                {
+                    count.Should().Be(5);
+                }
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -35,7 +35,7 @@
     <g class="mud-charts-bar-series">
         @foreach (var bar in _bars)
         {
-            <path class="mud-chart-bar" @onclick="() => SelectedIndex = bar.Index"  fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % ChartOptions.ChartPalette.Count()))" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % ChartOptions.ChartPalette.Count()))" stroke-width="8" d="@bar.Data"></path>
+            <path class="mud-chart-bar" @onclick="() => SelectedIndex = bar.Index" fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" stroke-width="8" d="@bar.Data"></path>
         }
     </g>
 

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor
@@ -7,7 +7,7 @@
     <circle class="mud-donut-ring" cx="21" cy="21" r="@(100 / (2 * Math.PI))"></circle>
     @foreach (var item in _circles.ToList())
     {
-        <circle class="mud-chart-serie mud-donut-segment" @onclick="() => SelectedIndex = item.Index"  stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % ChartOptions.ChartPalette.Count()))"
+        <circle class="mud-chart-serie mud-donut-segment" @onclick="() => SelectedIndex = item.Index" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % MudChartParent.ChartOptions.ChartPalette.Count()))"
                 cx="@ToS(item.CX)"
                 cy="@ToS(item.CY)"
                 r="@ToS(item.Radius)"

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor
@@ -35,7 +35,7 @@
     <g class="mud-charts-line-series">
         @foreach (var chartLine in _chartLines)
         {
-            <path class="mud-chart-line" @onclick="() => SelectedIndex = chartLine.Index"  fill="none" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(chartLine.Index % ChartOptions.ChartPalette.Count()))" stroke-width="@(MudChartParent.ChartOptions.LineStrokeWidth)" d="@chartLine.Data"></path>
+            <path class="mud-chart-line" @onclick="() => SelectedIndex = chartLine.Index" fill="none" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(chartLine.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" stroke-width="@(MudChartParent.ChartOptions.LineStrokeWidth)" d="@chartLine.Data"></path>
         }
     </g>
 

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor
@@ -6,7 +6,7 @@
     <Filters />
     @foreach (var item in _paths.ToList())
     {
-		<path @onclick="() => SelectedIndex = item.Index" class="mud-chart-serie" fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % ChartOptions.ChartPalette.Count()))" d="@item.Data"></path>
+        <path @onclick="() => SelectedIndex = item.Index" class="mud-chart-serie" fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" d="@item.Data"></path>
 	}
 
 	@MudChartParent?.CustomGraphics

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -35,7 +35,7 @@
     <g class="mud-charts-bar-series">
         @foreach (var bar in _bars)
         {
-            <path class="mud-chart-bar" @onclick="() => SelectedIndex = bar.Index"  fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % ChartOptions.ChartPalette.Count()))" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % ChartOptions.ChartPalette.Count()))" stroke-width="32" d="@bar.Data"></path>
+            <path class="mud-chart-bar" @onclick="() => SelectedIndex = bar.Index"  fill="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" stroke="@(MudChartParent.ChartOptions.ChartPalette.GetValue(bar.Index % MudChartParent.ChartOptions.ChartPalette.Count()))" stroke-width="32" d="@bar.Data"></path>
         }
     </g>
 

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -9,7 +9,7 @@
             <div class="mud-chart-legend-item" @onclick=@(()=>{ if (MudChartParent!=null) { MudChartParent.SelectedIndex=item.Index; }}) @onclick:stopPropagation=@(MudChartParent!=null) >
                 @if(MudChartParent?.CanHideSeries == false)
                 {
-                    <span class="mud-chart-legend-marker" style="@($"background-color:{MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % ChartOptions.ChartPalette.Count())}")"></span>
+                    <span class="mud-chart-legend-marker" style="@($"background-color:{MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % MudChartParent.ChartOptions.ChartPalette.Count())}")"></span>
                     <MudText Typo="Typo.body2" Inline="true">@item.Labels</MudText>
                 }
                 else


### PR DESCRIPTION
## Description
In "MudBlazor/Components/Chart/Charts", the files "Bar.razor", "Donut.razor", "Line.razor", "Pie.razor", and "StackedBar.razor" were modified. The modification was basically changing the operation ChartOptions.ChartPalette.Count() to  MudChartParent.ChartOptions.ChartPalette.Count(). MudChartParent allows Bar, Donut, Line, Pie, and StackedBar to access their parent MudChart's properties and methods. When accessing ChartPalette directly through ChartOptions class, then Count() operation will perform counting on the predefined array in "ChartOptions.cs":

string [] ChartPalette = { Colors.Blue.Accent3, Colors.Teal.Accent3, Colors.Amber.Accent3, Colors.Orange.Accent3, Colors.Red.Accent3, Colors.DeepPurple.Accent3, Colors.Green.Accent3, Colors.LightBlue.Accent3, Colors.Teal.Lighten1, Colors.Amber.Lighten1, Colors.Orange.Lighten1, Colors.Red.Lighten1, Colors.DeepPurple.Lighten1, Colors.Green.Lighten1, Colors.LightBlue.Lighten1, Colors.Amber.Darken2, Colors.Orange.Darken2, Colors.Red.Darken2, Colors.DeepPurple.Darken2, Colors.Grey.Darken2 };

The same modification was applied to "Legend.razor" in "MudBlazor/Components/Chart/Parts".

This PR therefore fixes #8099.

## How Has This Been Tested?
The fix was tested visually by inspecting few local made examples when running MudBlazor.Docs.Server. The example from this link https://try.mudblazor.com/snippet/GkcyulGAUNIYVebt was also used.

Test example (A stacked bar chart was used with 21 series and 21 colors. The colors have a pattern. Every 3 series have the colors green, blue, and red):
Before (21st bar is green, though it should be red):
![image](https://github.com/MudBlazor/MudBlazor/assets/57322272/623cb990-3f65-4ba5-a698-32c38809abfd)

After (21st bar is red as expected)
![image](https://github.com/MudBlazor/MudBlazor/assets/57322272/06cebae2-1850-40ac-aa2a-a843bba8867a)

Before (when specifying one color, while having 20 series)
System.IndexOutOfRangeException: 'Index was outside the bounds of the array.'

After (it succeeds mapping the color specified to all series)
![image](https://github.com/MudBlazor/MudBlazor/assets/57322272/8a826757-db0f-4116-be6c-40d8adc3f41b)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
