### PR TITLE
EnumExtensions: Remove ToDescriptionString

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -27,18 +27,5 @@ namespace MudBlazor.UnitTests.Extensions
             Align.Inherit.ToDescriptionString().Should().Be("inherit");
             Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
         }
-
-#pragma warning disable CS0618
-        /// <remarks>Remove this test(including DummyEnumEmpty) during The Big Break: Breaking Changes in v7</remarks>>
-        [Test]
-        public void ToDescriptionStringOld()
-        {
-            DummyEnumEmpty? dummyNullEnum = 0;
-            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Adornment.Start).Should().Be("start");
-            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Align.Inherit).Should().Be("inherit");
-            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(Breakpoint.Sm).Should().Be("sm");
-            MudBlazor.Extensions.EnumExtensions.ToDescriptionString(dummyNullEnum).Should().Be("0");
-        }
-#pragma warning restore CS0618
     }
 }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 
 namespace MudBlazor.Extensions
@@ -8,22 +7,6 @@ namespace MudBlazor.Extensions
 #nullable enable
     public static class EnumExtensions
     {
-        [Obsolete("Please use the auto-generated ToDescriptionString method instead or implement your own extension method.")]
-        public static string ToDescriptionString(this Enum value)
-        {
-            var field = value.GetType().GetField(value.ToString());
-            if (field is null)
-            {
-                return value.ToString().ToLower();
-            }
-
-            var attributes = Attribute.GetCustomAttributes(field, typeof(DescriptionAttribute), false) as DescriptionAttribute[];
-
-            return attributes is { Length: > 0 }
-                ? attributes[0].Description
-                : value.ToString().ToLower();
-        }
-
         /// <summary>
         /// Universal method that retrieves an array of the values of the constant in specified enumeration, works with nullable and non-nullable enums.
         /// Original <see cref="Enum.GetValues"/> works only with non-nullable enums and will throw exception.


### PR DESCRIPTION
## Description
Remove public `ToDescriptionString` enum extension.
We are using source-generator and we do not need this anymore.
People that used it in their own projects should add their own extension.
Also, I once saw a project that reference 3rd-party libraries, and there was 4 `ToDescription` extensions coming from different libraries, so it's pretty common extension and we don't need to add another one.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
