### PR TITLE
MudColor: Fix ColorRgbDarken and ColorRgbLighten

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -103,6 +103,41 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
+        [TestCase("rgba(12,204,210,0.5)", 12, 204, 210, 127)]
+        [TestCase("rgba(67,160,71,1)", 67, 160, 71, 1)]
+        [TestCase("#43a047", 67, 160, 71, 1)]
+        [TestCase("rgba(255,255,255,1)", 255, 255, 255, 255)]
+        public void FromString_RGBA_And_Darken(string input, byte r, byte g, byte b, byte alpha)
+        {
+            var cultures = new[] { new CultureInfo("en", false), new CultureInfo("se", false) };
+
+            foreach (var item in cultures)
+            {
+                CultureInfo.CurrentCulture = item;
+
+                MudColor color = new(input);
+
+                //lets darken it
+                var darkenColor = color.ColorRgbDarken();
+
+                //use as reference
+                var colorFromRGB = new MudColor(color.R, color.G, color.B, color.A);
+                var darkenColorFromRGB = colorFromRGB.ColorRgbDarken();
+
+                darkenColor.R.Should().Be(darkenColorFromRGB.R);
+                darkenColor.G.Should().Be(darkenColorFromRGB.G);
+                darkenColor.B.Should().Be(darkenColorFromRGB.B);
+
+                //MudColor implicitCasted = input;
+
+                //implicitCasted.R.Should().Be(r);
+                //implicitCasted.G.Should().Be(g);
+                //implicitCasted.B.Should().Be(b);
+                //implicitCasted.A.Should().Be(alpha);
+            }
+        }
+
+        [Test]
         public void FromRGB_Byte()
         {
             MudColor color = new((byte)123, (byte)240, (byte)130, (byte)76);

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -224,9 +224,8 @@ namespace MudBlazor.Utilities
                     GetByteFromValuePart(value,4),
                     GetByteFromValuePart(value,6),
                 };
-
-                CalculateHSL();
             }
+            CalculateHSL();
         }
 
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
Not complete initialization of `MudColor'`s hsl values lead to hard to detect bugs if those values are used like `ColorRgbDarken `or `ColorRgbLighten`
<!-- Note any issues that are resolved by this PR -->
resolves #8205 

## How Has This Been Tested?
Unit tests are added
<!-- Please describe how you tested your changes. -->
tests are parse rgb value and then darken it and compares with same darken colors but created from rgb parameters
<!-- Have you created new tests or updated existing ones? -->
I have created new unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
