### PR TITLE
ParameterState: Add ParameterChangedEventArgs to get previous and current value

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ public bool Expanded
 
 Note how the setter is invoking async functions which can not be awaited, because property setters can only have synchronous code. As a result, the async 
 functions are invoked and their return value `Task` is discarded. This not only creates hard to test multi-threaded behavior, it also prevents the user of this 
-component from being able to catch any errors in the asnc functions. Any exceptions that happen in these asynchronous functions may or may not bubble up
+component from being able to catch any errors in the async functions. Any exceptions that happen in these asynchronous functions may or may not bubble up
 to the user. In some cases Blazor just catches them and they are silently ignored, in other cases they may cause application crashes that can't be prevented with `try catch`. 
 
 The alternative would be to move the code from the setter into `SetParametersAsync` and depending on the component you would also need code in `OnInitializedAsync`. 
@@ -160,7 +160,7 @@ Using our new `ParameterState` pattern all this is not required.
 
 ### Example of a good Parameter definition
 ```c#
-private ParameterState<bool> _expandedState;
+private IParameterState<bool> _expandedState;
 
 [Parameter]
 public bool Expanded { get; set; }
@@ -241,7 +241,7 @@ private Task ToggleAsync()
 
 ### Example of a good code
 ```c#
-private ParameterState<bool> _expandedState;
+private IParameterState<bool> _expandedState;
 
 [Parameter]
 public bool Expanded { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateEventArgsTestComp.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateEventArgsTestComp.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.UnitTests
+
+<h3>ParameterStateEventArgsTestComponent</h3>
+<MudButton Class="increment-int-param" OnClick="@(() => _i++)">Increment IntParam</MudButton>
+<br/>
+<ParameterStateTestComp IntParam="@_i"/>
+
+@code
+{
+    public static string __description__ = "Tests the ParameterState framework's parameter change notification event args";
+
+    private int _i;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor
@@ -1,0 +1,18 @@
+﻿@inherits MudComponentBase
+@namespace MudBlazor.UnitTests
+
+<h3>ParameterStateTestComp</h3>
+
+<p>Parameter changes:</p>
+<div class="parameter-changes">
+    @foreach (var parameterChange in _parameterChanges)
+    {
+        <p>@parameterChange</p>
+    }
+</div>
+
+@code
+{
+    public static string __description__ = "A generic test component for the ParameterState Framework";
+}
+

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+
+namespace MudBlazor.UnitTests;
+
+#nullable enable
+public partial class ParameterStateTestComp : MudComponentBase
+{
+    private List<string> _parameterChanges = new();
+
+    public ParameterStateTestComp()
+    {
+        _intParam = RegisterParameter(nameof(IntParam), () => IntParam, OnIntParamChanged);
+    }
+
+    private IParameterState<int> _intParam;
+
+    private void OnIntParamChanged(ParameterChangedEventArgs<int> args)
+    {
+        _parameterChanges.Add($"IntParam: {args.LastValue}=>{args.Value}");
+    }
+
+    [Parameter]
+    public int IntParam { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateHandlerTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateHandlerTestComp.razor.cs
@@ -21,14 +21,14 @@ public partial class SharedStateHandlerTestComp : MudComponentBase
         _z = RegisterParameter(nameof(Z), () => Z, OnXyzChanged);
     }
 
-    private ParameterState<int> _a;
-    private ParameterState<int> _b;
-    private ParameterState<int> _c;
-    private ParameterState<int> _o;
-    private ParameterState<int> _p;
-    private ParameterState<int> _x;
-    private ParameterState<int> _y;
-    private ParameterState<int> _z;
+    private IParameterState<int> _a;
+    private IParameterState<int> _b;
+    private IParameterState<int> _c;
+    private IParameterState<int> _o;
+    private IParameterState<int> _p;
+    private IParameterState<int> _x;
+    private IParameterState<int> _y;
+    private IParameterState<int> _z;
 
     private void OnAbcChanged()
     {

--- a/src/MudBlazor.UnitTests/State/Mocks/ParameterChangedHandlerMock.cs
+++ b/src/MudBlazor.UnitTests/State/Mocks/ParameterChangedHandlerMock.cs
@@ -2,19 +2,23 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MudBlazor.State;
+
 
 namespace MudBlazor.UnitTests.State.Mocks;
 
 #nullable enable
-public class ParameterChangedHandlerMock : IParameterChangedHandler
+internal class ParameterChangedHandlerMock<TArgs> : IParameterChangedHandler<TArgs>
 {
-    public int FireCount { get; private set; }
+    private readonly List<ParameterChangedEventArgs<TArgs>> _changes = new();
 
-    public Task HandleAsync()
+    public IReadOnlyList<ParameterChangedEventArgs<TArgs>> Changes => _changes;
+
+    public Task HandleAsync(ParameterChangedEventArgs<TArgs> parameterChangedEventArgs)
     {
-        FireCount++;
+        _changes.Add(parameterChangedEventArgs);
 
         return Task.CompletedTask;
     }

--- a/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
@@ -37,7 +37,7 @@ public class ParameterHandlerUniquenessComparerTests
         // Arrange
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var parameterMetadata = new ParameterMetadata("Parameter1", "Handler1");
-        IParameterComponentLifeCycle parameterState = ParameterState.Attach(parameterMetadata, () => 0, () => {});
+        IParameterComponentLifeCycle parameterState = ParameterState.Attach(parameterMetadata, () => 0, () => { });
 
         // Act
         var result1 = comparer.Equals(parameterMetadata, null);

--- a/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
@@ -49,8 +49,183 @@ public class ParameterSetTests
     }
 
     [Test]
+    public async Task SetParametersAsync_ActionHandlerShouldFire()
+    {
+        // Arrange
+        ParameterChangedEventArgs<int>? parameter2ChangedEventArgs = null;
+        var handler1FireCount = 0;
+        var handler2FireCount = 0;
+        const int Parameter1 = 1;
+        const int Parameter2 = 2;
+        const int Parameter1NewValue = 2;
+        const int Parameter2NewValue = 3;
+        const string Parameter1Name = nameof(Parameter1);
+        const string Parameter2Name = nameof(Parameter2);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { Parameter1Name, Parameter1NewValue },
+            { Parameter2Name, Parameter2NewValue }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        var parameter1State = ParameterState.Attach(Parameter1Name, () => Parameter1, OnParameter1Change);
+        var parameter2State = ParameterState.Attach(Parameter2Name, () => Parameter2, OnParameter2Change);
+        var parameterSet = new ParameterSet { parameter1State, parameter2State };
+        void OnParameter1Change()
+        {
+            handler1FireCount++;
+        }
+        void OnParameter2Change(ParameterChangedEventArgs<int> parameterChangedEventArgs)
+        {
+            parameter2ChangedEventArgs = parameterChangedEventArgs;
+            handler2FireCount++;
+        }
+
+        // Act
+        await parameterSet.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+
+        // Assert
+        handler1FireCount.Should().Be(1);
+        handler2FireCount.Should().Be(1);
+        parameter2ChangedEventArgs.Should().NotBeNull();
+        parameter2ChangedEventArgs!.ParameterName.Should().Be(Parameter2Name);
+        parameter2ChangedEventArgs!.LastValue.Should().Be(Parameter2);
+        parameter2ChangedEventArgs!.Value.Should().Be(Parameter2NewValue);
+    }
+
+    [Test]
+    public async Task SetParametersAsync_ActionHandlerShouldNotFire()
+    {
+        // Arrange
+        ParameterChangedEventArgs<int>? parameter2ChangedEventArgs = null;
+        var handler1FireCount = 0;
+        var handler2FireCount = 0;
+        const int Parameter1 = 1;
+        const int Parameter2 = 2;
+        const string Parameter1Name = nameof(Parameter1);
+        const string Parameter2Name = nameof(Parameter2);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { Parameter1Name, Parameter1 },
+            { Parameter2Name, Parameter2 }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        var parameter1State = ParameterState.Attach(Parameter1Name, () => Parameter1, OnParameter1Change);
+        var parameter2State = ParameterState.Attach(Parameter2Name, () => Parameter2, OnParameter2Change);
+        var parameterSet = new ParameterSet { parameter1State, parameter2State };
+        void OnParameter1Change()
+        {
+            handler1FireCount++;
+        }
+        void OnParameter2Change(ParameterChangedEventArgs<int> parameterChangedEventArgs)
+        {
+            parameter2ChangedEventArgs = parameterChangedEventArgs;
+            handler2FireCount++;
+        }
+
+        // Act
+        await parameterSet.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+
+        // Assert
+        handler1FireCount.Should().Be(0);
+        handler2FireCount.Should().Be(0);
+        parameter2ChangedEventArgs.Should().BeNull();
+    }
+
+    [Test]
+    public async Task SetParametersAsync_FuncHandlerShouldFire()
+    {
+        // Arrange
+        ParameterChangedEventArgs<int>? parameter2ChangedEventArgs = null;
+        var handler1FireCount = 0;
+        var handler2FireCount = 0;
+        const int Parameter1 = 1;
+        const int Parameter2 = 2;
+        const int Parameter1NewValue = 2;
+        const int Parameter2NewValue = 3;
+        const string Parameter1Name = nameof(Parameter1);
+        const string Parameter2Name = nameof(Parameter2);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { Parameter1Name, Parameter1NewValue },
+            { Parameter2Name, Parameter2NewValue }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        var parameter1State = ParameterState.Attach(Parameter1Name, () => Parameter1, OnParameter1ChangeAsync);
+        var parameter2State = ParameterState.Attach(Parameter2Name, () => Parameter2, OnParameter2ChangeAsync);
+        var parameterSet = new ParameterSet { parameter1State, parameter2State };
+        Task OnParameter1ChangeAsync()
+        {
+            handler1FireCount++;
+
+            return Task.CompletedTask;
+        }
+        Task OnParameter2ChangeAsync(ParameterChangedEventArgs<int> parameterChangedEventArgs)
+        {
+            parameter2ChangedEventArgs = parameterChangedEventArgs;
+            handler2FireCount++;
+
+            return Task.CompletedTask;
+        }
+
+        // Act
+        await parameterSet.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+
+        // Assert
+        handler1FireCount.Should().Be(1);
+        handler2FireCount.Should().Be(1);
+        parameter2ChangedEventArgs.Should().NotBeNull();
+        parameter2ChangedEventArgs!.ParameterName.Should().Be(Parameter2Name);
+        parameter2ChangedEventArgs!.LastValue.Should().Be(Parameter2);
+        parameter2ChangedEventArgs!.Value.Should().Be(Parameter2NewValue);
+    }
+
+    [Test]
+    public async Task SetParametersAsync_FuncHandlerShouldNotFire()
+    {
+        // Arrange
+        ParameterChangedEventArgs<int>? parameter2ChangedEventArgs = null;
+        var handler1FireCount = 0;
+        var handler2FireCount = 0;
+        const int Parameter1 = 1;
+        const int Parameter2 = 2;
+        const string Parameter1Name = nameof(Parameter1);
+        const string Parameter2Name = nameof(Parameter2);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { Parameter1Name, Parameter1 },
+            { Parameter2Name, Parameter2 }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        var parameter1State = ParameterState.Attach(Parameter1Name, () => Parameter1, OnParameter1ChangeAsync);
+        var parameter2State = ParameterState.Attach(Parameter2Name, () => Parameter2, OnParameter2ChangeAsync);
+        var parameterSet = new ParameterSet { parameter1State, parameter2State };
+        Task OnParameter1ChangeAsync()
+        {
+            handler1FireCount++;
+
+            return Task.CompletedTask;
+        }
+        Task OnParameter2ChangeAsync(ParameterChangedEventArgs<int> parameterChangedEventArgs)
+        {
+            parameter2ChangedEventArgs = parameterChangedEventArgs;
+            handler2FireCount++;
+
+            return Task.CompletedTask;
+        }
+
+        // Act
+        await parameterSet.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+
+        // Assert
+        handler1FireCount.Should().Be(0);
+        handler2FireCount.Should().Be(0);
+        parameter2ChangedEventArgs.Should().BeNull();
+    }
+
+    [Test]
     public async Task SetParametersAsync_SameHandlerNamesShouldFireOnce()
     {
+        // Arrange
         var handlerFireCount = 0;
         const int Parameter1 = 1;
         const int Parameter2 = 2;
@@ -84,6 +259,7 @@ public class ParameterSetTests
     [Test]
     public async Task SetParametersAsync_LambdaHandlerNamesShouldFileAll()
     {
+        // Arrange
         var handlerFireCount = 0;
         const int Parameter1 = 1;
         const int Parameter2 = 2;
@@ -114,6 +290,7 @@ public class ParameterSetTests
     [Test]
     public async Task SetParametersAsync_NullHandlerNamesShouldFireAll()
     {
+        // Arrange
         var handlerFireCount = 0;
         const int Parameter1 = 1;
         const int Parameter2 = 2;
@@ -147,6 +324,7 @@ public class ParameterSetTests
     [Test]
     public async Task SetParametersAsync_DifferentHandlerNamesShouldFireAll()
     {
+        // Arrange
         var handlerFireCount = 0;
         const int Parameter1 = 1;
         const int Parameter2 = 2;

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -90,19 +90,72 @@ public class ParameterStateTests
     }
 
     [Test]
-    public async Task ParameterChangeHandleAsync_HandlesParameterChangeIfHandlerExists()
+    public async Task ParameterChangeHandleAsync_ShouldFire_WhenParameterChanged()
     {
         // Arrange
         const int InitialValue = 5;
-        var parameterChangedHandlerMock = new ParameterChangedHandlerMock();
-        var parameterState = ParameterState<int>.Attach(nameof(InitialValue), () => InitialValue, () => default, parameterChangedHandlerMock);
+        const int NewValue = 10;
+        const string ParameterName = nameof(InitialValue);
+        var parameterChangedHandlerMock = new ParameterChangedHandlerMock<int>();
+        var parameterState = ParameterState<int>.Attach(ParameterName, () => InitialValue, () => default, parameterChangedHandlerMock);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { ParameterName, NewValue }
+        };
+        var parameters = ParameterView.FromDictionary(parametersDictionary);
+
+        // Act
+        var changed = parameterState.HasParameterChanged(parameters);
+        await parameterState.ParameterChangeHandleAsync();
+
+        // Assert
+        changed.Should().BeTrue();
+        parameterState.HasHandler.Should().BeTrue();
+        parameterChangedHandlerMock.Changes.Should().BeEquivalentTo(new[]
+        {
+            new ParameterChangedEventArgs<int>(ParameterName, InitialValue, NewValue)
+        });
+    }
+
+    [Test]
+    public async Task ParameterChangeHandleAsync_ShouldNotFire_WhenParameterNotChanged()
+    {
+        // Arrange
+        const int InitialValue = 5;
+        const string ParameterName = nameof(InitialValue);
+        var parameterChangedHandlerMock = new ParameterChangedHandlerMock<int>();
+        var parameterState = ParameterState<int>.Attach(ParameterName, () => InitialValue, () => default, parameterChangedHandlerMock);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { ParameterName, InitialValue }
+        };
+        var parameters = ParameterView.FromDictionary(parametersDictionary);
+
+        // Act
+        var changed = parameterState.HasParameterChanged(parameters);
+        await parameterState.ParameterChangeHandleAsync();
+
+        // Assert
+        changed.Should().BeFalse();
+        parameterState.HasHandler.Should().BeTrue();
+        parameterChangedHandlerMock.Changes.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ParameterChangeHandleAsync_ShouldNotFire_WhenHasParameterChangedNotCalled()
+    {
+        // Arrange
+        const int InitialValue = 5;
+        const string ParameterName = nameof(InitialValue);
+        var parameterChangedHandlerMock = new ParameterChangedHandlerMock<int>();
+        var parameterState = ParameterState<int>.Attach(ParameterName, () => InitialValue, () => default, parameterChangedHandlerMock);
 
         // Act
         await parameterState.ParameterChangeHandleAsync();
 
         // Assert
         parameterState.HasHandler.Should().BeTrue();
-        parameterChangedHandlerMock.FireCount.Should().Be(1);
+        parameterChangedHandlerMock.Changes.Should().BeEmpty("HasParameterChanged wasn't called.");
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.State;
 
+#nullable enable
 [TestFixture]
 public class ParameterStateUsageTests : BunitTest
 {
@@ -31,5 +32,18 @@ public class ParameterStateUsageTests : BunitTest
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("4");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("2");
+    }
+
+    [Test]
+    public void EventArgsIntegrationTest()
+    {
+        var comp = Context.RenderComponent<ParameterStateEventArgsTestComp>();
+        comp.Find(".parameter-changes").Children.Length.Should().Be(0);
+        comp.Find("button.increment-int-param").Click();
+        comp.Find(".parameter-changes").Children.Length.Should().Be(1);
+        comp.Find(".parameter-changes").FirstChild?.TextContent.Trimmed().Should().Be("IntParam: 0=>1");
+        comp.Find("button.increment-int-param").Click();
+        comp.Find(".parameter-changes").Children.Length.Should().Be(2);
+        comp.Find(".parameter-changes").LastChild?.TextContent.Trimmed().Should().Be("IntParam: 1=>2");
     }
 }

--- a/src/MudBlazor.UnitTests/State/Rule/ParameterMetadataRulesTests.cs
+++ b/src/MudBlazor.UnitTests/State/Rule/ParameterMetadataRulesTests.cs
@@ -10,6 +10,19 @@ namespace MudBlazor.UnitTests.State.Rule;
 [TestFixture]
 public class ParameterMetadataRulesTests
 {
+    [Test]
+    public void Morph_ThrowsException()
+    {
+        // Arrange
+        ParameterMetadata? metadata = null;
+
+        // Act 
+        var addSameParameter = () => ParameterMetadataRules.Morph(metadata!);
+
+        // Assert
+        addSameParameter.Should().Throw<ArgumentNullException>();
+    }
+
     [TestCase(null, false)]
     [TestCase("", false)]
     [TestCase("OnParameterChanged", false)]

--- a/src/MudBlazor/Base/MudComponentBase.RegisterParameter.cs
+++ b/src/MudBlazor/Base/MudComponentBase.RegisterParameter.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+
+namespace MudBlazor;
+
+#nullable enable
+public abstract partial class MudComponentBase
+{
+    #region (ParameterName, ParameterValue, EventCallback, Action)
+
+    /// <summary>
+    /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+    /// <summary>
+    /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, EventCallbck, Func)
+
+    /// <summary>
+    /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    /// <summary>
+    /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, EventCallback)
+
+    /// <summary>
+    /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc)
+    {
+        var attach = ParameterState.Attach(parameterName, getParameterValueFunc, eventCallbackFunc);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, Action)
+
+    /// <summary>
+    /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Action parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    /// <summary>
+    /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, Func)
+
+    /// <summary>
+    /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    /// <summary>
+    /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
+    /// It is the new rule in MudBlazor, that parameters must be auto properties.
+    /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
+    /// This class is part of MudBlazor's ParameterState framework.
+    /// <para />
+    /// <b>NB!</b> This method must be called in the constructor!
+    /// </summary>
+    /// <remarks>
+    /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
+    /// </remarks>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    internal IParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
+    {
+        var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
+        _parameters.Add(attach);
+
+        return attach;
+    }
+
+    #endregion
+}

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
@@ -11,7 +10,7 @@ using MudBlazor.State;
 namespace MudBlazor
 {
 #nullable enable
-    public abstract class MudComponentBase : ComponentBase, IMudStateHasChanged
+    public abstract partial class MudComponentBase : ComponentBase, IMudStateHasChanged
     {
         private readonly ParameterSet _parameters = new();
 
@@ -84,132 +83,6 @@ namespace MudBlazor
         {
             base.OnParametersSet();
             _parameters.OnParametersSet();
-        }
-
-        /// <summary>
-        /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
-        /// It is the new rule in MudBlazor, that parameters must be auto properties.
-        /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
-        /// This class is part of MudBlazor's ParameterState framework.
-        /// <para />
-        /// <b>NB!</b> This method must be called in the constructor!
-        /// </summary>
-        /// <remarks>
-        /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
-        /// </remarks>
-        /// <typeparam name="T">The type of the component's property value.</typeparam>
-        /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
-        /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
-        /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
-        /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
-        /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
-        /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-        internal ParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
-        {
-            var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
-            _parameters.Add(attach);
-
-            return attach;
-        }
-
-        /// <summary>
-        /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
-        /// It is the new rule in MudBlazor, that parameters must be auto properties.
-        /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
-        /// This class is part of MudBlazor's ParameterState framework.
-        /// <para />
-        /// <b>NB!</b> This method must be called in the constructor!
-        /// </summary>
-        /// <remarks>
-        /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
-        /// </remarks>
-        /// <typeparam name="T">The type of the component's property value.</typeparam>
-        /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
-        /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
-        /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
-        /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
-        /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
-        /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-        internal ParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
-        {
-            var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
-            _parameters.Add(attach);
-
-            return attach;
-        }
-
-        /// <summary>
-        /// Register a component Parameter, its EventCallback and a change handler so that the base can manage it as a ParameterState object.
-        /// It is the new rule in MudBlazor, that parameters must be auto properties.
-        /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
-        /// This class is part of MudBlazor's ParameterState framework.
-        /// <para />
-        /// <b>NB!</b> This method must be called in the constructor!
-        /// </summary>
-        /// <remarks>
-        /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
-        /// </remarks>
-        /// <typeparam name="T">The type of the component's property value.</typeparam>
-        /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
-        /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
-        /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
-        /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-        internal ParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc)
-        {
-            var attach = ParameterState.Attach(parameterName, getParameterValueFunc, eventCallbackFunc);
-            _parameters.Add(attach);
-
-            return attach;
-        }
-
-        /// <summary>
-        /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
-        /// It is the new rule in MudBlazor, that parameters must be auto properties.
-        /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
-        /// This class is part of MudBlazor's ParameterState framework.
-        /// <para />
-        /// <b>NB!</b> This method must be called in the constructor!
-        /// </summary>
-        /// <remarks>
-        /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
-        /// </remarks>
-        /// <typeparam name="T">The type of the component's property value.</typeparam>
-        /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
-        /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
-        /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
-        /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
-        /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-        internal ParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Action parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
-        {
-            var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
-            _parameters.Add(attach);
-
-            return attach;
-        }
-
-        /// <summary>
-        /// Register a component Parameter and a change handler so that the base can manage it as a ParameterState object.
-        /// It is the new rule in MudBlazor, that parameters must be auto properties.
-        /// By registering the parameter with a change handler you can still execute code when the parameter value changes.
-        /// This class is part of MudBlazor's ParameterState framework.
-        /// <para />
-        /// <b>NB!</b> This method must be called in the constructor!
-        /// </summary>
-        /// <remarks>
-        /// See CONTRIBUTING.md for a more detailed explanation on why MudBlazor parameters have to registered. 
-        /// </remarks>
-        /// <typeparam name="T">The type of the component's property value.</typeparam>
-        /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
-        /// <param name="getParameterValueFunc">>A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
-        /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
-        /// <param name="handlerName">The handler's name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
-        /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-        internal ParameterState<T> RegisterParameter<T>(string parameterName, Func<T> getParameterValueFunc, Func<Task> parameterChangedHandler, [CallerArgumentExpression(nameof(parameterChangedHandler))] string? handlerName = null)
-        {
-            var attach = ParameterState.Attach(new ParameterMetadata(parameterName, handlerName), getParameterValueFunc, parameterChangedHandler);
-            _parameters.Add(attach);
-
-            return attach;
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
         }
 
         internal double _height;
-        private ParameterState<bool> _expandedState;
+        private IParameterState<bool> _expandedState;
         private bool _isRendered;
         private bool _updateHeight;
         private ElementReference _wrapper;

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
     public abstract partial class Column<T> : MudComponentBase
     {
         private static readonly RenderFragment<CellContext<T>> EmptyChildContent = _ => builder => { };
-        internal ParameterState<bool> HiddenState { get; }
+        internal IParameterState<bool> HiddenState { get; }
 
         internal readonly Guid uid = Guid.NewGuid();
 

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
 #nullable enable
     public partial class MudOverlay : MudComponentBase, IAsyncDisposable
     {
-        private ParameterState<bool> _visibleState;
+        private IParameterState<bool> _visibleState;
 
         protected string Classname =>
             new CssBuilder("mud-overlay")

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -32,17 +32,17 @@ namespace MudBlazor
             _fixedContent = RegisterParameter(nameof(FixedContent), () => FixedContent, OnParameterChanged);
         }
 
-        private ParameterState<T?> _value;
-        private ParameterState<IEnumerable<T?>?> _values;
-        private ParameterState<Color> _color;
-        private ParameterState<string?> _selectedClass;
-        private ParameterState<bool> _outline;
-        private ParameterState<bool> _delimiters;
-        private ParameterState<bool> _rtl;
-        private ParameterState<bool> _dense;
-        private ParameterState<bool> _rounded;
-        private ParameterState<bool> _checkMark;
-        private ParameterState<bool> _fixedContent;
+        private IParameterState<T?> _value;
+        private IParameterState<IEnumerable<T?>?> _values;
+        private IParameterState<Color> _color;
+        private IParameterState<string?> _selectedClass;
+        private IParameterState<bool> _outline;
+        private IParameterState<bool> _delimiters;
+        private IParameterState<bool> _rtl;
+        private IParameterState<bool> _dense;
+        private IParameterState<bool> _rounded;
+        private IParameterState<bool> _checkMark;
+        private IParameterState<bool> _fixedContent;
         private List<MudToggleItem<T>> _items = new();
 
         protected string Classes => new CssBuilder("mud-toggle-group")

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -31,11 +31,11 @@ namespace MudBlazor
             .AddClass("mud-toggle-item-delimiter", Parent?.Delimiters == true)
             .AddClass(Class)
             .Build();
-        
+
         protected string TextClassName => new CssBuilder()
             .AddClass(Parent?.TextClass)
             .Build();
-        
+
         protected string CheckMarkClasses => new CssBuilder()
             .AddClass(Parent?.CheckMarkClass)
             .AddClass("me-2")
@@ -96,7 +96,7 @@ namespace MudBlazor
         public string? SelectedIcon { get; set; } = Icons.Material.Filled.Check;
 
         private string? CurrentIcon => IsSelected ? SelectedIcon ?? UnselectedIcon : UnselectedIcon;
-        
+
         /// <summary>
         /// The text to show. You need to set this only if you want a text that differs from the Value. If null,
         /// show Value?.ToString().
@@ -136,6 +136,5 @@ namespace MudBlazor
         }
 
         protected internal bool IsEmpty => string.IsNullOrEmpty(Text) && Value is null;
-        
     }
 }

--- a/src/MudBlazor/Extensions/ParameterViewExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
@@ -14,7 +15,7 @@ namespace MudBlazor
         /// <summary>
         /// Checks if a parameter changed.
         /// </summary>
-        /// <typeparam name="T">The value type</typeparam>
+        /// <typeparam name="T">The value type.</typeparam>
         /// <param name="parameters">The parameters.</param>
         /// <param name="parameterName">Name of the parameter.</param>
         /// <param name="parameterValue">The parameter value.</param>
@@ -32,13 +33,13 @@ namespace MudBlazor
         /// <summary>
         /// Checks if a parameter changed.
         /// </summary>
-        /// <typeparam name="T">The value type</typeparam>
+        /// <typeparam name="T">The value type.</typeparam>
         /// <param name="parameters">The parameters.</param>
         /// <param name="parameterName">Name of the parameter.</param>
         /// <param name="parameterValue">The parameter value.</param>
         /// <param name="value">Receives the value, if any.</param>
         /// <returns><c>true</c> if the parameter value has changed, <c>false</c> otherwise.</returns>
-        public static bool HasParameterChanged<T>(this ParameterView parameters, string parameterName, T parameterValue, out T? value)
+        public static bool HasParameterChanged<T>(this ParameterView parameters, string parameterName, T parameterValue, [MaybeNullWhen(false)] out T value)
         {
             if (parameters.TryGetValue(parameterName, out value))
             {

--- a/src/MudBlazor/State/IParameterChangedHandler.cs
+++ b/src/MudBlazor/State/IParameterChangedHandler.cs
@@ -10,11 +10,13 @@ namespace MudBlazor.State;
 /// <summary>
 /// Represents an interface for handling parameter change.
 /// </summary>
-internal interface IParameterChangedHandler
+/// <typeparam name="T">The type of the component's property value.</typeparam>
+internal interface IParameterChangedHandler<T>
 {
     /// <summary>
     /// Handles parameter changes asynchronously.
     /// </summary>
+    /// <param name="parameterChangedEventArgs">The <see cref="ParameterChangedEventArgs{T}"/> containing the information about the last and current values of a parameter.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task HandleAsync();
+    Task HandleAsync(ParameterChangedEventArgs<T> parameterChangedEventArgs);
 }

--- a/src/MudBlazor/State/IParameterComponentLifeCycle.cs
+++ b/src/MudBlazor/State/IParameterComponentLifeCycle.cs
@@ -19,7 +19,7 @@ internal interface IParameterComponentLifeCycle
     ParameterMetadata Metadata { get; }
 
     /// <summary>
-    /// Indicates whether a <see cref="IParameterChangedHandler"/> is supplied for handling parameter changes.
+    /// Indicates whether a <see cref="IParameterChangedHandler{T}"/> is supplied for handling parameter changes.
     /// </summary>
     bool HasHandler { get; }
 
@@ -31,10 +31,12 @@ internal interface IParameterComponentLifeCycle
     bool HasParameterChanged(ParameterView parameters);
 
     /// <summary>
-    /// Called by the <see cref="ParameterState"/> framework when <see cref="IParameterChangedHandler"/> is supplied.
+    /// Called by the <see cref="ParameterState"/> framework when <see cref="IParameterChangedHandler{T}"/> is supplied.
     /// </summary>
     /// <remarks>
-    /// This method shouldn't be directly called and is controlled by the <see cref="MudComponentBase"/>.
+    /// This method is intended for internal use and is controlled by the <see cref="MudComponentBase"/> and <see cref="ParameterSet"/>.
+    /// It should only be invoked after <see cref="HasParameterChanged"/> has been called.
+    /// Direct invocation of this method by external code is discouraged.
     /// </remarks>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task ParameterChangeHandleAsync();
@@ -43,7 +45,8 @@ internal interface IParameterComponentLifeCycle
     /// Invoked when <see cref="ComponentBase.OnInitialized"/> is called, used to set the initial parameter value.
     /// </summary>
     /// <remarks>
-    /// This method shouldn't be directly called and is controlled by the <see cref="MudComponentBase"/>.
+    /// This method is intended for internal use and is controlled by the <see cref="MudComponentBase"/> and <see cref="ParameterSet"/>.
+    /// Direct invocation of this method by external code is discouraged.
     /// </remarks>
     void OnInitialized();
 
@@ -51,7 +54,8 @@ internal interface IParameterComponentLifeCycle
     /// Invoked when <see cref="ComponentBase.OnParametersSet"/> is called, used to synchronize the parameter value when Blazor updates the parameters.
     /// </summary>
     /// <remarks>
-    /// This method shouldn't be directly called and is controlled by the <see cref="MudComponentBase"/>.
+    /// This method is intended for internal use and is controlled by the <see cref="MudComponentBase"/> and <see cref="ParameterSet"/>.
+    /// Direct invocation of this method by external code is discouraged.
     /// </remarks>
     void OnParametersSet();
 }

--- a/src/MudBlazor/State/IParameterState.cs
+++ b/src/MudBlazor/State/IParameterState.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.State;
+
+#nullable enable
+/// <summary>
+/// The <see cref="ParameterState{T}"/> automatically manages parameter value changes for <see cref="ParameterAttribute"/> as part of
+/// MudBlazor's ParameterState framework. For details and usage please read CONTRIBUTING.md
+/// </summary>
+/// <remarks>
+/// You don't need to create this object directly.
+/// Instead, use the "MudComponentBase.RegisterParameter" method from within the component's constructor.
+/// </remarks>
+/// <typeparam name="T">The type of the component's property value.</typeparam>
+internal interface IParameterState<T>
+{
+    /// <summary>
+    /// Gets the current value.
+    /// </summary>
+    T? Value { get; }
+
+    /// <summary>
+    /// Set the parameter's value. 
+    /// </summary>
+    /// <remarks>
+    /// Note: you should never set the parameter's property directly from within the component.
+    /// Instead, use SetValueAsync on the ParameterState object.
+    /// </remarks>
+    /// <param name="value">New parameter's value.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task SetValueAsync(T value);
+}

--- a/src/MudBlazor/State/ParameterChangedEventArgs.cs
+++ b/src/MudBlazor/State/ParameterChangedEventArgs.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.State
+{
+    /// <summary>
+    /// Represents event arguments containing the last and current values of a parameter.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter value.</typeparam>
+#nullable enable
+    internal class ParameterChangedEventArgs<T> : EventArgs
+    {
+        /// <summary>
+        /// Gets the associated parameter name of the component's <see cref="ParameterAttribute"/>.
+        /// </summary>
+        public string ParameterName { get; }
+
+        /// <summary>
+        /// Gets the last value of the parameter.
+        /// </summary>
+        public T LastValue { get; }
+
+        /// <summary>
+        /// Gets the current value of the parameter.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterChangedEventArgs{T}"/> class with the specified last and current values.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="lastValue">The last value of the parameter.</param>
+        /// <param name="value">The current value of the parameter.</param>
+        public ParameterChangedEventArgs(string parameterName, T lastValue, T value)
+        {
+            LastValue = lastValue;
+            Value = value;
+            ParameterName = parameterName;
+        }
+    }
+}

--- a/src/MudBlazor/State/ParameterChangedLambdaArgsHandler.cs
+++ b/src/MudBlazor/State/ParameterChangedLambdaArgsHandler.cs
@@ -1,9 +1,5 @@
-﻿// Copyright (c) MudBlazor 2021
-// MudBlazor licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
+﻿using System.Threading.Tasks;
 using System;
-using System.Threading.Tasks;
 
 namespace MudBlazor.State;
 
@@ -13,15 +9,15 @@ namespace MudBlazor.State;
 /// using an Action lambda expression instead of directly implementing the interface.
 /// </summary>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
-internal class ParameterChangedLambdaHandler<T> : IParameterChangedHandler<T>
+internal class ParameterChangedLambdaArgsHandler<T> : IParameterChangedHandler<T>
 {
-    private readonly Action _lambda;
+    private readonly Action<ParameterChangedEventArgs<T>> _lambda;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ParameterChangedLambdaHandler{T}"/> class with the specified lambda expression.
     /// </summary>
     /// <param name="lambda">The Action lambda expression to be executed when handling parameter change.</param>
-    public ParameterChangedLambdaHandler(Action lambda)
+    public ParameterChangedLambdaArgsHandler(Action<ParameterChangedEventArgs<T>> lambda)
     {
         _lambda = lambda;
     }
@@ -33,7 +29,7 @@ internal class ParameterChangedLambdaHandler<T> : IParameterChangedHandler<T>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public Task HandleAsync(ParameterChangedEventArgs<T> parameterChangedEventArgs)
     {
-        _lambda();
+        _lambda(parameterChangedEventArgs);
 
         return Task.CompletedTask;
     }

--- a/src/MudBlazor/State/ParameterChangedLambdaArgsTaskHandler.cs
+++ b/src/MudBlazor/State/ParameterChangedLambdaArgsTaskHandler.cs
@@ -1,8 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
-// MudBlazor licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace MudBlazor.State;
@@ -13,15 +9,15 @@ namespace MudBlazor.State;
 /// using a Func&lt;Task&gt; lambda expression instead of directly implementing the interface.
 /// </summary>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
-internal class ParameterChangedLambdaTaskHandler<T> : IParameterChangedHandler<T>
+internal class ParameterChangedLambdaArgsTaskHandler<T> : IParameterChangedHandler<T>
 {
-    private readonly Func<Task> _lambda;
+    private readonly Func<ParameterChangedEventArgs<T>, Task> _lambda;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ParameterChangedLambdaTaskHandler{T}"/> class with the specified lambda expression.
     /// </summary>
-    /// <param name="lambda">The Func&lt;Task&gt; lambda expression to be executed when handling parameter changes.</param>
-    public ParameterChangedLambdaTaskHandler(Func<Task> lambda)
+    /// <param name="lambda">The Func&lt;ParameterChangedEventArgs&lt;T&gt;, Task&gt; lambda expression to be executed when handling parameter changes.</param>
+    public ParameterChangedLambdaArgsTaskHandler(Func<ParameterChangedEventArgs<T>, Task> lambda)
     {
         _lambda = lambda;
     }
@@ -33,6 +29,6 @@ internal class ParameterChangedLambdaTaskHandler<T> : IParameterChangedHandler<T
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public Task HandleAsync(ParameterChangedEventArgs<T> parameterChangedEventArgs)
     {
-        return _lambda();
+        return _lambda(parameterChangedEventArgs);
     }
 }

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -10,13 +10,14 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor.State;
 
 #nullable enable
-
 /// <summary>
 /// Helper class for creating <see cref="ParameterState{T}"/> object with different overloads to initialize <see cref="ParameterState{T}"/>.
 /// </summary>
 [ExcludeFromCodeCoverage]
 internal class ParameterState
 {
+    #region (ParameterMetadata, ParameterValue, EventCallback, Action)
+
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
     /// </summary>
@@ -31,14 +32,14 @@ internal class ParameterState
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
     public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaHandler<T>(parameterChangedHandler));
     }
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
     /// </summary>
     /// <typeparam name="T">The type of the component's property value.</typeparam>
-    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="metadata">The parameter's metadata.</param>
     /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
     /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
     /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
@@ -46,10 +47,14 @@ internal class ParameterState
     /// For details and usage please read CONTRIBUTING.md
     /// </remarks>
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action parameterChangedHandler)
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaArgsHandler<T>(parameterChangedHandler));
     }
