### PR TITLE
MudAutocomplete: Remove SearchFuncWithCancel, Add CancellationToken to SearchFunc

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteCancellationTokenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteCancellationTokenExample.razor
@@ -4,7 +4,7 @@
 
 <MudGrid>
 	<MudItem xs="12">
-		<MudAutocomplete T="string" Label="US States" @bind-Value="_state" SearchFuncWithCancel="@Search" Variant="Variant.Outlined" ShowProgressIndicator="true" />
+		<MudAutocomplete T="string" Label="US States" @bind-Value="_state" SearchFunc="@Search" Variant="Variant.Outlined" ShowProgressIndicator="true" />
 	</MudItem>
 </MudGrid>
 
@@ -14,9 +14,7 @@
 
 	private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
 	{
-		//the http endpoint does not return immediately. There is an artifical delay built-in
-		var result = await HttpClient.GetFromJsonAsync<IEnumerable<string>>($"webapi/AmericanStates/searchWithDelay/{value ?? string.Empty}", token);
-		return result;
+		// Forward the CancellationToken to methods which supported, such as HttpClient and DbContext
+		return await HttpClient.GetFromJsonAsync<IEnumerable<string>>($"webapi/AmericanStates/searchWithDelay/{value ?? string.Empty}", token);
 	}
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteClrObjectsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteClrObjectsExample.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Net.Http.Json
 @using MudBlazor.Examples.Data.Models
+@using System.Threading
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
@@ -33,8 +34,8 @@
 @code {
     private Element value1, value2;
 
-    private async Task<IEnumerable<Element>> Search(string value)
+    private async Task<IEnumerable<Element>> Search(string value, CancellationToken token)
     {
-        return  await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}");
+        return  await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}", token);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteMarginDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteMarginDenseExample.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
+@using System.Threading
 
 <MudGrid>
     <MudItem xs="12" sm="6">
@@ -49,10 +50,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompletePresentationExtrasExample.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Net.Http.Json
 @using MudBlazor.Examples.Data.Models
+@using System.Threading
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
@@ -47,14 +48,14 @@
 @code {
     private Element value1, value2, value3, value4;
 
-    private async Task<IEnumerable<Element>> Search(string value)
+    private async Task<IEnumerable<Element>> Search(string value, CancellationToken token)
     {
-        return await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}");
+        return await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}", token);
     }
 
-    private async Task<IEnumerable<Element>> SearchEmpty(string value)
+    private async Task<IEnumerable<Element>> SearchEmpty(string value, CancellationToken token)
     {
-        await Task.Delay(5);
+        await Task.Delay(5, token);
         return Array.Empty<Element>();
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteProgressExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteProgressExample.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
+@using System.Threading
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
@@ -60,10 +61,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(1000);
+        await Task.Delay(1000, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteStrictFalseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteStrictFalseExample.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Net.Http.Json
 @using MudBlazor.Examples.Data.Models
+@using System.Threading
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
@@ -19,8 +20,8 @@
 @code {
     private Element value1, value2;
 
-    private async Task<IEnumerable<Element>> Search(string value)
+    private async Task<IEnumerable<Element>> Search(string value, CancellationToken token)
     {
-        return await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}");
+        return await httpClient.GetFromJsonAsync<List<Element>>($"webapi/periodictable/{value}", token);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
+@using System.Threading
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
@@ -47,10 +48,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))
@@ -58,10 +59,10 @@
         return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
     }
 
