### PR TITLE
Autocomplete: Add class templates and FoundItemsCount (and improve docs mobile search dialog)

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -69,7 +69,9 @@
     <MudSpacer/>
     @if (DisplaySearchBar)
     {
-        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="async text => await Search(text)" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar mx-4" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
+                         AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined"
+                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
@@ -86,16 +88,25 @@
     </MudTooltip>
 </div>
 
-
-<MudDialog @bind-IsVisible="_searchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search">
+<MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search d-flex flex-column">
     <DialogContent>
-        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" Placeholder="Search docs" SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
+                         AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" FoundItemsCountChanged="c => _searchDialogFoundItemsCount = c">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
         </MudAutocomplete>
-        <div class="d-flex justify-center align-center mud-height-full pb-16">
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">Nothing found, do a search</MudText>
-        </div>
+
+        <MudText Typo="Typo.body2" Class="flex-grow-1 mud-text-secondary" Align="Align.Center">
+            @if (!_searchDialogAutocompleteOpen)
+            {
+                @("Use the box above to search the docs")
+            }
+            else if (_searchDialogFoundItemsCount == 0)
+            {
+                @("No results found")
+            }
+        </MudText>
     </DialogContent>
 </MudDialog>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -92,7 +92,7 @@
     <DialogContent>
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
                          AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" FoundItemsCountChanged="c => _searchDialogFoundItemsCount = c">
+                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
@@ -104,7 +104,7 @@
             {
                 @("Use the box above to search the docs")
             }
-            else if (_searchDialogFoundItemsCount == 0)
+            else if (_searchDialogReturnedItemsCount == 0)
             {
                 @("No results found")
             }

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -98,6 +98,7 @@
             </ItemTemplate>
         </MudAutocomplete>
 
+        @* This text element will always be rendered but it's easier to write it this way *@
         <MudText Typo="Typo.body2" Class="flex-grow-1 mud-text-secondary" Align="Align.Center">
             @if (!_searchDialogAutocompleteOpen)
             {

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -88,7 +88,7 @@
     </MudTooltip>
 </div>
 
-<MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search d-flex flex-column">
+<MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
                          AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -16,7 +16,7 @@ public partial class Appbar
 {
     private bool _searchDialogOpen;
     private bool _searchDialogAutocompleteOpen;
-    private int _searchDialogFoundItemsCount;
+    private int _searchDialogReturnedItemsCount;
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
@@ -99,7 +99,7 @@ public partial class Appbar
         set
         {
             _searchDialogAutocompleteOpen = default;
-            _searchDialogFoundItemsCount = default;
+            _searchDialogReturnedItemsCount = default;
             _searchDialogOpen = value;
         }
     }

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -15,6 +15,8 @@ namespace MudBlazor.Docs.Shared;
 public partial class Appbar
 {
     private bool _searchDialogOpen;
+    private bool _searchDialogAutocompleteOpen;
+    private int _searchDialogFoundItemsCount;
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
@@ -91,6 +93,17 @@ public partial class Appbar
         }
     ];
 
+    public bool IsSearchDialogOpen
+    {
+        get => _searchDialogOpen;
+        set
+        {
+            _searchDialogAutocompleteOpen = default;
+            _searchDialogFoundItemsCount = default;
+            _searchDialogOpen = value;
+        }
+    }
+
     [Inject]
     private NavigationManager NavigationManager { get; set; } = null!;
 
@@ -130,5 +143,5 @@ public partial class Appbar
         return ApiLinkService.Search(text);
     }
 
-    private void OpenSearchDialog() => _searchDialogOpen = true;
+    private void OpenSearchDialog() => IsSearchDialogOpen = true;
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -264,6 +264,8 @@ namespace MudBlazor.UnitTests.Components
 
             var mudText = comp.FindAll("p.mud-typography");
             mudText[mudText.Count - 1].InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
+
+            comp.FindAll("div.mud-popover .mud-autocomplete-more-items").Count.Should().Be(1);
         }
 
         /// <summary>
@@ -280,6 +282,8 @@ namespace MudBlazor.UnitTests.Components
 
             var mudText = comp.FindAll("p.mud-typography");
             mudText[mudText.Count - 1].InnerHtml.Should().Contain("No items found, try another search"); //ensure the text is shown
+
+            comp.FindAll("div.mud-popover .mud-autocomplete-no-items").Count.Should().Be(1);
         }
 
         /// <summary>
