### PR TITLE
Localization: Extend AbstractLocalizationInterceptor to be less specific.

### DIFF
--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -23,17 +23,37 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AbstractLocalizationInterceptor"/> class.
+    /// This creates an ResX reader for builtin <see cref="LanguageResource"/> with the default <see cref="LocalizationOptions"/>.
     /// </summary>
     /// <param name="loggerFactory">The logger factory.</param>
     /// <param name="mudLocalizer">The optional custom MudLocalizer.</param>
+    /// <remarks>
+    /// For more custom options use <see cref="AbstractLocalizationInterceptor(IStringLocalizer,MudBlazor.MudLocalizer)"/> constuctor.
+    /// </remarks>
     protected AbstractLocalizationInterceptor(ILoggerFactory loggerFactory, MudLocalizer? mudLocalizer = null)
+        : this(DefaultLanguageResourceReader(loggerFactory), mudLocalizer)
     {
-        var options = Options.Create(new LocalizationOptions());
-        var factory = new ResourceManagerStringLocalizerFactory(options, loggerFactory);
-        Localizer = factory.Create(typeof(LanguageResource));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AbstractLocalizationInterceptor"/> class.
+    /// </summary>
+    /// <param name="localizer">The instance of <see cref="IStringLocalizer"/>.</param>
+    /// <param name="mudLocalizer">The optional custom MudLocalizer.</param>
+    protected AbstractLocalizationInterceptor(IStringLocalizer localizer, MudLocalizer? mudLocalizer = null)
+    {
+        Localizer = localizer;
         MudLocalizer = mudLocalizer;
     }
 
     /// <inheritdoc />
     public abstract LocalizedString Handle(string key);
+
+    private static IStringLocalizer DefaultLanguageResourceReader(ILoggerFactory loggerFactory)
+    {
+        var options = Options.Create(new LocalizationOptions());
+        var factory = new ResourceManagerStringLocalizerFactory(options, loggerFactory);
+
+        return factory.Create(typeof(LanguageResource));
+    }
 }


### PR DESCRIPTION
## Description
After merging this https://github.com/MudBlazor/MudBlazor/pull/7389 and going to sleep
I thought that I need to add additional constructor overload to `AbstractLocalizationInterceptor` otherwise it would be too specific - creating the `ResourceManagerStringLocalizerFactory` for our `LanguageResource`. But what if they need other resource or some additional options, then this abstraction should have been namaed differently and be specific to ResX, this overload makes things better.

## How Has This Been Tested?
Existing unit tests should cover it.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