+
+    #endregion
+
+    #region (ParameterMetadata, ParameterValue, EventCallback, Func)
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
@@ -65,8 +70,159 @@ internal class ParameterState
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
     public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<Task> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaTaskHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaTaskHandler<T>(parameterChangedHandler));
     }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaArgsTaskHandler<T>(parameterChangedHandler));
+    }
+
+    #endregion
+
+    #region (ParameterMetadata, ParameterValue, EventCallback)
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, eventCallbackFunc);
+    }
+
+    #endregion
+
+    #region (ParameterMetadata, ParameterValue, Action)
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Action parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaHandler<T>(parameterChangedHandler));
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaArgsHandler<T>(parameterChangedHandler));
+    }
+
+    #endregion
+
+    #region (ParameterMetadata, ParameterValue, Func)
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<Task> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaTaskHandler<T>(parameterChangedHandler));
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaArgsTaskHandler<T>(parameterChangedHandler));
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, EventCallback, Action)
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaHandler<T>(parameterChangedHandler));
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaArgsHandler<T>(parameterChangedHandler));
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, EventCallback, Func)
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
@@ -82,8 +238,29 @@ internal class ParameterState
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
     public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<Task> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaTaskHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaTaskHandler<T>(parameterChangedHandler));
     }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
+    /// </summary>
+    /// <typeparam name="T">The type of the component's property value.</typeparam>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
+    /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
+    /// <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
+    /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
+    /// <remarks>
+    /// For details and usage, please read CONTRIBUTING.md
+    /// </remarks>
+    /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
+    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler)
+    {
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc, new ParameterChangedLambdaArgsTaskHandler<T>(parameterChangedHandler));
+    }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, EventCallback)
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
@@ -101,6 +278,10 @@ internal class ParameterState
         return ParameterState<T>.Attach(parameterName, getParameterValueFunc, eventCallbackFunc);
     }
 
