### PR TITLE
Fix BlockMask: Adjust Regex generation to allow a strict prefix

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/DifferentMaskImplementationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/DifferentMaskImplementationTest.razor
@@ -5,6 +5,10 @@
               @bind-Value="@BlockMaskValue" />
 
 <MudTextField Clearable
+              Mask="@_blockMaskPrefix"
+              @bind-Value="@BlockMaskValue" />
+
+<MudTextField Clearable
               Mask="@(new DateMask("dd/MM/yyyy"))"
               @bind-Value="@DateMaskValue" />
 
@@ -37,6 +41,7 @@
     public string RegexMaskValue { get; set; } = "127.000.000.001";
     
     private readonly BlockMask _blockMask = new(delimiters:" ", new Block('a', 1,3), new Block('0', 1,4));
+    private readonly BlockMask _blockMaskPrefix = new(delimiters: " ", new Block('a', 3, 3), new Block('0', 1, 4));
     private readonly MultiMask _multiMask = new("0000 0000 0000 0000");
     private readonly PatternMask _patternMask = new("000");
 }

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -766,30 +766,35 @@ namespace MudBlazor.UnitTests.Components
             var textFields = comp.FindComponents<MudTextField<string>>();
             var blockMaskComponent = masks[0];
             var blockMaskField = textFields[0].Instance;
-            var dateMaskComponent = masks[1];
-            var dateMaskField = textFields[1].Instance;
-            var multiMaskComponent = masks[2];
-            var multiMaskField = textFields[2].Instance;
-            var patternMaskComponent = masks[3];
-            var patternMaskField = textFields[3].Instance;
-            var regexMaskComponent = masks[4];
-            var regexMaskField = textFields[4].Instance;
-            
+            var prefixMaskComponent = masks[1];
+            var prefixMaskField = textFields[1].Instance;
+            var dateMaskComponent = masks[2];
+            var dateMaskField = textFields[2].Instance;
+            var multiMaskComponent = masks[3];
+            var multiMaskField = textFields[3].Instance;
+            var patternMaskComponent = masks[4];
+            var patternMaskField = textFields[4].Instance;
+            var regexMaskComponent = masks[5];
+            var regexMaskField = textFields[5].Instance;
+
             // act
-            
+
             // assert
             blockMaskComponent.Markup.Contains(blockMaskComponent.Instance.ClearIcon).Should().BeTrue();
             blockMaskField.Mask.Text.Should().Be(comp.Instance.BlockMaskValue);
-            
+
+            prefixMaskComponent.Markup.Contains(blockMaskComponent.Instance.ClearIcon).Should().BeTrue();
+            prefixMaskField.Mask.Text.Should().Be(comp.Instance.BlockMaskValue);
+
             dateMaskComponent.Markup.Contains(dateMaskComponent.Instance.ClearIcon).Should().BeTrue();
             dateMaskField.Mask.Text.Should().Be(comp.Instance.DateMaskValue);
-            
+
             multiMaskComponent.Markup.Contains(multiMaskComponent.Instance.ClearIcon).Should().BeTrue();
             multiMaskField.Mask.Text.Should().Be(comp.Instance.MultiMaskValue);
-            
+
             patternMaskComponent.Markup.Contains(patternMaskComponent.Instance.ClearIcon).Should().BeTrue();
             patternMaskField.Mask.Text.Should().Be(comp.Instance.PatternMaskValue);
-            
+
             regexMaskComponent.Markup.Contains(regexMaskComponent.Instance.ClearIcon).Should().BeTrue();
             regexMaskField.Mask.Text.Should().Be(comp.Instance.RegexMaskValue);
         }

