### PR TITLE
DataGrid: Fix editing of nullable values such as int?

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditWithNullableChangeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditWithNullableChangeTest.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items" ReadOnly="false" EditMode="@DataGridEditMode.Cell">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("John", 45), 
+        new Model("Johanna", 23), 
+        new Model("Steve", null)
+    };
+
+    public record Model(string Name, int? Age);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -511,6 +511,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridInlineEditWithNullableChangeTest()
+        {
+            var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithNullableTest.Model>>();
+
+            // try setting a value to null
+            dataGrid.FindAll("td input")[1].Change("");
+            dataGrid.Instance.Items.First().Age.Should().Be(null);
+
+            // try setting the value back to something not null
+            dataGrid.FindAll("td input")[1].Change("15");
+            dataGrid.Instance.Items.First().Age.Should().Be(15);
+        }
+
+        [Test]
         public async Task DataGridInlineEditWithNullableTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -109,8 +109,13 @@ namespace MudBlazor
 
                 if (memberExpression.Member is PropertyInfo propertyInfo)
                 {
-                    var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
-                    propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
+                    if (value == null) // We can't use the normal execution path for null values, because we can't use Convert.ChangeType with null for types such as int?, double?, etc
+                        propertyInfo.SetValue(item, null);
+                    else
+                    {
+                        var actualType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? PropertyType;
+                        propertyInfo.SetValue(item, Convert.ChangeType(value, actualType), null);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
This fix a bug with the datagrid where it was impossible to clear a value for nullable structs such as `int?`, `double?`, etc.
We could set a value, ex "25" but then if we clear the text "25" and hit "enter" there was a crash.
Try emptying the "Age" cell in one of the row: [https://try.mudblazor.com/snippet/ckwoYmmoLvDaySwa](https://try.mudblazor.com/snippet/ckwoYmmoLvDaySwa)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested using a small example and added a unit test

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