+    #endregion
+
+    #region (ParameterName, ParameterValue, Action)
+
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
     /// </summary>
@@ -114,24 +295,28 @@ internal class ParameterState
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
     public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Action parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, ()=> default, new ParameterChangedLambdaHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, () => default, new ParameterChangedLambdaHandler<T>(parameterChangedHandler));
     }
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
     /// </summary>
     /// <typeparam name="T">The type of the component's property value.</typeparam>
-    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
     /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
     /// <param name="parameterChangedHandler">An action containing code that needs to be executed when the parameter value changes.</param>
     /// <remarks>
     /// For details and usage, please read CONTRIBUTING.md
     /// </remarks>
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Action parameterChangedHandler)
+    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Action<ParameterChangedEventArgs<T>> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, () => default, new ParameterChangedLambdaArgsHandler<T>(parameterChangedHandler));
     }
+
+    #endregion
+
+    #region (ParameterName, ParameterValue, Func)
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
@@ -146,22 +331,24 @@ internal class ParameterState
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
     public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<Task> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, () => default, new ParameterChangedLambdaTaskHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, () => default, new ParameterChangedLambdaTaskHandler<T>(parameterChangedHandler));
     }
 
     /// <summary>
     /// Creates a <see cref="ParameterState{T}"/> object which automatically manages parameter value changes as part of MudBlazor's ParameterState framework.
     /// </summary>
     /// <typeparam name="T">The type of the component's property value.</typeparam>
