### PR TITLE
DateRangePicker: Validate range when manually entered

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -496,7 +496,6 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("");
             comp.Instance.DateRange.End.Should().BeNull();
             comp.Instance.DateRange.Start.Should().BeNull();
-
         }
 
         [Test]
@@ -508,7 +507,6 @@ namespace MudBlazor.UnitTests.Components
                     .Add(p=>p.Culture, CultureInfo.CurrentCulture));
             comp.Find("input").Change(dateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern));
             comp.Instance.DateRange.Start.Should().Be(dateTime);
-
         }
 
 
@@ -527,6 +525,25 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParam(nameof(MudDateRangePicker.DateRange), dr2);
 
             comp.Instance.DateRange.Should().Be(dr2);
+            wasEventCallbackCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void SetDateRange_InvalidRange_Error()
+        {
+            var dr1 = new DateRange(new DateTime(2024, 01, 01), new DateTime(2024, 01, 10));
+            var dr2 = new DateRange(new DateTime(2024, 10, 01), new DateTime(2024, 01, 10));
+
+            var wasEventCallbackCalled = false;
+
+            var comp = Context.RenderComponent<MudDateRangePicker>(
+                Parameter(nameof(MudDateRangePicker.DateRange), dr1),
+                EventCallback(nameof(MudDateRangePicker.DateRangeChanged), (DateRange _) => wasEventCallbackCalled = true));
+
+            comp.SetParam(nameof(MudDateRangePicker.DateRange), dr2);
+
+            comp.Instance.Error.Should().BeTrue();
+            comp.Instance.ErrorText.Should().Be("Start date greater than end date!");
             wasEventCallbackCalled.Should().BeFalse();
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -56,6 +56,13 @@ namespace MudBlazor
 
                 Touched = true;
 
+                if (range?.Start > range?.End)
+                {
+                    Error = true;
+                    ErrorText = "Start date greater than end date!";
+                    return;
+                }
+
                 _dateRange = range;
                 _value = range?.End;
 


### PR DESCRIPTION
Currently, using when Editable is enabled on the DateRangePicker, a user can set the start date as a date later than the end date. This PR adds a simple validation to prevent that. 

## How Has This Been Tested?
Tested via unit tests, test viewer and docs page. 

Created new unit test to cover the additional validation. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Current behavior (no validation - calendar is updated)
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/65f3e998-ef96-47eb-8ebd-464904d244af)
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/8d836a31-bc4a-4dc0-a971-be351e516d9f)

Updated behavior (input errors - calendar is not updated
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/bb4f3d69-aa08-4901-a4b0-bfadf0305af7)
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/0630cb64-c042-4e09-b1fb-8b937740ba8b)


## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
