### PR TITLE
MudTimePicker: Fix AM|PM  (#8032)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -472,9 +472,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DragAndClick_AllHours12h_TestCoverage()
+        public void DragAndClick_AllHours12h_AM_TestCoverage()
         {
-            var comp = OpenPicker(new ComponentParameter[] { Parameter("OpenTo", OpenTo.Hours), Parameter("AmPm", true) });
+            var comp = OpenPicker([Parameter("OpenTo", OpenTo.Hours), Parameter("AmPm", true)]);
             var picker = comp.Instance;
             var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
             // Any hours displayed
@@ -482,13 +482,40 @@ namespace MudBlazor.UnitTests.Components
             // click and drag
             for (var i = 0; i < 12; i++)
             {
+                var expected = i == 11 ? 0 : i + 1;
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-hour")[i].MouseOver();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-hour")[i].MouseUp();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-hour")[i].Click();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
+            }
+        }
+
+        [Test]
+        public void DragAndClick_AllHours12h_PM_TestCoverage()
+        {
+            var comp = OpenPicker([
+                Parameter("OpenTo", OpenTo.Hours),
+                Parameter("AmPm", true),
+                Parameter("Time", new TimeSpan(13, 0, 0))
+            ]);
+            var picker = comp.Instance;
+            var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
+            // Any hours displayed
+            comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
+            // click and drag
+            for (var i = 0; i < 12; i++)
+            {
+                var expected = i == 11 ? 12 : i + 13;
+                comp.Find("div.mud-time-picker-hour").MouseDown();
+                comp.FindAll("div.mud-hour")[i].MouseOver();
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
+                comp.FindAll("div.mud-hour")[i].MouseUp();
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
+                comp.FindAll("div.mud-hour")[i].Click();
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
             }
         }
 
@@ -504,24 +531,26 @@ namespace MudBlazor.UnitTests.Components
             // click and drag 13 to 00 on outer dial
             for (var i = 0; i < 12; i++)
             {
+                var expected = i + 13 == 24 ? 0 : i + 13;
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseOver();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseUp();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].Click();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
             }
             // click and drag 1 to 12 on inner dial
             for (var i = 0; i < 12; i++)
             {
+                var expected = i + 1;
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseOver();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseUp();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].Click();
-                underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
+                comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
             }
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -471,6 +471,18 @@ namespace MudBlazor
             }
         }
 
+        private int HourAmPm(int value)
+        {
+            if (AmPm)
+            {
+                if (IsAm && value == 12)
+                    return 0;
+                else if (IsPm && value < 12)
+                    return value + 12;
+            }
+            return value;
+        }
+
         /// <summary>
         /// If MouseDown is true enables "dragging" effect on the clock pin/stick.
         /// </summary>
@@ -478,7 +490,7 @@ namespace MudBlazor
         {
             if (MouseDown)
             {
-                _timeSet.Hour = value;
+                _timeSet.Hour = HourAmPm(value);
                 UpdateTime();
             }
         }
@@ -488,15 +500,7 @@ namespace MudBlazor
         /// </summary>
         private void OnMouseClickHour(int value)
         {
-            var h = value;
-            if (AmPm)
-            {
-                if (IsAm && value == 12)
-                    h = 0;
-                else if (IsPm && value < 12)
-                    h = value + 12;
-            }
-            _timeSet.Hour = h;
+            _timeSet.Hour = HourAmPm(value);
 
             if (_currentView == OpenTo.Hours
                 || _timeSet.Hour != _lastSelectedHour)


### PR DESCRIPTION
## Description

Resolves #8032

Fix `MudTimePicker` with `AmPm` when the mouse is dragged over a hour number, the time is set to AM.

Before :
![firefox_13Krp13L4O](https://github.com/MudBlazor/MudBlazor/assets/1659796/d289da9d-9c5a-472b-9e3d-a5d8a3934883)

After :
![chrome_64DY0JqPph](https://github.com/MudBlazor/MudBlazor/assets/1659796/4c0ffe53-a9b5-430b-8d06-33676dce4b62)



## How Has This Been Tested?

The test `DragAndClick_AllHours12h_TestCoverage` already check when the mouse is drag over hours, but only with AM selected.
But this test has a error. When the mouse is drag over 12 with AM selected, the time is `12h00m00s` (noon) instead of `00h00m00s` (midnight). I fixed it.

I created the test `DragAndClick_AllHours12h_PM_TestCoverage` to test when the mouse is drag over hours with PM selected and I renamed this test `DragAndClick_AllHours12h_TestCoverage` to `DragAndClick_AllHours12h_AM_TestCoverage`.

Also I encapsulated the assertion in `WaitForAssertion` because sometime the test fails because it is async.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