-    /// <param name="metadata">The parameter's metadata.</param>
+    /// <param name="parameterName">The name of the parameter, passed using nameof(...).</param>
     /// <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
     /// <param name="parameterChangedHandler">A function containing code that needs to be executed when the parameter value changes.</param>
     /// <remarks>
     /// For details and usage, please read CONTRIBUTING.md
     /// </remarks>
     /// <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterState<T> Attach<T>(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<Task> parameterChangedHandler)
+    public static ParameterState<T> Attach<T>(string parameterName, Func<T> getParameterValueFunc, Func<ParameterChangedEventArgs<T>, Task> parameterChangedHandler)
     {
-        return ParameterState<T>.Attach(metadata, getParameterValueFunc, () => default, new ParameterChangedLambdaTaskHandler(parameterChangedHandler));
+        return ParameterState<T>.Attach(parameterName, getParameterValueFunc, () => default, new ParameterChangedLambdaArgsTaskHandler<T>(parameterChangedHandler));
     }
+
+    #endregion
 }

--- a/src/MudBlazor/State/ParameterStateOfT.cs
+++ b/src/MudBlazor/State/ParameterStateOfT.cs
@@ -11,6 +11,7 @@ using MudBlazor.State.Rule;
 
 namespace MudBlazor.State;
 
