### PR TITLE
MudDataGrid: Add extensions method on `IQueryable` for easy filtering and ordering

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4187,5 +4187,27 @@ namespace MudBlazor.UnitTests.Components
             cells[28].TextContent.Should().Be("Calcium"); cells[29].TextContent.Should().Be("20");
         }
 
+        [Test]
+        public void QueryFilterExtensionTest()
+        {
+            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+
+            var nameFilter = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Column = dataGrid.Instance.GetColumnByPropertyName("Name"),
+                Operator = FilterOperator.String.Contains,
+                Value = "Sam",
+            };
+            var ageFilter = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Column = dataGrid.Instance.GetColumnByPropertyName("Age"),
+                Operator = FilterOperator.Number.GreaterThan,
+                Value = 42,
+            };
+
+            var query = Array.Empty<DataGridFiltersTest.Model>().AsQueryable().Where([nameFilter, ageFilter]);
+            query.ToString().Should().Match("*x.Name.Contains(*x.Age > Convert(42*");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4209,5 +4209,33 @@ namespace MudBlazor.UnitTests.Components
             var query = Array.Empty<DataGridFiltersTest.Model>().AsQueryable().Where([nameFilter, ageFilter]);
             query.ToString().Should().Match("*x.Name.Contains(*x.Age > Convert(42*");
         }
