### PR TITLE
MudBaseInput: Add "ShrinkLabel" parameter that prevents label from moving

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldShrinkLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldShrinkLabelExample.razor
@@ -1,0 +1,9 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudTextField ShrinkLabel @bind-Value="TextValue" Label="Standard" Variant="Variant.Text"></MudTextField>
+<MudTextField ShrinkLabel @bind-Value="TextValue" Label="Filled" Variant="Variant.Filled"></MudTextField>
+<MudTextField ShrinkLabel @bind-Value="TextValue" Label="Outlined" Variant="Variant.Outlined"></MudTextField>
+
+@code {
+    public string TextValue { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -56,6 +56,15 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Shrink Label">
+                <Description>With the <CodeInline>ShrinkLabel</CodeInline> property set to true, the label will not move into the field when empty.</Description>
+            </SectionHeader>
+            <SectionContent Code="TextFieldShrinkLabelExample" ShowCode="false">
+                <TextFieldShrinkLabelExample/>
+            </SectionContent>
+        </DocsPageSection>
+
     </SectionSubGroups>
 </DocsPageSection>
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -218,11 +218,11 @@ namespace MudBlazor
         public virtual string Pattern { get; set; }
 
         /// <summary>
-        /// Shrink prevents the label from moving down into the field when the field is empty.
+        /// ShrinkLabel prevents the label from moving down into the field when the field is empty.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public bool Shrink { get; set; } = false;
+        public bool ShrinkLabel { get; set; } = false;
 
         /// <summary>
         /// Derived classes need to override this if they can be something other than text

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -218,6 +218,13 @@ namespace MudBlazor
         public virtual string Pattern { get; set; }
 
         /// <summary>
+        /// Shrink prevents the label from moving down into the field when the field is empty.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public bool Shrink { get; set; } = false;
+
+        /// <summary>
         /// Derived classes need to override this if they can be something other than text
         /// </summary>
         internal virtual InputType GetInputType() { return InputType.Text; }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -21,6 +21,7 @@
                           OnKeyUp="@this.OnInputKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
                           Placeholder="@Placeholder" Immediate="true"
                           InputMode="@InputMode" Pattern="@Pattern"
+                          Shrink="@Shrink"
                           T="string" />
 
                 @if (ShowProgressIndicator && IsLoading)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -21,7 +21,7 @@
                           OnKeyUp="@this.OnInputKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
                           Placeholder="@Placeholder" Immediate="true"
                           InputMode="@InputMode" Pattern="@Pattern"
-                          Shrink="@Shrink"
+                          ShrinkLabel="@ShrinkLabel"
                           T="string" />
 
                 @if (ShowProgressIndicator && IsLoading)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     public partial class MudInput<T> : MudBaseInput<T>
     {
         protected string Classname => MudInputCssHelper.GetClassname(this,
-            () => HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder));
+            () => HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || Shrink);
 
         protected string InputClassname => MudInputCssHelper.GetInputClassname(this);
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     public partial class MudInput<T> : MudBaseInput<T>
     {
         protected string Classname => MudInputCssHelper.GetClassname(this,
-            () => HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || Shrink);
+            () => HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || ShrinkLabel);
 
         protected string InputClassname => MudInputCssHelper.GetInputClassname(this);
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -17,7 +17,7 @@
                           AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="UserAttributes" OnBlur="@OnBlurAsync"
-                          Shrink="@Shrink">
+                          ShrinkLabel="@ShrinkLabel">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -16,7 +16,8 @@
                           OnAdornmentClick="@OnAdornmentClick" AdornmentIcon="@_currentIcon" Adornment="@Adornment"
                           AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
-                          @attributes="UserAttributes" OnBlur="@OnBlurAsync">
+                          @attributes="UserAttributes" OnBlur="@OnBlurAsync"
+                          Shrink="@Shrink">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -61,7 +61,8 @@
                               HideSpinButtons="true"
                               Clearable="@Clearable"
                               OnClearButtonClick="@OnClearButtonClick"
-                              Pattern="@Pattern"/>
+                              Pattern="@Pattern"
+                              Shrink="@Shrink"/>
                 }
                 else
                 {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -62,7 +62,7 @@
                               Clearable="@Clearable"
                               OnClearButtonClick="@OnClearButtonClick"
                               Pattern="@Pattern"
-                              Shrink="@Shrink"/>
+                              ShrinkLabel="@ShrinkLabel"/>
                 }
                 else
                 {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
Adds support for a "Shrink" parameter to MudTextField, MudAutocomplete and MudSelect. The Shrink parameter prevents the label from moving down into the field when the field is empty. This is inspired by the prop of the same name in Material UI https://mui.com/material-ui/api/input-label/#input-label-prop-shrink

This **partially** fixes #1114

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
This has been tested visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

![image](https://github.com/MudBlazor/MudBlazor/assets/31126885/6b77ea09-d69b-4f7e-b3d2-164dbce3cab3)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
