### PR TITLE
MudDateRangePicker: Ignore timestamp when setting day classes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDateRangePicker PickerVariant="PickerVariant.Static" @bind-DateRange="DateTimeRange" />
+
+@code {
+    public static string __description__ = "DateTime range with a timestamp";
+
+    public DateRange DateTimeRange { get; set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        DateTimeRange = new DateRange(DateTime.Now.AddDays(-7), DateTime.Now);
+
+        return base.OnInitializedAsync();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDateRangePicker PickerVariant="PickerVariant.Static" @bind-DateRange="DateRange" />
+
+@code {
+    public static string __description__ = "DateTime range without a timestamp";
+
+    public DateRange DateRange { get; set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        DateRange = new DateRange(DateTime.Now.AddDays(-7).Date, DateTime.Now.Date);
+
+        return base.OnInitializedAsync();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1,15 +1,15 @@
 ﻿#pragma warning disable BL0005 // Set parameter outside component
 
-using System;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
 using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
@@ -46,6 +46,24 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudDateRangePicker>();
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Range Picker");
+        }
+
+        [Test]
+        public void DateRangePicker_Preset_No_Timestamp()
+        {
+            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>();
+
+            comp.Markup.Should().Contain("mud-range-start-selected");
+            comp.Markup.Should().Contain("mud-range-end-selected");
+        }
+
+        [Test]
+        public void DateRangePicker_Preset_Timestamp()
+        {
+            var comp = Context.RenderComponent<DateRangePickerPresetRangeWithTimestampTest>();
+            
+            comp.Markup.Should().Contain("mud-range-start-selected");
+            comp.Markup.Should().Contain("mud-range-end-selected");
         }
 
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -231,7 +231,7 @@ namespace MudBlazor
             {
                 return b.AddClass("mud-range", _secondDate is null && day != DateTime.Today)
                     .AddClass("mud-range-selection")
-                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate is { })
+                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate is not null)
                     .AddClass($"mud-current mud-{Color.ToDescriptionString()}-text mud-button-outlined mud-button-outlined-{Color.ToDescriptionString()}", day == DateTime.Today)
                     .Build();
             }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -172,6 +172,14 @@ namespace MudBlazor
             base.OnPickerClosed();
         }
 
+        private bool CheckDateRange(DateTime day, Func<DateTime, DateTime, bool> compareStart, Func<DateTime, DateTime, bool> compareEnd)
+        {
+            return _firstDate is null
+                && _dateRange is { Start: { } start, End: { } end }
+                && compareStart(start.Date, day)
+                && compareEnd(end.Date, day);
+        }
+
         protected override string GetDayClasses(int month, DateTime day)
         {
             var b = new CssBuilder("mud-day");
@@ -181,8 +189,13 @@ namespace MudBlazor
                 return b.AddClass("mud-hidden").Build();
             }
 
-            if ((_firstDate != null && _secondDate != null && _firstDate < day && _secondDate > day) ||
-                (_firstDate == null && _dateRange != null && _dateRange.Start < day && _dateRange.End > day))
+            static bool isLessThan(DateTime date1, DateTime date2) => date1 < date2;
+            static bool isGreaterThan(DateTime date1, DateTime date2) => date1 > date2;
+            static bool isEqualTo(DateTime date1, DateTime date2) => date1 == date2;
+            static bool isNotEqualTo(DateTime date1, DateTime date2) => date1 != date2;
+
+
+            if ((_firstDate?.Date < day && _secondDate?.Date > day) || CheckDateRange(day, compareStart: isLessThan, compareEnd: isGreaterThan))
             {
                 return b
                     .AddClass("mud-range")
@@ -191,8 +204,7 @@ namespace MudBlazor
                     .Build();
             }
 
-            if ((_firstDate != null && day == _firstDate) ||
-                (_firstDate == null && _dateRange != null && _dateRange.Start == day && DateRange.End != day))
+            if (_firstDate?.Date == day || CheckDateRange(day, compareStart: isEqualTo, compareEnd: isNotEqualTo))
             {
                 return b.AddClass("mud-selected")
                     .AddClass("mud-range")
@@ -202,8 +214,7 @@ namespace MudBlazor
                     .Build();
             }
 
-            if ((_firstDate != null && _secondDate != null && day == _secondDate) ||
-                (_firstDate == null && _dateRange != null && _dateRange.Start != day && _dateRange.End == day))
+            if ((_firstDate is { } && _secondDate?.Date == day) || CheckDateRange(day, compareStart: isNotEqualTo, compareEnd: isEqualTo))
             {
                 return b.AddClass("mud-selected")
                     .AddClass("mud-range")
@@ -212,15 +223,15 @@ namespace MudBlazor
                     .Build();
             }
 
-            if (_firstDate == null && _dateRange != null && _dateRange.Start == _dateRange.End && _dateRange.Start == day)
+            if (CheckDateRange(day, compareStart: isEqualTo, compareEnd: isEqualTo))
             {
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToDescriptionString()}").Build();
             }
-            else if (_firstDate != null && day > _firstDate)
+            else if (_firstDate?.Date < day)
             {
-                return b.AddClass("mud-range", _secondDate == null && day != DateTime.Today)
+                return b.AddClass("mud-range", _secondDate is null && day != DateTime.Today)
                     .AddClass("mud-range-selection")
-                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate != null)
+                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate is { })
                     .AddClass($"mud-current mud-{Color.ToDescriptionString()}-text mud-button-outlined mud-button-outlined-{Color.ToDescriptionString()}", day == DateTime.Today)
                     .Build();
             }


### PR DESCRIPTION
## Description
When setting the CSS classes for the selected dates in the date range picker, ignore any timestamps included in the start and end dates for the `DateRange`. 

Resolves #8339. 
Also, while not mentioned in the issue, the error meant that the start date was not included in the selected date range.

## How Has This Been Tested?
Tested using unit tests and unit test viewer. 
Added new test cases and test viewer components.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
