### PR TITLE
Skeleton: Allow changes after initialization

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Docs.Examples;
+using MudBlazor.Extensions;
+using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.Utilities;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class SkeletonTests : BunitTest
+    {
+        [Test]
+        public void SkeletonStyleIsAppliedAfterInitialRendering()
+        {
+            var comp = Context.RenderComponent<MudSkeleton>();
+
+            var skeleton = comp.Instance;
+            var span = comp.Find("span");
+
+            var skeletonClasses = comp.Find(".mud-skeleton");
+            // check initial state
+            span.Attributes.GetNamedItem("style")?.Value.Should().BeNullOrEmpty();
+            skeleton.Style.Should().BeNullOrEmpty();
+            skeletonClasses.ClassList.Should().ContainInOrder(new[] { "mud-skeleton", "mud-skeleton-text", "mud-skeleton-pulse" });
+
+            // add new style and check if it was applied
+            comp.SetParametersAndRender(p => p.Add(x => x.Style, "background:blue"));
+            span = comp.Find("span");
+            span.Attributes.GetNamedItem("style")?.Value.Should().Be("background:blue;");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Linq;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Docs.Examples;
-using MudBlazor.Extensions;
-using MudBlazor.UnitTests.TestComponents;
-using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -32,6 +25,46 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(p => p.Add(x => x.Style, "background:blue"));
             span = comp.Find("span");
             span.Attributes.GetNamedItem("style")?.Value.Should().Be("background:blue;");
+        }
+
+        [Test]
+        public void SkeletonHeightIsAppliedAfterInitialRendering()
+        {
+            var comp = Context.RenderComponent<MudSkeleton>(p => p.Add(x => x.Height, "100px"));
+
+            var skeleton = comp.Instance;
+            var span = comp.Find("span");
+
+            var skeletonClasses = comp.Find(".mud-skeleton");
+            // check initial state
+            span.Attributes.GetNamedItem("style")?.Value.Should().Be("height:100px;");
+            skeleton.Height.Should().Be("100px");
+            skeletonClasses.ClassList.Should().ContainInOrder(new[] { "mud-skeleton", "mud-skeleton-text", "mud-skeleton-pulse" });
+
+            // add new style and check if it was applied
+            comp.SetParametersAndRender(p => p.Add(x => x.Height, "50px"));
+            span = comp.Find("span");
+            span.Attributes.GetNamedItem("style")?.Value.Should().Be("height:50px;");
+        }
+
+        [Test]
+        public void SkeletonWidthIsAppliedAfterInitialRendering()
+        {
+            var comp = Context.RenderComponent<MudSkeleton>(p => p.Add(x => x.Width, "300px"));
+
+            var skeleton = comp.Instance;
+            var span = comp.Find("span");
+
+            var skeletonClasses = comp.Find(".mud-skeleton");
+            // check initial state
+            span.Attributes.GetNamedItem("style")?.Value.Should().Be("width:300px;");
+            skeleton.Width.Should().Be("300px");
+            skeletonClasses.ClassList.Should().ContainInOrder(new[] { "mud-skeleton", "mud-skeleton-text", "mud-skeleton-pulse" });
+
+            // add new style and check if it was applied
+            comp.SetParametersAndRender(p => p.Add(x => x.Width, "500px"));
+            span = comp.Find("span");
+            span.Attributes.GetNamedItem("style")?.Value.Should().Be("width:500px;");
         }
     }
 }

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase;
 
-<span @attributes="UserAttributes" class="@Classname" style="@_styleString"></span>
+<span @attributes="UserAttributes" class="@Classname" style="@Stylename"></span>

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -6,15 +7,18 @@ namespace MudBlazor
 #nullable enable
     public partial class MudSkeleton : MudComponentBase
     {
-        private string? _width;
-        private string? _height;
-        private string? _styleString;
-
         protected string Classname =>
             new CssBuilder("mud-skeleton")
                 .AddClass($"mud-skeleton-{SkeletonType.ToDescriptionString()}")
                 .AddClass($"mud-skeleton-{Animation.ToDescriptionString()}")
                 .AddClass(Class)
+                .Build();
+
+        protected string Stylename =>
+            new StyleBuilder()
+                .AddStyle("height", $"{Height}", !string.IsNullOrEmpty(Height))
+                .AddStyle("width", $"{Width}", !string.IsNullOrEmpty(Width))
+                .AddStyle(Style)
                 .Build();
 
         /// <summary>
@@ -44,20 +48,5 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Skeleton.Appearance)]
         public Animation Animation { set; get; } = Animation.Pulse;
-
-        protected override void OnInitialized()
-        {
-            if (!string.IsNullOrEmpty(Width))
-            {
-                _width = $"width:{Width};";
-            }
-
-            if (!string.IsNullOrEmpty(Height))
-            {
-                _height = $"height:{Height};";
-            }
-
-            _styleString = $"{_width}{_height}{Style}";
-        }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
Skeleton applies new styles after initialization now. Before the skeleton styles were applied just once at initialization and no changes were possible afterwards.
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I added new unit test module (none was existing for skeleton before). It contains three tests which test the parameters Width, Height, Style after initialization and after a further update of the parameter afterwards.
The tests will fail without the fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
