### PR TITLE
MudTable: Add CancellationToken into ServerData Function for Cancelable Requests

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
@@ -1,0 +1,98 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@using System.Threading
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable ServerDataWithCancel="@(new Func<TableState, CancellationToken, Task<TableData<Element>>>(ServerReload))"
+          Dense="true" Hover="true" @ref="table">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudSpacer />
+        <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="nr_field" T="Element">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="sign_field" T="Element">Sign</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="name_field" T="Element">Name</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="position_field" T="Element">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="mass_field" T="Element">Molar mass</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No matching records found</MudText>
+    </NoRecordsContent>
+    <LoadingContent>
+        <MudText>Loading...</MudText>
+    </LoadingContent>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    private IEnumerable<Element> pagedData;
+    private MudTable<Element> table;
+
+    private int totalItems;
+    private string searchString = null;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<Element>> ServerReload(TableState state, CancellationToken token)
+    {
+        // Forward the cancellation token to any long-running operations
+        IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable", token);
+        await Task.Delay(300, token);
+        data = data.Where(element =>
+        {
+            if (string.IsNullOrWhiteSpace(searchString))
+                return true;
+            if (element.Sign.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if ($"{element.Number} {element.Position} {element.Molar}".Contains(searchString))
+                return true;
+            return false;
+        }).ToArray();
+        totalItems = data.Count();
+        switch (state.SortLabel)
+        {
+            case "nr_field":
+                data = data.OrderByDirection(state.SortDirection, o => o.Number);
+                break;
+            case "sign_field":
+                data = data.OrderByDirection(state.SortDirection, o => o.Sign);
+                break;
+            case "name_field":
+                data = data.OrderByDirection(state.SortDirection, o => o.Name);
+                break;
+            case "position_field":
+                data = data.OrderByDirection(state.SortDirection, o => o.Position);
+                break;
+            case "mass_field":
+                data = data.OrderByDirection(state.SortDirection, o => o.Molar);
+                break;
+        }
+
+        pagedData = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToArray();
+        return new TableData<Element>() { TotalItems = totalItems, Items = pagedData };
+    }
+
+    private void OnSearch(string text)
+    {
+        searchString = text;
+        table.ReloadServerData();
+    }
+}
+
+

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
@@ -4,8 +4,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable ServerDataWithCancel="@(new Func<TableState, CancellationToken, Task<TableData<Element>>>(ServerReload))"
-          Dense="true" Hover="true">
+<MudTable ServerData="ServerReload" Dense="true" Hover="true">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
     </ToolBarContent>
@@ -52,5 +51,3 @@
         return new TableData<Element>() { TotalItems = totalItems, Items = pagedData };
     }
 }
-
-

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSideCancellationTokenExample.razor
@@ -1,16 +1,13 @@
-﻿@using System.Net.Http.Json
-@using MudBlazor.Examples.Data.Models
+﻿@using MudBlazor.Examples.Data.Models
+@using System.Net.Http.Json
 @using System.Threading
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
 <MudTable ServerDataWithCancel="@(new Func<TableState, CancellationToken, Task<TableData<Element>>>(ServerReload))"
