### PR TITLE
Docs: TreeView Descriptions and Example Fixes

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewHoverExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewHoverExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px" Elevation="0">
-    <MudTreeView T="string" CanHover="true">
+    <MudTreeView T="string" Hover="true">
         <MudTreeViewItem Value="@("content")">
             <MudTreeViewItem Value="@("logo.png")" />
         </MudTreeViewItem>

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -17,7 +17,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Hoverable">
-                <Description> If <CodeInline>Hover</CodeInline> is set to true, all treeview items will have a hover effect on mouse-over.</Description>
+                <Description>If <CodeInline>Hover</CodeInline> is set to true, all treeview items will have a hover effect on mouse-over.</Description>
             </SectionHeader>
             <SectionContent Code="TreeViewHoverExample" ShowCode="false">
                 <TreeViewHoverExample />

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -17,7 +17,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Hoverable">
-                <Description></Description>
+                <Description> If <CodeInline>Hover</CodeInline> is set to true, all treeview items will have a hover effect on mouse-over.</Description>
             </SectionHeader>
             <SectionContent Code="TreeViewHoverExample" ShowCode="false">
                 <TreeViewHoverExample />
@@ -26,7 +26,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Dense">
-                <Description></Description>
+                <Description>If <CodeInline>Dense</CodeInline> is set to true, compact vertical padding will be applied to all treeview items.</Description>
             </SectionHeader>
             <SectionContent Code="TreeViewDenseExample" ShowCode="false">
                 <TreeViewDenseExample />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Added descriptions to Hoverable and Dense sections, and in hover example replaced deprecated CanHover with Hover

## Description
Added descriptions to help illustrate what the Dense and Hover properties do. Replaced deprecated CanHover with Hover as it gives an error is used.

## How Has This Been Tested?
Just a docs change - visually tested.

![image](https://github.com/MudBlazor/MudBlazor/assets/22691956/9a397458-2896-4b01-b5ce-70e93f69403d)

![image](https://github.com/MudBlazor/MudBlazor/assets/22691956/3f27b075-ecc4-44fe-9968-405798f9efeb)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