+#nullable enable
 /// <summary>
 /// The <see cref="ParameterState{T}"/> automatically manages parameter value changes for <see cref="ParameterAttribute"/> as part of
 /// MudBlazor's ParameterState framework. For details and usage please read CONTRIBUTING.md
@@ -20,13 +21,16 @@ namespace MudBlazor.State;
 /// Instead, use the "MudComponentBase.RegisterParameter" method from within the component's constructor.
 /// </remarks>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
-#nullable enable
-internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<ParameterState<T>>
+internal class ParameterState<T> : IParameterState<T>, IParameterComponentLifeCycle, IEquatable<ParameterState<T>>
 {
     private T? _lastValue;
+    private ParameterChangedEventArgs<T>? _parameterChangedEventArgs;
     private readonly Func<T> _getParameterValueFunc;
     private readonly Func<EventCallback<T>> _eventCallbackFunc;
-    private readonly IParameterChangedHandler? _parameterChangedHandler;
+    private readonly IParameterChangedHandler<T>? _parameterChangedHandler;
+
+    [MemberNotNullWhen(true, nameof(_parameterChangedEventArgs))]
+    private bool HasParameterChangedEventArgs => _parameterChangedEventArgs is not null;
 
     /// <inheritdoc />
     public ParameterMetadata Metadata { get; }
@@ -44,12 +48,10 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
     [MemberNotNullWhen(true, nameof(_lastValue), nameof(Value))]
     public bool IsInitialized { get; private set; }
 
-    /// <summary>
-    /// Gets the current value.
-    /// </summary>
+    /// <inheritdoc/>
     public T? Value { get; private set; }
 
-    private ParameterState(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler? parameterChangedHandler = null)
+    private ParameterState(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null)
     {
         Metadata = ParameterMetadataRules.Morph(metadata);
         _getParameterValueFunc = getParameterValueFunc;
@@ -59,15 +61,7 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
         Value = default;
     }
 
-    /// <summary>
-    /// Set the parameter's value. 
-    /// </summary>
-    /// <remarks>
-    /// Note: you should never set the parameter's property directly from within the component. Instead, use SetValueAsync
-    /// on the ParameterState object.
-    /// </remarks>
-    /// <param name="value">New parameter's value.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <inheritdoc/>
     public Task SetValueAsync(T value)
     {
         if (!EqualityComparer<T>.Default.Equals(Value, value))
@@ -108,7 +102,18 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
     /// <inheritdoc />
     public Task ParameterChangeHandleAsync()
     {
-        return HasHandler ? _parameterChangedHandler.HandleAsync() : Task.CompletedTask;
+        if (HasHandler)
+        {
+            if (HasParameterChangedEventArgs)
+            {
+                // Since the ParameterSet lifecycles control all operations, it is acceptable to trigger the handler only when
+                // HasParameterChanged has been invoked and stored the ParameterChangedEventArgs.
+                // Direct invocation of this method by external callers is discouraged, so we shouldn't worry about it.
+                return _parameterChangedHandler.HandleAsync(_parameterChangedEventArgs);
+            }
+        }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -116,7 +121,17 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
     {
         var currentParameterValue = _getParameterValueFunc();
 
-        return parameters.HasParameterChanged(Metadata.ParameterName, currentParameterValue);
+        var changed = false;
+        _parameterChangedEventArgs = null;
+        // This if construction is to trigger [MaybeNullWhen(false)] for newValue, otherwise it wouldn't if we assign it directly to a variable,
+        // and we'd need to suppress it's nullability.
+        if (parameters.HasParameterChanged(Metadata.ParameterName, currentParameterValue, out var newValue))
+        {
+            changed = true;
+            _parameterChangedEventArgs = new ParameterChangedEventArgs<T>(Metadata.ParameterName, currentParameterValue, newValue);
+        }
+
+        return changed;
     }
 
     ///  <summary>
@@ -134,7 +149,7 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
     ///  For details and usage please read CONTRIBUTING.md
     ///  </remarks>
     ///  <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterState<T> Attach(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler? parameterChangedHandler = null, string? handlerName = null)
+    public static ParameterState<T> Attach(string parameterName, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, string? handlerName = null)
     {
         var metadata = new ParameterMetadata(parameterName, handlerName);
 
@@ -155,7 +170,7 @@ internal class ParameterState<T> : IParameterComponentLifeCycle, IEquatable<Para
     ///  For details and usage please read CONTRIBUTING.md
     ///  </remarks>
     ///  <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterState<T> Attach(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler? parameterChangedHandler = null)
+    public static ParameterState<T> Attach(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null)
     {
         return new ParameterState<T>(metadata, getParameterValueFunc, eventCallbackFunc, parameterChangedHandler);
     }

--- a/src/MudBlazor/State/Rule/ParameterMetadataRules.cs
+++ b/src/MudBlazor/State/Rule/ParameterMetadataRules.cs
@@ -3,6 +3,7 @@ using MudBlazor.State.Rule.Exclusion;
 
 namespace MudBlazor.State.Rule;
 
+#nullable enable
 /// <summary>
 /// Provides rules for processing <see cref="ParameterMetadata"/>.
 /// </summary>


### PR DESCRIPTION
## Description

This change should be cheap, we already always call `HasParameterChanged` when handler is supplied, and it was already receiving the new value from the `ParameterView` in the `ParameterViewExtensions.HasParameterChanged` it was just never returned back before (discarded).
So basically only one null check was added which is cheap and storage of the `ParameterChangedEventArgs` in local variable.

### Changes:

#### Made `MudComponentBase` as partial and split to `MudComponentBase.RegisterParameter.cs`.
To enhance the structure as the number of overloads increases it's better to add the registration overloads to separate partial class, I also added regions. While I typically dislike when people use them, but it's due to reason that they add no value regions like: "private field", "constructor", "static" - those are boilerplate.
In this case, I find their usage justified:
![structure](https://github.com/MudBlazor/MudBlazor/assets/19953225/3b94eb86-62a2-4e3a-a97a-904926f62d38)

**NB!** Same was added for `ParameterState.cs`:
![structure1](https://github.com/MudBlazor/MudBlazor/assets/19953225/7bba2698-06d8-47a4-b87c-6dfe07dde54f)

#### Made `ParameterChangedEventArgs` optional for anonymous functions or method groups.
While it adds more boilerplate code and overloads we do not break existing code, now we have the flexibility to have method group with the `EventArgs` or without.
![overloads](https://github.com/MudBlazor/MudBlazor/assets/19953225/bcf0e4ab-8893-4f7f-bdd4-46d2bb31b2ef)

## How Has This Been Tested?
Adopted existing unit tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