-    private async Task<IEnumerable<string>> Search2(string value)
+    private async Task<IEnumerable<string>> Search2(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, don't return values (drop-down will not open)
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -1,5 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 @using System.ComponentModel.DataAnnotations
+@using System.Threading
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
@@ -95,10 +96,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> SearchAsync(string value)
+    private async Task<IEnumerable<string>> SearchAsync(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
@@ -6,7 +6,7 @@
 <MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
 
 <div>
-    <MudRadioGroup T="Position" @bind-SelectedValue="LegendPosition">
+    <MudRadioGroup T="Position" @bind-Value="LegendPosition">
         <MudRadio Value="@(Position.Bottom)" Color="Color.Primary">Bottom</MudRadio>
         <MudRadio Value="@(Position.Top)" Color="Color.Primary">Top</MudRadio>
         <MudRadio Value="@(Position.Left)" Color="Color.Primary">Left</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridFilteringExample.razor
@@ -18,7 +18,7 @@
 </MudDataGrid>
 
 <div class="d-flex flex-wrap mt-4">
-    <MudRadioGroup T="DataGridFilterMode" @bind-SelectedValue="@_filterMode">
+    <MudRadioGroup T="DataGridFilterMode" @bind-Value="@_filterMode">
         <MudRadio Dense="true" Value="@DataGridFilterMode.Simple" Color="Color.Primary">Simple</MudRadio>
         <MudRadio Dense="true" Value="@DataGridFilterMode.ColumnFilterMenu" Color="Color.Tertiary">Column Menu</MudRadio>
         <MudRadio Dense="true" Value="@DataGridFilterMode.ColumnFilterRow">Column Row</MudRadio>
@@ -26,7 +26,7 @@
 </div>
 
 <div class="d-flex flex-wrap mt-4">
-    <MudRadioGroup T="DataGridFilterCaseSensitivity" @bind-SelectedValue="@_caseSensitivity">
+    <MudRadioGroup T="DataGridFilterCaseSensitivity" @bind-Value="@_caseSensitivity">
         <MudRadio Dense="true" Value="@DataGridFilterCaseSensitivity.Default" Color="Color.Primary">Default Case Sensitivity</MudRadio>
         <MudRadio Dense="true" Value="@DataGridFilterCaseSensitivity.CaseInsensitive" Color="Color.Tertiary">Case Insensitive</MudRadio>
     </MudRadioGroup>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridSortingExample.razor
@@ -24,7 +24,7 @@
 
 <div class="d-flex flex-wrap mt-4">
     <MudSwitch @bind-Value="_sortNameByLength" Color="Color.Primary">Sort Name Column By Length</MudSwitch>
-    <MudRadioGroup T=SortMode @bind-SelectedValue="@_sortMode">
+    <MudRadioGroup T=SortMode @bind-Value="@_sortMode">
         <MudRadio Dense=true Value=@SortMode.Multiple Color="Color.Primary">Multiple</MudRadio>
         <MudRadio Dense=true Value=@SortMode.Single Color="Color.Tertiary">Single</MudRadio>
         <MudRadio Dense=true Value=@SortMode.None>None</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -102,7 +102,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Blurry Dialog">
-                <Description>Dialog background can be changed via <CodeInline>ClassBackground</CodeInline> dialog option.</Description>
+                <Description>Dialog background can be changed via <CodeInline>BackgroundClass</CodeInline> dialog option.</Description>
             </SectionHeader>
             <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogBlurryExample"), new CodeFile("Dialog.razor", "DialogBlurryExample_Dialog")})">
                 <DialogBlurryExample />

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogBlurryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogBlurryExample.razor
@@ -3,7 +3,7 @@
 @inject IDialogService DialogService
 
 
-<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Simple Dialog
 </MudButton>
 
@@ -15,9 +15,10 @@
 
 @code {
 
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {
         var options = new DialogOptions { BackgroundClass = "my-custom-class" };
-        DialogService.Show<DialogBlurryExample_Dialog>("Simple Dialog", options);
+
+        return DialogService.ShowAsync<DialogBlurryExample_Dialog>("Simple Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogBlurryExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogBlurryExample_Dialog.razor
@@ -11,8 +11,10 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogConfigurationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogConfigurationExample.razor
@@ -8,5 +8,4 @@
     NoHeader="true"
     Position="DialogPosition.Center"
     CloseOnEscapeKey="true"
-    BackgroundClass="my-custom-class"
-/>
+    BackgroundClass="my-custom-class"/>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogFocusExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogFocusExample.razor
@@ -3,16 +3,16 @@
 @inject IDialogService DialogService
 
 
-<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Dialog
 </MudButton>
 
-
 @code {
 
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true };
-        DialogService.Show<DialogFocusExample_Dialog>("Last element focused", options);
+
+        return DialogService.ShowAsync<DialogFocusExample_Dialog>("Last element focused", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogFocusExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogFocusExample_Dialog.razor
@@ -11,10 +11,11 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogInlineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogInlineExample.razor
@@ -4,10 +4,10 @@
     <MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
         Edit rating
     </MudButton>
-    <MudRating SelectedValue="rating" Disabled="true" Class="mt-1 ml-3" />
+    <MudRating SelectedValue="_rating" Disabled="true" Class="mt-1 ml-3" />
 </div>
 
-<MudDialog @bind-IsVisible="visible" Options="dialogOptions">
+<MudDialog @bind-IsVisible="_visible" Options="_dialogOptions">
     <TitleContent>
         <MudText Typo="Typo.h6">
             <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-3" /> Edit rating
@@ -15,7 +15,7 @@
     </TitleContent>
     <DialogContent>
         <p>How awesome are inline dialogs?</p>
-        <MudRating @bind-SelectedValue="rating" Class="mt-3" />
+        <MudRating @bind-SelectedValue="_rating" Class="mt-3" />
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Submit" Class="px-10">Close</MudButton>
@@ -23,10 +23,11 @@
 </MudDialog>
 
 @code {
-    private bool visible;
-    private int rating;
-    private void OpenDialog() => visible = true;
-    void Submit() => visible = false;
+    private bool _visible;
+    private int _rating;
+    private readonly DialogOptions _dialogOptions = new() { FullWidth = true };
 
-    private DialogOptions dialogOptions = new() { FullWidth = true };
+    private void OpenDialog() => _visible = true;
+
+    private void Submit() => _visible = false;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample.razor
@@ -3,17 +3,16 @@
 @inject IDialogService DialogService
 
 
-<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Dialog
 </MudButton>
 
-
 @code {
 
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {    
-        DialogOptions closeOnEscapeKey = new DialogOptions() { CloseOnEscapeKey = true };
+        var options = new DialogOptions { CloseOnEscapeKey = true };
 
-        DialogService.Show<DialogKeyboardNavigationExample_Dialog>("Simple Dialog", closeOnEscapeKey);
+        return DialogService.ShowAsync<DialogKeyboardNavigationExample_Dialog>("Simple Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
@@ -16,10 +16,11 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample.razor
@@ -2,14 +2,15 @@
 
 @inject IDialogService DialogService
 
-<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Simple Dialog
 </MudButton>
 
 @code {
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true };
-        var dialog = DialogService.Show<DialogNestedExample_Dialog>("First Level Dialog", options);
+
+        return DialogService.ShowAsync<DialogNestedExample_Dialog>("First Level Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample_Dialog.razor
@@ -8,18 +8,19 @@
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="OpenSecondDialog">Open Second Dialog</MudButton>
+        <MudButton Color="Color.Primary" OnClick="OpenSecondDialogAsync">Open Second Dialog</MudButton>
     </DialogActions>
 </MudDialog>
 
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Cancel() => MudDialog.Cancel();
+    private void Cancel() => MudDialog.Cancel();
 
-    private void OpenSecondDialog()
+    private Task OpenSecondDialogAsync()
     {
-        DialogService.Show<DialogNestedExample_Dialog2>("Second Level Dialog");
+        return DialogService.ShowAsync<DialogNestedExample_Dialog2>("Second Level Dialog");
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample_Dialog2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedExample_Dialog2.razor
@@ -12,13 +12,10 @@
 
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Cancel() => MudDialog.Cancel();
 
-    private void CancelAll()
-    {
-        MudDialog.CancelAll();
-    }
+    private void CancelAll() => MudDialog.CancelAll();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedInlineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedInlineExample.razor
@@ -3,15 +3,15 @@
 @inject IDialogService DialogService
 
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Open">Open Inline</MudButton>
-<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Open2">Open With Show</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Open2Async">Open With Show</MudButton>
 
 @*Outer inline dialog*@
-<MudDialog @bind-IsVisible="visible">
+<MudDialog @bind-IsVisible="_visible">
     <DialogContent>
         <MudText>Hi There, I'm an inline dialog!</MudText>
         <MudButton Variant="Variant.Filled" Color="Color.Tertiary" OnClick="OpenNested">Open Nested</MudButton>
         @*Nested inline dialog*@
-        <MudDialog @bind-IsVisible="nestedVisible">
+        <MudDialog @bind-IsVisible="_nestedVisible">
             <DialogContent>
                 <MudText Class="nested">Nested inline dialog!</MudText>
             </DialogContent>
@@ -26,14 +26,17 @@
 </MudDialog>
 
 @code {
-    private bool visible;
-    private bool nestedVisible;
+    private bool _visible;
+    private bool _nestedVisible;
 
-    private void Open() => visible = true;
-    private void Close() => visible = false;
-    private void OpenNested() => nestedVisible = true;
-    private void CloseNested() => nestedVisible = false;
+    private void Open() => _visible = true;
+
+    private void Close() => _visible = false;
+
+    private void OpenNested() => _nestedVisible = true;
+
+    private void CloseNested() => _nestedVisible = false;
 
     @*Open a non-inline dialog component that nests an inline dialog*@
-    private void Open2() => DialogService.Show<DialogNestedInlineExample_Dialog>();
+    private Task Open2Async() => DialogService.ShowAsync<DialogNestedInlineExample_Dialog>();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedInlineExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogNestedInlineExample_Dialog.razor
@@ -6,7 +6,7 @@
         <MudText>Hi There, I'm a regular dialog!</MudText>
         <MudButton Variant="Variant.Filled" Color="Color.Tertiary" OnClick="OpenNested">Open Nested</MudButton>
         @*Nested dialog*@
-        <MudDialog @bind-IsVisible="nestedVisible">
+        <MudDialog @bind-IsVisible="_nestedVisible">
             <DialogContent>
                 <MudText Class="nested">Nested inline dialog!</MudText>
             </DialogContent>
@@ -20,11 +20,13 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    private bool _nestedVisible;
 
-    private bool nestedVisible;
-    private void OpenNested() => nestedVisible = true;
-    private void CloseNested() => nestedVisible = false;
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
+
+    private void OpenNested() => _nestedVisible = true;
+
+    private void CloseNested() => _nestedVisible = false;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
@@ -2,24 +2,24 @@
 
 @inject IDialogService Dialog
 
-<MudButton OnClick="@((e) => OpenDialog(maxWidth))">Open MaxWidth Dialog</MudButton>
-<MudButton OnClick="@((e) => OpenDialog(closeButton))" Color="Color.Primary">Close Button Dialog</MudButton>
-<MudButton OnClick="@((e) => OpenDialog(noHeader))" Color="Color.Secondary">No header Dialog</MudButton>
-<MudButton OnClick="@((e) => OpenDialog(disableBackdropClick))" Color="Color.Tertiary">Disable backdrop dialog</MudButton>
-<MudButton OnClick="@((e) => OpenDialog(fullScreen))" Color="Color.Info">Full Screen Dialog</MudButton>
-<MudButton OnClick="@((e) => OpenDialog(topCenter))" Color="Color.Success">Top Center Dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_maxWidth))">Open MaxWidth Dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_closeButton))" Color="Color.Primary">Close Button Dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_noHeader))" Color="Color.Secondary">No header Dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_disableBackdropClick))" Color="Color.Tertiary">Disable backdrop dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_fullScreen))" Color="Color.Info">Full Screen Dialog</MudButton>
+<MudButton OnClick="@(() => OpenDialogAsync(_topCenter))" Color="Color.Success">Top Center Dialog</MudButton>
 
 
 @code {
-    DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true };
-    DialogOptions closeButton = new DialogOptions() { CloseButton = true };
-    DialogOptions noHeader = new DialogOptions() {  NoHeader = true };
-    DialogOptions disableBackdropClick = new DialogOptions() { DisableBackdropClick = true };
-    DialogOptions fullScreen = new DialogOptions() { FullScreen = true, CloseButton = true };
-    DialogOptions topCenter = new DialogOptions() { Position = DialogPosition.TopCenter };
+    private readonly DialogOptions _maxWidth = new() { MaxWidth = MaxWidth.Medium, FullWidth = true };
+    private readonly DialogOptions _closeButton = new() { CloseButton = true };
+    private readonly DialogOptions _noHeader = new() { NoHeader = true };
+    private readonly DialogOptions _disableBackdropClick = new() { DisableBackdropClick = true };
+    private readonly DialogOptions _fullScreen = new() { FullScreen = true, CloseButton = true };
+    private readonly DialogOptions _topCenter = new() { Position = DialogPosition.TopCenter };
 
-    private void OpenDialog(DialogOptions options)
+    private Task OpenDialogAsync(DialogOptions options)
     {
-        Dialog.Show<DialogUsageExample_Dialog>("Custom Options Dialog", options);
+        return Dialog.ShowAsync<DialogUsageExample_Dialog>("Custom Options Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample_Dialog.razor
@@ -10,10 +10,11 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample.razor
@@ -8,16 +8,16 @@
     {
         <MudPaper Class="d-flex align-center pa-2 mx-2 my-2">
             <MudText>@item.Name</MudText>
-            <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="@((e) => DeleteServer(item))">Delete</MudButton>
+            <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="@((e) => DeleteServerAsync(item))">Delete</MudButton>
         </MudPaper>
     }
 </div>
 
 @code {
 
-    async Task DeleteServer(Server server)
+    private async Task DeleteServerAsync(Server server)
     {
-        var parameters = new DialogParameters<DialogPassingDataExample_Dialog> { { x => x.server, server } };
+        var parameters = new DialogParameters<DialogPassingDataExample_Dialog> { { x => x.Server, server } };
 
         var dialog = await DialogService.ShowAsync<DialogPassingDataExample_Dialog>("Delete Server", parameters);
         var result = await dialog.Result;
@@ -39,6 +39,3 @@
         new Server{ Id = Guid.NewGuid(), Name = "Server4", Location = "Germany", IpAddress = "193.168.1.1" },
     };
 }
-
-
-

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample_Dialog.razor
@@ -11,10 +11,10 @@
         </MudText>
     </TitleContent>
     <DialogContent>
-        <MudTextField Value="@server.Id.ToString()" Label="Server ID" ReadOnly="true"/>
-        <MudTextField Value="@server.Name" Label="Server Name" ReadOnly="true"/>
-        <MudTextField Value="@server.Location" Label="Location" ReadOnly="true"/>
-        <MudTextField Value="@server.IpAddress" Label="IP Address" ReadOnly="true"/>
+        <MudTextField Value="@Server.Id.ToString()" Label="Server ID" ReadOnly="true"/>
+        <MudTextField Value="@Server.Name" Label="Server Name" ReadOnly="true"/>
+        <MudTextField Value="@Server.Location" Label="Location" ReadOnly="true"/>
+        <MudTextField Value="@Server.IpAddress" Label="IP Address" ReadOnly="true"/>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
@@ -22,21 +22,19 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    [Parameter] public Server server { get; set; } = new Server();
+    [Parameter]
+    public Server Server { get; set; } = new Server();
 
-    private void Cancel()
-    {
-        MudDialog.Cancel();
-    }
+    private void Cancel() => MudDialog.Cancel();
 
     private void DeleteServer()
     {
         //In a real world scenario this bool would probably be a service to delete the item from api/database
         Snackbar.Add("Server Deleted", Severity.Success);
-        MudDialog.Close(DialogResult.Ok(server.Id));
+        MudDialog.Close(DialogResult.Ok(Server.Id));
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample.razor
@@ -2,20 +2,21 @@
 
 @inject IDialogService DialogService
 
-<MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton OnClick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Scrollable Dialog
 </MudButton>
 
 @code {
-    bool license_accepted = false;
+    private bool _licenseAccepted = false;
 
-    async Task OpenDialog()
+    private async Task OpenDialogAsync()
     {
-        var result = await DialogService.Show<DialogScrollableExample_Dialog>("MudBlazor License").Result;
+        var dialog = await DialogService.ShowAsync<DialogScrollableExample_Dialog>("MudBlazor License");
+        var result = await dialog.Result;
 
         if (!result.Canceled)
         {
-            license_accepted = (bool)(result.Data ?? false);
+            _licenseAccepted = (bool)(result.Data ?? false);
         }
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample_Dialog.razor
@@ -1,17 +1,15 @@
-﻿@using System.Net
-@using System.Text
-@namespace MudBlazor.Docs.Examples
+﻿@namespace MudBlazor.Docs.Examples
 
 <MudDialog DisableSidePadding="true">
     <DialogContent>
         <MudContainer Style="max-height: 300px; overflow-y: scroll">
-            @if (Loading)
+            @if (_loading)
             {
                 <MudProgressCircular Indeterminate="true"></MudProgressCircular>
             }
             else
             {
-                <MudText Style="white-space: pre-wrap;">@LicenseText</MudText>
+                <MudText Style="white-space: pre-wrap;">@_licenseText</MudText>
             }
         </MudContainer>
     </DialogContent>
@@ -22,24 +20,23 @@
 
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    private string _licenseText;
+    private bool _loading;
 
-    [Inject] HttpClient HttpClient { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
+
+    [Inject]
+    private HttpClient HttpClient { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        Loading = true;
+        _loading = true;
         var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE");
-        LicenseText = await response.Content.ReadAsStringAsync();
-        Loading = false;
+        _licenseText = await response.Content.ReadAsStringAsync();
+        _loading = false;
     }
 
-    private string LicenseText;
-    private bool Loading = false;
-
-    private void Ok()
-    {
-        MudDialog.Close(DialogResult.Ok(true));
-    }
+    private void Ok() => MudDialog.Close(DialogResult.Ok(true));
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample.razor
@@ -2,14 +2,14 @@
 
 @inject IDialogService DialogService
 
-<MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton OnClick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Options Dialog
 </MudButton>
 
 @code {
 
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {
-        DialogService.Show<DialogSetOptionsExample_Dialog>("Options Dialog");
+        return DialogService.ShowAsync<DialogSetOptionsExample_Dialog>("Options Dialog");
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample_Dialog.razor
@@ -15,28 +15,29 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Close() => MudDialog.Close(DialogResult.Ok(true));
+    private void Close() => MudDialog.Close(DialogResult.Ok(true));
 
-    void ChangeTitle()
+    private void ChangeTitle()
     {
-        MudDialog.SetTitle("Current time is: " + DateTime.Now);
+        MudDialog.SetTitle($"Current time is: {DateTime.Now}");
     }
 
-    void ToggleCloseButton()
+    private void ToggleCloseButton()
     {
         MudDialog.Options.CloseButton = !(MudDialog.Options.CloseButton ?? false);
         MudDialog.SetOptions(MudDialog.Options);
     }
 
-    void ToggleFullWidth()
+    private void ToggleFullWidth()
     {
         MudDialog.Options.FullWidth = !(MudDialog.Options.FullWidth ?? true);
         MudDialog.SetOptions(MudDialog.Options);
     }
 
-    void ToggleHeader()
+    private void ToggleHeader()
     {
         MudDialog.Options.NoHeader = !(MudDialog.Options.NoHeader ?? false);
         MudDialog.SetOptions(MudDialog.Options);

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogStylingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogStylingExample.razor
@@ -2,16 +2,15 @@
 
 @inject IDialogService DialogService
 
-
 <MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Custom Styled Dialog
 </MudButton>
-
 
 @code {
     private Task OpenDialogAsync()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true, CloseButton = true };
+
         return DialogService.ShowAsync<DialogStylingExample_Dialog>("Styling Example Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogStylingExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogStylingExample_Dialog.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDialog TitleClass="mud-primary" ClassContent="mud-secondary" ClassActions="mud-tertiary">
+<MudDialog TitleClass="mud-primary" ContentClass="mud-secondary" ActionsClass="mud-tertiary">
     <DialogContent>
         Dialog Content
     </DialogContent>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample.razor
@@ -3,41 +3,47 @@
 @inject IDialogService DialogService
 
 
-<MudButton @onclick="DeleteUser" Variant="Variant.Filled" Color="Color.Error">Delete Records</MudButton>
-<MudButton @onclick="Confirm" Variant="Variant.Filled" Color="Color.Success">Remove Email</MudButton>
-<MudButton @onclick="Download" Variant="Variant.Filled" Color="Color.Warning">Slow Computer</MudButton>
+<MudButton @onclick="DeleteUserAsync" Variant="Variant.Filled" Color="Color.Error">Delete Records</MudButton>
+<MudButton @onclick="ConfirmAsync" Variant="Variant.Filled" Color="Color.Success">Remove Email</MudButton>
+<MudButton @onclick="DownloadAsync" Variant="Variant.Filled" Color="Color.Warning">Slow Computer</MudButton>
 
 @code {
 
-    private void DeleteUser()
+    private Task DeleteUserAsync()
     {
-        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
-        parameters.Add(x => x.ContentText, "Do you really want to delete these records? This process cannot be undone.");
-        parameters.Add(x => x.ButtonText, "Delete");
-        parameters.Add(x => x.Color, Color.Error);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>
+        {
+            { x => x.ContentText, "Do you really want to delete these records? This process cannot be undone." },
+            { x => x.ButtonText, "Delete" },
+            { x => x.Color, Color.Error }
+        };
 
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
 
-        DialogService.Show<DialogTemplateExample_Dialog>("Delete", parameters, options);
+        return DialogService.ShowAsync<DialogTemplateExample_Dialog>("Delete", parameters, options);
     }
 
-    private void Confirm()
+    private Task ConfirmAsync()
     {
-        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
-        parameters.Add(x => x.ContentText, "Are you sure you want to remove thisguy@emailz.com from this account?");
-        parameters.Add(x => x.ButtonText, "Yes");
-        parameters.Add(x => x.Color, Color.Success);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>
+        {
+            { x => x.ContentText, "Are you sure you want to remove thisguy@emailz.com from this account?" },
+            { x => x.ButtonText, "Yes" },
+            { x => x.Color, Color.Success }
+        };
 
-        DialogService.Show<DialogTemplateExample_Dialog>("Confirm", parameters);
+        return DialogService.ShowAsync<DialogTemplateExample_Dialog>("Confirm", parameters);
     }
 
-    private void Download()
+    private Task DownloadAsync()
     {
-        var parameters = new DialogParameters<DialogTemplateExample_Dialog>();
-        parameters.Add(x => x.ContentText, "Your computer seems very slow, click the download button to download free RAM.");
-        parameters.Add(x => x.ButtonText, "Download");
-        parameters.Add(x => x.Color, Color.Info);
+        var parameters = new DialogParameters<DialogTemplateExample_Dialog>
+        {
+            { x => x.ContentText, "Your computer seems very slow, click the download button to download free RAM." },
+            { x => x.ButtonText, "Download" },
+            { x => x.Color, Color.Info }
+        };
 
-        DialogService.Show<DialogTemplateExample_Dialog>("Slow Computer Detected", parameters);
+        return DialogService.ShowAsync<DialogTemplateExample_Dialog>("Slow Computer Detected", parameters);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogTemplateExample_Dialog.razor
@@ -10,16 +10,20 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    [Parameter] public string ContentText { get; set; }
+    [Parameter]
+    public string ContentText { get; set; }
 
-    [Parameter] public string ButtonText { get; set; }
+    [Parameter]
+    public string ButtonText { get; set; }
 
-    [Parameter] public Color Color { get; set; }
+    [Parameter]
+    public Color Color { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample.razor
@@ -2,17 +2,16 @@
 
 @inject IDialogService DialogService
 
-
-<MudButton @onclick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+<MudButton @onclick="OpenDialogAsync" Variant="Variant.Filled" Color="Color.Primary">
     Open Simple Dialog
 </MudButton>
 
-
 @code {
 
-    private void OpenDialog()
+    private Task OpenDialogAsync()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true };
-        DialogService.Show<DialogUsageExample_Dialog>("Simple Dialog", options);
+
+        return DialogService.ShowAsync<DialogUsageExample_Dialog>("Simple Dialog", options);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample_Dialog.razor
@@ -10,10 +10,11 @@
     </DialogActions>
 </MudDialog>
 
-
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAdvancedPopoverExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAdvancedPopoverExample.razor
@@ -3,7 +3,7 @@
 <MudGrid>
     <MudItem xs="3">
         <MudText Typo="Typo.h6">Anchor Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column">
+        <MudRadioGroup T="Origin" @bind-Value="AnchorOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
@@ -26,7 +26,7 @@
     </MudItem>
     <MudItem xs="3">
         <MudText Typo="Typo.h6">Transform Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column">
+        <MudRadioGroup T="Origin" @bind-Value="TransformOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAnchorOriginExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAnchorOriginExample.razor
@@ -3,14 +3,14 @@
 <MudGrid>
     <MudItem xs="12" md="3">
         <MudText Typo="Typo.h6">Anchor Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column my-2">
+        <MudRadioGroup T="Origin" @bind-Value="AnchorOrigin" Class="d-flex flex-column my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomLeft">Bottom-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomRight">Bottom-Right</MudRadio>
         </MudRadioGroup>
         <MudText Typo="Typo.h6">Transform Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column  my-2">
+        <MudRadioGroup T="Origin" @bind-Value="TransformOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter" Disabled="true">Top-Center</MudRadio>
         </MudRadioGroup>
     </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuTransformOriginExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuTransformOriginExample.razor
@@ -3,11 +3,11 @@
 <MudGrid>
     <MudItem xs="12" md="3">
         <MudText Typo="Typo.h6">Anchor Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column  my-2">
+        <MudRadioGroup T="Origin" @bind-Value="AnchorOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft" Disabled="true">Top-Left</MudRadio>
         </MudRadioGroup>
         <MudText Typo="Typo.h6">Transform Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column  my-2">
+        <MudRadioGroup T="Origin" @bind-Value="TransformOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
         </MudRadioGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
@@ -3,7 +3,7 @@
 <MudGrid>
     <MudItem xs="3">
         <MudText Typo="Typo.h6">Anchor Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column">
+        <MudRadioGroup T="Origin" @bind-Value="AnchorOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
@@ -29,7 +29,7 @@
     </MudItem>
     <MudItem xs="3">
         <MudText Typo="Typo.h6">Transform Origin</MudText>
-        <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column">
+        <MudRadioGroup T="Origin" @bind-Value="TransformOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackCombinedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackCombinedExample.razor
@@ -9,7 +9,7 @@
 </MudPaper>
 
 <MudStack Row="true" Justify="Justify.Center">
-    <MudRadioGroup T="bool" @bind-SelectedValue="@_row">
+    <MudRadioGroup T="bool" @bind-Value="@_row">
         <MudRadio Value="false" Dense="true">Column</MudRadio>
         <MudRadio Value="true" Dense="true">Row</MudRadio>
     </MudRadioGroup>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -88,7 +88,7 @@
     </MudTooltip>
 </div>
 
-<MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
+<MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
                          AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -71,7 +71,7 @@
     {
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
                          AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined"
-                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+                         SearchFunc="async (text, token) => await Search(text, token)" ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
@@ -92,7 +92,7 @@
     <DialogContent>
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
                          AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-                         SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
+                         SearchFunc="async (text, token) => await Search(text, token)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -69,7 +69,7 @@
     <MudSpacer/>
     @if (DisplaySearchBar)
     {
-        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="async text => await Search(text)" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar mx-4" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="async (text, token) => await Search(text, token)" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar mx-4" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
@@ -89,7 +89,7 @@
 
 <MudDialog @bind-IsVisible="_searchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ClassContent="docs-mobile-dialog-search">
     <DialogContent>
-        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" Placeholder="Search docs" SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+        <MudAutocomplete AutoFocus="true" @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" Placeholder="Search docs" SearchFunc="async (text, token) => await Search(text, token)" ValueChanged="OnSearchResult" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -118,7 +119,7 @@ public partial class Appbar
         return page == LayoutService.GetDocsBasePage(NavigationManager.Uri) ? "mud-chip-text mud-chip-color-primary mx-1 px-3" : "mx-1 px-3";
     }
 
-    private Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text)
+    private Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text, CancellationToken token)
     {
         if (string.IsNullOrWhiteSpace(text))
         {

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -131,7 +132,7 @@ public partial class Appbar
         return page == LayoutService.GetDocsBasePage(NavigationManager.Uri) ? "mud-chip-text mud-chip-color-primary mx-1 px-3" : "mx-1 px-3";
     }
 
-    private Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text)
+    private Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text, CancellationToken token)
     {
         if (string.IsNullOrWhiteSpace(text))
         {

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @using System.Reflection
+@using System.Threading
 
 <MudLayout>
     <MudAppBar Elevation="0">
@@ -107,7 +108,7 @@
         return (string)field.GetValue(null);
     }
 
-    private Task<IEnumerable<Type>> Search(string text)
+    private Task<IEnumerable<Type>> Search(string text, CancellationToken token)
     {
         if (string.IsNullOrWhiteSpace(text))
             return Task.FromResult<IEnumerable<Type>>(new Type[0]);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentChange.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentChange.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" AdornmentIcon="@Icon" />
@@ -31,10 +32,10 @@
 	[Parameter]
 	public string Icon { get; set; } = Icons.Material.Filled.Abc;
 
-	private async Task<IEnumerable<string>> Search1(string value)
+	private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
 	{
 		// In real life use an asynchronous function for fetching data from an api.
-		await Task.Delay(5);
+		await Task.Delay(5, token);
 
 		// if text is null or empty, show complete list
 		if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteChangeBoundObjectTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteChangeBoundObjectTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudGrid>
     <MudItem xs="12" sm="4">
@@ -50,10 +51,10 @@
         StateHasChanged();
     }
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider></MudPopoverProvider>
 
@@ -36,7 +37,7 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private Task<IEnumerable<string>> Search(string value)
+    private Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
         return Task.FromResult(result);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListBeforeAndAfterRendersWithItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListBeforeAndAfterRendersWithItemsTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search" MaxItems="10">
@@ -33,7 +34,7 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private Task<IEnumerable<string>> Search(string value)
+    private Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
         return Task.FromResult(result);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListEndRendersTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
@@ -30,10 +31,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
-    // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5, token);
 
         return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteListStartRendersTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
@@ -30,10 +31,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
         return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteRequiredTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider></MudPopoverProvider>
 
@@ -29,7 +30,7 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private Task<IEnumerable<string>> Search(string value)
+    private Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         var result = string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
         return Task.FromResult(result);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetTest.razor
@@ -33,7 +33,7 @@
         return Task.CompletedTask;
     }
 
-    private Task<IEnumerable<string>> Search(string value)
+    private Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         if (string.IsNullOrEmpty(value))
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSetParametersInitialization.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSetParametersInitialization.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
  @* Based on this try https://try.mudblazor.com/snippet/GacPunvDUyjdUJAh
   and this issue https://github.com/MudBlazor/MudBlazor/issues/1235*@
@@ -50,9 +51,9 @@
         };
     }
 
-    private async Task<IEnumerable<ExternalList>> Search2(string value)
+    private async Task<IEnumerable<ExternalList>> Search2(string value, CancellationToken token)
     {
-        await Task.Delay(0);
+        await Task.Delay(0, token);
         if (string.IsNullOrEmpty(value))
             return _externalList;
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider />
 
@@ -23,9 +24,9 @@
 		return text.Equals("carrot", StringComparison.InvariantCulture);
 	};
 
-	public async Task<IEnumerable<string>> Search(string text)
-	{
-		await Task.Delay(100);
+    public async Task<IEnumerable<string>> Search(string text, CancellationToken token)
+    {
+		await Task.Delay(100, token);
 
 		if (string.IsNullOrWhiteSpace(text))
 		{

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete Label="State" SearchFunc="@SearchStateAsync" 
@@ -15,17 +16,17 @@
     public State StateDetails { get; set; }
     public State StateDetails2 { get; set; }
 
-    public async Task<IEnumerable<State>> SearchStateAsync(string value)
+    public async Task<IEnumerable<State>> SearchStateAsync(string value, CancellationToken token)
     {
-        await Task.Delay(5);
+        await Task.Delay(5, token);
         if (string.IsNullOrEmpty(value))
             return states.Select(x => new State(x));
         return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)).Select(x => new State(x));
     }
 
-    public async Task<IEnumerable<State>> SearchStateToStringAsync(string value)
+    public async Task<IEnumerable<State>> SearchStateToStringAsync(string value, CancellationToken token)
     {
-        await Task.Delay(5);
+        await Task.Delay(5, token);
         if (string.IsNullOrEmpty(value))
             return states.Select(x => new StateToString(x));
         return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)).Select(x => new StateToString(x));

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteSyncTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 
 <MudPopoverProvider />
 
@@ -11,7 +12,7 @@
 
     public static readonly string[] Items = { "One", "Two", "Three" };
 
-    private Task<IEnumerable<string>> Search(string text)
+    private Task<IEnumerable<string>> Search(string text, CancellationToken token)
     {
         var result = string.IsNullOrWhiteSpace(text)
             ? Items

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
@@ -26,10 +27,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(50);
+        await Task.Delay(50, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" MinCharacters="3" />
@@ -26,10 +27,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete Label="State" SearchFunc="@SearchStateAsync" 
@@ -67,10 +68,10 @@
         StateList = new List<State> { s1, s2, s3, s4, s5, s6, s7 };
     }
 
-    public async Task<IEnumerable<State>> SearchStateAsync(string value)
+    public async Task<IEnumerable<State>> SearchStateAsync(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         IEnumerable<State> list;
         if (string.IsNullOrEmpty(value)) list = StateList;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete Label="State" SearchFunc="@SearchStateAsync" 
@@ -10,10 +11,10 @@
     public IEnumerable<State> StateList { get; set; }
     public State StateDetails { get; set; } = new State() { StateName = "Assam"};
 
-    public async Task<IEnumerable<State>> SearchStateAsync(string value)
+    public async Task<IEnumerable<State>> SearchStateAsync(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         return new State[0];
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest5.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete ReadOnly="true" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" />
@@ -26,10 +27,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest6.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
@@ -30,10 +31,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest7.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest7.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" MaxItems="10">
@@ -30,10 +31,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         return states.Where(x => x.Contains("some string", StringComparison.InvariantCultureIgnoreCase));
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestClearable.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestClearable.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" Clearable="true" />
@@ -26,10 +27,10 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-    private async Task<IEnumerable<string>> Search1(string value)
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.
-        await Task.Delay(5);
+        await Task.Delay(5, token);
 
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationDataAttrTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationDataAttrTest.razor
@@ -1,5 +1,6 @@
 ﻿@using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Components.Forms
+@using System.Threading
 @namespace MudBlazor.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 
@@ -29,7 +30,7 @@
     "Foo", "Bar", "Qux", "Quux"
     };
 
-    private async Task<IEnumerable<string>> Search(string value)
+    private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudGrid>
@@ -21,7 +22,7 @@
         "Alabama", "Alaska", "American Samoa", "Arizona"
     };
 
-    private async Task<IEnumerable<string>> Search(string value)
+    private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDialog Class="test-class" ClassContent="content-class" Style="color: red;" ContentStyle="color: blue;">
+<MudDialog Class="test-class" ContentClass="content-class" Style="color: red;" ContentStyle="color: blue;">
     <DialogContent>
         <MudText>Wabalabadubdub!</MudText>
     </DialogContent>
@@ -11,8 +11,9 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] public MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    public MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogRender.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogRender.razor
@@ -14,13 +14,16 @@
     public static int OnInitializedCount = 0;
     public static int OnParametersSetCount = 0;
 
-    [CascadingParameter] public MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    public MudDialogInstance MudDialog { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();    
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    private void Cancel() => MudDialog.Cancel();
 
     protected override async Task OnInitializedAsync()
     {
+        await base.OnInitializedAsync();
+
         await Task.Delay(10);
 
         OnInitializedCount++;
@@ -28,6 +31,8 @@
 
     protected override async Task OnParametersSetAsync()
     {
+        await base.OnParametersSetAsync();
+
         await Task.Delay(10);
 
         OnParametersSetCount++;
@@ -35,8 +40,12 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        await base.OnAfterRenderAsync(firstRender);
+
         if (firstRender)
+        {
             return;
+        }
 
         await Task.Delay(10);
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogThatUpdatesItsTitle.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogThatUpdatesItsTitle.razor
@@ -1,10 +1,10 @@
 ﻿@using MudBlazor.Interfaces
 <MudDialog>
     <TitleContent>
-     Title: @textTest
+     Title: @_textTest
     </TitleContent>
     <DialogContent>
-      Body: @textTest
+      Body: @_textTest
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
@@ -14,13 +14,18 @@
 
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
-    string textTest;
-    void Submit(){
-        textTest = "Test123";
+    private string _textTest;
+
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
+
+    private void Submit()
+    {
+        _textTest = "Test123";
         ((IMudStateHasChanged)MudDialog).StateHasChanged();
     }
-    void Cancel(){
-        
+
+    private void Cancel()
+    {
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogToggleFullscreen.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogToggleFullscreen.razor
@@ -9,11 +9,12 @@
     </DialogActions>
 </MudDialog>
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    void Close() => MudDialog.Close(DialogResult.Ok(true));
+    private void Close() => MudDialog.Close(DialogResult.Ok(true));
 
-    void ToggleFullscreen()
+    private void ToggleFullscreen()
     {
         MudDialog.Options.FullScreen = !(MudDialog.Options.FullScreen ?? false);
         MudDialog.SetOptions(MudDialog.Options);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithActionsClass.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithActionsClass.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDialog ClassActions="@ClassActions">
+<MudDialog ActionsClass="@ActionsClass">
     <DialogContent>
     </DialogContent>
     <DialogActions>
@@ -12,5 +12,5 @@
     private MudDialogInstance MudDialog { get; set; }
 
     [Parameter]
-    public string ClassActions { get; set; } = string.Empty;
+    public string ActionsClass { get; set; } = string.Empty;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithContentClass.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithContentClass.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDialog ClassContent="@ClassContent" DisableSidePadding="@DisableSidePadding">
+<MudDialog ContentClass="@ContentClass" DisableSidePadding="@DisableSidePadding">
     <DialogContent>
     </DialogContent>
 </MudDialog>
@@ -10,7 +10,7 @@
     private MudDialogInstance MudDialog { get; set; }
 
     [Parameter]
-    public string ClassContent { get; set; } = string.Empty;
+    public string ContentClass { get; set; } = string.Empty;
     
     [Parameter]
     public bool DisableSidePadding { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
@@ -1,7 +1,7 @@
 ﻿<MudDialog>
     <DialogContent>
         Dialog Content
-        <MudTextField T="string" Immediate TextChanged="@(text=>OnTextChanged(text))"/>
+        <MudTextField T="string" Immediate TextChanged="@OnTextChangedAsync" />
         <div @onclick="OnClick">
             Click here!
         </div>
@@ -14,15 +14,18 @@
 
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    [Parameter] public EventCallback<string> OnSearch { get; set; }
-    [Parameter] public EventCallback OnClick { get; set; }
+    [Parameter]
+    public EventCallback<string> OnSearch { get; set; }
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
-    void Cancel() => MudDialog.Cancel();
+    [Parameter]
+    public EventCallback OnClick { get; set; }
 
-    async void OnTextChanged(string text) {
-        await OnSearch.InvokeAsync(text);
-    }
+    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private Task OnTextChangedAsync(string text) => OnSearch.InvokeAsync(text);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallbackTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallbackTest.razor
@@ -5,33 +5,37 @@
     Open Simple Dialog
 </MudButton>
 <p>
-Search Text:  @searchText
+Search Text:  @_searchText
 </p>
 <span>
-Clicked: @(clicked ? "Yes" : "No")
+Clicked: @(_clicked ? "Yes" : "No")
 </span>
 
 @code {
-    string searchText;
-    bool clicked = false;
+    private string _searchText;
+    private bool _clicked;
 
-    private void OpenDialog()
+    private Task OpenDialog()
     {
-        DialogService.Show<DialogWithEventCallback>("Simple Dialog", 
-            new DialogParameters(){
-                 {"OnSearch",  new EventCallbackFactory().Create(this, new Action<string>(OnSearch)) },
-                 {"OnClick",  new EventCallbackFactory().Create(this, OnClick) },
+        return DialogService.ShowAsync<DialogWithEventCallback>("Simple Dialog", 
+            new DialogParameters
+            {
+                {"OnSearch",  new EventCallbackFactory().Create(this, new Action<string>(OnSearch)) },
+                {"OnClick",  new EventCallbackFactory().Create(this, OnClickAsync) },
             });
     }
 
-    private void OnSearch(string text){
-        searchText=text;
+    private void OnSearch(string text)
+    {
+        _searchText = text;
         StateHasChanged();
     }
     
-    private Task OnClick() {
-        clicked = true;
+    private Task OnClickAsync()
+    {
+        _clicked = true;
         StateHasChanged();
+
         return Task.CompletedTask;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithOnBackdropClickEvent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithOnBackdropClickEvent.razor
@@ -1,21 +1,20 @@
 ﻿@using MudBlazor.Interfaces
 <MudDialog OnBackdropClick="@OnBackdropClick">
     <TitleContent>
-        Title: @textTest
+        Title: @_textTest
     </TitleContent>
 </MudDialog>
 
 
 @code {
+    private string _textTest;
 
     [CascadingParameter]
-    MudDialogInstance MudDialog { get; set; }
+    private MudDialogInstance MudDialog { get; set; }
 
-    string textTest;
-
-    void OnBackdropClick()
+    private void OnBackdropClick()
     {
-        textTest = "Backdrop clicked";
+        _textTest = "Backdrop clicked";
         ((IMudStateHasChanged)MudDialog).StateHasChanged();
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
@@ -12,15 +12,21 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
-    [Parameter] public string TestValue { get; set; }
-    [Parameter] public Color Color_Test { get; set; }
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 
-    public int ParamtersSetCounter { get; private set; }
+    [Parameter]
+    public string TestValue { get; set; }
+
+    [Parameter]
+    public Color ColorTest { get; set; }
+
+    public int ParametersSetCounter { get; private set; }
+
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        ParamtersSetCounter++;
+        ParametersSetCounter++;
     }
 
     private void OnTest()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithReturnValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithReturnValue.razor
@@ -11,6 +11,6 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
-
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
@@ -6,7 +6,7 @@
     </MudButton>
 </div>
 
-<MudDialog @bind-IsVisible="visible">
+<MudDialog @bind-IsVisible="_visible">
     <TitleContent>
         <MudText Typo="Typo.h6">
             <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-3"/> Edit rating
@@ -20,6 +20,7 @@
 </MudDialog>
 
 @code { 
-    private bool visible;
-    private void OpenDialog() => visible = true;
+    private bool _visible;
+
+    private void OpenDialog() => _visible = true;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
@@ -1,15 +1,15 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 @inject IDialogService DialogService
 
-<MudButton Variant="Variant.Filled" OnClick="()=>visible=true">Open</MudButton>
+<MudButton Variant="Variant.Filled" OnClick="()=>_visible=true">Open</MudButton>
 
-<MudDialog @bind-IsVisible="visible" Options="inlineOptions" Class="test-class" ClassContent="content-class" Style="color: red;" ContentStyle="color: blue;" Tag="@((string)"test-tag")">
+<MudDialog @bind-IsVisible="_visible" Options="_inlineOptions" Class="test-class" ContentClass="content-class" Style="color: red;" ContentStyle="color: blue;" Tag="@((string)"test-tag")">
     <DialogContent>
         <MudText>Wabalabadubdub!</MudText>
-        <MudRating @bind-SelectedValue="rating" Class="mt-3"/>
+        <MudRating @bind-SelectedValue="_rating" Class="mt-3"/>
     </DialogContent>
     <DialogActions>
-        <MudButton Color="Color.Primary" OnClick="()=>visible=false">Close</MudButton>
+        <MudButton Color="Color.Primary" OnClick="()=>_visible=false">Close</MudButton>
         <MudButton Color="Color.Primary" OnClick="CloseAndOpen">Close and open</MudButton>
     </DialogActions>
 </MudDialog>
@@ -17,13 +17,14 @@
 @code {
     public static string __description__ = "Click on open will open the inlined dialog";
 
-    bool visible;
-    private int rating;
+    private bool _visible;
+    private int _rating;
+    private readonly DialogOptions _inlineOptions = new() { FullWidth = true };
 
-    Task CloseAndOpen() {
-        visible=false;
+    Task CloseAndOpen()
+    {
+        _visible = false;
+
         return DialogService.ShowMessageBox(title: "hello from inline", message: "BUG4871", yesText: "BUG4871");
     }
-
-    private DialogOptions inlineOptions = new() { FullWidth = true };
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestNestedInlineDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestNestedInlineDialog.razor
@@ -1,28 +1,28 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudButton Variant="Variant.Filled" OnClick="()=>visible=true">Open</MudButton>
+<MudButton Variant="Variant.Filled" OnClick="()=>_visible=true">Open</MudButton>
 
-<MudDialog @bind-IsVisible="visible">
+<MudDialog @bind-IsVisible="_visible">
     <DialogContent>
         <MudText>Scorpiany!</MudText>
-        <MudButton Variant="Variant.Filled" OnClick="()=>nestedVisible=true">Open Nested</MudButton>
-        <MudDialog @bind-IsVisible="nestedVisible">
+        <MudButton Variant="Variant.Filled" OnClick="()=>_nestedVisible=true">Open Nested</MudButton>
+        <MudDialog @bind-IsVisible="_nestedVisible">
             <DialogContent>
                 <MudText Class="nested">Nested dialog!</MudText>
             </DialogContent>
             <DialogActions>
-                <MudButton Color="Color.Primary" OnClick="()=>nestedVisible=false">Close</MudButton>
+                <MudButton Color="Color.Primary" OnClick="()=>_nestedVisible=false">Close</MudButton>
             </DialogActions>
         </MudDialog>
     </DialogContent>
     <DialogActions>
-        <MudButton Color="Color.Primary" OnClick="()=>visible=false">Close</MudButton>
+        <MudButton Color="Color.Primary" OnClick="()=>_visible=false">Close</MudButton>
     </DialogActions>
 </MudDialog>
 
 @code {
     public static string __description__ = "Click on open will open the inlined dialog, and the nested dialog can be opened with a second click";
 
-    bool visible;
-    bool nestedVisible;
+    private bool _visible;
+    private bool _nestedVisible;
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -220,11 +220,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.DebounceInterval, 0);
-                a.Add(x => x.SearchFunc, new Func<string, Task<IEnumerable<string>>>(async s => null)); // <--- searchfunc returns null instead of sequence
+                a.Add(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>(async (s, token) => null)); // <--- searchfunc returns null instead of sequence
             });
             // enter a text so the search func will return null, and it shouldn't throw an exception
             comp.SetParam(a => a.Text, "Do not throw");
-            comp.SetParam(x => x.SearchFunc, new Func<string, Task<IEnumerable<string>>>(s => null)); // <-- search func returns null instead of task!
+            comp.SetParam(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, token) => null)); // <-- search func returns null instead of task!
             comp.SetParam(a => a.Text, "Don't throw here neither");
         }
 
@@ -996,7 +996,7 @@ namespace MudBlazor.UnitTests.Components
 
             var first = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 cancelToken = cancellationToken;
                 // Return task that never completes.
@@ -1015,7 +1015,7 @@ namespace MudBlazor.UnitTests.Components
 
             var second = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 return second.Task;
             }));

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -220,11 +220,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.DebounceInterval, 0);
-                a.Add(x => x.SearchFunc, new Func<string, Task<IEnumerable<string>>>(async s => null)); // <--- searchfunc returns null instead of sequence
+                a.Add(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>(async (s, token) => null)); // <--- searchfunc returns null instead of sequence
             });
             // enter a text so the search func will return null, and it shouldn't throw an exception
             comp.SetParam(a => a.Text, "Do not throw");
-            comp.SetParam(x => x.SearchFunc, new Func<string, Task<IEnumerable<string>>>(s => null)); // <-- search func returns null instead of task!
+            comp.SetParam(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, token) => null)); // <-- search func returns null instead of task!
             comp.SetParam(a => a.Text, "Don't throw here neither");
         }
 
@@ -1000,7 +1000,7 @@ namespace MudBlazor.UnitTests.Components
 
             var first = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 cancelToken = cancellationToken;
                 // Return task that never completes.
@@ -1019,7 +1019,7 @@ namespace MudBlazor.UnitTests.Components
 
             var second = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFuncWithCancel, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 return second.Task;
             }));

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1311,7 +1311,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_ReturnedItemsCount_Should_Be_Accurate()
         {
-            Task<IEnumerable<string>> search(string value)
+            Task<IEnumerable<string>> search(string value, CancellationToken token)
             {
                 var values = new string[] { "Lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit" };
                 return Task.FromResult(values.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -188,14 +188,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFuncWithCancel { get; set; }
-
-        /// <summary>
-        /// The SearchFunc returns a list of items matching the typed text
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; }
+        public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFunc { get; set; }
 
         /// <summary>
         /// Maximum items to display, defaults to 10.
@@ -537,9 +530,7 @@ namespace MudBlazor
                 searchingWhileSelected = !Strict && Value != null && (Value.ToString() == Text || (ToStringFunc != null && ToStringFunc(Value) == Text)); //search while selected if enabled and the Text is equivalent to the Value
                 var searchText = searchingWhileSelected ? string.Empty : Text;
 
-                var searchTask = SearchFuncWithCancel != null ?
-                    SearchFuncWithCancel(searchText, _cancellationTokenSrc.Token) :
-                    SearchFunc(searchText);
+                var searchTask = SearchFunc(searchText, _cancellationTokenSrc.Token);
 
                 _currentSearchTask = searchTask;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -188,14 +188,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFuncWithCancel { get; set; }
-
-        /// <summary>
-        /// The SearchFunc returns a list of items matching the typed text
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; }
+        public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFunc { get; set; }
 
         /// <summary>
         /// Maximum items to display, defaults to 10.
@@ -521,9 +514,7 @@ namespace MudBlazor
                 searchingWhileSelected = !Strict && Value != null && (Value.ToString() == Text || (ToStringFunc != null && ToStringFunc(Value) == Text)); //search while selected if enabled and the Text is equivalent to the Value
                 var searchText = searchingWhileSelected ? string.Empty : Text;
 
-                var searchTask = SearchFuncWithCancel != null ?
-                    SearchFuncWithCancel(searchText, _cancellationTokenSrc.Token) :
-                    SearchFunc(searchText);
+                var searchTask = SearchFunc(searchText, _cancellationTokenSrc.Token);
 
                 _currentSearchTask = searchTask;
 

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor
@@ -15,7 +15,7 @@
 
         @if (DialogActions != null)
         {
-            <div class="@ActionClassname">
+            <div class="@ActionsClassname">
                 @DialogActions
             </div>
         }

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -12,19 +12,13 @@ namespace MudBlazor
 {
     public partial class MudDialog : MudComponentBase
     {
-        [Obsolete($"Use {nameof(ContentClassname)} instead.")]
-        protected string ContentClass => ContentClassname;
-
         protected string ContentClassname => new CssBuilder("mud-dialog-content")
             .AddClass("mud-dialog-no-side-padding", DisableSidePadding)
-            .AddClass(ClassContent)
+            .AddClass(ContentClass)
             .Build();
 
-        [Obsolete($"Use {nameof(ActionClassname)} instead.")]
-        protected string ActionClass => ActionClassname;
-
-        protected string ActionClassname => new CssBuilder("mud-dialog-actions")
-            .AddClass(ClassActions)
+        protected string ActionsClassname => new CssBuilder("mud-dialog-actions")
+            .AddClass(ActionsClass)
             .Build();
 
         [CascadingParameter] private MudDialogInstance DialogInstance { get; set; }
@@ -90,14 +84,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string ClassContent { get; set; }
+        public string ContentClass { get; set; }
 
         /// <summary>
         /// CSS class that will be applied to the action buttons container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string ClassActions { get; set; }
+        public string ActionsClass { get; set; }
 
         /// <summary>
         /// CSS styles to be applied to the dialog content
@@ -164,8 +158,8 @@ namespace MudBlazor
                 [nameof(OnBackdropClick)] = OnBackdropClick,
                 [nameof(DisableSidePadding)] = DisableSidePadding,
                 [nameof(TitleClass)] = TitleClass,
-                [nameof(ClassContent)] = ClassContent,
-                [nameof(ClassActions)] = ClassActions,
+                [nameof(ContentClass)] = ContentClass,
+                [nameof(ActionsClass)] = ActionsClass,
                 [nameof(ContentStyle)] = ContentStyle,
                 [nameof(DefaultFocus)] = DefaultFocus,
             };


### PR DESCRIPTION
This breaking change removes the `SearchFuncWithCancel` method and moves the `CancellationToken` functionality to the `SearchFunc` method.  

## Description

Recent changes to the MudTable `ServerData` method ([PR 8407](https://github.com/MudBlazor/MudBlazor/pull/8407)) led to a desire to use the same single-method pattern for other cancelable methods.  This update:

* Removes the `SearchFuncWithCancel` method
* Moves the `CancellationToken` parameter to the `SearchFunc` method
* Updates all tests and examples to include the new `CancellationToken` parameter.

## How Has This Been Tested?

Existing tests for `MudAutocomplete` were modified to include the `CancellationToken` parameter.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.

## Notes for Reviewers

This should probably get a `v7` tag and be released with similar breaking changes to `MudTable` in the works for #8447 