### PR TITLE
DatePicker: Show first selected date when DatePicker is nested

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="6">
+        <MudDatePicker Style="max-width: 300px"
+                       Placeholder="dd-MM-yyyy"
+                       Editable="true"
+                       Required="false"
+                       Mask="@(new DateMask("dd-MM-yyyy"))"
+                       DateFormat="dd-MM-yyyy"
+                       Variant="Variant.Outlined"
+                       @bind-Date="SelectedDate">
+        </MudDatePicker>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public static string __description__ = "Selected date should show in input on first selection";
+
+    public DateTime? SelectedDate { get; set; }
+}

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -107,7 +107,7 @@ namespace MudBlazor
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
-                Submit();
+                await Task.Run(() => Submit());
 
                 if (PickerVariant != PickerVariant.Static)
                 {


### PR DESCRIPTION
## Description
When the `DatePicker` is wrapped/nested in another component (example `MudForm` or `MudGrid`), the first selected date does not update the input box value. It should be noted that the `Date` and `Text` properties are successfully updated, however it would appear to the user as thought nothing happened.

Resolves #5708
 
## How Has This Been Tested?
Tested using the unit test viewer

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