--- a/src/MudBlazor.UnitTests/Utilities/Mask/BlockMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/BlockMaskTests.cs
@@ -106,10 +106,10 @@ public class BlockMaskTests
     {
         var mask = new BlockMask(".", new Block('('), new Block('0', 2, 2), new Block(')'));
         mask.Clear(); // make sure it is initialized
-        mask.Mask.Should().Be(@"^\(([\.](\d(\d([\.](\))?)?)?)?)?$");
+        mask.Mask.Should().Be(@"^(\(([\.](\d(\d([\.](\))?)?)?)?)?)?$");
         mask = new BlockMask(".", new Block('0', 1, 2), new Block('0', 1, 2), new Block('0', 2, 4));
         mask.Clear(); // make sure it is initialized
-        mask.Mask.Should().Be(@"^\d(\d)?([\.](\d(\d)?([\.](\d(\d(\d(\d)?)?)?)?)?)?)?$");
+        mask.Mask.Should().Be(@"^(\d(\d)?([\.](\d(\d)?([\.](\d(\d(\d(\d)?)?)?)?)?)?)?)?$");
         Assert.Throws<ArgumentException>(() => new BlockMask());
     }
 

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
@@ -59,7 +59,7 @@ public class BlockMask : RegexMask
             var block = blocks[i];
             AddRequiredCharacters(regexBuilder, block, ref openParenthesisCount);
             AddOptionalCharacters(regexBuilder, block, ref openParenthesisCount);
-            AddDelimiter(regexBuilder, block, blocks, ref openParenthesisCount);
+            AddDelimiter(regexBuilder, i, blocks, ref openParenthesisCount);
         }
 
         CloseOpenParentheses(regexBuilder, openParenthesisCount);
@@ -107,9 +107,9 @@ public class BlockMask : RegexMask
     }
 
     // Helper method to add delimiter if there are more blocks to process
