### PR TITLE
BrowserViewportService: Improve performance

### DIFF
--- a/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
@@ -548,7 +548,7 @@ public class BrowserViewportServiceTests
         await service.DisposeAsync();
 
         // Assert
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners", It.Is<object[]>(args => args.Length == 1 && ((Guid[])args[0]).Length == 1)), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -569,7 +569,7 @@ public class BrowserViewportServiceTests
         await service.DisposeAsync();
 
         // Assert
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners", It.Is<object[]>(args => args.Length == 1 && ((Guid[])args[0]).Length == 3)), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]

--- a/src/MudBlazor/Interop/ResizeListenerInterop.cs
+++ b/src/MudBlazor/Interop/ResizeListenerInterop.cs
@@ -42,6 +42,11 @@ internal class ResizeListenerInterop
         return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListeners", jsListenerIds);
     }
 
+    public ValueTask Dispose()
+    {
+        return _jsRuntime.InvokeVoidAsyncIgnoreErrors("mudResizeListenerFactory.dispose");
+    }
+
     public async ValueTask<BrowserWindowSize> GetBrowserWindowSize()
     {
         var size = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize");

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -132,5 +132,12 @@ window.mudResizeListenerFactory = {
         for (let i = 0; i < ids.length; i++) {
             window.mudResizeListenerFactory.cancelListener(ids[i]);
         }
+    },
+
+    dispose() {
+        var map = window.mudResizeListenerFactory.mapping;
+        for (var id in map) {
+            window.mudResizeListenerFactory.cancelListener(id);
+        }
     }
 }


### PR DESCRIPTION
## Description
Uses the new lock mechanism introduced in https://github.com/MudBlazor/MudBlazor/pull/8210

I also added new `mudResizeListenerFactory.dispose` method to JS in analogue with `mudPopover.dispose`.
I always wondered why this method wasn't added when we dispose the service, why do we need to get all the ids from the C# side and pass it `mudResizeListenerFactory.cancelListeners`, this is expensive. It's better to do it like it's done in popover.

Risks:
Every time we update js someone creates an issue that `xyz was not found` and that they do not try to clear the cache.

## How Has This Been Tested?
Via docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