+
+        [Test]
+        public void QuerySortExtensionTest()
+        {
+            var nameSort = new SortDefinition<DataGridFiltersTest.Model>("Name", Descending: true, 0, default!);
+            var ageSort = new SortDefinition<DataGridFiltersTest.Model>("Age", Descending: false, 1, default!);
+
+            var query = Array.Empty<DataGridFiltersTest.Model>().AsQueryable().OrderBy([nameSort, ageSort]);
+            query.ToString().Should().Be("MudBlazor.UnitTests.TestComponents.DataGridFiltersTest+Model[].OrderByDescending(x => x.Name).ThenBy(x => x.Age)");
+        }
+
+        [Test]
+        public void QuerySortExtensionTestAscendingThenDescending()
+        {
+            var nameSort = new SortDefinition<DataGridFiltersTest.Model>("Name", Descending: false, 0, default!);
+            var ageSort = new SortDefinition<DataGridFiltersTest.Model>("Age", Descending: true, 1, default!);
+
+            var query = Array.Empty<DataGridFiltersTest.Model>().AsQueryable().OrderBy([nameSort, ageSort]);
+            query.ToString().Should().Be("MudBlazor.UnitTests.TestComponents.DataGridFiltersTest+Model[].OrderBy(x => x.Name).ThenByDescending(x => x.Age)");
+        }
+
+        [Test]
+        public void QuerySortExtensionTestEmptyDefinitions()
+        {
+            var source = Array.Empty<DataGridFiltersTest.Model>().AsQueryable();
+            var query = source.OrderBy([]);
+            query.Should().BeSameAs(source);
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/QueryFilterExtensions.cs
+++ b/src/MudBlazor/Components/DataGrid/QueryFilterExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MudBlazor
+{
+#nullable enable
+    public static class QueryFilterExtensions
+    {
+        /// <summary>
+        /// Filters a sequence of values based on a collection of filter definitions.
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}"/> to filter.</param>
+        /// <param name="filterDefinitions">A collection of <see cref="IFilterDefinition{T}"/> to apply.</param>
+        /// <param name="caseSensitivity">The filtering case sensitivity. Defaults to <see cref="DataGridFilterCaseSensitivity.Ignore"/> for best compatibility with database providers.</param>
+        /// <typeparam name="T">The type of the elements of source.</typeparam>
+        /// <returns>An <see cref="IQueryable{T}"/> that contains elements from the input sequence that satisfy the filter definitions.</returns>
+        public static IQueryable<T> Where<T>(
+            this IQueryable<T> source,
+            IEnumerable<IFilterDefinition<T>> filterDefinitions,
+            DataGridFilterCaseSensitivity caseSensitivity = DataGridFilterCaseSensitivity.Ignore)
+        {
+            var filterOptions = new FilterOptions { FilterCaseSensitivity = caseSensitivity };
+            return filterDefinitions.Aggregate(source, (current, filter) => current.Where(FilterExpressionGenerator.GenerateExpression(filter, filterOptions)));
+        }
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/QuerySortExtensions.cs
+++ b/src/MudBlazor/Components/DataGrid/QuerySortExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace MudBlazor
+{
+#nullable enable
+    public static class QuerySortExtensions
+    {
+        private static readonly MethodInfo OrderByMethod = typeof(Queryable).GetMethods()
+            .Where(m => m is { Name: nameof(Queryable.OrderBy), IsGenericMethodDefinition: true })
+            .Single(m => m.GetParameters().Length == 2);
+
+        private static readonly MethodInfo OrderByDescendingMethod = typeof(Queryable).GetMethods()
+            .Where(m => m is { Name: nameof(Queryable.OrderByDescending), IsGenericMethodDefinition: true })
+            .Single(m => m.GetParameters().Length == 2);
+
+        private static readonly MethodInfo ThenByMethod = typeof(Queryable).GetMethods()
+            .Where(m => m is { Name: nameof(Queryable.ThenBy), IsGenericMethodDefinition: true })
+            .Single(m => m.GetParameters().Length == 2);
+
+        private static readonly MethodInfo ThenByDescendingMethod = typeof(Queryable).GetMethods()
+            .Where(m => m is { Name: nameof(Queryable.ThenByDescending), IsGenericMethodDefinition: true })
+            .Single(m => m.GetParameters().Length == 2);
+
+        /// <summary>
+        /// Sorts the elements of a sequence in the order described by the sort definitions.
+        /// </summary>
+        /// <param name="source">A sequence of values to order.</param>
+        /// <param name="sortDefinitions">A collection of <see cref="SortDefinition{T}"/> that describe how to sort the source.</param>
+        /// <typeparam name="T">The type of the elements of source</typeparam>
+        /// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to the sort definitions or the <paramref name="source"/> itself if the sort definitions are empty.</returns>
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Suppressing because T is a type supplied by the user and it is unlikely that it is not referenced by their code.")]
+        public static IQueryable<T> OrderBy<T>(this IQueryable<T> source, IEnumerable<SortDefinition<T>> sortDefinitions)
+        {
+            return OrderBy(source, sortDefinitions, (parameter, sortDefinition) => Expression.Property(parameter, sortDefinition.SortBy));
+        }
+
+        /// <summary>
+        /// Sorts the elements of a sequence in the order described by the sort definitions.
+        /// </summary>
+        /// <param name="source">A sequence of values to order.</param>
+        /// <param name="sortDefinitions">A collection of <see cref="SortDefinition{T}"/> that describe how to sort the source.</param>
+        /// <param name="expression">A function that constructs the body of the lambda expression for the given parameter expression and sort definition.</param>
+        /// <typeparam name="T">The type of the elements of source</typeparam>
+        /// <returns>An <see cref="IOrderedQueryable{T}"/> whose elements are sorted according to the sort definitions or the <paramref name="source"/> itself if the sort definitions are empty.</returns>
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Suppressing because T is a type supplied by the user and it is unlikely that it is not referenced by their code.")]
+        public static IQueryable<T> OrderBy<T>(this IQueryable<T> source, IEnumerable<SortDefinition<T>> sortDefinitions, Func<ParameterExpression, SortDefinition<T>, Expression> expression)
+        {
+            IOrderedQueryable<T>? query = null;
+
+            foreach (var sortDefinition in sortDefinitions)
+            {
+                var parameter = Expression.Parameter(typeof(T), "x");
+                var body = expression(parameter, sortDefinition);
+                var keySelector = Expression.Lambda(body, parameter);
+                if (query is null)
+                {
+                    var orderBy = (sortDefinition.Descending ? OrderByDescendingMethod : OrderByMethod).MakeGenericMethod(typeof(T), keySelector.ReturnType);
+                    query = (IOrderedQueryable<T>?)orderBy.Invoke(null, [source, keySelector]);
+                }
+                else
+                {
+                    var thenBy = (sortDefinition.Descending ? ThenByDescendingMethod : ThenByMethod).MakeGenericMethod(typeof(T), keySelector.ReturnType);
+                    query = (IOrderedQueryable<T>?)thenBy.Invoke(null, [query, keySelector]);
+                }
+            }
+
+            return query ?? source;
+        }
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces two new extensions methods on `IQueryable`: `Where` that takes a `IEnumerable<IFilterDefinition<T>>` and `OrderBy` that takes a `IEnumerable<SortDefinition<T>>`.

This enables a straightforward implementations of the `ServerData` function, for example with EF Core.
```csharp
using System.Linq;
using System.Threading;
using System.Threading.Tasks;
using Microsoft.EntityFrameworkCore;

namespace MudBlazor;

internal static class QueryGridExtensions
{
    public static async Task<GridData<T>> LoadServerDataAsync<T>(this IQueryable<T> source, GridState<T> state, CancellationToken cancellationToken = default)
    {
        var query = source.Where(state.FilterDefinitions).OrderBy(state.SortDefinitions);
        var items = await query.Skip(state.Page * state.PageSize).Take(state.PageSize).ToListAsync(cancellationToken);
        var totalItems = await query.CountAsync(cancellationToken);
        return new GridData<T> { Items = items, TotalItems = totalItems };
    }
}
```

(A good implementation would need to order the source with a default ordering in case the sort definitions are empty.)

It also fixes #6682.

## How Has This Been Tested?
Two new unit tests have been added: `QueryFilterExtensionTest` and `QuerySortExtensionTest`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