@@ -1237,6 +1241,8 @@ namespace MudBlazor.UnitTests.Components
 
             var mudText = comp.FindAll("p.mud-typography");
             mudText[0].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
+
+            comp.FindAll("div.mud-popover .mud-autocomplete-before-items").Count.Should().Be(1);
         }
 
         /// <summary>
@@ -1253,6 +1259,8 @@ namespace MudBlazor.UnitTests.Components
 
             var mudText = comp.FindAll("p.mud-typography");
             mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
+
+            comp.FindAll("div.mud-popover .mud-autocomplete-after-items").Count.Should().Be(1);
         }
 
         /// <summary>
@@ -1301,20 +1309,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TemplateDivClasses()
+        public async Task Autocomplete_FoundItemsCount_Should_Be_Accurate()
         {
+            Task<IEnumerable<string>> search(string value)
+            {
+                var values = new string[] { "Lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit" };
+                return Task.FromResult(values.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
+            }
+
             var comp = Context.RenderComponent<MudAutocomplete<string>>();
             comp.SetParametersAndRender(p => p
-                .Add(x => x.AfterItemsTemplate, _ => { })
-                .Add(x => x.BeforeItemsTemplate, _ => { })
-                .Add(x => x.MoreItemsTemplate, _ => { })
-                .Add(x => x.NoItemsTemplate, _ => { })
-            );
+                .Add(x => x.Value, "nothing will ever match this")
+                .Add(x => x.SearchFunc, search)
+                .Add(x => x.DebounceInterval, 0));
 
-            comp.FindAll(".mud-autocomplete>.mud-autocomplete-after-items").Count.Should().Be(1);
-            comp.FindAll(".mud-autocomplete>.mud-autocomplete-before-items").Count.Should().Be(1);
-            comp.FindAll(".mud-autocomplete>.mud-autocomplete-more-items").Count.Should().Be(1);
-            comp.FindAll(".mud-autocomplete>.mud-autocomplete-no-items").Count.Should().Be(1);
+            comp.Instance.FoundItemsCount.Should().Be(0);
+
+            comp.Find("input").Input("Lorem");
+            comp.WaitForAssertion(() => comp.Instance.FoundItemsCount.Should().Be(1));
+            ;
+            comp.Find("input").Input("ip");
+            comp.WaitForAssertion(() => comp.Instance.FoundItemsCount.Should().Be(2));
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1309,7 +1309,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_FoundItemsCount_Should_Be_Accurate()
+        public async Task Autocomplete_ReturnedItemsCount_Should_Be_Accurate()
         {
             Task<IEnumerable<string>> search(string value)
             {
@@ -1323,13 +1323,17 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.SearchFunc, search)
                 .Add(x => x.DebounceInterval, 0));
 
-            comp.Instance.FoundItemsCount.Should().Be(0);
+            int? count = null;
+            comp.Instance.ReturnedItemsCountChanged = new EventCallbackFactory().Create<int>(this, v => count = v);
 
             comp.Find("input").Input("Lorem");
-            comp.WaitForAssertion(() => comp.Instance.FoundItemsCount.Should().Be(1));
+            comp.WaitForAssertion(() => count.Should().Be(1));
             ;
             comp.Find("input").Input("ip");
-            comp.WaitForAssertion(() => comp.Instance.FoundItemsCount.Should().Be(2));
+            comp.WaitForAssertion(() => count.Should().Be(2));
+            ;
+            comp.Find("input").Input("wtf");
+            comp.WaitForAssertion(() => count.Should().Be(0));
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -170,7 +170,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => autocomplete.Value.Should().Be("Austria"));
             autocomplete.Text.Should().Be("Austria");
         }
-        
+
         /// <summary>
         /// Test to cover issue #5993.
         /// </summary>
@@ -189,7 +189,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
             autocompletecomp.SetParam(p => p.Text, "Austria"); // not part of the U.S.
-            
+
             comp.WaitForAssertion(() => autocomplete.Value.Should().Be("Austria"));
             autocomplete.Text.Should().Be("Austria");
         }
@@ -1238,7 +1238,7 @@ namespace MudBlazor.UnitTests.Components
             var mudText = comp.FindAll("p.mud-typography");
             mudText[0].InnerHtml.Should().Contain("StartList_Content"); //ensure the text is shown
         }
