### PR TITLE
MudTextField: Remove phantom scrollbars when auto grow is enabled and height is uncapped

### DIFF
--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -34,7 +34,7 @@ window.mudInputAutoGrow = {
             if (maxHeight > 0) {
                 newHeight = Math.min(newHeight, maxHeight);
             } else {
-                // Hide phantom scrollbars that randomly appear.
+                // Hide phantom scrollbars https://github.com/MudBlazor/MudBlazor/pull/8235.
                 elem.style.overflow = 'hidden';
             }
 

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -33,6 +33,9 @@ window.mudInputAutoGrow = {
             let newHeight = Math.max(minHeight, elem.scrollHeight);
             if (maxHeight > 0) {
                 newHeight = Math.min(newHeight, maxHeight);
+            } else {
+                // Hide phantom scrollbars that randomly appear.
+                elem.style.overflow = 'hidden';
             }
 
             elem.style.height = newHeight + "px";


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->


Sometimes, and admittedly I couldn't figure out why, phantom scroll bars would appear with certain text. This PR removes the scrollbars when the auto grow height is uncapped so it's not a problem.

Wish I knew why it was happening in the first place.

https://github.com/MudBlazor/MudBlazor/assets/7112040/6e4b7c6b-a841-4f7a-885a-baf8a2e10d1e

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
