### PR TITLE
Snackbar: Fix type class not taking into account per-snackbar options

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarVariantsExample.razor
@@ -2,19 +2,18 @@
 
 @inject ISnackbar Snackbar
 
-<MudButton @onclick="@(() => ChangeVariant("Text Snackbar", Variant.Text))" Color="Color.Primary">Open Text Snackbar Variants</MudButton>
-<MudButton @onclick="@(() => ChangeVariant("Filled Snackbar", Variant.Filled))" Color="Color.Secondary">Open Filled Snackbar Variants</MudButton>
-<MudButton @onclick="@(() => ChangeVariant("Outlined Snackbar", Variant.Outlined))" Color="Color.Tertiary">Open Outlined Snackbar Variants</MudButton>
+<MudButton @onclick="@(() => ShowVariant("Text Snackbar", Variant.Text))" Color="Color.Primary">Open Text Snackbar Variants</MudButton>
+<MudButton @onclick="@(() => ShowVariant("Filled Snackbar", Variant.Filled))" Color="Color.Secondary">Open Filled Snackbar Variants</MudButton>
+<MudButton @onclick="@(() => ShowVariant("Outlined Snackbar", Variant.Outlined))" Color="Color.Tertiary">Open Outlined Snackbar Variants</MudButton>
 
 @code {
-    void ChangeVariant(string message, Variant variant)
+    void ShowVariant(string message, Variant variant)
     {
-        Snackbar.Configuration.SnackbarVariant = variant;
         Snackbar.Configuration.MaxDisplayedSnackbars = 10;
-        Snackbar.Add($"Normal {message}", Severity.Normal);
-        Snackbar.Add($"Info {message}", Severity.Info);
-        Snackbar.Add($"Success {message}", Severity.Success);
-        Snackbar.Add($"Warning {message}", Severity.Warning);
-        Snackbar.Add($"Error {message}", Severity.Error);
+        Snackbar.Add($"Normal {message}", Severity.Normal, c => c.SnackbarVariant = variant);
+        Snackbar.Add($"Info {message}", Severity.Info, c => c.SnackbarVariant = variant);
+        Snackbar.Add($"Success {message}", Severity.Success, c => c.SnackbarVariant = variant);
+        Snackbar.Add($"Warning {message}", Severity.Warning, c => c.SnackbarVariant = variant);
+        Snackbar.Add($"Error {message}", Severity.Error, c => c.SnackbarVariant = variant);
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -258,6 +258,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task PerSnackbarClassTypes()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/5027.
+
+            await _provider.InvokeAsync(() =>
+                _service.Add("Boom, big reveal. Im a pickle!",
+                    Severity.Success,
+                    c =>
+                    {
+                        // Non-default settings.
+                        c.SnackbarVariant = Variant.Outlined;
+                        c.BackgroundBlurred = true;
+                    }
+                )
+            );
+
+            var snackbarClassList = _provider.Find(".mud-snackbar").ClassList;
+            snackbarClassList.Should().Contain("mud-snackbar-blurred");
+            snackbarClassList.Should().Contain("mud-alert-outlined-success");
+        }
+
+        [Test]
         public async Task DisposeTest()
         {
             // shoot out a snackbar

--- a/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
@@ -69,7 +69,14 @@ namespace MudBlazor
         {
             get
             {
-                var result = $"mud-snackbar {Options.SnackbarTypeClass}";
+                var baseTypeClass = $"mud-alert-{Options.SnackbarVariant.ToDescriptionString()}-{Options.Severity.ToDescriptionString()}";
+
+                if (Options.SnackbarVariant != Variant.Filled)
+                {
+                    baseTypeClass += Options.BackgroundBlurred ? " mud-snackbar-blurred" : " mud-snackbar-surface";
+                }
+
+                var result = $"mud-snackbar {baseTypeClass} {Options.SnackbarTypeClass}";
 
                 if (Options.Onclick != null && !ShowActionButton)
                     result += " force-cursor";

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Components.Snackbar;
-using MudBlazor.Extensions;
 
 namespace MudBlazor
 {
@@ -61,13 +58,6 @@ namespace MudBlazor
         public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {
             Severity = severity;
-
-            SnackbarTypeClass = $"mud-alert-{SnackbarVariant.ToDescriptionString()}-{severity.ToDescriptionString()}";
-
-            if (SnackbarVariant != Variant.Filled)
-            {
-                SnackbarTypeClass += BackgroundBlurred ? " mud-snackbar-blurred" : " mud-snackbar-surface";
-            }
 
             if (string.IsNullOrEmpty(Icon))
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Fixes #5027.

```cs
var options = new SnackbarOptions(severity, Configuration);
configure?.Invoke(options);
```

`SnackbarTypeClass` was set in the `SnackbarOptions` constructor **before** the snackbar's configuration was assigned, thus falling back to the global configuration. Now the class creation is handled in `SnackBarMessageState.SnackbarClass` and `SnackbarTypeClass` is kept pure.

Docs were updated to reflect this new opportunity.

Note: `SnackbarTypeClass` can now be null but it's only used in one place (internally) inside a string.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [x] I've added relevant tests.
