### PR TITLE
Docs: Remove any mentions of MudStore / MudAcademy

### DIFF
--- a/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
+++ b/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
@@ -33,7 +33,7 @@
 <DocsPageSection>
     <SectionHeader Title="New Docs">
         <Description>
-            You probably noticed this by now, but our landing page and docs have gotten a complete overhaul. There has been a lot of research and prototyping but I am really happy about the final result.
+            You probably noticed this by now, but our landing page and docs have gotten a complete overhaul. There has been a lot of research and prototyping, but I am really happy about the final result.
         </Description>
     </SectionHeader>
 </DocsPageSection>

--- a/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
+++ b/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
@@ -24,17 +24,6 @@
     </SectionHeader>
     <MudList DisableGutters="true">
         <MudListItem>
-            <MudText Typo="Typo.subtitle1" Inline="true"><b>Mud</b></MudText><MudText Inline="true" Color="Color.Primary"><b>Store</b></MudText>
-            <MudText>Marketplace for templates and themes.</MudText>
-        </MudListItem>
-        <MudListItem>
-            <MudText Typo="Typo.subtitle1" Inline="true"><b>Mud</b></MudText><MudText Inline="true" Color="Color.Success"><b>Academy</b></MudText>
-            <MudText>
-                Online learning platform for Blazor and Mudblazor, this will be a 100% free learning platform with courses, lessons, articles.<br/>
-                On release there will be one course available.
-            </MudText>
-        </MudListItem>
-        <MudListItem>
             <MudText Typo="Typo.subtitle1" Inline="true"><b>Mud</b></MudText><MudText Inline="true" Color="Color.Warning"><b>Extensions</b></MudText>
             <MudText>MudBlazor extensions platform where users can add their own projects, write documentation and find extensions made by others.</MudText>
         </MudListItem>

--- a/src/MudBlazor.Docs/Pages/Mud/Introduction.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Introduction.razor
@@ -23,17 +23,6 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Grow into an ecosystem">
-                <Description>
-                    <MudText>While we consider MudBlazor a big success regarding our vision, we know this can only be the first step. There are still more obstacles for developers or ways to make their life easier. During the upcoming months, we will start products around MudBlazor to fulfill this goal. </MudText>
-                    <MudText>You will be able to sell and buy custom themes in the MudStore, supporting you in starting more rapidly and efficiently or offering your design skills to a broader audience. </MudText>
-                    <MudText>With the MudAcademy, we will start a program bootstrapping and accelerating your knowledge growth around Blazor. </MudText>
-                    <MudText>And this is just the beginning of many Mud around the Place. Stay tuned for our latest updates. </MudText>
-                </Description>
-            </SectionHeader>
-        </DocsPageSection>
-
-        <DocsPageSection>
             <SectionHeader Title="MudBlazor is a community">
                 <Description>
                     <MudText>Empowerment is not an act of a single person or team. We are so happy that developers are actively engaging in the MudCommunity. So many have spent (and are still spending) hours of their life to help us improve the library, asking and answering questions on Github or Discord, speaking at conferences, podcasts and with their colleagues, and in endless more ways. We are proud and grateful for your support and thanks for your engagement: Each day of your work brings us closer to our vision. </MudText>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -60,18 +60,6 @@
             <MudOverlay Visible="true" LightBackground="true" Absolute="true" Class="docs-menu-overlay" />
             <MudListItem>
                 <MudBadge Class="d-flex mr-16" Content="@_badgeTextSoon" Color="Color.Info" Overlap="true">
-                    <MudText>Mud</MudText><MudText Color="Color.Primary">Store</MudText>
-                </MudBadge>
-                <MudText Typo="Typo.body2">Marketplace for templates and themes</MudText>
-            </MudListItem>
-            <MudListItem>
-                <MudBadge Class="d-flex mr-16" Content="@_badgeTextSoon" Color="Color.Info" Overlap="true">
-                    <MudText>Mud</MudText><MudText Color="Color.Success">Academy</MudText>
-                </MudBadge>
-                <MudText Typo="Typo.body2">Learning Blazor and MudBlazor</MudText>
-            </MudListItem>
-            <MudListItem>
-                <MudBadge Class="d-flex mr-16" Content="@_badgeTextSoon" Color="Color.Info" Overlap="true">
                     <MudText>Mud</MudText><MudText Color="Color.Warning">Extensions</MudText>
                 </MudBadge>
                 <MudText Typo="Typo.body2">Official and Community Extensions</MudText>

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -33,8 +33,6 @@
                         <MudNavLink Href="https://github.com/MudBlazor/ThemeManager">ThemeManager</MudNavLink>
                         <MudNavLink Href="https://github.com/MudBlazor/Templates">Templates</MudNavLink>
                         <MudListSubheader Class="mt-4 pl-8 pb-2"><b>Coming soon</b></MudListSubheader>
-                        <MudNavLink Disabled="true">MudStore</MudNavLink>
-                        <MudNavLink Disabled="true">MudAcademy</MudNavLink>
                         <MudNavLink Disabled="true">MudExtensions</MudNavLink>
                     </MudNavGroup>
                 </MudNavMenu>

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -46,7 +46,7 @@
     </MudItem>
     <MudItem xs="12">
         <MudToolBar DisableGutters="true" Dense="true">
-            <MudText Typo="Typo.body1">Copyright © 2020-2022 MudBlazor.</MudText>
+            <MudText Typo="Typo.body1">@($">Copyright © 2020-{DateTime.Now.Year} MudBlazor.")</MudText>
         </MudToolBar>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -46,7 +46,7 @@
     </MudItem>
     <MudItem xs="12">
         <MudToolBar DisableGutters="true" Dense="true">
-            <MudText Typo="Typo.body1">@($">Copyright © 2020-{DateTime.Now.Year} MudBlazor.")</MudText>
+            <MudText Typo="Typo.body1">@($"Copyright © 2020-{DateTime.Now.Year} MudBlazor.")</MudText>
         </MudToolBar>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -21,8 +21,6 @@
                 <MudNavLink Href="https://github.com/MudBlazor/ThemeManager">ThemeManager</MudNavLink>
                 <MudNavLink Href="https://github.com/MudBlazor/Templates">Templates</MudNavLink>
                 <MudListSubheader Class="mt-4 pl-8 pb-2"><b>Coming soon</b></MudListSubheader>
-                <MudNavLink Disabled="true">MudStore</MudNavLink>
-                <MudNavLink Disabled="true">MudAcademy</MudNavLink>
                 <MudNavLink Disabled="true">MudExtensions</MudNavLink>
             </MudNavGroup>
         </MudNavMenu>


### PR DESCRIPTION
## Description
Removes mentions of MudStore and MudAcademy as agreed, people still asking when it will be out, but people that worked on it are not active anymore.
Not sure if it was correct to modify `Announcement_MudBlazorIsHereToStay` since it's like a blog post.


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.