### PR TITLE
v7: Drop .NET6 as supported framework.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,7 @@ Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
 
 ## Minimal Prerequisites to Compile from Source
 
-- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
-- [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0)
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 
 ## Pull Requests
 - Your Pull Request (PR) must only consist of one topic. It is better to split Pull Requests with more than one feature or bug fix in seperate Pull Requests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1>
+﻿<h1>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="content/MudBlazor-GitHub-NoBg-Dark.png">
     <source media="(prefers-color-scheme: light)" srcset="content/MudBlazor-GitHub-NoBg.png">
@@ -16,8 +16,8 @@
 [![Discussions](https://img.shields.io/github/discussions/mudblazor/mudblazor?color=594ae2&logo=github&style=flat-square)](https://github.com/mudblazor/mudblazor/discussions)
 [![Discord](https://img.shields.io/discord/786656789310865418?color=%237289da&label=Discord&logo=discord&logoColor=%237289da&style=flat-square)](https://discord.gg/mudblazor)
 [![Twitter](https://img.shields.io/twitter/follow/MudBlazor?color=1DA1F2&label=Twitter&logo=Twitter&style=flat-square)](https://twitter.com/MudBlazor)
-[![Nuget version](https://img.shields.io/nuget/v/MudBlazor?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
-[![Nuget downloads](https://img.shields.io/nuget/dt/MudBlazor?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
+[![NuGet version](https://img.shields.io/nuget/v/MudBlazor?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
 
 MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers you to adapt, fix or extend the framework. There are plenty of examples in the documentation, which makes understanding and learning MudBlazor very easy.
 
@@ -26,36 +26,41 @@ MudBlazor is an ambitious Material Design component framework for Blazor with an
 - [Try.MudBlazor.com](https://try.mudblazor.com/)
 
 ### Why is MudBlazor so successful?
- - Clean and aesthetic graphic design based on Material Design.
- - Clear and easy to understand structure.
- - Good documentation with many examples and source snippets.
- - All components are written entirely in C#, no JavaScript allowed (except where absolutely necessary).
- - Users can make beautiful apps without needing CSS (but they can of course use CSS too).
- - No dependencies on other component libraries, 100% control over components and features.
- - Stability! We strive for a complete test coverage.
- - Releasing often so developers can get their PRs and fixes in a timely fashion.
+- Clean and aesthetic graphic design based on Material Design.
+- Clear and easy to understand structure.
+- Good documentation with many examples and source snippets.
+- All components are written entirely in C#, no JavaScript allowed (except where absolutely necessary).
+- Users can make beautiful apps without needing CSS (but they can of course use CSS too).
+- No dependencies on other component libraries, 100% control over components and features.
+- Stability! We strive for a complete test coverage.
+- Releases often so developers can get their PRs and fixes in a timely fashion.
 
-## Prerequisities
+## Prerequisites
 | MudBlazor | .NET | Support |
 | :--- | :---: | :---: |
 | 1.x.x - 2.0.x | .NET 3.1 | Ended 03/2021 |
 | 5.x.x | .NET 5 | Ended 01/2022 |
-| 6.0.x | [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0) | :heavy_check_mark: |
-| 6.1.x | [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) | :heavy_check_mark: |
+| 6.x.x | [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 7](https://dotnet.microsoft.com/download/dotnet/7.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) | :heavy_check_mark: |
+| 7.x.x | [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) | :heavy_check_mark: |
 
-Note: With .NET 8, currently only the interactive rendering modes are supported in BSS and WASM.
+:information_source: Currently only interactive rendering modes are supported - [Learn more](https://learn.microsoft.com/aspnet/core/blazor/components/render-modes).
 
 ## Stats
 ![Alt](https://repobeats.axiom.co/api/embed/db53a44092e88fc34a4c0f37db12773b6787ec7e.svg "Repobeats analytics image")
 
 ## Contributing
-- Check out the [contribution guidelines](/CONTRIBUTING.md) if you want to help improve MudBlazor.
+👋 Thanks for wanting to contribute!  
+We will try to merge all (non-breaking) bugfix PRs and we will deliberate the value of feature PRs for the community.
+But be warned that there is no guarantee that new features will be merged.
+If you want to be sure before investing the work please contact the team about your planned feature PR.
+
+Check out the [contribution guidelines](/CONTRIBUTING.md) to understand our goals and to learn more about the internals of the project.
 
 ## Getting Started
-- Full installation instructions can be found at [mudblazor.com](https://mudblazor.com/getting-started/installation)  
+- Full installation instructions can be found at [mudblazor.com](https://mudblazor.com/getting-started/installation).  
 - Alternatively use one of our templates from the [MudBlazor.Templates](https://github.com/mudblazor/Templates) repo.
-### Quick Installation Guide
 
+### Quick Installation Guide
 Install Package
 ```
 dotnet add package MudBlazor

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ MudBlazor is an ambitious Material Design component framework for Blazor with an
 | 1.x.x - 2.0.x | .NET 3.1 | Ended 03/2021 |
 | 5.x.x | .NET 5 | Ended 01/2022 |
 | 6.x.x | [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 7](https://dotnet.microsoft.com/download/dotnet/7.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) | :heavy_check_mark: |
-| 7.x.x | [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) | :heavy_check_mark: |
+| 7.x.x | [.NET 7](https://dotnet.microsoft.com/download/dotnet/7.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) | :heavy_check_mark: |
 
 :information_source: Currently only interactive rendering modes are supported - [Learn more](https://learn.microsoft.com/aspnet/core/blazor/components/render-modes).
 

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,7 +12,7 @@
     <Copyright>Copyright 2024 MudBlazor</Copyright>
     <PackageTags>Blazor, MudBlazor, Material, Material Design, Components, Blazor Components, Blazor Library</PackageTags>
     <Description>MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers them to adapt, fix or extend the framework and the multitude of examples in the documentation makes learning MudBlazor very easy.</Description>
-    <PackageProjectUrl>http://mudblazor.com/</PackageProjectUrl>
+    <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
@@ -60,18 +60,6 @@
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.28" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.28" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.28" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.17" />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.3" />

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -60,6 +60,12 @@
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.17" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.3" />


### PR DESCRIPTION
## Description

Part of #8435

- Drops support for .NET 6 as done in #7134
- Updates Minimal Prerequisites to Compile from Source
- PackageProjectUrl is now https
- README
  - Minor cleanup
  - Combines `6.0.x` and `6.1.x` into `6.x.x` for simplicity
  - Adds `7.x.x` for the new branch and only states support for .NET7 and .NET 8
  - Adds a link to the render modes page to avoid questions
  - Adds new text to Contributing including from the issue template

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
