### PR TITLE
MudStack: Add Wrap Property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
@@ -24,11 +24,11 @@
 </MudStack>
 
 @code {
-    private Wrap _wrap = Wrap.NoWrap;    
-    
+    private Wrap _wrap = Wrap.NoWrap;
+
     private int _width { get; set; } = 200;
     private int _height { get; set; } = 200;
     private bool _row { get; set; } = true;
 
-    private string _size => $"width: {_width}px; height: {_height}px;"; 
+    private string _size => $"width: {_width}px; height: {_height}px;";
 }

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using MudBlazor.Utilities
+
+    <MudPaper Outlined="true" Class="border-dashed pa-4">
+        <MudStack Wrap="@_wrap" Spacing="4" Row="@_row" Style="@_size" AlignItems="AlignItems.Start">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 1</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 2</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 3</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 4</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 5</MudButton>
+        </MudStack>
+    </MudPaper>
+
+
+<MudSlider @bind-Value="@_width" Min="100" Max="800">Width: @_width.ToString()px</MudSlider>
+<MudSlider @bind-Value="@_height" Min="100" Max="800">Height: @_height.ToString()px</MudSlider>
+
+<MudStack Row AlignItems="AlignItems.Center">
+    <MudSwitch @bind-Value="@_row" Color="Color.Primary">Row</MudSwitch>
+    <MudChipSet Filter="true" Mandatory="true">
+        <MudChip Text="No Wrap" OnClick="@(() => _wrap = Wrap.NoWrap)" SelectedColor="Color.Primary" Variant="Variant.Text" Default="true"/>
+        <MudChip Text="Wrap" OnClick="@(() => _wrap = Wrap.Wrap)" SelectedColor="Color.Primary" Variant="Variant.Text" />
+        <MudChip Text="Wrap Reverse" OnClick="@(() => _wrap = Wrap.WrapReverse)" SelectedColor="Color.Primary" Variant="Variant.Text" />
+    </MudChipSet>
+</MudStack>
+
+@code {
+    
+    private Wrap _wrap = Wrap.NoWrap;    
+    private int _width { get; set; } = 200;
+    private int _height { get; set; } = 200;
+    private bool _row { get; set; } = true;
+
+    private string _size => $"width: {_width}px; height: {_height}px;";
+}

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
-@using MudBlazor.Utilities
 
 <MudPaper Outlined="true" Class="border-dashed pa-4">
     <MudStack Wrap="@_wrap" Spacing="4" Row="@_row" Style="@_size" AlignItems="AlignItems.Start">

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackWrappingExample.razor
@@ -1,16 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 @using MudBlazor.Utilities
 
-    <MudPaper Outlined="true" Class="border-dashed pa-4">
-        <MudStack Wrap="@_wrap" Spacing="4" Row="@_row" Style="@_size" AlignItems="AlignItems.Start">
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 1</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 2</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 3</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 4</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 5</MudButton>
-        </MudStack>
-    </MudPaper>
-
+<MudPaper Outlined="true" Class="border-dashed pa-4">
+    <MudStack Wrap="@_wrap" Spacing="4" Row="@_row" Style="@_size" AlignItems="AlignItems.Start">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 1</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 2</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 3</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 4</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="" >Button 5</MudButton>
+    </MudStack>
+</MudPaper>
 
 <MudSlider @bind-Value="@_width" Min="100" Max="800">Width: @_width.ToString()px</MudSlider>
 <MudSlider @bind-Value="@_height" Min="100" Max="800">Height: @_height.ToString()px</MudSlider>
@@ -25,11 +24,11 @@
 </MudStack>
 
 @code {
-    
     private Wrap _wrap = Wrap.NoWrap;    
+    
     private int _width { get; set; } = 200;
     private int _height { get; set; } = 200;
     private bool _row { get; set; } = true;
 
-    private string _size => $"width: {_width}px; height: {_height}px;";
+    private string _size => $"width: {_width}px; height: {_height}px;"; 
 }

