### PR TITLE
MudDialog: Change default value of DefaultFocus to "Element" to shift the focus into the dialog.

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -121,7 +121,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public DefaultFocus DefaultFocus { get; set; }
+        public DefaultFocus DefaultFocus { get; set; } = DefaultFocus.Element;
 
         private bool IsInline => IsNested || DialogInstance == null;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

Today, when you open a dialog the focus is left on the place you use to open the dialog (Usually a button). This meant pressing Enter/Return would keep opening up new dialogs by triggering the onClick action of the button.

I've changed it so that the parameter DefaultFocus has the value "DefaultFocus.Element" by default, which means that the focus will be changed to the FocusTrap when opening a new dialog.

NOTE: The default value of "DefaultFocus" on the **MudFocusTrap** component is DefaultFocus.FirstChild. There is an argument to be made that the DefaultFocus of the MudDialog should also be FirstChild, to match the FocusTrap. But i personally feel that DefaultFocus.Element makes more sense in this case.

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes #5111
Fixes #5540 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note: Technically we are changing the default behaviour of MudDialog, and one could consider this a breaking change. But I think its farfetched.

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
