### PR TITLE
PopoverService: Attemp to fix SemaphoreFullException

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -204,11 +204,11 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
             var handler = new MudPopoverHandler((tree) => { }, mock.Object, () => { });
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>())
                 .Verifiable();
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
                 .Verifiable();
 
@@ -243,11 +243,11 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
             var handler = new MudPopoverHandler(_ => { }, mock.Object, () => { });
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>())
                 .Verifiable();
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
                 .Verifiable();
 
@@ -418,11 +418,13 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
             x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.connect",
+                It.IsAny<CancellationToken>(),
                 It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
             x.InvokeAsync<IJSVoidResult>(
                 "mudPopover.disconnect",
+                It.IsAny<CancellationToken>(),
                 It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId))).ThrowsAsync(new InvalidOperationException()).Verifiable();
 
             var updateCounter = 0;
@@ -448,7 +450,7 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
             var handler = new MudPopoverHandler(_ => { }, mock.Object, () => { });
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
                 .Verifiable();
 
@@ -472,11 +474,11 @@ namespace MudBlazor.UnitTests.Components
             var mock = new Mock<IJSRuntime>();
             var handler = new MudPopoverHandler(_ => { }, mock.Object, () => { });
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .Returns(new ValueTask<IJSVoidResult>(connectTcs.Task))
                 .Verifiable();
 
-            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
+            mock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.IsAny<CancellationToken>(), It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == handler.Id)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>())
                 .Verifiable();
 
@@ -523,7 +525,8 @@ namespace MudBlazor.UnitTests.Components
 
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
-               "mudPopover.initialize",
+               "mudPopover.initialize"
+               , It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             {
@@ -546,6 +549,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ThrowsAsync(new JSDisconnectedException("JSDisconnectedException")).Verifiable();
             {
                 var service = new MudPopoverService(mock.Object);
@@ -563,6 +567,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ThrowsAsync(new TaskCanceledException()).Verifiable();
             {
                 var service = new MudPopoverService(mock.Object);
@@ -589,6 +594,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "my-custom-class" && (int)x[1] == 12))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             var service = new MudPopoverService(mock.Object, optionMock.Object);
@@ -607,6 +613,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(300)).Verifiable();
 
             Task[] tasks = new Task[5];
@@ -622,6 +629,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Verify(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0)), Times.Once());
         }
 
@@ -642,11 +650,13 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
             x.InvokeAsync<IJSVoidResult>(
             "mudPopover.dispose",
+            It.IsAny<CancellationToken>(),
             It.Is<object[]>(x => x.Length == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             var service = new MudPopoverService(mock.Object);
@@ -666,11 +676,13 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(x =>
            x.InvokeAsync<IJSVoidResult>(
                "mudPopover.initialize",
+               It.IsAny<CancellationToken>(),
                It.Is<object[]>(x => x.Length == 2 && (string)x[0] == "mudblazor-main-content" && (int)x[1] == 0))).ReturnsAsync(Mock.Of<IJSVoidResult>).Verifiable();
 
             mock.Setup(x =>
             x.InvokeAsync<IJSVoidResult>(
             "mudPopover.dispose",
+            It.IsAny<CancellationToken>(),
             It.Is<object[]>(x => x.Length == 0))).ThrowsAsync(new TaskCanceledException()).Verifiable();
 
             var service = new MudPopoverService(mock.Object);
@@ -793,6 +805,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(jsRuntime =>
                     jsRuntime.InvokeAsync<IJSVoidResult>(
                         "mudPopover.connect",
+                        It.IsAny<CancellationToken>(),
                         It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>)
                 .Verifiable();
@@ -800,6 +813,7 @@ namespace MudBlazor.UnitTests.Components
             mock.Setup(jsRuntime =>
                     jsRuntime.InvokeAsync<IJSVoidResult>(
                         "mudPopover.disconnect",
+                        It.IsAny<CancellationToken>(),
                         It.Is<object[]>(x => x.Length == 1 && (Guid)x[0] == handlerId)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>)
                 .Verifiable();

--- a/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Services.Popover.Mocks;
@@ -15,7 +16,7 @@ internal class PopoverObserverMock : IPopoverObserver
 
     public List<Guid> PopoverNotifications { get; } = new();
 
-    public Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container)
+    public Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container, CancellationToken cancellationToken)
     {
         foreach (var holder in container.Holders)
         {

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -632,6 +632,22 @@ public class PopoverServiceTests
     }
 
     [Test]
+    public async Task DisposeAsync_ShouldNotAcceptObservers()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        await service.DisposeAsync();
+        service.Subscribe(new PopoverObserverMock());
+        service.Subscribe(new PopoverObserverMock());
+
+        // Assert
+        service.ObserversCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task DisposeAsync_ShouldNotCreateOrUpdateWhenDisposed()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -101,7 +101,7 @@ public class PopoverServiceTests
     }
 
     [Test]
-    public async Task IsInitialized_ShouldConnectAutomaticallyAfterCountProvidersAsync()
+    public async Task IsInitialized_ShouldNotConnectAutomaticallyAfterCountProvidersAsync()
     {
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
@@ -114,7 +114,49 @@ public class PopoverServiceTests
         await service.GetProviderCountAsync();
 
         // Assert
-        service.IsInitialized.Should().BeTrue();
+        service.IsInitialized.Should().BeFalse();
+    }
+
+    [Test]
+    public void Unsubscribe_ShouldThrowWheNullObserver()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        var unsubscribe = () => service.Unsubscribe(null!);
+
+        // Assert
+        unsubscribe.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void Subscribe_ShouldThrowWheNullObserver()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        var subscribe = () => service.Subscribe(null!);
+
+        // Assert
+        subscribe.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CreatePopoverAsync_ShouldThrowWheNullPopover()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        var createPopover = () => service.CreatePopoverAsync(null!);
+
+        // Assert
+        await createPopover.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Test]
@@ -138,6 +180,20 @@ public class PopoverServiceTests
     }
 
     [Test]
