### PR TITLE
MudMenu: Fix when PositionAtCursor is true and touch is used.

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
@@ -285,8 +286,18 @@ namespace MudBlazor
         public void OpenMenu(EventArgs args)
         {
             if (Disabled)
+            {
                 return;
-            if (PositionAtCursor) SetPopoverStyle((MouseEventArgs)args);
+            }
+
+            if (PositionAtCursor)
+            {
+                if (args is MouseEventArgs mouseEventArgs)
+                {
+                    SetPopoverStyle(mouseEventArgs);
+                }
+            }
+
             _isOpen = true;
             StateHasChanged();
             IsOpenChanged.InvokeAsync(_isOpen);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7006
The problem was obvious that the `ToggleMenuTouch(TouchEventArgs args)` casts args to `EventArgs` for `OpenMenu`, but then `OpenMenu` would cast it to `MouseEventArgs` without validation if it's possible, it works for mouse but not for touch, like the issue author said it does not account for the args potentially being `TouchEventArgs` when casting the `EventArgs`.

## How Has This Been Tested?
Manually, but let me know if we need unit test for this.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
