### PR TITLE
MudBarChart: Single x-axis value no longer throws exception

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/BarChartWithSingleXAxisTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/BarChartWithSingleXAxisTest.razor
@@ -1,0 +1,18 @@
+﻿<div>
+    <MudChart ChartType="ChartType.Bar" ChartSeries="@Series" @bind-SelectedIndex="@_index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
+</div>
+
+@code {
+    public static string __description__ = "Single x-axis value with 3 bars";
+
+    private int _index = -1; //default value cannot be 0 -> first selectedindex is 0.
+
+    public List<ChartSeries> Series = new List<ChartSeries>()
+    {
+        new ChartSeries() { Name = "United States", Data = new double[] { 40} },
+        new ChartSeries() { Name = "Germany", Data = new double[] { 19 } },
+        new ChartSeries() { Name = "Sweden", Data = new double[] { 8 } },
+    };
+
+    public string[] XAxisLabels = { "Jan" };
+}

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -126,6 +126,18 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Using only one x-axis value should not throw an exception
+        /// this is from issue #7736
+        /// </summary>
+        [Test]
+        public void BarChartWithSingleXAxisValue()
+        {
+            var comp = Context.RenderComponent<BarChartWithSingleXAxisTest>();
+
+            comp.Markup.Should().NotContain("NaN");
+        }
+
+        /// <summary>
         /// High values should not lead to millions of horizontal grid lines
         /// this is from issue #1591 "Line chart is not able to plot big Double values"
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -110,6 +110,60 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
+        public void BarChartExampleSingleXAxis()
+        {
+            List<ChartSeries> chartSeries = new List<ChartSeries>()
+            {
+                new () { Name = "United States", Data = new double[] { 40, 20, 25, 27, 46, 60, 48, 80, 15 } },
+                new () { Name = "Germany", Data = new double[] { 19, 24, 35, 13, 28, 15, -4, 16, 31 } },
+                new () { Name = "Sweden", Data = new double[] { 8, 6, -11, 13, 4, 16, 10, 16, 18 } },
+            };
+            string[] xAxisLabels = { "Jan" };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = _baseChartPalette })
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.XAxisLabels, xAxisLabels));
+
+            comp.Instance.ChartSeries.Should().NotBeEmpty();
+
+            comp.Markup.Should().Contain("class=\"mud-charts-xaxis\"");
+            comp.Markup.Should().Contain("class=\"mud-charts-yaxis\"");
+            comp.Markup.Should().Contain("mud-chart-legend-item");
+
+            // find legend
+            var legend = comp.FindComponent<Legend>();
+            const string LEGEND_CSS_SELECTOR = "div.mud-chart-legend-item";
+            legend.Should().NotBeNull(because: "we have a legend");
+            legend.FindAll(LEGEND_CSS_SELECTOR).Should().HaveCount(chartSeries.Count, because: "the number series should match the legend item count");
+
+            if (chartSeries.Count <= 3)
+            {
+                comp.Markup.Should().
+                    Contain("United States").And.Contain("Germany").And.Contain("Sweden");
+            }
+
+            if (chartSeries.Count == 3 && chartSeries.Any(x => x.Data.Contains(40)))
+            {
+                comp.Markup.Should()
+                    .Contain("d=\"M 30 265 L 30 145\"");
+            }
+
+            if (chartSeries.Count == 3 && chartSeries.Any(x => x.Data.Contains(80)))
+            {
+                comp.Markup.Should()
+                    .Contain("d=\"M 546.25 265 L 546.25 25\"");
+            }
+
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.ChartOptions, new ChartOptions() { ChartPalette = _modifiedPalette }));
+
+            comp.Markup.Should().Contain(_modifiedPalette[0]);
+        }
+
+        [Test]
         public void BarChartColoring()
         {
             List<ChartSeries> chartSeries = new List<ChartSeries>()

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -37,8 +37,8 @@ namespace MudBlazor.Charts
 
             ComputeUnitsAndNumberOfLines(out double gridXUnits, out double gridYUnits, out int numHorizontalLines, out int lowestHorizontalLine, out int numVerticalLines);
 
-            var horizontalSpace = (BoundWidth - HorizontalStartSpace - HorizontalEndSpace) / (numVerticalLines - 1);
-            var verticalSpace = (BoundHeight - VerticalStartSpace - VerticalEndSpace) / (numHorizontalLines - 1);
+            var horizontalSpace = (BoundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, numVerticalLines - 1);
+            var verticalSpace = (BoundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, numHorizontalLines - 1);
 
             GenerateHorizontalGridLines(numHorizontalLines, lowestHorizontalLine, gridYUnits, verticalSpace);
             GenerateVerticalGridLines(numVerticalLines, gridXUnits, horizontalSpace);


### PR DESCRIPTION
## Description
If the x-axis data for a bar chart contains only one item, an exception is thrown since horizontalSpace is calculated as infinite
Resolves #7736 (similar to #8327)

## How Has This Been Tested?
Tested via unit tests and test viewer
Created new unit test and unit test viewer component

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
