### PR TITLE
MudTabs: Vertical tabs headers now stretch to fill available horizontal space

### DIFF
--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -10,6 +10,10 @@
 
   &.mud-tabs-vertical {
     flex-direction: row;
+
+    .mud-tooltip-root {
+        width: auto;
+    }
   }
 
   &.mud-tabs-vertical-reverse {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
fixes #8253
Prior to this PR, if you have vertical tabs and one or more tabs is oversized, then those tabs which have less width than the largest tab will not fill the available space within the tab header container. This fixes that, so that the entire area is once again clickable (which I think most users would expect) and the hover / ripple zone looks correct also.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually - its a small css change and nothing more

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
Before:
![image](https://github.com/MudBlazor/MudBlazor/assets/11229848/6bdb42f3-ee7e-4b4a-936e-b7620f6209b2)

After:
![image](https://github.com/MudBlazor/MudBlazor/assets/11229848/f151d3e7-d26e-4d5a-8213-48b50dacec87)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
