### PR TITLE
MudRadio: Fix Stack overflow caused by recurrence.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -240,6 +240,9 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => radio.Instance.IMudRadioGroup = null);
             await comp.InvokeAsync(() => radio.Instance.OnClickAsync());
+#pragma warning disable CS0618 // Type or member is obsolete
+            comp.WaitForAssertion(() => radio.Instance.Option.Should().Be("1"));
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning disable BL0005
             await comp.InvokeAsync(() => radio.Instance.Disabled = true);
             comp.WaitForAssertion(() => group.Instance.Value.Should().Be(null));

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -112,7 +112,7 @@ namespace MudBlazor
         {
             get
             {
-                return Option;
+                return Value;
             }
             set
             {


### PR DESCRIPTION
This change will make MudRadio.Option return Value instead of Option. This causes recurrence and results in Stack overflow exception.

## Description
Fixes: #8411 

## How Has This Been Tested?
UnitTests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