--- a/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
@@ -34,6 +34,17 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Wrapping">
+                <Description>
+                    The default wrap behavior can be changed by setting the <CodeInline>Wrap property.</CodeInline>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="StackWrappingExample" ShowCode="false">
+                <StackWrappingExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Usage Examples">
                 <Description>Here is two simple examples to demonstrate what <CodeInline>MudStack</CodeInline> can be used for.</Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/StackTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StackTests.cs
@@ -109,6 +109,18 @@ namespace MudBlazor.UnitTests.Components
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"align-{expectedClass}", "gap-3" });
         }
+
+        [Test]
+        [TestCase(Wrap.NoWrap, "nowrap")]
+        [TestCase(Wrap.Wrap, "wrap")]
+        [TestCase(Wrap.WrapReverse, "wrap-reverse")]
+        public void CheckWrapClass(Wrap wrap, string expectedClass)
+        {
+            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Wrap, wrap));
+
+            var stackClass = stack.Find(".d-flex");
+            stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"flex-{expectedClass}", "gap-3" });
+        }
     }
 }
 

--- a/src/MudBlazor/Components/Stack/MudStack.razor.cs
+++ b/src/MudBlazor/Components/Stack/MudStack.razor.cs
@@ -15,6 +15,7 @@ public partial class MudStack : MudComponentBase
             .AddClass($"flex-{(Row ? "row" : "column")}{(Reverse ? "-reverse" : string.Empty)}")
             .AddClass($"justify-{Justify?.ToDescriptionString()}", Justify != null)
             .AddClass($"align-{AlignItems?.ToDescriptionString()}", AlignItems != null)
+            .AddClass($"flex-{Wrap?.ToDescriptionString()}", Wrap != null)
             .AddClass($"gap-{Spacing}")
             .AddClass(Class)
             .Build();
@@ -53,6 +54,13 @@ public partial class MudStack : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public AlignItems? AlignItems { get; set; }
+
+    /// <summary>
+    /// Defines the flexbox wrapping behavior of its items.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Stack.Behavior)]
+    public Wrap? Wrap { get; set; }
 
     /// <summary>
     /// Child content of the component.

--- a/src/MudBlazor/Enums/Wrap.cs
+++ b/src/MudBlazor/Enums/Wrap.cs
@@ -2,12 +2,30 @@
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// The flex-wrap CSS property sets whether flex items are forced onto one line or 
+    /// can wrap onto multiple lines. If wrapping is allowed, it sets the direction that lines are stacked.
+    /// </summary>
     public enum Wrap
     {
+        /// <summary>
+        /// This is the default value.
+        /// The flex items are laid out in a single line which may cause the flex container to overflow. 
+        /// The cross-start is either equivalent to start or before depending on the flex-direction value. 
+        /// </summary>
         [Description("nowrap")]
         NoWrap,
+
+        /// <summary>
+        /// The flex items break into multiple lines. The cross-start is either equivalent to start or before 
+        /// depending flex-direction value and the cross-end is the opposite of the specified cross-start.
+        /// </summary>
         [Description("wrap")]
         Wrap,
+
+        /// <summary>
+        /// Behaves the same as wrap but cross-start and cross-end are permuted.
+        /// </summary>
         [Description("wrap-reverse")]
         WrapReverse
     }

--- a/src/MudBlazor/Enums/Wrap.cs
+++ b/src/MudBlazor/Enums/Wrap.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace MudBlazor
+{
+    public enum Wrap
+    {
+        [Description("nowrap")]
+        NoWrap,
+        [Description("wrap")]
+        Wrap,
+        [Description("wrap-reverse")]
+        WrapReverse
+    }
+}


### PR DESCRIPTION
Added the optional `flex-wrap: wrap|nowrap|wrap-reverse` to the `<Stack />` component.

Docs section added.

![image](https://github.com/MudBlazor/MudBlazor/assets/31780463/4866c8c3-8f34-4283-bc2d-95544349e8d5)
![image](https://github.com/MudBlazor/MudBlazor/assets/31780463/70180ef4-a36c-43f0-802b-dd4d683f6b20)
