### PR TITLE
MudDataGrid: Fix grouping for bound and unbound scenarios using ParameterState

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnsPanelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnsPanelExample.razor
@@ -11,7 +11,7 @@
         <PropertyColumn Property="x => x.Sign" Hidden="true" DragAndDropEnabled="false" Groupable="false" Sortable="false" Filterable="false" />
         <PropertyColumn Property="x => x.Name" Title="Name" Hidden="false" DragAndDropEnabled="true" Groupable="true" Sortable="true" Filterable="true" Grouping="false" />
         <PropertyColumn Property="x => x.Position" Filterable="false" Hideable="false" />
-        <PropertyColumn Property="x => x.Molar" Title="Molar mass" @bind-Hidden="_hideMolar" @bind-Grouping="_groupMolar"  Hideable="true" />
+        <PropertyColumn Property="x => x.Molar" Title="Molar mass" @bind-Hidden="_hideMolar" @bind-Grouping="_groupMolar" Hideable="true" />
         <PropertyColumn Property="x => x.Group" Hidden="_hideCategory" Grouping="_groupCategory" Title="Category" />
         <TemplateColumn Title="Template" />
     </Columns>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnsPanelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnsPanelExample.razor
@@ -3,16 +3,16 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid T="Element" @ref="grid" Items="@_elements" DragDropColumnReordering="@_dragDropReorderingEnabled" ColumnsPanelReordering="@_columnsPanelReorderingEnabled"
-             ColumnResizeMode="ResizeMode.Container" Hideable="@_hideable" Filterable="@_filterable" Groupable="@_groupable" FilterMode="@_filterMode" ShowMenuIcon="true">
+<MudDataGrid T="Element" @ref="grid" Items="_elements" DragDropColumnReordering="_dragDropReorderingEnabled" ColumnsPanelReordering="_columnsPanelReorderingEnabled"
+             ColumnResizeMode="ResizeMode.Container" Hideable="_hideable" Filterable="_filterable" Groupable="_groupable" FilterMode="_filterMode" ShowMenuIcon="true">
     <Columns>
         <SelectColumn T="Element"/>
         <PropertyColumn Property="x => x.Number" Title="Nr" />
         <PropertyColumn Property="x => x.Sign" Hidden="true" DragAndDropEnabled="false" Groupable="false" Sortable="false" Filterable="false" />
-        <PropertyColumn Property="x => x.Name" Title="Name" Hidden="false" DragAndDropEnabled="true" Groupable="true" Sortable="true" Filterable="true" />
+        <PropertyColumn Property="x => x.Name" Title="Name" Hidden="false" DragAndDropEnabled="true" Groupable="true" Sortable="true" Filterable="true" Grouping="false" />
         <PropertyColumn Property="x => x.Position" Filterable="false" Hideable="false" />
-        <PropertyColumn Property="x => x.Molar" Title="Molar mass" @bind-Hidden="@_hideMolar" Hideable="true" />
-        <PropertyColumn Property="x => x.Group" Hidden="_hideGroup" Title="Category" />
+        <PropertyColumn Property="x => x.Molar" Title="Molar mass" @bind-Hidden="_hideMolar" @bind-Grouping="_groupMolar"  Hideable="true" />
+        <PropertyColumn Property="x => x.Group" Hidden="_hideCategory" Grouping="_groupCategory" Title="Category" />
         <TemplateColumn Title="Template" />
     </Columns>
     <PagerContent>
@@ -23,11 +23,24 @@
 <div class="d-flex flex-rows flex-wrap mr-4">
     <MudSwitch @bind-Value="_dragDropReorderingEnabled" Color="Color.Primary">Drag Drop Column Reordering</MudSwitch>
     <MudSwitch @bind-Value="_columnsPanelReorderingEnabled" Color="Color.Primary">Columns Panel Column Reordering</MudSwitch>
-    <MudSwitch @bind-Value="_hideable" Color="Color.Primary">Hideable</MudSwitch>
     <MudSwitch @bind-Value="_filterable" Color="Color.Primary">Filterable</MudSwitch>
