### PR TITLE
Buttons: Fix exception doesn't flow to ErrorBoundary.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
@@ -1,18 +1,30 @@
-﻿<ErrorBoundary>
+﻿<ErrorBoundary @ref="errorBoundary">
     <ChildContent>
-        <MudButton OnClick="HandleClickAsync" Variant="Variant.Filled" Color="Color.Primary">
-            <MudText>Click me</MudText>
+        <MudButton OnClick="HandleClickAsync">
+            <MudText>MudButton</MudText>
         </MudButton>
+        <MudFab OnClick="HandleClickAsync" StartIcon="@Icons.Material.Filled.Add">
+            <MudText>MudFab</MudText>
+        </MudFab>
+        <MudIconButton OnClick="HandleClickAsync" Icon="@Icons.Material.Filled.Delete">
+            <MudText>MudFab</MudText>
+        </MudIconButton>
     </ChildContent>
     <ErrorContent>
         <MudAlert Severity="Severity.Error">Oh my! We caught an error and handled it!</MudAlert>
     </ErrorContent>
 </ErrorBoundary>
 
+
 @code {
+#nullable enable
+    private ErrorBoundary? errorBoundary;
+
     public async Task HandleClickAsync()
     {
         await Task.Delay(100);
         throw new Exception("Something went wrong...");
     }
+
+    public void Recover() => errorBoundary?.Recover();
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
@@ -1,0 +1,18 @@
+﻿<ErrorBoundary>
+    <ChildContent>
+        <MudButton OnClick="HandleClickAsync" Variant="Variant.Filled" Color="Color.Primary">
+            <MudText>Click me</MudText>
+        </MudButton>
+    </ChildContent>
+    <ErrorContent>
+        <MudAlert Severity="Severity.Error">Oh my! We caught an error and handled it!</MudAlert>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    public async Task HandleClickAsync()
+    {
+        await Task.Delay(100);
+        throw new Exception("Something went wrong...");
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
+using Bunit.Rendering;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
@@ -465,14 +468,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task OnClickErrorContentCaughtException()
+        public async Task ButtonsOnClickErrorContentCaughtException()
         {
             var comp = Context.RenderComponent<ButtonErrorContenCaughtException>();
-            await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs());
-            var mudAlert = comp.FindComponent<MudAlert>();
-            var text = mudAlert.Find("div.mud-alert-message");
+            var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
+            IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
+            IRefreshableElementCollection<IElement> Buttons() => comp.FindAll("button.mud-button-root");
+            IElement MudButton() => Buttons()[0];
+            IElement MudFab() => Buttons()[1];
+            IElement MudIconButton() => Buttons()[2];
 
-            text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            // MudButton
+            await MudButton().ClickAsync(new MouseEventArgs());
+            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            await comp.InvokeAsync(comp.Instance.Recover);
+            alertTextFunc.Should().Throw<ComponentNotFoundException>();
+
+            // MudFab
+            await MudFab().ClickAsync(new MouseEventArgs());
+            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            await comp.InvokeAsync(comp.Instance.Recover);
+            alertTextFunc.Should().Throw<ComponentNotFoundException>();
+
+            // MudIconButton
+            await MudIconButton().ClickAsync(new MouseEventArgs());
+            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            await comp.InvokeAsync(comp.Instance.Recover);
+            alertTextFunc.Should().Throw<ComponentNotFoundException>();
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.TestComponents.Button;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -462,6 +462,17 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudButton>().Find("button").HasAttribute("disabled").Should().BeTrue();
             comp.FindComponent<MudFab>().Find("button").HasAttribute("disabled").Should().BeTrue();
             comp.FindComponent<MudIconButton>().Find("button").HasAttribute("disabled").Should().BeTrue();
+        }
+
+        [Test]
+        public async Task OnClickErrorContentCaughtException()
+        {
+            var comp = Context.RenderComponent<ButtonErrorContenCaughtException>();
+            await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs());
+            var mudAlert = comp.FindComponent<MudAlert>();
+            var text = mudAlert.Find("div.mud-alert-message");
+
+            text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -6,7 +6,7 @@
             Class="@Classname" 
             Style="@Style"
             @attributes="UserAttributes"
-            @onclick="EventUtil.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+            @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()"
             href="@Href" 
             target="@Target"

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -104,7 +104,7 @@ namespace MudBlazor
         /// <remarks>
         /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
         /// <para/>
-        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// Since <see cref="MudButton"/> implements only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally within the component.
         /// </remarks>
         Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
 #nullable enable
-    public partial class MudButton : MudBaseButton
+    public partial class MudButton : MudBaseButton, IHandleEvent
     {
         protected string Classname =>
             new CssBuilder("mud-button-root mud-button")
@@ -98,5 +99,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public RenderFragment? ChildContent { get; set; }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
+        /// <para/>
+        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// </remarks>
+        Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }
 }

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -6,7 +6,7 @@
             Class="@Classname"
             Style="@Style"
             @attributes="UserAttributes"
-            @onclick="EventUtil.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+            @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()"
             href="@Href"
             target="@Target"

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
 #nullable enable
-    public partial class MudFab : MudBaseButton
+    public partial class MudFab : MudBaseButton, IHandleEvent
     {
         protected string Classname =>
             new CssBuilder("mud-button-root mud-fab")
@@ -79,5 +80,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public string? Title { get; set; }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
+        /// <para/>
+        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// </remarks>
+        Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }
 }

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -85,7 +85,7 @@ namespace MudBlazor
         /// <remarks>
         /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
         /// <para/>
