### PR TITLE
ParameterState: Fix when subscribing only to EventCallback

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor
@@ -1,0 +1,9 @@
+﻿@inherits MudComponentBase
+@namespace MudBlazor.UnitTests
+
+<MudButton id="@($"childBtn{Id}")" OnClick="ToggleAsync">@(_isExpandedState.Value ? "Show" : "Hide")</MudButton>
+
+@if (_isExpandedState.Value)
+{
+    <MudAlert id="@($"childAlert{Id}")">@($"Oh my! We got secret content{Id}!")</MudAlert>
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+
+namespace MudBlazor.UnitTests;
+
+#nullable enable
+public partial class ParameterStateChildBindingTestComp : MudComponentBase
+{
+    private readonly List<(bool lastValue, bool value)> _parameterChangedEvents = new();
+
+    private readonly IParameterState<bool> _isExpandedState;
+
+    [Parameter]
+    public string? Id { get; set; }
+
+    [Parameter]
+    public bool IsExpanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> IsExpandedChanged { get; set; }
+
+    public bool IsExpandedStateValue => _isExpandedState.Value;
+
+    public IReadOnlyList<(bool lastValue, bool value)> ParameterChangedEvents => _parameterChangedEvents;
+
+    public ParameterStateChildBindingTestComp()
+    {
+        _isExpandedState = RegisterParameter(nameof(IsExpanded), () => IsExpanded, () => IsExpandedChanged, ParameterChangedHandler);
+    }
+
+    private void ParameterChangedHandler(ParameterChangedEventArgs<bool> args)
+    {
+        _parameterChangedEvents.Add(new ValueTuple<bool, bool>(args.LastValue, args.Value));
+    }
+
+    public Task ToggleAsync()
+    {
+        return _isExpandedState.SetValueAsync(!_isExpandedState.Value);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateParentBindingTestComp.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateParentBindingTestComp.razor
@@ -1,0 +1,49 @@
+﻿@inherits MudComponentBase
+@namespace MudBlazor.UnitTests
+
+<ParameterStateChildBindingTestComp Id="1" @ref="Child1Instance" @bind-IsExpanded="IsExpandedChild1BindSyntax" />
+<ParameterStateChildBindingTestComp Id="2" @ref="Child2Instance" IsExpanded="IsExpandedChild2VariableAndCallback" IsExpandedChanged="IsExpandedChangedChild2" />
+<ParameterStateChildBindingTestComp Id="3" @ref="Child3Instance" IsExpandedChanged="IsExpandedChangedChild3" />
+<ParameterStateChildBindingTestComp Id="4" @ref="Child4Instance" IsExpanded="IsExpandedChild4OneWay" />
+
+<MudButton id="parentBtn1" OnClick="ToggleAsync1">@(IsExpandedChild1BindSyntax ? "Show" : "Hide")</MudButton>
+<MudButton id="parentBtn2" OnClick="ToggleAsync2">@(IsExpandedChild2VariableAndCallback ? "Show" : "Hide")</MudButton>
+<MudButton id="parentBtn4" OnClick="ToggleAsync4">@(IsExpandedChild4OneWay ? "Show" : "Hide")</MudButton>
+
+@code {
+#nullable enable
+    public ParameterStateChildBindingTestComp Child1Instance = null!;
+    public ParameterStateChildBindingTestComp Child2Instance = null!;
+    public ParameterStateChildBindingTestComp Child3Instance = null!;
+    public ParameterStateChildBindingTestComp Child4Instance = null!;
+
+    public bool IsExpandedChild1BindSyntax { get; set; }
+
+    public bool IsExpandedChild2VariableAndCallback { get; set; }
+
+    public bool IsExpandedChild4OneWay { get; set; }
+
+    private void IsExpandedChangedChild2(bool newValue)
+    {
+        IsExpandedChild2VariableAndCallback = newValue;
+    }
+
+    private void IsExpandedChangedChild3(bool newValue)
+    {
+    }
+
+    private void ToggleAsync1()
+    {
+        IsExpandedChild1BindSyntax = !IsExpandedChild1BindSyntax;
+    }
+
+    private void ToggleAsync2()
+    {
+        IsExpandedChild2VariableAndCallback = !IsExpandedChild2VariableAndCallback;
+    }
+
+    private void ToggleAsync4()
+    {
+        IsExpandedChild4OneWay = !IsExpandedChild4OneWay;
+    }
+}

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
+using Bunit.Rendering;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.Components;
 using NUnit.Framework;
 
@@ -65,5 +69,282 @@ public class ParameterStateUsageTests : BunitTest
         ParamChanges().Children[2].TextContent.Trimmed().Should().Be("DoubleParam: 10001=>1000000");
         comp.SetParametersAndRender(parameters => parameters.Add(parameter => parameter.DoubleParam, 1000001f));
         comp.Find(".parameter-changes").Children.Length.Should().Be(3, "Within the epsilon tolerance. Therefore, change handler shouldn't fire.");
+    }
+
+    [Test]
+    public async Task Child_TwoWayBinding_Test()
+    {
+        var isExpanded = false;
+
+        var comp = Context.RenderComponent<ParameterStateChildBindingTestComp>(parameters =>
+            parameters.Bind(parameter => parameter.IsExpanded, isExpanded, newValue => isExpanded = newValue));
+
+        var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
+        IElement Button() => comp.Find("#childBtn");
+        IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
+
+        // Inner modifications
+
+        // Initial
+        isExpanded.Should().BeFalse("Initial value is false.");
+        comp.Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        // Show
+        await Button().ClickAsync(new MouseEventArgs());
+        alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
+        isExpanded.Should().BeTrue("Two way binding must change when inner modification happen.");
+        comp.Instance.IsExpanded.Should().BeFalse("We do not write to parameter directly.");
+        comp.Instance.IsExpandedStateValue.Should().BeTrue("We do write to state, it should change.");
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        // Hide
+        await Button().ClickAsync(new MouseEventArgs());
+        alertTextFunc.Should().Throw<ComponentNotFoundException>();
+        isExpanded.Should().BeFalse("Two way binding must change when inner modification happen.");
+        comp.Instance.IsExpanded.Should().BeFalse("We do not write to parameter directly.");
+        comp.Instance.IsExpandedStateValue.Should().BeFalse("We do write to state, it should change.");
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        // Outer modifications
+
+        // Show
+        comp.SetParametersAndRender(parameters => parameters.Add(parameter => parameter.IsExpanded, true));
+        alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
+        comp.Instance.IsExpanded.Should().BeTrue("We changed the parameter directly, must change.");
+        comp.Instance.IsExpandedStateValue.Should().BeTrue("We sync on OnInitialized, must be same as IsExpanded.");
+        comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
+        {
+            (false, true)
+        });
+
+        // Hide
+        comp.SetParametersAndRender(parameters => parameters.Add(parameter => parameter.IsExpanded, false));
+        alertTextFunc.Should().Throw<ComponentNotFoundException>();
+        comp.Instance.IsExpanded.Should().BeFalse("We changed the parameter directly, must change.");
+        comp.Instance.IsExpandedStateValue.Should().BeFalse("We sync on OnInitialized, must be same as IsExpanded.");
+        comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
+        {
+            (false, true),
+            (true, false)
+        });
+    }
+
+    [Test]
+    public async Task Child_EventCallBackOnly_Test()
+    {
+        var callBackEvents = new List<bool>();
+        Action<bool> isExpandedCallBack = value => { callBackEvents.Add(value); };
+
+        var comp = Context.RenderComponent<ParameterStateChildBindingTestComp>(parameters =>
+            parameters.Add(parameter => parameter.IsExpandedChanged, isExpandedCallBack));
+
+        var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
+        IElement Button() => comp.Find("#childBtn");
+        IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
+
+        // Inner modifications
+
+        // Initial
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+        callBackEvents.Should().BeEmpty();
+
+        // Show
+        await Button().ClickAsync(new MouseEventArgs());
+        alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+        callBackEvents.Should().BeEquivalentTo(new[] { true });
+
+        // Hide
+        await Button().ClickAsync(new MouseEventArgs());
+        alertTextFunc.Should().Throw<ComponentNotFoundException>();
+        comp.Instance.ParameterChangedEvents.Should().BeEmpty();
+        callBackEvents.Should().BeEquivalentTo(new[] { true, false });
+
+        // Outer modifications
+
+        // Show
+        comp.SetParametersAndRender(parameters => parameters.Add(parameter => parameter.IsExpanded, true));
+        alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
+        comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
+        {
+            (false, true)
+        });
+        callBackEvents.Should().BeEquivalentTo(new[] { true, false });
+
+        // Hide
+        comp.SetParametersAndRender(parameters => parameters.Add(parameter => parameter.IsExpanded, false));
+        alertTextFunc.Should().Throw<ComponentNotFoundException>();
+        comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
+        {
+            (false, true),
+            (true, false)
+        });
+        callBackEvents.Should().BeEquivalentTo(new[] { true, false });
+    }
+
+    [Test]
+    public async Task Parent_TwoWayBinding_Test()
+    {
+        var comp = Context.RenderComponent<ParameterStateParentBindingTestComp>();
+
+        var alertChild1TextFunc = () => comp.Find("#childAlert1 div.mud-alert-message");
+        var alertChild2TextFunc = () => comp.Find("#childAlert2 div.mud-alert-message");
+        var alertChild3TextFunc = () => comp.Find("#childAlert3 div.mud-alert-message");
+        var alertChild4TextFunc = () => comp.Find("#childAlert4 div.mud-alert-message");
+        IElement ButtonChild1() => comp.Find("#childBtn1");
+        IElement ButtonChild2() => comp.Find("#childBtn2");
+        IElement ButtonChild3() => comp.Find("#childBtn3");
+        IElement ButtonChild4() => comp.Find("#childBtn4");
+        IElement ButtonParent1() => comp.Find("#parentBtn1");
+        IElement ButtonParent2() => comp.Find("#parentBtn2");
+        IElement ButtonParent4() => comp.Find("#parentBtn4");
+
+        // Child modifications
+
+        // Initial
+        comp.Instance.Child1Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child2Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child3Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child4Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        comp.Instance.Child1Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpanded.Should().BeFalse();
+
+        comp.Instance.Child1Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpandedStateValue.Should().BeFalse();
+
+        comp.Instance.IsExpandedChild1BindSyntax.Should().BeFalse();
+        comp.Instance.IsExpandedChild2VariableAndCallback.Should().BeFalse();
+        comp.Instance.IsExpandedChild4OneWay.Should().BeFalse();
+
+        // Show
+        // Trigger button on a child component
+        await ButtonChild1().ClickAsync(new MouseEventArgs());
+        await ButtonChild2().ClickAsync(new MouseEventArgs());
+        await ButtonChild3().ClickAsync(new MouseEventArgs());
+        await ButtonChild4().ClickAsync(new MouseEventArgs());
+
+        alertChild1TextFunc().InnerHtml.Should().Be("Oh my! We got secret content1!");
+        alertChild2TextFunc().InnerHtml.Should().Be("Oh my! We got secret content2!");
+        alertChild3TextFunc().InnerHtml.Should().Be("Oh my! We got secret content3!");
+        alertChild4TextFunc().InnerHtml.Should().Be("Oh my! We got secret content4!");
+
+        comp.Instance.Child1Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true) });
+        comp.Instance.Child2Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true) });
+        comp.Instance.Child3Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child4Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        comp.Instance.Child1Instance.IsExpanded.Should().BeTrue();
+        comp.Instance.Child2Instance.IsExpanded.Should().BeTrue();
+        comp.Instance.Child3Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpanded.Should().BeFalse();
+
+        comp.Instance.Child1Instance.IsExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child2Instance.IsExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child3Instance.IsExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child4Instance.IsExpandedStateValue.Should().BeTrue();
+
+        comp.Instance.IsExpandedChild1BindSyntax.Should().BeTrue();
+        comp.Instance.IsExpandedChild2VariableAndCallback.Should().BeTrue();
+        comp.Instance.IsExpandedChild4OneWay.Should().BeFalse("One way do not change, when child is being modified.");
+
+        // Hide
+        // Trigger button on a child component
+        await ButtonChild1().ClickAsync(new MouseEventArgs());
+        await ButtonChild2().ClickAsync(new MouseEventArgs());
+        await ButtonChild3().ClickAsync(new MouseEventArgs());
+        await ButtonChild4().ClickAsync(new MouseEventArgs());
+
+        alertChild1TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild2TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild3TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild4TextFunc.Should().Throw<ElementNotFoundException>();
+
+        comp.Instance.Child1Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false) });
+        comp.Instance.Child2Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false) });
+        comp.Instance.Child3Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child4Instance.ParameterChangedEvents.Should().BeEmpty();
+
+        comp.Instance.Child1Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpanded.Should().BeFalse();
+
+        comp.Instance.Child1Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpandedStateValue.Should().BeFalse();
+
+        comp.Instance.IsExpandedChild1BindSyntax.Should().BeFalse();
+        comp.Instance.IsExpandedChild2VariableAndCallback.Should().BeFalse();
+        comp.Instance.IsExpandedChild4OneWay.Should().BeFalse();
+
+        // Parent modifications
+
+        // Show
+        // Trigger button on a parent component
+        await ButtonParent1().ClickAsync(new MouseEventArgs());
+        await ButtonParent2().ClickAsync(new MouseEventArgs());
+        await ButtonParent4().ClickAsync(new MouseEventArgs());
+
+        alertChild1TextFunc().InnerHtml.Should().Be("Oh my! We got secret content1!");
+        alertChild2TextFunc().InnerHtml.Should().Be("Oh my! We got secret content2!");
+        alertChild3TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild4TextFunc().InnerHtml.Should().Be("Oh my! We got secret content4!");
+
+        comp.Instance.Child1Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false), (false, true) });
+        comp.Instance.Child2Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false), (false, true) });
+        comp.Instance.Child3Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child4Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true) });
+
+        comp.Instance.Child1Instance.IsExpanded.Should().BeTrue();
+        comp.Instance.Child2Instance.IsExpanded.Should().BeTrue();
+        comp.Instance.Child3Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpanded.Should().BeTrue();
+
+        comp.Instance.Child1Instance.IsExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child2Instance.IsExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child3Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpandedStateValue.Should().BeTrue();
+
+        comp.Instance.IsExpandedChild1BindSyntax.Should().BeTrue();
+        comp.Instance.IsExpandedChild2VariableAndCallback.Should().BeTrue();
+        comp.Instance.IsExpandedChild4OneWay.Should().BeTrue("Now it must change since changed by parent.");
+
+        // Hide
+        // Trigger button on a parent component
+        await ButtonParent1().ClickAsync(new MouseEventArgs());
+        await ButtonParent2().ClickAsync(new MouseEventArgs());
+        await ButtonParent4().ClickAsync(new MouseEventArgs());
+
+        alertChild1TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild2TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild3TextFunc.Should().Throw<ElementNotFoundException>();
+        alertChild4TextFunc.Should().Throw<ElementNotFoundException>();
+
+        comp.Instance.Child1Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false), (false, true), (true, false) });
+        comp.Instance.Child2Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false), (false, true), (true, false) });
+        comp.Instance.Child3Instance.ParameterChangedEvents.Should().BeEmpty();
+        comp.Instance.Child4Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[] { (false, true), (true, false) });
+
+        comp.Instance.Child1Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpanded.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpanded.Should().BeFalse();
+
+        comp.Instance.Child1Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child2Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child3Instance.IsExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child4Instance.IsExpandedStateValue.Should().BeFalse();
+
+        comp.Instance.IsExpandedChild1BindSyntax.Should().BeFalse();
+        comp.Instance.IsExpandedChild2VariableAndCallback.Should().BeFalse();
+        comp.Instance.IsExpandedChild4OneWay.Should().BeFalse();
     }
 }