-    <MudSwitch @bind-Value="_groupable" Color="Color.Primary">Groupable</MudSwitch>
+</div>
+
+<div class="d-flex flex-rows flex-wrap mr-4">
+    <MudSwitch @bind-Value="_hideable" Color="Color.Primary">Hideable</MudSwitch>
     <MudSwitch @bind-Value="_hideMolar" Color="Color.Primary" Converter="_oppositeBoolConverter">Molar Mass Visible</MudSwitch>
-    <MudSwitch @bind-Value="_hideGroup" Color="Color.Primary" Converter="_oppositeBoolConverter">Category Visible</MudSwitch>
+    <MudSwitch @bind-Value="_hideCategory" Color="Color.Primary" Converter="_oppositeBoolConverter">Category Visible</MudSwitch>
+</div>
+
+<div class="d-flex flex-wrap mt-4 gap-1">
+    <MudButton OnClick="@(() => HideColumnsAsync(false))" Variant="Variant.Filled" Color="Color.Primary">Show All Columns</MudButton>
+    <MudButton OnClick="@(() => HideColumnsAsync(true))" Variant="Variant.Filled" Color="Color.Primary">Hide All Columns</MudButton>
+</div>
+
+<div class="d-flex flex-rows flex-wrap mr-4">
+    <MudSwitch @bind-Value="_groupable" Color="Color.Primary">Groupable</MudSwitch>
+    <MudSwitch @bind-Value="_groupMolar" Color="Color.Primary">Group By Molar</MudSwitch>
+    <MudSwitch @bind-Value="_groupCategory" Color="Color.Primary">Group By Category</MudSwitch>
 </div>
 
 <div class="d-flex flex-wrap mt-4">
@@ -38,10 +51,6 @@
     </MudRadioGroup>
 </div>
 