-          Dense="true" Hover="true" @ref="table">
+          Dense="true" Hover="true">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
-        <MudSpacer />
-        <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start"
-                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="nr_field" T="Element">Nr</MudTableSortLabel></MudTh>
@@ -38,60 +35,21 @@
 </MudTable>
 
 @code {
-    private IEnumerable<Element> pagedData;
-    private MudTable<Element> table;
-
-    private int totalItems;
-    private string searchString = null;
-
     /// <summary>
-    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// Here we simulate getting the paged, filtered and ordered data from the server, with a token for canceling this request
     /// </summary>
     private async Task<TableData<Element>> ServerReload(TableState state, CancellationToken token)
     {
-        // Forward the cancellation token to any long-running operations
-        IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable", token);
+        // Forward the provided token to methods which support it
+        var data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable", token);
+        // Simulate a long-running operation
         await Task.Delay(300, token);
-        data = data.Where(element =>
-        {
-            if (string.IsNullOrWhiteSpace(searchString))
-                return true;
-            if (element.Sign.Contains(searchString, StringComparison.OrdinalIgnoreCase))
-                return true;
-            if (element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
-                return true;
-            if ($"{element.Number} {element.Position} {element.Molar}".Contains(searchString))
-                return true;
-            return false;
-        }).ToArray();
-        totalItems = data.Count();
-        switch (state.SortLabel)
-        {
-            case "nr_field":
-                data = data.OrderByDirection(state.SortDirection, o => o.Number);
-                break;
-            case "sign_field":
-                data = data.OrderByDirection(state.SortDirection, o => o.Sign);
-                break;
-            case "name_field":
-                data = data.OrderByDirection(state.SortDirection, o => o.Name);
-                break;
-            case "position_field":
-                data = data.OrderByDirection(state.SortDirection, o => o.Position);
-                break;
-            case "mass_field":
-                data = data.OrderByDirection(state.SortDirection, o => o.Molar);
-                break;
-        }
-
-        pagedData = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToArray();
+        // Get the total count
+        var totalItems = data.Count();
+        // Get the paged data
+        var pagedData = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToList();
+        // Return the data
         return new TableData<Element>() { TotalItems = totalItems, Items = pagedData };
-    }
-
-    private void OnSearch(string text)
-    {
-        searchString = text;
-        table.ReloadServerData();
     }
 }
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
@@ -1,10 +1,10 @@
 @using System.Net.Http.Json
 @using MudBlazor.Examples.Data.Models
+@using System.Threading
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<Element>>>(ServerReload))"
-          Dense="true" Hover="true" @ref="table">
+<MudTable ServerData="ServerReload" Dense="true" Hover="true" @ref="table">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudSpacer />
@@ -46,10 +46,10 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<Element>> ServerReload(TableState state)
+    private async Task<TableData<Element>> ServerReload(TableState state, CancellationToken token)
     {
-        IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-        await Task.Delay(300);
+        IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable", token);
+        await Task.Delay(300, token);
         data = data.Where(element =>
         {
             if (string.IsNullOrWhiteSpace(searchString))

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -162,11 +162,10 @@
         <DocsPageSection>
             <SectionHeader Title="Server Side Data With Cancellation">
                 <Description>
-                    Set <CodeInline>ServerDataWithCancel</CodeInline> to load data from the backend just like <CodeInline>ServerData</CodeInline> but with automatic cancellation whenever a new data
-                    request occurs.  Actions such as rapidly changing pages, sorting, filtering, or calls to <CodeInline>ReloadTableData</CodeInline> will cause any in-progress request to be cancelled 
-                    in order to maintain responsiveness.
+                    Use the <CodeInline>CancellationToken</CodeInline> to detect when a request for data has been superceded by a new request.  By forwarding the token to methods which support it,
+                    such as common <CodeInline>HttpClient</CodeInline> or <CodeInline>DbContent</CodeInline> methods, the table can perform well even with frequent updates.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                        Note: When using <CodeInline>ServerDataWithCancel</CodeInline>, you don't need <CodeInline>Items</CodeInline> or <CodeInline>Filter</CodeInline>.  Also, <CodeInline>ServerData</CodeInline> will not be called.
+                        Note: When using <CodeInline>ServerData</CodeInline>, you don't need <CodeInline>Items</CodeInline> or <CodeInline>Filter</CodeInline>.
                     </MudAlert>
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -160,6 +160,22 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Server Side Data With Cancellation">
+                <Description>
+                    Set <CodeInline>ServerDataWithCancel</CodeInline> to load data from the backend just like <CodeInline>ServerData</CodeInline> but with automatic cancellation whenever a new data
+                    request occurs.  Actions such as rapidly changing pages, sorting, filtering, or calls to <CodeInline>ReloadTableData</CodeInline> will cause any in-progress request to be cancelled 
+                    in order to maintain responsiveness.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                        Note: When using <CodeInline>ServerDataWithCancel</CodeInline>, you don't need <CodeInline>Items</CodeInline> or <CodeInline>Filter</CodeInline>.  Also, <CodeInline>ServerData</CodeInline> will not be called.
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(TableServerSideCancellationTokenExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TableServerSideCancellationTokenExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Record Type Support">
                 <Description>
                     By default, mutable <CodeInline>record</CodeInline> types do not work with multi-selection or editing. This is due to the way record equality works. To support multi-selection or editing of records in a <CodeInline>MudTable</CodeInline>,

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest9.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest9.razor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.TestComponents
@@ -32,7 +33,7 @@ namespace MudBlazor.UnitTests.TestComponents
         private HashSet<ComplexObject> _selectedItems = new();
         private ElementComparer Comparer = new();
 
-        protected async Task<TableData<ComplexObject>> ServerData(TableState state)
+        protected async Task<TableData<ComplexObject>> ServerData(TableState state, CancellationToken token)
         {
             try
             {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTest.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -27,7 +28,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
         IEnumerable<int> data = new List<int>() { 1, 2, 3 };
         totalItems = data.Count();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTestWithCancel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerDataLoadingTestWithCancel.razor
@@ -1,0 +1,30 @@
+﻿@using System.Threading
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable T="int" ServerDataWithCancel="@(new Func<TableState, CancellationToken, Task<TableData<int>>>(ServerReload))">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "The table should cancel prior requests for server data when using ServerDataWithCancel.";
+
+    /// <summary>
+    /// Reloads the data from the server, with support for cancellation.
+    /// </summary>
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
+    {
+        // Simulate "loading data" for two seconds
+        await Task.Delay(2000, token);
+
+        // Make some test data to return
+        IEnumerable<int> data = new List<int>() { 1, 2, 3 };
+
+        // Return the data
+        return new TableData<int>() { TotalItems = data.Count(), Items = data.ToArray() };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest1.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -20,7 +21,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
         IEnumerable<int> data = new List<int>() { 1,2,3 };
         totalItems = data.Count();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest2.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -23,7 +24,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
         var p = state.Page*3;
         IEnumerable<int> data = new List<int>() { 1 + p, 2 + p, 3 + p };

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." InitialDirection="SortDirection.Descending" T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -21,7 +22,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
         //if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
         //    throw new ArgumentException("SortDirection is set but SortLabel is not");

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4.razor
@@ -1,8 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<TestModel>>>(ServerReload))" SortLabel="Sort by">
+<MudTable ServerData="ServerReload" SortLabel="Sort by">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="a" T="TestModel">a</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortLabel="b" T="TestModel">b</MudTableSortLabel></MudTh>
@@ -30,7 +31,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<TestModel>> ServerReload(TableState state)
+    private async Task<TableData<TestModel>> ServerReload(TableState state, CancellationToken token)
     {
         IEnumerable<TestModel> data = new List<TestModel>() { new TestModel() { a=1, b=3 },
                                             new TestModel() { a=2, b=2 },

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4b.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4b.razor
@@ -1,8 +1,9 @@
 @namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<TestModel>>>(ServerReload))" SortLabel="Sort by">
+<MudTable ServerData="ServerReload" SortLabel="Sort by">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="a" T="TestModel">a</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortLabel="b" T="TestModel">b</MudTableSortLabel></MudTh>
@@ -30,7 +31,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<TestModel>> ServerReload(TableState state)
+    private async Task<TableData<TestModel>> ServerReload(TableState state, CancellationToken token)
     {
         // This creates an in-memory IQueryable variation of our IEnumerable test
         IQueryable<TestModel> data = new List<TestModel>() { new TestModel() { a=1, b=3 },

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest5.razor
@@ -1,9 +1,10 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <span id="counter">@reloadCounter</span>
 <button id="reseter" @onclick="() => reloadCounter = 0">Reset</button>
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." InitialDirection="SortDirection.Descending" T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -25,7 +26,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
 
         ++reloadCounter;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest6.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="ServerReload">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
@@ -16,7 +17,7 @@
     /// <summary>
     /// Here we simulate getting the paged, filtered and ordered data from the server
     /// </summary>
-    private async Task<TableData<int>> ServerReload(TableState state)
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
     {
         return new TableData<int>();
     }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1242,8 +1242,8 @@ namespace MudBlazor.UnitTests.Components
             CancellationToken? cancelToken = null;
             // Make a task completion source
             var first = new TaskCompletionSource<TableData<int>>();
-            // Set the ServerDataWithCancel function 
-            table.SetParam(p => p.ServerDataWithCancel, new Func<TableState, CancellationToken, Task<TableData<int>>>((s, cancellationToken) =>
+            // Set the ServerData function 
+            table.SetParam(p => p.ServerData, new Func<TableState, CancellationToken, Task<TableData<int>>>((s, cancellationToken) =>
             {
                 // Remember the cancellation token
                 cancelToken = cancellationToken;
@@ -1260,8 +1260,8 @@ namespace MudBlazor.UnitTests.Components
 
             // Arrange a table refresh
             var second = new TaskCompletionSource<TableData<int>>();
-            // Set the ServerDataWithCancel function to a new method...
-            table.SetParam(p => p.ServerDataWithCancel, new Func<TableState, CancellationToken, Task<TableData<int>>>((s, cancellationToken) =>
+            // Set the ServerData function to a new method...
+            table.SetParam(p => p.ServerData, new Func<TableState, CancellationToken, Task<TableData<int>>>((s, cancellationToken) =>
             {
                 // ... which returns the second task.
                 return second.Task;

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -8,7 +8,7 @@
 @(ClearFilterCache()) @*Clear filtered items cache for this render*@
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-@if (Items != null || ServerData != null)
+@if (Items != null || ServerData != null || ServerDataWithCancel != null)
 {
     <CascadingValue Value="TableContext" IsFixed="true">
         @if (ToolBarContent != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -8,7 +8,7 @@
 @(ClearFilterCache()) @*Clear filtered items cache for this render*@
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-@if (Items != null || ServerData != null || ServerDataWithCancel != null)
+@if (Items != null || ServerData != null)
 {
     <CascadingValue Value="TableContext" IsFixed="true">
         @if (ToolBarContent != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -572,7 +572,7 @@ namespace MudBlazor
                 _cancellationTokenSrc = new CancellationTokenSource();
             }
         }
-        
+
 
         internal override bool HasServerData => ServerData != null;
 
@@ -708,14 +708,7 @@ namespace MudBlazor
         /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
         {
-            if (_cancellationTokenSrc != null)
-            {
-                try
-                {
-                    _cancellationTokenSrc.Dispose();
-                }
-                catch { /*ignored*/ }
-            }
+            _cancellationTokenSrc.Dispose();
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -708,7 +708,7 @@ namespace MudBlazor
         /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
         {
-            _cancellationTokenSrc.Dispose();
+            _cancellationTokenSrc?.Dispose();
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -561,10 +561,10 @@ namespace MudBlazor
         /// Gets or sets the cancelable function for requesting filtered, paginated, and sorted data from the server.
         /// </summary>
         /// <remarks>
-        /// This function behaves like the <see cref="ServerData"/> except that a <see cref="CancellationToken"/> parameter
-        /// is also passed into the function.  Forward this cancellation token to any calls such as API calls using <see cref="System.Net.Http.HttpClient" />
-        /// or functions which query data such as to ensure that operations are
-        /// properly canceled.  Using this function can improve responsiveness by keeping up with frequent table updates.
+        /// This function behaves like the <see cref="ServerData"/> property except that a <see cref="CancellationToken"/> parameter
+        /// is passed into the function to allow for cancelation of ongoing functions.  Forward this cancellation token to any calls 
+        /// such as API calls using <see cref="System.Net.Http.HttpClient" /> or functions which query data such as DbContext to ensure 
+        /// that operations are properly canceled.  Using this function can improve responsiveness when a table has frequent updates.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]


### PR DESCRIPTION
This update modifies the `ServerData` function of the `MudTable` component to add a `CancellationToken` parameter.  By adding this parameter, requests for data can be canceled, which improves the performance of tables during frequent updates.

## How Has This Been Tested?

This feature has been tested by adding a bUnit test to the `TableTests` class, as well as modifying existing tests to include the new `CancellationToken` parameter.  The new bUnit test will ensure that:

* The initial call to reload the data via `ServerData` does NOT cancel the current `CancellationToken`
* Any subsequent call to reload the data via `ServerData` DOES cancel the current `CancellationToken`

This branch has also been used with a production Blazor Server application which received frequent table updates via SignalR messages.  I have spammed clicking on table sort labels to rapidly change sorting, and the table keeps up nicely without error.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is a functional change which aims to improve the performance of MudTable when frequent refreshes via server data occur.  To use this feature, users should forward the provided `CancellationToken` to any cancelable tasks, such as making a call to `HttpClient`, `DbContext`, or other potentially long-running operation.   

## Checklist:

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.

## Notes for Reviewers

* This PR adds the `IDisposable` class to the `MudTable` component due to disposing the new `TokenCancellationSource`

## Upgrading Your Existing ServerData Code 

Existing code which uses `ServerData` can be upgraded to use this feature in two steps:

1. In your Blazor code, add a `CancellationToken token` parameter to your server data function
2. Forward this token to any cancelable operations such as calls to an `HttpClient` or `DbContext`

Before:

```
<MudTable T="int" ServerData="OnReloadData">
</MudTable>

@code 
{
    public async Task<TableData<int>> OnReloadData(TableState state)
    {
            var client = new HttpClient();
            var someData = await client.GetAsync("http://example.com");

            var context = new MyDbContext();
            var someMoreData = await context.MyTable.ToListAsync();

            return new TableData<int>() { TotalItems = ..., Items = ... };            
    }
}
```

After:

```
<MudTable T="int" ServerData="OnReloadData">
</MudTable>

@code 
{
    public async Task<TableData<int>> OnReloadData(TableState state, CancellationToken token)
    {
        var client = new HttpClient();
        var someData = await client.GetAsync("http://example.com", token); // <-- Forward the token here

        var context = new MyDbContext();
        var someMoreData = await context.MyTable.ToListAsync(token)); // <-- Forward the token here

        return new TableData<int>() { TotalItems = ..., Items = ... };            
    }
}
```