-        
+
         /// <summary>
         /// AfterItemsTemplate should render when there are items
         /// </summary>
@@ -1298,6 +1298,23 @@ namespace MudBlazor.UnitTests.Components
             inputControl.Click();
 
             comp.WaitForAssertion(() => comp.Find("div.mud-list-item").ClassList.Should().Contain(listItemClassTest));
+        }
+
+        [Test]
+        public async Task TemplateDivClasses()
+        {
+            var comp = Context.RenderComponent<MudAutocomplete<string>>();
+            comp.SetParametersAndRender(p => p
+                .Add(x => x.AfterItemsTemplate, _ => { })
+                .Add(x => x.BeforeItemsTemplate, _ => { })
+                .Add(x => x.MoreItemsTemplate, _ => { })
+                .Add(x => x.NoItemsTemplate, _ => { })
+            );
+
+            comp.FindAll(".mud-autocomplete>.mud-autocomplete-after-items").Count.Should().Be(1);
+            comp.FindAll(".mud-autocomplete>.mud-autocomplete-before-items").Count.Should().Be(1);
+            comp.FindAll(".mud-autocomplete>.mud-autocomplete-more-items").Count.Should().Be(1);
+            comp.FindAll(".mud-autocomplete>.mud-autocomplete-no-items").Count.Should().Be(1);
         }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -48,7 +48,7 @@
                         <MudList Class="@ListClass" Clickable="true" Dense="@Dense">
                             @if (BeforeItemsTemplate != null)
                             {
-                                <div class="pa-1">
+                                <div class="mud-autocomplete-before-items pa-1">
                                     @BeforeItemsTemplate
                                 </div>
                             }
@@ -80,15 +80,15 @@
                                     }
                                 </MudListItem>
                             }
-                            @if (MoreItemsTemplate != null && _itemsReturned > MaxItems)
+                            @if (MoreItemsTemplate != null && FoundItemsCount > MaxItems)
                             {
-                                <div class="pa-1">
+                                <div class="mud-autocomplete-more-items pa-1">
                                     @MoreItemsTemplate
                                 </div>
                             }
                             @if (AfterItemsTemplate != null)
                             {
-                                <div class="pa-1">
+                                <div class="mud-autocomplete-after-items pa-1">
                                     @AfterItemsTemplate
                                 </div>
                             }
@@ -96,7 +96,7 @@
                     }
                     else if (NoItemsTemplate != null)
                     {
-                        <div class="pa-1">
+                        <div class="mud-autocomplete-no-items pa-1">
                             @NoItemsTemplate
                         </div>
                     }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -80,7 +80,7 @@
                                     }
                                 </MudListItem>
                             }
-                            @if (MoreItemsTemplate != null && FoundItemsCount > MaxItems)
+                            @if (MoreItemsTemplate != null && _returnedItemsCount > MaxItems)
                             {
                                 <div class="mud-autocomplete-more-items pa-1">
                                     @MoreItemsTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -364,7 +364,7 @@ namespace MudBlazor
         /// <para>The number of items that were found by the search query.</para>
         /// <para>
         /// If the number is <c>0</c>, <see cref="NoItemsTemplate"/> will be shown.<br />
-        /// If the number is at least <see cref="MaxItems"/>, <see cref="MoreItemsTemplate"/> will be shown.
+        /// If the number is beyond <see cref="MaxItems"/>, <see cref="MoreItemsTemplate"/> will be shown.
         /// </para>
         /// </summary>
         [Category(CategoryTypes.FormComponent.Behavior)]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         private bool _isProcessingValue;
         private int _selectedListItemIndex = 0;
         private int _elementKey = 0;
-        private int _itemsReturned; //the number of items returned by the search function
+        private int _returnedItemsCount;
         private bool _isOpen;
         private MudInput<string> _elementReference;
         private CancellationTokenSource _cancellationTokenSrc;
@@ -355,28 +355,14 @@ namespace MudBlazor
         public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         /// <summary>
-        /// An event triggered when the number of items returned by the search query has changed.
-        /// </summary>
-        [Parameter]
-        public EventCallback<int> FoundItemsCountChanged { get; set; }
-
-        /// <summary>
-        /// <para>The number of items that were found by the search query.</para>
+        /// <para>An event triggered when the number of items returned by the search query has changed.</para>
         /// <para>
         /// If the number is <c>0</c>, <see cref="NoItemsTemplate"/> will be shown.<br />
         /// If the number is beyond <see cref="MaxItems"/>, <see cref="MoreItemsTemplate"/> will be shown.
         /// </para>
         /// </summary>
-        [Category(CategoryTypes.FormComponent.Behavior)]
-        public int FoundItemsCount
-        {
-            get => _itemsReturned;
-            private set
-            {
-                _itemsReturned = value;
-                FoundItemsCountChanged.InvokeAsync(value).AndForget();
-            }
-        }
+        [Parameter]
+        public EventCallback<int> ReturnedItemsCountChanged { get; set; }
 
         /// <summary>
         /// Returns the open state of the drop-down.
@@ -518,6 +504,12 @@ namespace MudBlazor
             }
         }
 
