### PR TITLE
Snackbar: Only allow action invoke once, Add button classes, Add ForceClose

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -31,8 +31,8 @@ namespace MudBlazor.UnitTests.Components
         public void SnackbarTearDown()
         {
             // Force close all snackbars directly from their class.
-            // We used to simulate the close button but this is quicker.
-            // We keep checking instead of using a cached list because new ones can be spawned from the close event.
+            // We used to simulate clicking the close button but this is quicker because it skips transitions.
+            // We keep checking instead of using a cached list because new snackbars could be spawned from the close event.
             while (_service.ShownSnackbars.Any())
             {
                 _service.ShownSnackbars.First().ForceClose();
@@ -639,24 +639,28 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
+            // Click as many times as possible during the hide transition.
             while (true)
             {
                 var clicked = false;
 
+                // Click the action button if one was found.
                 await _provider.InvokeAsync(() =>
                 {
                     if (_provider.FindAll(".mud-snackbar-action-button").Count == 1)
                     {
                         _provider.Find(".mud-snackbar-action-button").Click();
-                        clickAttempts++;
                         clicked = true;
                     }
                 });
 
-                if (!clicked)
+                if (clicked)
+                    clickAttempts++;
+                else
                     break;
             }
 
+            // Only one click should have been successful and multiple clicks should have been attempted.
             successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);
         }
 
@@ -681,24 +685,28 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
+            // Click as many times as possible during the hide transition.
             while (true)
             {
                 var clicked = false;
 
+                // Click the snackbar if one was found.
                 await _provider.InvokeAsync(() =>
                 {
                     if (_provider.FindAll(".mud-snackbar").Count == 1)
                     {
                         _provider.Find(".mud-snackbar").Click();
-                        clickAttempts++;
                         clicked = true;
                     }
                 });
 
-                if (!clicked)
+                if (clicked)
+                    clickAttempts++;
+                else
                     break;
             }
 
+            // Only one click should have been successful and multiple clicks should have been attempted.
             successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -681,10 +681,22 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
-            while (_provider.FindAll(".mud-snackbar").Count > 0)
+            while (true)
             {
-                _provider.Find(".mud-snackbar").Click();
-                clickAttempts++;
+                var clicked = false;
+
+                await _provider.InvokeAsync(() =>
+                {
+                    if (_provider.FindAll(".mud-snackbar").Count == 1)
+                    {
+                        _provider.Find(".mud-snackbar").Click();
+                        clickAttempts++;
+                        clicked = true;
+                    }
+                });
+
+                if (!clicked)
+                    break;
             }
 
             successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -29,12 +29,12 @@
 
             @if (ShowActionButton)
             {
-                <MudButton Variant="@ActionVariant" Color="@ActionColor" OnClick="ActionClicked" DisableElevation>@Action</MudButton>
+                <MudButton Class="mud-snackbar-action-button" Variant="@ActionVariant" Color="@ActionColor" OnClick="ActionClicked" DisableElevation>@Action</MudButton>
             }
 
             @if (ShowCloseIcon)
             {
-                <MudIconButton Icon="@CloseIcon" Size="Size.Small" Class="ms-2" OnClick="CloseIconClicked" />
+                <MudIconButton Class="mud-snackbar-close-button ms-2" Icon="@CloseIcon" Size="Size.Small" OnClick="CloseIconClicked" />
             }
         </div>
     }

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -50,6 +50,14 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Forcibly close the snackbar without performing any animations.
+        /// </summary>
+        public void ForceClose()
+        {
+            TransitionTo(SnackbarState.Hiding, false, false);
+        }
+
+        /// <summary>
         /// Transitions the snackbar to the specified state.
         /// </summary>
         /// <param name="state">The state to transition to</param>

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -32,6 +32,9 @@ namespace MudBlazor
 
         internal void Clicked(bool fromCloseIcon)
         {
+            if (State.UserHasInteracted)
+                return; // You should only be able to interact with the snackbar once.
+
             if (!fromCloseIcon)
             {
                 // Do not start the hiding transition if no click action


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

- Limits the number of actions that can be performed to **one** so you can't keep triggering a snackbar that's fading away by checking `State.UserHasInteracted`.
- Adds distinct classes to the action and close buttons along with updating tests to take advantage of that.
- Adds `Snackbar.ForceClose` for instantly closing a snackbar in code without any animation and uses it in `SnackbarTearDown` for efficiency.
- Small refactors on tests from other PR.

Resolves #8349

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