-    private void AddDelimiter(StringBuilder regexBuilder, Block block, Block[] blocks, ref int openParenthesisCount)
+    private void AddDelimiter(StringBuilder regexBuilder, int index, Block[] blocks, ref int openParenthesisCount)
     {
-        if (_delimiters.Count > 0 && Array.IndexOf(blocks, block) < blocks.Length - 1)
+        if (_delimiters.Count > 0 && index < blocks.Length - 1)
         {
             regexBuilder.Append("([");
             openParenthesisCount++;
@@ -132,12 +132,12 @@ public class BlockMask : RegexMask
     public override void UpdateFrom(IMask other)
     {
         base.UpdateFrom(other);
-        if (other is not BlockMask o)
-            return;
-
-        Blocks = o.Blocks ?? Array.Empty<Block>();
-        Delimiters = o.Delimiters;
-        _initialized = false;
-        Refresh();
+        if (other is BlockMask o)
+        {
+            Blocks = o.Blocks ?? Array.Empty<Block>();
+            Delimiters = o.Delimiters;
+            _initialized = false;
+            Refresh();
+        }
     }
 }

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -32,7 +30,7 @@ public class BlockMask : RegexMask
     protected override void InitInternals()
     {
         base.InitInternals();
-        Blocks ??= new Block[0];
+        Blocks ??= Array.Empty<Block>();
         Mask = BuildRegex(Blocks);
         _regex = new Regex(Mask);
     }
@@ -52,63 +50,92 @@ public class BlockMask : RegexMask
     /// <returns></returns>
     protected virtual string BuildRegex(Block[] blocks)
     {
-        var s = new StringBuilder();
-        int i = 0;
-        int blockIndex = 0;
-        s.Append("^");
-        foreach (var b in blocks)
+        var regexBuilder = new StringBuilder();
+        var openParenthesisCount = 0;
+        regexBuilder.Append('^');
+
+        for (var i = 0; i < blocks.Length; i++)
         {
-            for (int j = 0; j < b.Min; j++)
-            {
-                if (i > 0)
-                    s.Append("(");
-                if (_maskDict.TryGetValue(b.MaskChar, out var maskDef))
-                    s.Append(maskDef.Regex);
-                else
-                    s.Append(Regex.Escape(b.MaskChar.ToString()));
-            }
-
-            i += b.Min;
-            if (b.Max > b.Min)
-            {
-                for (int j = b.Min; j < b.Max; j++)
-                {
-                    s.Append("(");
-                    if (_maskDict.TryGetValue(b.MaskChar, out var maskDef))
-                        s.Append(maskDef.Regex);
-                    else
-                        s.Append(Regex.Escape(b.MaskChar.ToString()));
-                }
-
-                for (int j = b.Min; j < b.Max; j++)
-                    s.Append(")?");
-            }
-
-            if (_delimiters.Count > 0 && blockIndex < blocks.Length - 1)
-            {
-                s.Append("([");
-                foreach (var d in _delimiters)
-                    s.Append(Regex.Escape(d.ToString()));
-                s.Append("]");
-                i++;
-            }
-
-            blockIndex++;
+            var block = blocks[i];
+            AddRequiredCharacters(regexBuilder, block, ref openParenthesisCount);
+            AddOptionalCharacters(regexBuilder, block, ref openParenthesisCount);
+            AddDelimiter(regexBuilder, block, blocks, ref openParenthesisCount);
         }
 
-        for (int j = 0; j < i - 1; j++)
-            s.Append(")?");
-        s.Append("$");
-        return s.ToString();
+        CloseOpenParentheses(regexBuilder, openParenthesisCount);
+        regexBuilder.Append('$');
+        return regexBuilder.ToString();
     }
+
+    // Helper method to add required characters for the block
+    private void AddRequiredCharacters(StringBuilder regexBuilder, Block block, ref int openParenthesisCount)
+    {
+        for (var i = 0; i < block.Min; i++)
+        {
+            regexBuilder.Append('(');
+            openParenthesisCount++;
+
+            if (_maskDict.TryGetValue(block.MaskChar, out var maskDef))
+                regexBuilder.Append(maskDef.Regex);
+            else
+                regexBuilder.Append(Regex.Escape(block.MaskChar.ToString()));
+        }
+    }
+
+    // Helper method to add optional characters for the block
+    private void AddOptionalCharacters(StringBuilder regexBuilder, Block block, ref int openParenthesisCount)
+    {
+        if (block.Max > block.Min)
+        {
+            for (var i = block.Min; i < block.Max; i++)
+            {
+                regexBuilder.Append('(');
+                openParenthesisCount++;
+
+                if (_maskDict.TryGetValue(block.MaskChar, out var maskDef))
+                    regexBuilder.Append(maskDef.Regex);
+                else
+                    regexBuilder.Append(Regex.Escape(block.MaskChar.ToString()));
+            }
+
+            for (var i = block.Min; i < block.Max; i++)
+            {
+                regexBuilder.Append(")?");
+                openParenthesisCount--;
+            }
+        }
+    }
+
+    // Helper method to add delimiter if there are more blocks to process
+    private void AddDelimiter(StringBuilder regexBuilder, Block block, Block[] blocks, ref int openParenthesisCount)
+    {
+        if (_delimiters.Count > 0 && Array.IndexOf(blocks, block) < blocks.Length - 1)
+        {
+            regexBuilder.Append("([");
+            openParenthesisCount++;
+
+            foreach (var delimiter in _delimiters)
+                regexBuilder.Append(Regex.Escape(delimiter.ToString()));
+
+            regexBuilder.Append(']');
+        }
+    }
+
+    // Helper method to close any open parentheses
+    private static void CloseOpenParentheses(StringBuilder regexBuilder, int openParenthesisCount)
+    {
+        for (var i = 0; i < openParenthesisCount; i++)
+            regexBuilder.Append(")?");
+    }
+
 
     public override void UpdateFrom(IMask other)
     {
         base.UpdateFrom(other);
-        var o = other as BlockMask;
-        if (o == null)
+        if (other is not BlockMask o)
             return;
-        Blocks = o.Blocks ?? new Block[0];
+
+        Blocks = o.Blocks ?? Array.Empty<Block>();
         Delimiters = o.Delimiters;
         _initialized = false;
         Refresh();


### PR DESCRIPTION


## Description
Currently, the logic for generating the regex for a BlockMask requires the first Block to use a range from 1 to X.   
If not, the generated regex is invalid.

Resolves #8308

## How Has This Been Tested?
Tested using the original unit test and updated it to include an additional check.
The unit test viewer was also used to test the UI component.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