+        private Task SetReturnedItemsCountAsync(int value)
+        {
+            _returnedItemsCount = value;
+            return ReturnedItemsCountChanged.InvokeAsync(value);
+        }
+
         /// <remarks>
         /// This async method needs to return a task and be awaited in order for
         /// unit tests that trigger this method to work correctly.
@@ -566,7 +558,7 @@ namespace MudBlazor
                 Logger.LogWarning("The search function failed to return results: " + e.Message);
             }
 
-            FoundItemsCount = searchedItems.Length;
+            await SetReturnedItemsCountAsync(searchedItems.Length);
             if (MaxItems.HasValue)
             {
                 searchedItems = searchedItems.Take(MaxItems.Value).ToArray();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -355,6 +355,30 @@ namespace MudBlazor
         public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         /// <summary>
+        /// An event triggered when the number of items returned by the search query has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<int> FoundItemsCountChanged { get; set; }
+
+        /// <summary>
+        /// <para>The number of items that were found by the search query.</para>
+        /// <para>
+        /// If the number is <c>0</c>, <see cref="NoItemsTemplate"/> will be shown.<br />
+        /// If the number is at least <see cref="MaxItems"/>, <see cref="MoreItemsTemplate"/> will be shown.
+        /// </para>
+        /// </summary>
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public int FoundItemsCount
+        {
+            get => _itemsReturned;
+            private set
+            {
+                _itemsReturned = value;
+                FoundItemsCountChanged.InvokeAsync(value).AndForget();
+            }
+        }
+
+        /// <summary>
         /// Returns the open state of the drop-down.
         /// </summary>
         public bool IsOpen
@@ -542,7 +566,7 @@ namespace MudBlazor
                 Logger.LogWarning("The search function failed to return results: " + e.Message);
             }
 
-            _itemsReturned = searchedItems.Length;
+            FoundItemsCount = searchedItems.Length;
             if (MaxItems.HasValue)
             {
                 searchedItems = searchedItems.Take(MaxItems.Value).ToArray();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Originally discussed at https://github.com/MudBlazor/MudBlazor/pull/8276#issuecomment-1987849744

### Autocomplete

Exposes a `FoundItemsCount` property that lets consumers subscribe to the actual number of search results to allow finer control than just the templates.

Adds classes to the divs surrounding `AfterItemsTemplate`, `BeforeItemsTemplate`, `MoreItemsTemplate`, `NoItemsTemplate` for customizability. Other templates weren't included to avoid breaking changes.

### Docs

Utilizing the new API, the mobile search panel now shows different messages depending on the context:

Before

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/90989b3f-daf9-4644-ae5c-67f07b606318)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/38547d05-ca32-4221-b3bf-3c9f05b35706)


After

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/9092af03-ea5f-4748-bbc6-8bc983ed23f6)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/35af04da-6e9c-4893-bde9-34e97e85a068)


and isn't visible behind the search results:

Before

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/076e76fd-d0e0-411d-b3e7-d80f8106839c)


After

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/193f0e87-46f5-432f-91cb-3cba95571b39)

and the scrollbar was naturally eliminated:

Before

https://github.com/MudBlazor/MudBlazor/assets/7112040/cc6c19fe-73b5-42ec-b8bf-a7644782e334

After


https://github.com/MudBlazor/MudBlazor/assets/7112040/625401f8-41fe-4e24-be96-efc1e2c5a4c2

And it now focuses the search box


https://github.com/MudBlazor/MudBlazor/assets/7112040/d5bdec25-694b-4e61-ab46-843be892289b



## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

See above

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