--- a/src/MudBlazor/State/ParameterStateOfT.cs
+++ b/src/MudBlazor/State/ParameterStateOfT.cs
@@ -73,8 +73,6 @@ internal class ParameterState<T> : IParameterState<T>, IParameterComponentLifeCy
             var eventCallback = _eventCallbackFunc();
             if (eventCallback.HasDelegate)
             {
-                _lastValue = value;
-
                 return eventCallback.InvokeAsync(value);
             }
         }


### PR DESCRIPTION
## Description
This fixes an interesting problem when you subscribe only to `EventCallback` and modify the child, for example you have content collapsed and you want to expand it via public method like `ToggleAsync`, the content would not expand, when it should.

This problem was found here: https://github.com/MudBlazor/MudBlazor/pull/8446

Consider this as example:
```razor
<MudExpansionPanels>
	<MudExpansionPanel Text="Panel with async loaded contents" MaxHeight="1000" IsExpandedChanged="ExpandedChanged">
		Secret content
	</MudExpansionPanel>
</MudExpansionPanels>

@code {
    private void ExpandedChanged(bool newVal)
    {   
    }
}
```
Note that when you click on expansion, you are triggering inner child toggle method

#### Before
![before](https://github.com/MudBlazor/MudBlazor/assets/19953225/edcd1fd6-f301-4202-98e5-a76dda2e7cdd)

#### After
![after](https://github.com/MudBlazor/MudBlazor/assets/19953225/4eda2988-e1a2-4dc5-94d8-5eb5cf5567f9)

The line in unit tests that specifically tests that this moment is covered:
https://github.com/MudBlazor/MudBlazor/blob/16d23398c928027782e1ef5bae545229834237a9/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs#L235
and
https://github.com/MudBlazor/MudBlazor/blob/16d23398c928027782e1ef5bae545229834237a9/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs#L250

aka the content must show when clicked and state should correspond that it's opened, before the fix this would fail.

## How Has This Been Tested?
New bUnit tests that took me few hours to make...

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