+    public async Task UpdatePopoverAsync_ShouldThrowWheNullPopover()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        var updatePopover = () => service.UpdatePopoverAsync(null!);
+
+        // Assert
+        await updatePopover.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
     public async Task UpdatePopoverAsync_ShouldNotUpdateWhenNotCreated()
     {
         // Arrange
@@ -149,24 +205,6 @@ public class PopoverServiceTests
 
         // Act
         var result = await service.UpdatePopoverAsync(popover);
-
-        // Assert
-        result.Should().BeFalse();
-        observer.PopoverNotifications.Should().BeEmpty();
-    }
-
-    [Test]
-    public async Task UpdatePopoverAsync_ShouldNotDestroyWhenNotCreated()
-    {
-        // Arrange
-        var jsRuntimeMock = Mock.Of<IJSRuntime>();
-        var popover = new PopoverMock();
-        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
-        var observer = new PopoverObserverMock();
-        service.Subscribe(observer);
-
-        // Act
-        var result = await service.DestroyPopoverAsync(popover);
 
         // Assert
         result.Should().BeFalse();
@@ -269,6 +307,63 @@ public class PopoverServiceTests
     }
 
     [Test]
+    public async Task UpdatePopoverAsync_ShouldNotUpdateStateWhenDetached()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var popover = new PopoverMock();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var observer = new PopoverObserverMock();
+        service.Subscribe(observer);
+
+        // Act
+        await service.CreatePopoverAsync(popover);
+        //Get reference before destroyed
+        var updatedState = service.ActivePopovers.FirstOrDefault(x => x.Id == popover.Id);
+        if (updatedState is MudPopoverHolder internalHolder)
+        {
+            internalHolder.IsDetached = true;
+        }
+
+        var isUpdated = await service.UpdatePopoverAsync(popover);
+
+        // Assert
+        isUpdated.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task DestroyPopoverAsync_ShouldThrowWheNullPopover()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+
+        // Act
+        var destroyPopover = () => service.DestroyPopoverAsync(null!);
+
+        // Assert
+        await destroyPopover.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task DestroyPopoverAsync_ShouldNotDestroyWhenNotCreated()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var popover = new PopoverMock();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var observer = new PopoverObserverMock();
+        service.Subscribe(observer);
+
+        // Act
+        var result = await service.DestroyPopoverAsync(popover);
+
+        // Assert
+        result.Should().BeFalse();
+        observer.PopoverNotifications.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task DestroyPopoverAsync_ShouldRemoveStateAndNotifyObservers()
     {
         // Arrange
@@ -328,9 +423,10 @@ public class PopoverServiceTests
 
         observerMock
             .Setup(h => h.PopoverCollectionUpdatedNotificationAsync(
-                It.IsAny<PopoverHolderContainer>()))
+                It.IsAny<PopoverHolderContainer>(),
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
-            .Callback<PopoverHolderContainer>(containerNotificationList.Add);
+            .Callback<PopoverHolderContainer, CancellationToken>((container, _) => containerNotificationList.Add(container));
 
         // Act
         await service.CreatePopoverAsync(popover);
@@ -418,17 +514,17 @@ public class PopoverServiceTests
             .Returns(Task.CompletedTask)
             .Callback(signalEvent.Set);
 
-        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.initialize",
+        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.initialize", It.IsAny<CancellationToken>(),
                 It.Is<object[]>(y => y.Length == 2)))
             .ReturnsAsync(Mock.Of<IJSVoidResult>())
             .Verifiable();
 
