### PR TITLE
BrowserViewportService & PopoverService: Decrease PoolSize and set PoolInitialFill

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -321,6 +321,8 @@ public class ServiceCollectionExtensionsTests
             options.FlipMargin = 100;
             options.ThrowOnDuplicateProvider = false;
             options.Mode = PopoverMode.Legacy;
+            options.PoolSize = 200;
+            options.PoolInitialFill = 10;
             expectedOptions = options;
         });
         var serviceProvider = services.BuildServiceProvider();
@@ -545,6 +547,8 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.FlipMargin = 100;
             options.PopoverOptions.ThrowOnDuplicateProvider = false;
             options.PopoverOptions.Mode = PopoverMode.Legacy;
+            options.PopoverOptions.PoolSize = 300;
+            options.PopoverOptions.PoolInitialFill = 5;
 
             expectedOptions = options;
         });
@@ -620,6 +624,8 @@ public class ServiceCollectionExtensionsTests
         actualPopoverOptions.FlipMargin.Should().Be(expectedOptions.PopoverOptions.FlipMargin);
         actualPopoverOptions.ThrowOnDuplicateProvider.Should().Be(expectedOptions.PopoverOptions.ThrowOnDuplicateProvider);
         actualPopoverOptions.Mode.Should().Be(expectedOptions.PopoverOptions.Mode);
+        actualPopoverOptions.PoolSize.Should().Be(expectedOptions.PopoverOptions.PoolSize);
+        actualPopoverOptions.PoolInitialFill.Should().Be(expectedOptions.PopoverOptions.PoolInitialFill);
 
         actualResizeObserverOptions.EnableLogging.Should().Be(expectedOptions.ResizeObserverOptions.EnableLogging);
         actualResizeObserverOptions.ReportRate.Should().Be(expectedOptions.ResizeObserverOptions.ReportRate);

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -297,6 +297,8 @@ namespace MudBlazor.Services
                 popoverOptions.QueueDelay = options.QueueDelay;
                 popoverOptions.ThrowOnDuplicateProvider = options.ThrowOnDuplicateProvider;
                 popoverOptions.Mode = options.Mode;
+                popoverOptions.PoolSize = options.PoolSize;
+                popoverOptions.PoolInitialFill = options.PoolInitialFill;
             });
 
             return services;
@@ -499,6 +501,8 @@ namespace MudBlazor.Services
                     popoverOptions.QueueDelay = options.PopoverOptions.QueueDelay;
                     popoverOptions.ThrowOnDuplicateProvider = options.PopoverOptions.ThrowOnDuplicateProvider;
                     popoverOptions.Mode = options.PopoverOptions.Mode;
+                    popoverOptions.PoolSize = options.PopoverOptions.PoolSize;
+                    popoverOptions.PoolInitialFill = options.PopoverOptions.PoolInitialFill;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -55,7 +55,8 @@ internal class BrowserViewportService : IBrowserViewportService
         ResizeOptions = options?.Value ?? new ResizeOptions();
         _semaphore = new AsyncKeyedLocker<Guid>(lockOptions =>
         {
-            lockOptions.PoolSize = 10000;
+            lockOptions.PoolSize = 300;
+            lockOptions.PoolInitialFill = 50;
         });
         _resizeListenerInterop = new ResizeListenerInterop(jsRuntime);
         _observerManager = new ObserverManager<BrowserViewportSubscription, IBrowserViewportObserver>(logger);

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -46,5 +46,29 @@ namespace MudBlazor
         /// for backward compatibility.
         /// </remarks>
         public PopoverMode Mode { get; set; } = PopoverMode.Default;
+
+        /// <summary>
+        /// The size of the pool to use in order for generated objects to be reused. This is NOT a concurrency limit,
+        /// but if the pool is empty then a new object will be created rather than waiting for an object to return to
+        /// the pool.
+        /// Defaults to 3000.
+        /// <para/>
+        /// <b>NB!</b> This setting is ignored in <see cref="PopoverMode.Default"/>.
+        /// </summary>
+        /// <remarks>
+        /// For more info please visit: <see href="https://github.com/MarkCiliaVincenti/AsyncKeyedLock/wiki/How-to-use-AsyncKeyedLocker#pooling">AsyncKeyedLocker</see>.
+        /// </remarks>
+        public int PoolSize { get; set; } = 3000;
+
+        /// <summary>
+        /// The number of items to fill the pool with during initialization.
+        /// Defaults to 100.
+        /// <para/>
+        /// <b>NB!</b> This setting is ignored in <see cref="PopoverMode.Default"/>.
+        /// </summary>
+        /// <remarks>
+        /// For more info please visit: <see href="https://github.com/MarkCiliaVincenti/AsyncKeyedLock/wiki/How-to-use-AsyncKeyedLocker#pooling">AsyncKeyedLocker</see>.
+        /// </remarks>
+        public int PoolInitialFill { get; set; } = 100;
     }
 }

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -66,7 +66,8 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         _initializeSemaphore = new SemaphoreSlim(1, 1);
         _popoverSemaphore = new AsyncKeyedLocker<Guid>(lockOptions =>
         {
-            lockOptions.PoolSize = 10000;
+            lockOptions.PoolSize = PopoverOptions.PoolSize;
+            lockOptions.PoolInitialFill = PopoverOptions.PoolInitialFill;
         });
         _holders = new Dictionary<Guid, MudPopoverHolder>();
         _popoverJsInterop = new PopoverJsInterop(jsInterop);


### PR DESCRIPTION
## Description
Resolves: https://github.com/MudBlazor/MudBlazor/issues/8301
Additional information: https://github.com/MudBlazor/MudBlazor/pull/8210#issuecomment-1985121063
The issue makes a good point.

10000 PoolSize is way too much, I don't think that that most websites need this much, especially that on BSS it's created for each connection (for now).

For `PopoverService` I set `3000` pool size(still might be high), but the initial is only `100`. I made it according to my feelings on what the average website might need, but it's hard to find the golden mean therefore the settings are now exposed for the `PopoverOptions`.

For `BrowserViewportService` the settings are not exposed, but I lowered it significantly, I wouldn't expect anyone to have more than 50 listeners at same time for browser size / breakpoint listening, don't think the website would respond fast with this amount.


## How Has This Been Tested?
Unit tests that options are set.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
