### PR TITLE
Build: Remove custom SASS compiler in favour of original

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -90,20 +90,18 @@
     <ProjectReference Include="..\MudBlazor.SourceCodeGenerator\MudBlazor.SourceCodeGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <SassCompilerEnableWatcher>false</SassCompilerEnableWatcher>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="MudBlazor.SassCompiler" Version="2.0.4">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
+  <!--Overide the default BeforeTargets in the MSBuild Tasks-->
   <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="Compile Sass" BeforeTargets="BeforeBuild">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazorDocs.min.css')" Text="Missing MudBlazorDocs.min.css in wwwroot" />
     <ItemGroup>
       <!--Include without duplication-->
+      <_NewCompiledCssFiles Remove="@(_NewCompiledCssFiles)" />
       <_NewCompiledDocsCssFiles Include="wwwroot\MudBlazorDocs.min.css" Exclude="@(Content)" />
       <Content Include="@(_NewCompiledDocsCssFiles)" />
     </ItemGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -91,7 +91,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -96,17 +96,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <!--Overide the default BeforeTargets in the MSBuild Tasks-->
-  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="Compile Sass" BeforeTargets="BeforeBuild">
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazorDocs.min.css')" Text="Missing MudBlazorDocs.min.css in wwwroot" />
-    <ItemGroup>
-      <!--Include without duplication-->
-      <_NewCompiledCssFiles Remove="@(_NewCompiledCssFiles)" />
-      <_NewCompiledDocsCssFiles Include="wwwroot\MudBlazorDocs.min.css" Exclude="@(Content)" />
-      <Content Include="@(_NewCompiledDocsCssFiles)" />
-    </ItemGroup>
-  </Target>
-
   <!--Dont Include in build output-->
   <ItemGroup>
     <Content Remove="compilerconfig.json" />

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -76,28 +76,27 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.2" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <SassCompilerEnableWatcher>false</SassCompilerEnableWatcher>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="MudBlazor.SassCompiler" Version="2.0.4">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor.JSCompiler" Version="1.0.12">
+    <PackageReference Include="MudBlazor.JSCompiler" Version="1.0.14">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
+  <!--Overide the default BeforeTargets in the MSBuild Tasks-->
   <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="Compile Sass;Compile JS" BeforeTargets="BeforeBuild">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.css')" Text="Missing MudBlazor.min.css in wwwroot" />
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.js')" Text="Missing MudBlazor.min.js in wwwroot" />
     <ItemGroup>
       <!--Include without duplication-->
+      <_NewCompiledCssFiles Remove="@(_NewCompiledCssFiles)" />
       <_NewCompiledCssFiles Include="wwwroot\MudBlazor.min.css" Exclude="@(Content)" />
-      <_NewCompiledJsFiles Include="wwwroot\MudBlazor.min.js" Exclude="@(Content)" />
+      <_NewCompiledJsFile Remove="@(_NewCompiledJsFile)" />
+      <_NewCompiledJsFile Include="wwwroot\MudBlazor.min.js" Exclude="@(Content)" />
       <Content Include="@(_NewCompiledCssFiles)" />
-      <Content Include="@(_NewCompiledJsFiles)" />
+      <Content Include="@(_NewCompiledJsFile)" />
     </ItemGroup>
   </Target>
 

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -85,21 +85,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <!--Overide the default BeforeTargets in the MSBuild Tasks-->
-  <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="Compile Sass;Compile JS" BeforeTargets="BeforeBuild">
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.css')" Text="Missing MudBlazor.min.css in wwwroot" />
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)/wwwroot/MudBlazor.min.js')" Text="Missing MudBlazor.min.js in wwwroot" />
-    <ItemGroup>
-      <!--Include without duplication-->
-      <_NewCompiledCssFiles Remove="@(_NewCompiledCssFiles)" />
-      <_NewCompiledCssFiles Include="wwwroot\MudBlazor.min.css" Exclude="@(Content)" />
-      <_NewCompiledJsFile Remove="@(_NewCompiledJsFile)" />
-      <_NewCompiledJsFile Include="wwwroot\MudBlazor.min.js" Exclude="@(Content)" />
-      <Content Include="@(_NewCompiledCssFiles)" />
-      <Content Include="@(_NewCompiledJsFile)" />
-    </ItemGroup>
-  </Target>
-
   <!--Dont Include in build output-->
   <ItemGroup>
     <Content Remove="compilerconfig.json" />

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -77,10 +77,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.71.1.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor.JSCompiler" Version="1.0.14">
+    <PackageReference Include="MudBlazor.JSCompiler" Version="1.0.15">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
There have been some changes to [AspNetCore.SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler) recently that allows us to revert to the original library instead of a custom version.
This is great for the future of MudBlazor as it relieves the maintainance and gets regular updates from the original author.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Lots of building.
There are no unit tests for this type of change.
In particular `git clone` followed by `dotnet pack` for the nuget and `dotnet publish` for the website.
I have seen some strange behaviour in the IDE sometimes and I think this is down to incremental build.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