-        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect",
+        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.connect", It.IsAny<CancellationToken>(),
                 It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == popover.Id)))
             .ReturnsAsync(Mock.Of<IJSVoidResult>())
             .Verifiable();
 
-        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect",
+        jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudPopover.disconnect", It.IsAny<CancellationToken>(),
                 It.Is<object[]>(y => y.Length == 1 && (Guid)y[0] == popover.Id)))
             .Returns(new ValueTask<IJSVoidResult>())
             .Verifiable();
@@ -533,5 +629,69 @@ public class PopoverServiceTests
         // Assert
         beforeObserversCount.Should().Be(5);
         afterObserversCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task DisposeAsync_ShouldNotCreateOrUpdateWhenDisposed()
+    {
+        // Arrange
+        var popoverOperations = new List<PopoverHolderOperation>();
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var popover = new PopoverMock();
+        var observerMock = new Mock<IPopoverObserver>();
+        service.Subscribe(observerMock.Object);
+
+        observerMock
+            .Setup(h => h.PopoverCollectionUpdatedNotificationAsync(
+                It.IsAny<PopoverHolderContainer>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<PopoverHolderContainer, CancellationToken>((container, token) =>
+            {
+                popoverOperations.Add(container.Operation);
+            });
+
+        // Act
+        await service.DisposeAsync();
+        await service.CreatePopoverAsync(popover);
+        await service.UpdatePopoverAsync(popover);
+
+        // Assert
+        popoverOperations.Should().BeEquivalentTo(new[] { PopoverHolderOperation.Remove });
+    }
+
+    [Test]
+    public async Task DisposeAsync_PopoverCollectionUpdatedNotificationAsync_IsCancellationRequested()
+    {
+        //Arrange
+        var isCancellationRequested = false;
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var popover = new PopoverMock();
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var observerMock = new Mock<IPopoverObserver>();
+        service.Subscribe(observerMock.Object);
+
+        observerMock
+            .Setup(h => h.PopoverCollectionUpdatedNotificationAsync(
+                It.IsAny<PopoverHolderContainer>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<PopoverHolderContainer, CancellationToken>((container, token) =>
+            {
+                isCancellationRequested = token.IsCancellationRequested;
+            });
+
+        // Act
+        await service.CreatePopoverAsync(popover);
+
+        // Assert
+        isCancellationRequested.Should().BeFalse();
+
+        // Act
+        await service.DisposeAsync();
+
+        // Assert
+        isCancellationRequested.Should().BeTrue();
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/Background/BackgroundWorkerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Background/BackgroundWorkerTests.cs
@@ -112,7 +112,7 @@ public class BackgroundWorkerTests
 
         await worker.StartAsync(CancellationToken.None);
 
-        await worker.DisposeAsync();
+        worker.Dispose();
     }
 
     [Test]
@@ -124,16 +124,16 @@ public class BackgroundWorkerTests
 
         await worker.StartAsync(tokenSource.Token);
 
-        tokenSource.Cancel();
+        await tokenSource.CancelAsync();
 
         Assert.ThrowsAsync<TaskCanceledException>(() => worker.ExecutingTask);
     }
 
     [Test]
-    public async Task DisposeAsync_ShouldNotThrow()
+    public void Dispose_ShouldNotThrow()
     {
         var worker = new WaitForCancelledTokenWorkerMock();
 
-        await worker.DisposeAsync();
+        worker.Dispose();
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -118,7 +119,7 @@ namespace MudBlazor
         Guid IPopoverObserver.Id { get; } = Guid.NewGuid();
 
         /// <inheritdoc />
-        async Task IPopoverObserver.PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container)
+        async Task IPopoverObserver.PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container, CancellationToken cancellationToken)
         {
             switch (container.Operation)
             {
@@ -127,6 +128,11 @@ namespace MudBlazor
                     {
                         foreach (var holder in container.Holders)
                         {
+                            if (cancellationToken.IsCancellationRequested)
+                            {
+                                return;
+                            }
+
                             if (holder.ElementReference is not null)
                             {
                                 await InvokeAsync(holder.ElementReference.StateHasChanged);

--- a/src/MudBlazor/Interop/PopoverJsInterop.cs
+++ b/src/MudBlazor/Interop/PopoverJsInterop.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
@@ -18,28 +19,28 @@ internal class PopoverJsInterop
         _jsRuntime = jsRuntime;
     }
 
-    public ValueTask<bool> Initialize(string containerClass, int flipMargin)
+    public ValueTask<bool> Initialize(string containerClass, int flipMargin, CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.initialize", containerClass, flipMargin);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.initialize", cancellationToken, containerClass, flipMargin);
     }
 
-    public ValueTask<bool> Connect(Guid id)
+    public ValueTask<bool> Connect(Guid id, CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.connect", id);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.connect", cancellationToken, id);
     }
 
-    public ValueTask<bool> Disconnect(Guid id)
+    public ValueTask<bool> Disconnect(Guid id, CancellationToken cancellationToken = default)
     {
-       return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.disconnect", id);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.disconnect", cancellationToken, id);
     }
 
-    public ValueTask<(bool success, int value)> CountProviders()
+    public ValueTask<(bool success, int value)> CountProviders(CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeAsyncWithErrorHandling<int>("mudpopoverHelper.countProviders");
+        return _jsRuntime.InvokeAsyncWithErrorHandling<int>("mudpopoverHelper.countProviders", cancellationToken);
     }
 
-    public ValueTask Dispose()
+    public ValueTask Dispose(CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncIgnoreErrors("mudPopover.dispose");
+        return _jsRuntime.InvokeVoidAsyncIgnoreErrors("mudPopover.dispose", cancellationToken);
     }
 }

--- a/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtentions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
@@ -47,13 +48,88 @@ namespace MudBlazor
         /// </summary>
         /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
         /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
         /// <param name="args">JSON-serializable arguments.</param>
-        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation and resolves to true in case no exception has occured ohterwise false.</returns>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation.</returns>
+        public static async ValueTask InvokeVoidAsyncIgnoreErrors(this IJSRuntime jsRuntime, string identifier, CancellationToken cancellationToken, params object[] args)
+        {
+            try
+            {
+                await jsRuntime.InvokeVoidAsync(identifier, cancellationToken, args);
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+            }
+#endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+            }
+            catch (JSDisconnectedException)
+            {
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation and resolves to true in case no exception has occured otherwise false.</returns>
         public static async ValueTask<bool> InvokeVoidAsyncWithErrorHandling(this IJSRuntime jsRuntime, string identifier, params object[] args)
         {
             try
             {
                 await jsRuntime.InvokeVoidAsync(identifier, args);
+                return true;
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+                return false;
+            }
+#endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
+            catch (JSDisconnectedException)
+            {
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>A <see cref="ValueTask"/> that represents the asynchronous invocation operation and resolves to true in case no exception has occured otherwise false.</returns>
+        public static async ValueTask<bool> InvokeVoidAsyncWithErrorHandling(this IJSRuntime jsRuntime, string identifier, CancellationToken cancellationToken, params object[] args)
+        {
+            try
+            {
+                await jsRuntime.InvokeVoidAsync(identifier, cancellationToken, args);
                 return true;
             }
 #if DEBUG
@@ -90,6 +166,21 @@ namespace MudBlazor
             => await jsRuntime.InvokeAsyncWithErrorHandling(default(TValue), identifier, args);
 
         /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException. In case an exception occured the default value of <typeparamref name="TValue"/> is returned
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value into a tuple. The first item (sucess) is true in case where there was no exception, otherwise fall.</returns>
+        public static async ValueTask<(bool success, TValue value)> InvokeAsyncWithErrorHandling<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(this IJSRuntime jsRuntime, string identifier, CancellationToken cancellationToken, params object[] args)
+            => await jsRuntime.InvokeAsyncWithErrorHandling(default(TValue), identifier, cancellationToken, args);
+
+        /// <summary>
         /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
         /// </summary>
         /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
@@ -103,6 +194,48 @@ namespace MudBlazor
             try
             {
                 var result = await jsRuntime.InvokeAsync<TValue>(identifier: identifier, args: args);
+                return (true, result);
+            }
+#if DEBUG
+#else
+            catch (JSException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
+            // catch prerending errors since there is no browser at this point.
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return (false, fallbackValue);
+            }
+            catch (JSDisconnectedException)
+            {
+                return (false, fallbackValue);
+            }
+            catch (TaskCanceledException)
+            {
+                return (false, fallbackValue);
+            }
+        }
+
+        /// <summary>
+        /// Invokes the specified JavaScript function asynchronously and catches JSException, JSDisconnectedException and TaskCanceledException
+        /// </summary>
+        /// <typeparam name="TValue">The JSON-serializable return type.</typeparam>
+        /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
+        /// <param name="fallbackValue">The value that should be returned in case an exception occured</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <param name="identifier">An identifier for the function to invoke. For example, the value <c>"someScope.someFunction"</c> will invoke the function <c>window.someScope.someFunction</c>.</param>
+        /// <param name="args">JSON-serializable arguments.</param>
+        /// <returns>An instance of <typeparamref name="TValue"/> obtained by JSON-deserializing the return value into a tuple. The first item (sucess) is true in case where there was no exception, otherwise fall.</returns>
+        public static async ValueTask<(bool success, TValue value)> InvokeAsyncWithErrorHandling<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(this IJSRuntime jsRuntime, TValue fallbackValue, string identifier, CancellationToken cancellationToken, params object[] args)
+        {
+            try
+            {
+                var result = await jsRuntime.InvokeAsync<TValue>(identifier: identifier, cancellationToken, args: args);
                 return (true, result);
             }
 #if DEBUG

--- a/src/MudBlazor/Services/Popover/IPopoverObserver.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverObserver.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MudBlazor;
@@ -23,9 +24,10 @@ public interface IPopoverObserver
     /// This notification is triggered only when <see cref="IPopoverService.CreatePopoverAsync"/>, <see cref="IPopoverService.UpdatePopoverAsync"/> or <see cref="IPopoverService.DestroyPopoverAsync"/> is called.
     /// </summary>
     /// <param name="container">The container holding the collection of updated popover holders and the corresponding operation.</param>
+    /// <param name="cancellationToken">Indicates that the process has been aborted.</param>
     /// <returns>A task representing the asynchronous notification operation.</returns>
     /// /// <remarks>
     /// Please note that this notification will not be triggered if <see cref="IPopoverService.UpdatePopoverAsync"/>, <see cref="IPopoverService.DestroyPopoverAsync"/> return <c>false</c>.
     /// </remarks>
-    Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container);
+    Task PopoverCollectionUpdatedNotificationAsync(PopoverHolderContainer container, CancellationToken cancellationToken = default);
 }

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -199,7 +199,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         // In the future, there might be a requirement to split the jobs and introduce a change where instead of using IReadOnlyCollection<MudPopoverHolder>,
         // we would utilize IReadOnlyCollection<PopoverQueueContainer>. This new collection would consist of various operations, such as detaching items, rendering items,
         // and triggering the PopoverCollectionUpdatedNotification, among others.
-        return DetachRange(items);
+        return DetachRangeAsync(items);
     }
 
     /// <inheritdoc />
@@ -270,7 +270,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         return true;
     }
 
-    private async Task DetachRange(IReadOnlyCollection<MudPopoverHolder> holders)
+    private async Task DetachRangeAsync(IReadOnlyCollection<MudPopoverHolder> holders)
     {
         if (_disposed)
         {

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -73,7 +73,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         _holders = new Dictionary<Guid, MudPopoverHolder>();
         _cancellationTokenSource = new CancellationTokenSource();
         _popoverJsInterop = new PopoverJsInterop(jsInterop);
-        _batchExecutor = new BatchPeriodicQueue<MudPopoverHolder>(this, PopoverOptions.QueueDelay, tickOnDispose: false);
+        _batchExecutor = new BatchPeriodicQueue<MudPopoverHolder>(this, PopoverOptions.QueueDelay);
         _observerManager = new ObserverManager<Guid, IPopoverObserver>(logger);
     }
 
@@ -216,9 +216,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             _cancellationTokenSource.Cancel();
             await DestroyPopoversQuick();
 
-            // BatchPeriodicQueue(tickOnDispose) should be false, since BatchPeriodicQueue.OnBatchTimerElapsedAsync will cause deadlock on WinForm and WPF.
-            // We do not care about guaranteed "mudPopover.disconnect" JS call on all popovers from OnBatchTimerElapsedAsync -> DetachRange as the "mudPopover.dispose" already does it on JS side.
-            await _batchExecutor.DisposeAsync();
+            _batchExecutor.Dispose();
 
             // In case someone has custom implementation and didn't unsubscribe
             _observerManager.Clear();

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -173,7 +173,6 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 
         if (_disposed)
         {
-            // 
             return false;
         }
 
@@ -273,14 +272,18 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 
     private async Task DetachRange(IReadOnlyCollection<MudPopoverHolder> holders)
     {
-        // Ignore task if zero items in collection to not enter the semaphore
-        if (holders.Count == 0)
+        if (_disposed)
         {
             return;
         }
 
         foreach (var holder in holders)
         {
+            if (_cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                return;
+            }
+
             using (await _popoverSemaphore.LockAsync(holder.Id, _cancellationTokenSource.Token))
             {
                 try

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -141,10 +141,9 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             return false;
         }
 
+        // It's a legacy thing that should be removed, new popover doesn't need this.
         if (holder.IsDetached)
         {
-            // Unlikely scenario since during DestroyPopoverAsync it's gone from the dictionary
-            // It's a legacy thing that should be removed, new popover doesn't need this.
             return false;
         }
 
@@ -309,17 +308,9 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 
         using (await _popoverSemaphore.LockAsync(holder.Id, _cancellationTokenSource.Token))
         {
+            // Double-check if IsConnected has been completed by another thread.
             if (holder.IsConnected || holder.IsDetached)
             {
-                // It is not redundant to include a check before and after the semaphore.
-                // If we call InitializePopoverIfNeededAsync multiple times in parallel in the background,
-                // it may lead to double connection, which is undesired.
-                // For example if InitializePopoverIfNeededAsync is invoked multiple times asynchronously for a specific popover and AfterFirstRender is not set,
-                // and IsConnected takes a while to resolve, subsequent calls during this period will encounter the semaphore,
-                // awaiting its release from the preceding call.
-                // Once IsConnected is set to true by the previous call, the second if case will be exited.
-                // Subsequent invocations for the same popover will exit the function from the first if case, bypassing the semaphore block.
-                // The initial check helps to prevent double initialization of the popover.
                 return;
             }
 

--- a/src/MudBlazor/Utilities/Background/BackgroundWorkerBase.cs
+++ b/src/MudBlazor/Utilities/Background/BackgroundWorkerBase.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.Utilities.Background;
 /// in a background worker. It simplifies the implementation of scenarios where you need to execute asynchronous
 /// operations in the background. It also provides built-in support for graceful shutdown.
 /// </remarks>
-internal abstract class BackgroundWorkerBase : IAsyncDisposable
+internal abstract class BackgroundWorkerBase : IDisposable
 {
     private Task? _executeTask;
     private CancellationTokenSource? _stoppingCts;
@@ -91,10 +91,8 @@ internal abstract class BackgroundWorkerBase : IAsyncDisposable
     }
 
     /// <inheritdoc/>
-    public virtual ValueTask DisposeAsync()
+    public virtual void Dispose()
     {
         _stoppingCts?.Cancel();
-
-        return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Description
Attempt to fix https://github.com/MudBlazor/MudBlazor/pull/8210#issuecomment-1985671425

1. Made `InitializeServiceIfNeededAsync` lock free
2. Added `_disposed`
   * We do not accept new subscribers after dispose.
   * We do not let to create a new popovers after dispose.
   * We do not let to update an existing popover after dispose.
   * We ignore if `Dispose` is called multiple times.
3. Added `CancellationToken`
   * We pass it to the `AsyncKeyedLock`.
   * We pass it to the `JSRuntime` - I had to extend the `IIJSRuntimeExtentions`.
   * We pass it to the `BatchPeriodicQueue`.
   * We pass it now to the `IPopoverObserver.PopoverCollectionUpdatedNotificationAsync` - this can be handy to abort for loops.
4. We do not initialize service anymore on `GetProviderCountAsync` call. I had idea to initialize it at any opportunity, but don't think it's worth.
5. Removed `tickOnDispose` in `BatchPeriodicQueue`, it doesn't have any use in the code anymore and it implements now `IDisposable` instead.

Open topics:
1. Should we add `_disposed` for the `DestroyPopoverAsync`? Technically this method doesn't use any locking, only the batch does but the list is empty anyway so do we care about early exit?
2. Should I use Lazy for `InitializeServiceIfNeededAsync` instead?

## How Has This Been Tested?
Unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
