### PR TITLE
DatePicker: Show first selected date when DatePicker is nested 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
@@ -3,8 +3,9 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudGrid>
-    <MudItem xs="12" sm="12" md="6">
-        <MudDatePicker Style="max-width: 300px"
+    <MudItem>
+        <MudDatePicker @ref="@Picker"
+                       Style="max-width: 300px"
                        Placeholder="dd-MM-yyyy"
                        Editable="true"
                        Required="false"
@@ -14,10 +15,14 @@
                        @bind-Date="SelectedDate">
         </MudDatePicker>
     </MudItem>
+    <MudItem Class="align-self-center">
+        <MudText>@Picker?.Text</MudText>
+    </MudItem>
 </MudGrid>
 
 @code {
     public static string __description__ = "Selected date should show in input on first selection";
 
     public DateTime? SelectedDate { get; set; }
+    public MudDatePicker Picker { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WrappedDatePickerTest.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="6">
+        <MudDatePicker Style="max-width: 300px"
+                       Placeholder="dd-MM-yyyy"
+                       Editable="true"
+                       Required="false"
+                       Mask="@(new DateMask("dd-MM-yyyy"))"
+                       DateFormat="dd-MM-yyyy"
+                       Variant="Variant.Outlined"
+                       @bind-Date="SelectedDate">
+        </MudDatePicker>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public static string __description__ = "Selected date should show in input on first selection";
+
+    public DateTime? SelectedDate { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1,12 +1,6 @@
 ﻿#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
@@ -15,6 +9,11 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
 using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
@@ -1258,6 +1257,21 @@ namespace MudBlazor.UnitTests.Components
 
             picker.Date.Should().NotBeNull();
             picker.Date!.Value.Kind.Should().Be(oldDate.Kind);
+        }
+
+        [Test]
+        public void Display_SelectedDate_WhenWrapped()
+        {
+            var comp = Context.RenderComponent<WrappedDatePickerTest>();
+
+            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            comp.Find(".mud-input-adornment button").Click();
+            comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
+
+            comp.FindAll("button.mud-picker-calendar-day")
+                .Where(x => x.TrimmedText().Equals("15")).First().Click();
+
+            ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be(comp.Instance.Picker.Text);
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -37,7 +37,7 @@ namespace MudBlazor
             {
                 date = DateTime.SpecifyKind(date.Value, _value.Value.Kind);
             }
- 
+
             var now = DateTime.UtcNow;
             
             /* See #7866 for more details
@@ -50,7 +50,7 @@ namespace MudBlazor
             }
 
             _lastSetTime = now;
-            
+
             // When the _value is null and an invalid date is entered into the UI, the data value passed to this method
             // will be null. We need to check if the text has been set my the user and if so handle tha validation
             // without this the UI doesn't display a validation error correctly
@@ -107,8 +107,8 @@ namespace MudBlazor
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
-                await Task.Run(() => Submit());
-
+                await Task.Run(() => InvokeAsync(Submit));
+                
                 if (PickerVariant != PickerVariant.Static)
                 {
                     await Task.Delay(ClosingDelay);

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -107,7 +107,7 @@ namespace MudBlazor
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
-                Submit();
+                await Task.Run(() => Submit());
 
                 if (PickerVariant != PickerVariant.Static)
                 {


### PR DESCRIPTION
## Description
When the `DatePicker` is wrapped/nested in another component (example `MudForm` or `MudGrid`), the first selected date does not update the input box value. 
It should be noted that the `Date` and `Text` properties are successfully updated, however it would appear to the user as thought nothing happened since `<input>` isn't set.

Resolves #5708
 
## How Has This Been Tested?
Tested using the unit test viewer

Before 
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/59e2f465-2336-443f-b57a-a924c6c5b9b0)

After 
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/f40949d8-b1f6-4889-bd33-91fb4fb797aa)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
