### PR TITLE
Input: Make AutoGrow responsive to parameters & Fix empty line after scrollbar is hidden

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -8,7 +8,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudInput<T> : MudBaseInput<T>
+    public partial class MudInput<T> : MudBaseInput<T>, IAsyncDisposable
     {
         protected string Classname =>
            new CssBuilder(
@@ -179,10 +179,16 @@ namespace MudBlazor
         }
 
         private string _internalText;
+        private bool _shouldInitAutoGrow;
 
         public override async Task SetParametersAsync(ParameterView parameters)
         {
+            var oldLines = Lines;
+            var oldMaxLines = MaxLines;
+            var oldAutoGrow = AutoGrow;
+
             await base.SetParametersAsync(parameters);
+
             //if (!_isFocused || _forceTextUpdate)
             //    _internalText = Text;
             if (RuntimeLocation.IsServerSide && TextUpdateSuppression)
@@ -197,6 +203,27 @@ namespace MudBlazor
                 // in WASM (or in BSS with TextUpdateSuppression==false) we always update
                 _internalText = Text;
             }
+
+            // AutoGrow:
+            if (!oldAutoGrow && AutoGrow)
+            {
+                // Enable it.
+                _shouldInitAutoGrow = true;
+            }
+            else if (oldAutoGrow && !AutoGrow)
+            {
+                // Disable it.
+                _shouldInitAutoGrow = false;
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.destroy", ElementReference);
+            }
+            else if (!_shouldInitAutoGrow && (oldLines != Lines || oldMaxLines != MaxLines))
+            {
+                if (AutoGrow && !_shouldInitAutoGrow)
+                {
+                    // Update it (if it was already enabled).
+                    await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.updateParams", ElementReference, MaxLines);
+                }
+            }
         }
 
         [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
@@ -205,15 +232,19 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (AutoGrow && firstRender)
+            if (AutoGrow)
             {
-                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.initAutoGrow", ElementReference, MaxLines);
-                _oldText = _internalText;
-            }
-            else if(AutoGrow && _oldText != _internalText)
-            {
-                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.adjustHeight", ElementReference);
-                _oldText = _internalText;
+                if (firstRender || _shouldInitAutoGrow)
+                {
+                    _shouldInitAutoGrow = false;
+                    await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.initAutoGrow", ElementReference, MaxLines);
+                    _oldText = _internalText;
+                }
+                else if (_oldText != _internalText)
+                {
+                    await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.adjustHeight", ElementReference);
+                    _oldText = _internalText;
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -235,6 +266,14 @@ namespace MudBlazor
         {
             return GetInputType() is InputType.Color or InputType.Date or InputType.DateTimeLocal or InputType.Month
                 or InputType.Time or InputType.Week;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (AutoGrow)
+            {
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.destroy", ElementReference);
+            }
         }
     }
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -216,7 +216,7 @@ namespace MudBlazor
                 _shouldInitAutoGrow = false;
                 await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputAutoGrow.destroy", ElementReference);
             }
-            else if (!_shouldInitAutoGrow && (oldLines != Lines || oldMaxLines != MaxLines))
+            else if (oldLines != Lines || oldMaxLines != MaxLines)
             {
                 if (AutoGrow && !_shouldInitAutoGrow)
                 {

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -5,7 +5,6 @@ window.mudInputAutoGrow = {
     initAutoGrow: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);
         const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
-        const initialOverflowY = elem.style.overflowY;
         const initialHeight = elem.style.height;
 
         let maxHeight = 0;
@@ -21,7 +20,7 @@ window.mudInputAutoGrow = {
         }
 
         // Capture min and max height in closure to trigger height adjustment on element in the input.
-        elem.adjustAutoGrowHeight = function () {
+        elem.adjustAutoGrowHeight = function (setAlign = null) {
             // Save scroll positions https://github.com/MudBlazor/MudBlazor/issues/8152.
             const scrollTops = [];
             let curElem = elem;
@@ -31,6 +30,8 @@ window.mudInputAutoGrow = {
                 }
                 curElem = curElem.parentNode;
             }
+
+            let initialOverflowY = compStyle.overflowY;
 
             elem.style.height = 0;
 
@@ -48,18 +49,33 @@ window.mudInputAutoGrow = {
 
             elem.style.height = newHeight + "px";
 
+            if (setAlign !== null) {
+                elem.style.textAlign = setAlign;
+            }
+
             // Restore scroll positions.
             scrollTops.forEach(([node, scrollTop]) => {
                 node.style.scrollBehavior = 'auto';
                 node.scrollTop = scrollTop;
                 node.style.scrollBehavior = null;
             });
+
+            // Force another adjustment after the scrollbar is hidden to avoid an extra empty line https://github.com/MudBlazor/MudBlazor/pull/8385.
+            if (initialOverflowY !== compStyle.overflowY && setAlign !== null) {
+                let align = compStyle.textAlign;
+
+                if (compStyle.overflowY === 'hidden') {
+                    elem.style.textAlign = textAlign === 'start' ? 'end' : 'start';
+                }
+
+                elem.adjustAutoGrowHeight(align);
+            }
         }
 
         // Terminate the ability to auto-grow and restore the input element back to its original state.
         elem.restoreToInitialState = function () {
             elem.removeEventListener('input', elem.adjustAutoGrowHeight);
-            elem.style.overflowY = initialOverflowY;
+            elem.style.overflowY = null;
             elem.style.height = initialHeight;
         }
 

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -19,7 +19,7 @@ window.mudInputAutoGrow = {
         }
 
         // Capture min and max height in closure to trigger height adjustment on element in the input.
-        elem.adjustAutoGrowHeight = function (resetAlign = false) {
+        elem.adjustAutoGrowHeight = function (didReflow = false) {
             // Save scroll positions https://github.com/MudBlazor/MudBlazor/issues/8152.
             const scrollTops = [];
             let curElem = elem;
@@ -32,7 +32,7 @@ window.mudInputAutoGrow = {
 
             elem.style.height = 0;
 
-            if (resetAlign) {
+            if (didReflow) {
                 elem.style.textAlign = null;
             }
 
@@ -58,8 +58,8 @@ window.mudInputAutoGrow = {
                 node.style.scrollBehavior = null;
             });
 
-            // Force another adjustment after the scrollbar is hidden to avoid an extra empty line https://github.com/MudBlazor/MudBlazor/pull/8385.
-            if (!resetAlign && initialOverflowY !== elem.style.overflowY && elem.style.overflowY === 'hidden') {
+            // Force another adjustment after the scrollbar is hidden to avoid an empty line https://github.com/MudBlazor/MudBlazor/pull/8385.
+            if (!didReflow && initialOverflowY !== elem.style.overflowY && elem.style.overflowY === 'hidden') {
                 elem.style.textAlign = 'end'; // Change to something other than the default.
                 elem.adjustAutoGrowHeight(true);
             }

--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -1,21 +1,26 @@
 ﻿// Copyright (c) MudBlazor 2023
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 window.mudInputAutoGrow = {
     initAutoGrow: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);
         const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
-
-        let minHeight = lineHeight * elem.rows;
+        const initialOverflowY = elem.style.overflowY;
+        const initialHeight = elem.style.height;
 
         let maxHeight = 0;
-        if (maxLines > 0) {
-            // Cap the height to the number of lines specified in MudTextField.
-            maxHeight = lineHeight * maxLines;
+
+        // Update parameters that effect the functionality and visuals of the auto-growing input.
+        elem.updateParameters = function (newMaxLines) {
+            if (newMaxLines > 0) {
+                // Cap the height to the number of lines specified in the input.
+                maxHeight = lineHeight * newMaxLines;
+            } else {
+                maxHeight = 0;
+            }
         }
 
-        // Capture min and max height in closure to trigger height adjustment on element in MudTextField.
+        // Capture min and max height in closure to trigger height adjustment on element in the input.
         elem.adjustAutoGrowHeight = function () {
             // Save scroll positions https://github.com/MudBlazor/MudBlazor/issues/8152.
             const scrollTops = [];
@@ -29,6 +34,7 @@ window.mudInputAutoGrow = {
 
             elem.style.height = 0;
 
+            let minHeight = lineHeight * elem.rows;
             let newHeight = Math.max(minHeight, elem.scrollHeight);
             if (maxHeight > 0 && newHeight > maxHeight) {
                 // Content height exceeds the max height so we'll see a scrollbar.
@@ -50,22 +56,40 @@ window.mudInputAutoGrow = {
             });
         }
 
+        // Terminate the ability to auto-grow and restore the input element back to its original state.
+        elem.restoreToInitialState = function () {
+            elem.removeEventListener('input', elem.adjustAutoGrowHeight);
+            elem.style.overflowY = initialOverflowY;
+            elem.style.height = initialHeight;
+        }
+
         // Adjust height when input happens.
-        elem.addEventListener('input', () => {
-            elem.adjustAutoGrowHeight();
-        });
+        elem.addEventListener('input', elem.adjustAutoGrowHeight);
 
         // Adjust height when the window resizes.
-        window.addEventListener('resize', () => {
-            elem.adjustAutoGrowHeight();
-        });
+        window.addEventListener('resize', elem.adjustAutoGrowHeight);
 
-        // Initial height adjustment.
+        // Initial parameters and height adjustment.
+        elem.updateParameters(maxLines);
         elem.adjustAutoGrowHeight();
     },
     adjustHeight: (elem) => {
         if (typeof elem.adjustAutoGrowHeight === 'function') {
             elem.adjustAutoGrowHeight();
+        }
+    },
+    updateParams: (elem, maxLines) => {
+        if (typeof elem.updateParameters === 'function') {
+            elem.updateParameters(maxLines);
+        }
+        if (typeof elem.adjustAutoGrowHeight === 'function') {
+            elem.adjustAutoGrowHeight();
+        }
+    },
+    destroy: (elem) => {
+        window.removeEventListener('resize', elem.adjustAutoGrowHeight);
+        if (typeof elem.restoreToInitialState === 'function') {
+            elem.restoreToInitialState();
         }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Input is now responsive to:
- AutoGrow
- Lines
- MaxLines

In respect to auto-growing.

You can turn AutoGrow off and on or change the MaxLines etc.
The events subscribed by AutoGrow will be unsubscribed on dispose or when AutoGrow is disabled.

In addition, an empty line that would appear when the scrollbar is hidden has been taken care of by forcing a reflow.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->


In this video you can see how responsive it is now and how the event listeners are properly removed.

https://github.com/MudBlazor/MudBlazor/assets/7112040/3c0bfd35-5267-4831-836f-2c3af543df18

This was not possible and now is:

https://github.com/MudBlazor/MudBlazor/assets/7112040/b0b8097f-41d5-432a-90c5-e6dcfc822501


Then we have the empty line issue:

https://github.com/MudBlazor/MudBlazor/assets/7112040/2068b552-b7b8-4db7-96d4-b0f1c3bbea3f


https://github.com/MudBlazor/MudBlazor/assets/7112040/ceea6a2e-46bf-43fe-905f-eb1bb12200d5


Which now looks like


https://github.com/MudBlazor/MudBlazor/assets/7112040/aeacb6f9-f8bf-4e9d-8f6c-fee9f36f47d8

We could go even further and test if the scrollbar can be removed so it reflows one line earlier (7 instead of 8 in the last video) but I'll save that for another time.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