-        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// Since <see cref="MudFab"/> implements only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally within the component.
         /// </remarks>
         Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -6,7 +6,7 @@
             Class="@Classname" 
             Style="@Style"
             @attributes="UserAttributes" 
-            @onclick="EventUtil.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+            @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()" 
             href="@Href" 
             target="@Target"

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
 #nullable enable
-    public partial class MudIconButton : MudBaseButton
+    public partial class MudIconButton : MudBaseButton, IHandleEvent
     {
         protected string Classname =>
             new CssBuilder("mud-button-root mud-icon-button")
@@ -71,5 +72,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public RenderFragment? ChildContent { get; set; }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
+        /// <para/>
+        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// </remarks>
+        Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }
 }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -77,7 +77,7 @@ namespace MudBlazor
         /// <remarks>
         /// See: https://github.com/MudBlazor/MudBlazor/issues/8365
         /// <para/>
-        /// Since <see cref="MudFab"/> implents only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally withing the component.
+        /// Since <see cref="MudIconButton"/> implements only single <see cref="EventCallback"/> <see cref="MudBaseButton.OnClick"/> this is safe to disable globally within the component.
         /// </remarks>
         Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg) => callback.InvokeAsync(arg);
     }

--- a/src/MudBlazor/Utilities/EventUtil.cs
+++ b/src/MudBlazor/Utilities/EventUtil.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<Task> AsNonRenderingEventHandler(Func<Task> callback)
-            => new AsyncReceiver(callback).Invoke;
+            => async () => await new AsyncReceiver(callback).Invoke();
 
         /// <summary>
         /// Converts the provided <see cref="Func{TValue, Task}"/> callback into a non-rendering event handler.
@@ -47,7 +47,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<TValue, Task> AsNonRenderingEventHandler<TValue>(Func<TValue, Task> callback)
-            => new AsyncReceiver<TValue>(callback).Invoke;
+            => async value => await new AsyncReceiver<TValue>(callback).Invoke(value);
 
         private record SyncReceiver(Action Callback) : ReceiverBase
         {
@@ -71,8 +71,7 @@ namespace MudBlazor
 
         private record ReceiverBase : IHandleEvent
         {
-            public Task HandleEventAsync(EventCallbackWorkItem item, object? arg)
-                => item.InvokeAsync(arg);
+            public Task HandleEventAsync(EventCallbackWorkItem item, object? arg) => item.InvokeAsync(arg);
         }
     }
 }

--- a/src/MudBlazor/Utilities/EventUtil.cs
+++ b/src/MudBlazor/Utilities/EventUtil.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<Task> AsNonRenderingEventHandler(Func<Task> callback)
-            => async () => await new AsyncReceiver(callback).Invoke(); // https://github.com/dotnet/aspnetcore/issues/54543
+            => new AsyncReceiver(callback).Invoke;
 
         /// <summary>
         /// Converts the provided <see cref="Func{TValue, Task}"/> callback into a non-rendering event handler.
@@ -47,7 +47,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<TValue, Task> AsNonRenderingEventHandler<TValue>(Func<TValue, Task> callback)
-            => async value => await new AsyncReceiver<TValue>(callback).Invoke(value); // https://github.com/dotnet/aspnetcore/issues/54543
+            => new AsyncReceiver<TValue>(callback).Invoke;
 
         private record SyncReceiver(Action Callback) : ReceiverBase
         {
@@ -71,7 +71,8 @@ namespace MudBlazor
 
         private record ReceiverBase : IHandleEvent
         {
-            public Task HandleEventAsync(EventCallbackWorkItem item, object? arg) => item.InvokeAsync(arg);
+            public Task HandleEventAsync(EventCallbackWorkItem item, object? arg)
+                => item.InvokeAsync(arg);
         }
     }
 }

--- a/src/MudBlazor/Utilities/EventUtil.cs
+++ b/src/MudBlazor/Utilities/EventUtil.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<Task> AsNonRenderingEventHandler(Func<Task> callback)
-            => async () => await new AsyncReceiver(callback).Invoke();
+            => async () => await new AsyncReceiver(callback).Invoke(); // https://github.com/dotnet/aspnetcore/issues/54543
 
         /// <summary>
         /// Converts the provided <see cref="Func{TValue, Task}"/> callback into a non-rendering event handler.
@@ -47,7 +47,7 @@ namespace MudBlazor
         /// <param name="callback">The asynchronous callback to be converted.</param>
         /// <returns>A non-rendering event handler.</returns>
         public static Func<TValue, Task> AsNonRenderingEventHandler<TValue>(Func<TValue, Task> callback)
-            => async value => await new AsyncReceiver<TValue>(callback).Invoke(value);
+            => async value => await new AsyncReceiver<TValue>(callback).Invoke(value); // https://github.com/dotnet/aspnetcore/issues/54543
 
         private record SyncReceiver(Action Callback) : ReceiverBase
         {


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/8365
See: https://github.com/MudBlazor/MudBlazor/issues/8365#issuecomment-1997916812 and https://github.com/dotnet/aspnetcore/issues/54543
PR that introduced regression: https://github.com/MudBlazor/MudBlazor/pull/8203

## How Has This Been Tested?
New unit tests for MudButton / MudFab / MudIconButton that check that `ErrorBoundary` is now working for button. 
Also checked on @danielchalmers repro https://github.com/danielchalmers/ScrollToTopBeforeNavigate that the old behaviour with scrolling to top is not back with this change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
