### PR TITLE
MudDrawer: Opening mini drawer pushes MudMainContent to the right (#7775)

### DIFF
--- a/src/MudBlazor/Styles/layout/_main.scss
+++ b/src/MudBlazor/Styles/layout/_main.scss
@@ -65,19 +65,17 @@
     &-mini {
         @each $breakpoint in map-keys($breakpoints) {
             &-#{$breakpoint} {
-                @media (min-width: map-get($breakpoints, $breakpoint)) {
-                    &-left .mud-main-content {
-                        margin-left: var(--mud-drawer-width-left);
-                    }
+                &-left .mud-main-content {
+                    margin-left: var(--mud-drawer-width-left);
+                }
 
-                    &-right .mud-main-content {
+                &-right .mud-main-content {
                         margin-right: var(--mud-drawer-width-right);
-                    }
+                }
 
-                    &-left#{&}-right .mud-main-content {
-                        margin-right: var(--mud-drawer-width-right);
-                        margin-left: var(--mud-drawer-width-left);
-                    }
+                &-left#{&}-right .mud-main-content {
+                    margin-right: var(--mud-drawer-width-right);
+                    margin-left: var(--mud-drawer-width-left);
                 }
             }
         }


### PR DESCRIPTION
## Description
See #7775 for description & details.
Fixes #7775

## How Has This Been Tested?
visually & documented via screen capture in aforementioned issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

![Animation](https://github.com/MudBlazor/MudBlazor/assets/5111490/454e7084-6081-446a-801f-3e7e6934cbd0)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.