### PR TITLE
MudTimePicker: Double pad hours like minutes already are

### DIFF
--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -237,7 +237,7 @@ namespace MudBlazor
             if (TimeIntermediate == null)
                 return "--";
             var h = AmPm ? TimeIntermediate.Value.ToAmPmHour() : TimeIntermediate.Value.Hours;
-            return Math.Min(23, Math.Max(0, h)).ToString(CultureInfo.InvariantCulture);
+            return $"{Math.Min(23, Math.Max(0, h)):D2}";
         }
 
         private string GetMinuteString()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Maintains visual structure and brings the component closer to other common time pickers.


MUI 
![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/70c06524-4f02-4b92-b117-9155ced37578)

mdbootstrap
![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/0e1419a0-0fa4-48d0-9c5c-3076497f3c58)

m2.material.io
![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/9ea45791-4c39-4c25-a65f-eaff0349cc5b)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/6095b80a-61ef-4cdb-bee6-ea762dc97dd6)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/f65103d2-0c46-481e-88d9-58b3c894a30f)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
