### PR TITLE
MudTextField: Fix scrollbars appearing with AutoGrow on scaled displays due to rounding error

### DIFF
--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 window.mudInputAutoGrow = {
-
     initAutoGrow: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);
         const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
@@ -12,7 +11,7 @@ window.mudInputAutoGrow = {
 
         let maxHeight = 0;
         if (maxLines > 0) {
-            // Cap the height to the max number of lines.
+            // Cap the height to the number of lines specified in MudTextField.
             maxHeight = lineHeight * maxLines;
         }
 
@@ -22,20 +21,19 @@ window.mudInputAutoGrow = {
             const scrollTops = [];
             let curElem = elem;
             while (curElem && curElem.parentNode && curElem.parentNode instanceof Element) {
-                if (curElem.parentNode.scrollTop) {
+                if (curElem.parentNode.scrollTop)
                     scrollTops.push([curElem.parentNode, curElem.parentNode.scrollTop]);
-                }
                 curElem = curElem.parentNode;
             }
 
             elem.style.height = 0;
 
-            let newHeight = Math.max(minHeight, elem.scrollHeight);
+            let newHeight = Math.max(minHeight, elem.scrollHeight + 1); // 1px is added to beat the rounding that occurs on scaled displays.
             if (maxHeight > 0) {
                 newHeight = Math.min(newHeight, maxHeight);
             } else {
-                // Hide phantom scrollbars https://github.com/MudBlazor/MudBlazor/pull/8235.
-                elem.style.overflow = 'hidden';
+                // Scrollbar isn't needed and could cause flashing.
+                elem.style.overflowY = 'hidden';
             }
 
             elem.style.height = newHeight + "px";

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -21,8 +21,9 @@ window.mudInputAutoGrow = {
             const scrollTops = [];
             let curElem = elem;
             while (curElem && curElem.parentNode && curElem.parentNode instanceof Element) {
-                if (curElem.parentNode.scrollTop)
+                if (curElem.parentNode.scrollTop) {
                     scrollTops.push([curElem.parentNode, curElem.parentNode.scrollTop]);
+                }
                 curElem = curElem.parentNode;
             }
 

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -28,11 +28,14 @@ window.mudInputAutoGrow = {
 
             elem.style.height = 0;
 
-            let newHeight = Math.max(minHeight, elem.scrollHeight + 1); // 1px is added to beat the rounding that occurs on scaled displays.
-            if (maxHeight > 0) {
-                newHeight = Math.min(newHeight, maxHeight);
+            let newHeight = Math.max(minHeight, elem.scrollHeight);
+            if (maxHeight > 0 && newHeight > maxHeight) {
+                // Content height exceeds the max height so we'll see a scrollbar.
+                elem.style.overflowY = 'auto';
+                newHeight = maxHeight;
             } else {
-                // Scrollbar isn't needed and could cause flashing.
+                // Scrollbar isn't needed and could either flash on resize or could appear
+                // due to rounding inaccuracy in scrollHeight when the display is scaled.
                 elem.style.overflowY = 'hidden';
             }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

I would notice scrollbars appearing that could barely be moved, specifically on my Android phone with scaling >100%.

Similar fix in #8235 for unrestricted text fields and I believe this PR conclusively fixes it for fields that have MaxLines too.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

[scrollHeight](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight) is rounded while line-height and others aren't. This causes subpixel inaccuracy resulting in useless scrollbars.

Before:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/6b9c73e0-1e8d-4aa1-b38b-95c4021f0801)

After:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/ae8f097e-60f6-493e-9dd8-ae1b37a34dab)

Now we don't show a scrollbar at all unless we EXCEED the specified (fractional) max height.

Related:
- https://groups.google.com/a/chromium.org/g/blink-dev/c/_Q7A4AQBFKY/m/S4ahQ5iE28QJ?pli=1
- https://issues.chromium.org/issues/40384509
- https://issues.chromium.org/issues/41417874

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