-<div class="d-flex flex-wrap mt-4 gap-1">
-    <MudButton OnClick="@(() => HideColumnsAsync(false))" Variant="Variant.Filled" Color="Color.Primary">Show All Columns</MudButton>
-    <MudButton OnClick="@(() => HideColumnsAsync(true))" Variant="Variant.Filled" Color="Color.Primary">Hide All Columns</MudButton>
-</div>
 
 @code {
     private IEnumerable<Element> _elements = new List<Element>();
@@ -53,7 +62,9 @@
     private bool _filterable = true;
     private bool _groupable = true;
     private bool _hideMolar = false;
-    private bool _hideGroup = false;
+    private bool _hideCategory = false;
+    private bool _groupMolar = false;
+    private bool _groupCategory = false;
     public MudDataGrid<Element> grid = null;
 
     private MudBlazor.Converter<bool, bool?> _oppositeBoolConverter = new()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
@@ -4,22 +4,36 @@
 <MudPopoverProvider />
 <MudDataGrid T="Model" ShowMenuIcon="true" Items="@_items" Groupable="true">
     <Columns>
-        <PropertyColumn Property="x => x.Name" Title="Name" />
-        <PropertyColumn Property="x => x.Age" Title="Age" />
+        <PropertyColumn Property="x => x.Name" Title="Name" Grouping="true" HeaderClass="name" />
+        <PropertyColumn Property="x => x.Age" Title="Age" Grouping="@IsAgeGrouped" HeaderClass="age" />
         <PropertyColumn Property="x => x.Gender" Title="Gender" @bind-Grouping="@IsGenderGrouped" HeaderClass="gender"/>
     </Columns>
 </MudDataGrid>
 
+<MudButton Class="GroupByGender" @onclick="GroupByGender">Group By Gender</MudButton>
+<MudButton Class="GroupByAge" @onclick="GroupByAge">Group By Age</MudButton>
 @code {
 
-    public bool IsGenderGrouped { get; set; } = false;
+    public bool IsGenderGrouped { get; set; }
+    public bool IsAgeGrouped { get; set; }
 
-    private List<Model> _items = new List<Model>()
+    public List<Model> _items = new List<Model>()
     {
         new Model("John", 45, "Male"), 
         new Model("Johanna", 23, "Female"), 
-        new Model("Steve", 32, "Male")
+        new Model("Steve", 32, "Male"),
+        new Model("Alice", 32, "Female")
     };
 
     public record Model(string Name, int Age, string Gender);
+
+    void GroupByGender(MouseEventArgs args)
+    {
+        IsGenderGrouped = true;
+    }
+
+    void GroupByAge(MouseEventArgs args)
+    {
+        IsAgeGrouped = true;
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3408,5 +3408,67 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.GridRenderedColumnsCount.Should().Be(0);
         }
+
+        [Test]
+        public async Task DataGridGroupingTestBoundAndUnboundScenarios()
+        {
+            var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnGroupingTest.Model>>();
+            var popoverProvider = comp.FindComponent<MudPopoverProvider>();
+
+            // Assert that initially, before any user interaction, IsGenderGrouped and IsAgeGrouped should be false
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            comp.Instance.IsAgeGrouped.Should().Be(false);
+
+            var ageGrouping = comp.Find(".GroupByAge");
+            ageGrouping.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(true);
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            var rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(5, because: "1 header row + 3 data rows + 1 footer row");
+
+            var genderGrouping = comp.Find(".GroupByGender");
+            genderGrouping.Click();
+            comp.Instance.IsGenderGrouped.Should().Be(true);
+            comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");
+            rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
+
+            //click age grouping in grid
+            var headerOption = comp.Find("th.age .mud-menu button");
+            headerOption.Click();
+            var listItems = popoverProvider.FindComponents<MudListItem>();
+            listItems.Count.Should().Be(2);
+            var clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(true);
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(5, because: "1 header row + 3 data rows + 1 footer row");
+
+            //click gender grouping in grid
+            headerOption = comp.Find("th.gender .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudListItem>();
+            listItems.Count.Should().Be(2);
+            clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover.Click();
+            comp.Instance.IsGenderGrouped.Should().Be(true);
+            comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");
+            rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
+
+            //click Name grouping in grid
+            headerOption = comp.Find("th.name .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudListItem>();
+            listItems.Count.Should().Be(2);
+            clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover.Click();
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");
+            rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(6, because: "1 header row + 4 data rows + 1 footer row");
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -113,7 +113,7 @@ else if (Column != null && !Column.HiddenState.Value)
                         }
                         @if (groupable)
                         {
-                            if (Column?.grouping ?? false)
+                            if (Column?.GroupingState.Value ?? false)
                             {
                                 <MudMenuItem OnClick="@UngroupColumn">@Localizer["MudDataGrid.Ungroup"]</MudMenuItem>
                             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -109,7 +109,7 @@
                                                             </MudStack>
                                                         }
 
-                                                        @if (context?.grouping ?? false)
+                                                        @if (context?.GroupingState.Value ?? false)
                                                         {
                                                             <MudIconButton DisableRipple="true" Icon="@Icons.Material.Filled.AccountTree" Size="@Size.Small" Title=@Localizer["MudDataGrid.Ungroup"] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.UngroupColumn())"></MudIconButton>
                                                         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -827,7 +827,7 @@ namespace MudBlazor
         {
             get
             {
-                return RenderedColumns.FirstOrDefault(x => x.grouping);
+                return RenderedColumns.FirstOrDefault(x => x.GroupingState.Value);
             }
         }
 


### PR DESCRIPTION
Fixes MudDataGrid column grouping so it works for bound and unbound scenarios.

## Description
Fixes: #8159
This fix implements the ParameterState framework for MudDataGrid column grouping. Allowing the parameter to be used in a bound state or as an initializer as disussed in #8258

There is a breaking change (minor I believe) in relation to the `Groupable` parameter. If you set `grouping` in code to true and `groupable` to false it will render grouped. Similarly if you `@bind-grouping` it won't respect the groupable parameter. Previously the behaviour was inconsistent between the initial value and an updated parameter. **The grid UI fully respects the groupable parameter as before.** 

I think this is appropriate behaviour, the UI enforces the groupable parameter but the developer has the choice to ignore it and group by any column. I can't think of a scenario where this will be an issue. There is potentially a way to retain the behaviour but it does mean in `@bind-grouping` scenarios with `groupable="false"` there is an immediate event callback to reset grouping. It would seem less flexible to me anyway.

## How Has This Been Tested?
Tested visually

Added test `DataGridGroupingTestBoundAndUnboundScenarios` to try grouping for bound and unbound scenarios and expected behaviour.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
