### PR TITLE
IScrollSpy: Fix DotNetObjectReference instance was already disposed

### DIFF
--- a/src/MudBlazor/Services/Scroll/ScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpy.cs
@@ -11,16 +11,18 @@ namespace MudBlazor
 {
     public class ScrollSectionCenteredEventArgs
     {
+        public string Id { get; }
+
         public ScrollSectionCenteredEventArgs(string id)
         {
             Id = id;
         }
-
-        public string Id { get; init; }
     }
 
     public interface IScrollSpy : IAsyncDisposable
     {
+        event EventHandler<ScrollSectionCenteredEventArgs> ScrollSectionSectionCentered;
+
         /// <summary>
         /// Start spying for scroll events for elements with the specified classes
         /// </summary>
@@ -41,14 +43,13 @@ namespace MudBlazor
         /// <param name="uri">The uri which contains the fragment. If no fragment it scrolls to the top of the page</param>
         /// <returns></returns>
         Task ScrollToSection(Uri uri);
-        event EventHandler<ScrollSectionCenteredEventArgs> ScrollSectionSectionCentered;
 
         /// <summary>
         /// Does the same as ScrollToSection but without the scrolling. This can be used to initially set an value
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        Task SetSectionAsActive(String id);
+        Task SetSectionAsActive(string id);
 
         /// <summary>
         /// Get the current position of the centered section
@@ -60,7 +61,7 @@ namespace MudBlazor
     {
         public string CenteredSection { get; private set; }
         private readonly IJSRuntime _js;
-        private DotNetObjectReference<ScrollSpy> _dotNetRef;
+        private readonly DotNetObjectReference<ScrollSpy> _dotNetRef;
 
         [DynamicDependency(nameof(SectionChangeOccured))]
         public ScrollSpy(IJSRuntime js)
@@ -69,8 +70,7 @@ namespace MudBlazor
             _dotNetRef = DotNetObjectReference.Create(this);
         }
 
-        public async Task StartSpying(string containerSelector) => await _js.InvokeVoidAsync
-            ("mudScrollSpy.spying", containerSelector, _dotNetRef);
+        public async Task StartSpying(string containerSelector) => await _js.InvokeVoidAsync("mudScrollSpy.spying", containerSelector, _dotNetRef);
 
         [JSInvokable]
         public void SectionChangeOccured(string id)
@@ -84,15 +84,13 @@ namespace MudBlazor
         public async Task ScrollToSection(string id)
         {
             CenteredSection = id;
-            await _js.InvokeVoidAsyncWithErrorHandling
-            ("mudScrollSpy.scrollToSection", id.Trim('#'));
+            await _js.InvokeVoidAsyncWithErrorHandling("mudScrollSpy.scrollToSection", id.Trim('#'));
         }
 
         public async Task SetSectionAsActive(string id)
         {
             CenteredSection = id;
-            await _js.InvokeVoidAsyncWithErrorHandling
-            ("mudScrollSpy.activateSection", id.Trim('#'));
+            await _js.InvokeVoidAsyncWithErrorHandling("mudScrollSpy.activateSection", id.Trim('#'));
         }
 
         public async Task ScrollToSection(Uri uri) => await ScrollToSection(uri.Fragment);
@@ -101,11 +99,12 @@ namespace MudBlazor
         {
             try
             {
-                _dotNetRef?.Dispose();
                 await _js.InvokeVoidAsyncWithErrorHandling("mudScrollSpy.unspy");
+                _dotNetRef?.Dispose();
             }
             catch (Exception)
             {
+                // ignored
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes https://github.com/MudBlazor/MudBlazor/issues/7965

I think the problem was simply in the dispose order.
The DotNetObjectReference was dispose before the unsubscription on the js side, and in-between this frame there could be scrolling happening.
At least I could not reproduce it anymore.

## How Has This Been Tested?
1. run mudblazor source code (locally, not the mudblazor.com)
2. open any component documentation
3. scroll and hit the back button
4. should be no exceptions anymore

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
