### PR TITLE
MudTable: Fix excessive SelectedItemsChanged callback

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionSelectedItemsChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionSelectedItemsChangedTest.razor
@@ -1,0 +1,24 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable T="int" Items="items" MultiSelection="true" SelectedItemsChanged="SelectedItemsChanged">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+        </RowTemplate>
+</MudTable>
+<MudText id="counter">@counter</MudText>
+
+@code {
+    public static string __description__ = "Selecting the 'Select All' checkbox should trigger the 'SelectedItemsChanged' event only once";
+
+    private int counter = 0;
+
+    private int[] items = new int[] { 0, 1 };
+
+    private void SelectedItemsChanged(HashSet<int> selectedItems)
+    {
+        counter++;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2210,5 +2210,17 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell")[1].TextContent.Should().Be("Value_0");
             comp.FindAll(".mud-table-body .mud-table-row .mud-table-cell .mud-checkbox-input")[0].IsChecked().Should().Be(true);
         }
+
+        /// <summary>
+        /// Selecting the 'Select All' checkbox should trigger the 'SelectedItemsChanged' event only once
+        /// </summary>
+        [Test]
+        public async Task TestSelectedItemsChanedWithMultiSelection()
+        {
+            var comp = Context.RenderComponent<TableMultiSelectionSelectedItemsChangedTest>();
+            var selectAllCheckbox = comp.Find("input");
+            selectAllCheckbox.Change(true);
+            comp.Find("#counter").TextContent.Should().Be("1");
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -51,7 +51,7 @@ namespace MudBlazor
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new List<MudTableSortLabel<T>>();
 
         /// <summary>
-        /// Updates the state of all group- and/or header/footer checkboxs.
+        /// Updates the state of all checkboxes.
         /// </summary>
         /// <remarks>
         /// Setting checkbox state for Row items and refresh all, is triggered from MudTable OnAfterRenderAsync.
@@ -60,6 +60,14 @@ namespace MudBlazor
         {
             if (!Table.MultiSelection)
                 return;
+
+            // Update row checkboxes
+            foreach (var pair in Rows.ToArray())
+            {
+                var row = pair.Value;
+                var item = pair.Key;
+                row.SetChecked(Selection.Contains(item), notify: false);
+            }
 
             if (updateGroups)
             {


### PR DESCRIPTION
## Description
Reintroduces code that was removed in PR #6075, which broke the fix provided in PR #1104 for issue #977.

## How Has This Been Tested?
A new unit test is added to confirm that the `SelectedItemsChanged` event is triggered only once upon selecting the 'Select All' checkbox in the `MudTable`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
