### PR TITLE
MudTextField: Fix double validation on blur (#7034)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -980,6 +980,27 @@ namespace MudBlazor.UnitTests.Components
             callCounter.Should().Be(1);
         }
 
+        /// <summary>
+        /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
+        /// </summary>
+        [Test]
+        public async Task OnBlurWithModifiedValueTriggerValidationOnce3()
+        {
+            var callCounter = 0;
+            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+                .Add(p => p.OnlyValidateIfDirty, true)
+                .Add(p => p.Validation, async (string value) => {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                    callCounter++;
+                    return true;
+                })
+            );
+            comp.Find("input").Change("A");
+            callCounter.Should().Be(1);
+            comp.Find("input").Blur();
+            callCounter.Should().Be(1);
+        }
+
         [Test]
         public async Task OnKeyDownErrorContentCaughtException()
         {

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -990,11 +990,12 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
                 .Add(p => p.OnlyValidateIfDirty, true)
                 .Add(p => p.Validation, async (string value) => {
-                    await Task.Delay(TimeSpan.FromMilliseconds(100));
                     callCounter++;
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
                     return true;
                 })
             );
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
             comp.Find("input").Change("A");
             callCounter.Should().Be(1);
             comp.Find("input").Blur();

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -995,10 +995,10 @@ namespace MudBlazor.UnitTests.Components
                     return true;
                 })
             );
-            await Task.Delay(TimeSpan.FromMilliseconds(300));
             comp.Find("input").Change("A");
-            callCounter.Should().Be(1);
+            comp.WaitForAssertion(() => callCounter.Should().Be(1));
             comp.Find("input").Blur();
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
             callCounter.Should().Be(1);
         }
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -473,7 +473,9 @@ namespace MudBlazor
 
         protected override async Task ValidateValue()
         {
-            if (SubscribeToParentForm) {
+            if (SubscribeToParentForm)
+            {
+                _validated = true;
                 await base.ValidateValue();
                 _validated = true;
             }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -477,7 +477,6 @@ namespace MudBlazor
             {
                 _validated = true;
                 await base.ValidateValue();
-                _validated = true;
             }
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description

In the precedent PR #7996, we introduced a boolean "_validated" to know when the validation already occurred and to avoid multiple validation.

But  "_validated" is set to true after the validation is finished. When the validation is async, it's possible to start multiple validation in parallel, before "_validated" is set to true.

Resolves #7034.

## How Has This Been Tested?

I added a test that test when the validation is async.
The test fail without the fix.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.