### PR TITLE
MudTextField: Preserve scroll position while typing with AutoGrow and update when window is resized

### DIFF
--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -32,7 +32,15 @@ window.mudInputAutoGrow = {
         }
 
         elem.addEventListener('input', () => {
+            var startOffset = window.scrollY;
+
             elem.adjustAutoGrowHeight();
+
+            // Preserve scroll position.
+            // https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize#comment122501893_25621277.
+            if (startOffset > window.scrollY) {
+                window.scrollTo({ top: startOffset });
+            }
         });
 
         elem.adjustAutoGrowHeight();

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -15,6 +15,10 @@ window.mudInputAutoGrow = {
             maxHeight = lineHeight * maxLines;
         }
 
+        // Fix scrollbar flashing.
+        // https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize#comment23512418_8522283.
+        elem.setAttribute("style", "overflow-y:hidden;");
+
         // Capture min and max height in closure to trigger height adjustment on element in MudTextField.
         elem.adjustAutoGrowHeight = function () {
             elem.style.height = 0;

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -12,12 +12,9 @@ window.mudInputAutoGrow = {
 
         let maxHeight = 0;
         if (maxLines > 0) {
+            // Cap the height to the max number of lines.
             maxHeight = lineHeight * maxLines;
         }
-
-        // Fix scrollbar flashing.
-        // https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize#comment23512418_8522283.
-        elem.style.overflowY = "hidden";
 
         // Capture min and max height in closure to trigger height adjustment on element in MudTextField.
         elem.adjustAutoGrowHeight = function () {
@@ -48,14 +45,17 @@ window.mudInputAutoGrow = {
             });
         }
 
+        // Adjust height when input happens.
         elem.addEventListener('input', () => {
             elem.adjustAutoGrowHeight();
         });
 
+        // Adjust height when the window resizes.
         window.addEventListener('resize', () => {
             elem.adjustAutoGrowHeight();
         });
 
+        // Initial height adjustment.
         elem.adjustAutoGrowHeight();
     },
     adjustHeight: (elem) => {

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -52,6 +52,10 @@ window.mudInputAutoGrow = {
             elem.adjustAutoGrowHeight();
         });
 
+        window.addEventListener('resize', () => {
+            elem.adjustAutoGrowHeight();
+        });
+
         elem.adjustAutoGrowHeight();
     },
     adjustHeight: (elem) => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves #8152 and part of #8091.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

Before:

https://github.com/MudBlazor/MudBlazor/assets/7112040/4ba74e8e-518f-4bea-8473-d5b08d702644

https://github.com/MudBlazor/MudBlazor/assets/7112040/d3b7baf9-be07-4894-99b8-1d4ce41b3a61


After:

https://github.com/MudBlazor/MudBlazor/assets/7112040/ed68a26c-8f7d-451b-8eb8-017b7a48aae6



https://github.com/MudBlazor/MudBlazor/assets/7112040/b74766e7-7269-4409-b8cc-d3d28218020c



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
