### PR TITLE
Corrected casing of Typo enum members

### DIFF
--- a/src/MudBlazor.Docs.Server/App.razor
+++ b/src/MudBlazor.Docs.Server/App.razor
@@ -22,7 +22,7 @@
                         <path d="M832.06,417.88l52.06-30.06L835.87,158.26l-52.06,30.05Z" transform="translate(-315.12 -126.28)" style="fill:#594ae2" />
                         <path d="M780.07,126.29,728,156.34l55.8,32,52.06-30.05Z" transform="translate(-315.12 -126.28)" style="fill:#7467ef" />
                     </svg>
-                    <MudText Typo="Typo.h3" Class="mt-6 mb-16" Align="Align.Center">Page doesn't exist.</MudText>
+                    <MudText Typo="Typo.H3" Class="mt-6 mb-16" Align="Align.Center">Page doesn't exist.</MudText>
                 </div>
             </MudContainer>
         </LayoutView>

--- a/src/MudBlazor.Docs.Wasm/App.razor
+++ b/src/MudBlazor.Docs.Wasm/App.razor
@@ -22,7 +22,7 @@
                         <path d="M832.06,417.88l52.06-30.06L835.87,158.26l-52.06,30.05Z" transform="translate(-315.12 -126.28)" style="fill:#594ae2" />
                         <path d="M780.07,126.29,728,156.34l55.8,32,52.06-30.05Z" transform="translate(-315.12 -126.28)" style="fill:#7467ef" />
                     </svg>
-                    <MudText Typo="Typo.h3" Class="mt-6 mb-16" Align="Align.Center">Page doesn't exist.</MudText>
+                    <MudText Typo="Typo.H3" Class="mt-6 mb-16" Align="Align.Center">Page doesn't exist.</MudText>
                 </div>
             </MudContainer>
         </LayoutView>

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -37,13 +37,13 @@
                             @if (_propertiesGrouping == Grouping.Inheritance && (Type)context.Key != Type)
                             {
                                 <MudTh colspan="4">
-                                    <MudText Typo="Typo.h6">@($"Inherited from {((Type)context.Key).GetTypeDisplayName()}")</MudText>
+                                    <MudText Typo="Typo.H6">@($"Inherited from {((Type)context.Key).GetTypeDisplayName()}")</MudText>
                                 </MudTh>
                             }
                             else if (_propertiesGrouping == Grouping.Categories)
                             {
                                 <MudTh colspan="4">
-                                    <MudText Typo="Typo.h6">@context.Key</MudText>
+                                    <MudText Typo="Typo.H6">@context.Key</MudText>
                                 </MudTh>
                             }
                         </GroupHeaderTemplate>

--- a/src/MudBlazor.Docs/Components/DocsExploreCard.razor
+++ b/src/MudBlazor.Docs/Components/DocsExploreCard.razor
@@ -5,7 +5,7 @@
                 @ChildContent
             </div>
         </MudPaper>
-        <MudText Typo="Typo.subtitle2" Class="mt-3">@Title</MudText>
+        <MudText Typo="Typo.Subtitle2" Class="mt-3">@Title</MudText>
     </MudPaper>
 </a>
 

--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -21,16 +21,16 @@
         // Just show copyright and version
         <MudContainer MaxWidth="MaxWidth.Large">
             <MudToolBar DisableGutters="true" Dense="true">
-                <MudText Typo="Typo.body1">Copyright © 2020-@DateTime.Now.Year MudBlazor.</MudText>
+                <MudText Typo="Typo.Body1">Copyright © 2020-@DateTime.Now.Year MudBlazor.</MudText>
                 <MudSpacer/>
-                <MudText Typo="Typo.body1">Powered by .NET @Environment.Version.ToString()</MudText>
+                <MudText Typo="Typo.Body1">Powered by .NET @Environment.Version.ToString()</MudText>
             </MudToolBar>
         </MudContainer>
     }
     <MudDrawer Class="docs-page-content-navigation-drawer" @bind-Open="_contentDrawerOpen" Breakpoint="Breakpoint.Lg" Anchor="Anchor.End" ClipMode="DrawerClipMode.Always" Elevation="0" Color="Color.Transparent">
         @if (_displayView)
         {
-            <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
+            <MudText Typo="Typo.Subtitle1" Class="title" GutterBottom="true">
                 Mode
             </MudText>
             <div class="d-flex px-2 mb-2">

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor
@@ -32,7 +32,7 @@
 else
 {
     <div class="docs-page-header mt-6 mb-12">
-        <MudText Typo="@Typo.h3">@Title</MudText>
+        <MudText Typo="@Typo.H3">@Title</MudText>
         <MudText>@GetSubTitle() @Description</MudText>
         <DocsRenderBenchmark/>
     </div>

--- a/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
+++ b/src/MudBlazor.Docs/Components/DocsTypeInfo.razor
@@ -6,7 +6,7 @@
         <ChildContent>@Type.GetTypeDisplayName()</ChildContent>
         <TooltipContent>
             enumeration type
-            <MudText Align="Align.Left" Typo="Typo.body2">
+            <MudText Align="Align.Left" Typo="Typo.Body2">
                 @foreach (var name in Enum.GetNames(_nonnullableType))
                 {
                     @(_nonnullableType.Name + "." + name)<br />

--- a/src/MudBlazor.Docs/Components/LandingPage/CalculatorApp/Calculator.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/CalculatorApp/Calculator.razor
@@ -4,10 +4,10 @@
 
 <MudPaper Square="true" Elevation="0" Height="30%" Class="d-flex justify-end align-center px-10 mud-transparent">
     <div>
-        <MudText Typo="Typo.h4" Align="Align.End" Class="mud-text-secondary">
+        <MudText Typo="Typo.H4" Align="Align.End" Class="mud-text-secondary">
             @Last
         </MudText>
-        <MudText Typo="Typo.h1">
+        <MudText Typo="Typo.H1">
             @CalcExpression
         </MudText>
     </div>

--- a/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
@@ -8,7 +8,7 @@
     <div class="@MiniDrawerClassNames" style="@GetDrawerWidth()">
         <div class="d-flex align-center px-4">
             <MudBlazorLogo Class="me-3" Style="width:36px;"/>
-            <MudText Typo="Typo.h6">Mud Mini</MudText>
+            <MudText Typo="Typo.H6">Mud Mini</MudText>
         </div>
         <MudList Clickable="true" @bind-SelectedItem="selectedItem" @bind-SelectedValue="selectedValue" Class="py-6 mini-fake-nav">
 
@@ -52,8 +52,8 @@
                 </ActivatorContent>
                 <ChildContent>
                     <div class="px-4">
-                        <MudText Typo="Typo.subtitle2">Martin Mudsson</MudText>
-                        <MudText Class="mt-n2" Typo="Typo.body1">martin@mudsson.se</MudText>
+                        <MudText Typo="Typo.Subtitle2">Martin Mudsson</MudText>
+                        <MudText Class="mt-n2" Typo="Typo.Body1">martin@mudsson.se</MudText>
                     </div>
                     <MudDivider Class="my-2"/>
                     <MudListItem Dense="true" Icon="@Icons.Material.Rounded.Person">Profile</MudListItem>
@@ -65,14 +65,14 @@
         <div class="lp-app-grid">
             <MudPaper Class="py-4 px-6 rounded-lg d-flex align-center">
                 <div class="flex-grow-1">
-                    <MudText Typo="Typo.h6">Graphite on roof</MudText>
+                    <MudText Typo="Typo.H6">Graphite on roof</MudText>
                     <div class="d-flex align-center my-1">
                         <MudAvatar Class="me-2 pa-4" Style="background-color: var(--mud-palette-primary-hover);" Size="Size.Small">
                             <MudIcon Color="Color.Primary" Icon="@Icons.Material.Filled.TrendingDown" Size="Size.Small"/>
                         </MudAvatar>
-                        <MudText Typo="Typo.subtitle2">+2.6%</MudText>
+                        <MudText Typo="Typo.Subtitle2">+2.6%</MudText>
                     </div>
-                    <MudText Typo="Typo.h4">149,567</MudText>
+                    <MudText Typo="Typo.H4">149,567</MudText>
                 </div>
                 <div class="d-flex align-end justify-end mud-height-full py-8">
                     <MudPaper Height="80%" Width="6px" Square="true" Class="mud-primary mr-1 rounded-t"/>
@@ -89,14 +89,14 @@
             </MudPaper>
             <MudPaper Class="py-4 px-6 rounded-lg d-flex align-center">
                 <div class="flex-grow-1">
-                    <MudText Typo="Typo.h6">Global Spread</MudText>
+                    <MudText Typo="Typo.H6">Global Spread</MudText>
                     <div class="d-flex align-center my-1">
                         <MudAvatar Class="me-2 pa-4" Style="background-color: var(--mud-palette-secondary-hover);" Size="Size.Small">
                             <MudIcon Color="Color.Secondary" Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small"/>
                         </MudAvatar>
-                        <MudText Typo="Typo.subtitle2">+9.6%</MudText>
+                        <MudText Typo="Typo.Subtitle2">+9.6%</MudText>
                     </div>
-                    <MudText Typo="Typo.h4">12%</MudText>
+                    <MudText Typo="Typo.H4">12%</MudText>
                 </div>
                 <div class="d-flex align-end justify-end mud-height-full py-8">
                     <MudPaper Height="15%" Width="6px" Square="true" Class="mud-secondary mr-1 rounded-t"/>
@@ -113,14 +113,14 @@
             </MudPaper>
             <MudPaper Class="py-4 px-6 rounded-lg d-flex align-center">
                 <div class="flex-grow-1">
-                    <MudText Typo="Typo.h6">Roentgen</MudText>
+                    <MudText Typo="Typo.H6">Roentgen</MudText>
                     <div class="d-flex align-center my-1">
                         <MudAvatar Class="me-2 pa-4" Style="background-color: var(--mud-palette-tertiary-hover);" Size="Size.Small">
                             <MudIcon Color="Color.Tertiary" Icon="@Icons.Material.Filled.TrendingFlat" Size="Size.Small"/>
                         </MudAvatar>
-                        <MudText Typo="Typo.subtitle2">~0.0%</MudText>
+                        <MudText Typo="Typo.Subtitle2">~0.0%</MudText>
                     </div>
-                    <MudText Typo="Typo.h4">3,6</MudText>
+                    <MudText Typo="Typo.H4">3,6</MudText>
                 </div>
                 <div class="d-flex align-end justify-end mud-height-full py-8">
                     <MudPaper Height="10%" Width="6px" Square="true" Class="mud-tertiary mr-1 rounded-t"/>
@@ -138,14 +138,14 @@
         </div>
         <div class="my-6 d-flex gap-6 flex-wrap">
             <MudPaper Class="py-4 px-6 rounded-lg d-flex flex-column">
-                    <MudText Typo="Typo.h6">Uranium-235</MudText>
+                    <MudText Typo="Typo.H6">Uranium-235</MudText>
                     <div class="d-flex align-center gap-4">
                         <MudRating ReadOnly="true" SelectedValue="4" />
-                        <MudText Typo="Typo.subtitle2" Color="Color.Primary">See all 137 reviews</MudText>
+                        <MudText Typo="Typo.Subtitle2" Color="Color.Primary">See all 137 reviews</MudText>
                     </div>
                     <MudText>This is the type of uranium used in the RBMK reactors.</MudText>
                     <MudDivider Class="my-3"/>
-                    <MudText Typo="Typo.subtitle2" GutterBottom="true">Reactor Type</MudText>
+                    <MudText Typo="Typo.Subtitle2" GutterBottom="true">Reactor Type</MudText>
                     <div class="mx-n2 mb-2">
                         <MudChip Color="Color.Primary">RBMK-1000</MudChip><MudChip>RBMK-1500</MudChip><MudChip>RBMKP-2400</MudChip>
                     </div>
@@ -189,7 +189,7 @@
             <MudPaper Class="rounded-lg d-flex flex-column">
                 <div class="d-flex align-center px-4 pt-4 pb-3 gap-4">
                     <MudIcon Icon="@Icons.Custom.Brands.MudBlazor" Color="Color.Primary" />
-                    <MudText Typo="Typo.subtitle2">MudPay</MudText>
+                    <MudText Typo="Typo.Subtitle2">MudPay</MudText>
                 </div>
                 <MudDivider/>
                 <div class="d-flex flex-column pa-4 gap-4">
@@ -212,11 +212,11 @@
                 </MudTabs>
                 <div class="d-flex gap-6 flex-grow-1">
                     <MudPaper Class="d-flex flex-column align-center py-2">
-                        <MudText Typo="Typo.body2">100°C</MudText>
+                        <MudText Typo="Typo.Body2">100°C</MudText>
                         <div class="mud-height-full my-n6">
                             <MudSlider Value="@sliderValue" Vertical="true" Class="d-flex mx-n8"/>
                         </div>
-                        <MudText Typo="Typo.body2">0°C</MudText>
+                        <MudText Typo="Typo.Body2">0°C</MudText>
                     </MudPaper>
                     <div class="d-flex flex-column gap-6">
                         <MudPaper Class="d-flex">

--- a/src/MudBlazor.Docs/Components/LandingPage/Phone.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/Phone.razor
@@ -7,7 +7,7 @@
             <div class="relative mud-height-full mud-width-full">
                 <div class="lp-device-toolbar">
                     <div class="lp-time d-flex justify-start align-end ml-4">
-                        <MudText Typo="Typo.subtitle1">@GetTime()</MudText>
+                        <MudText Typo="Typo.Subtitle1">@GetTime()</MudText>
                     </div>
                     <svg class="lp-phone-notch" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 278.97 29.67">
                         <path d="M0,29.67A29.63,29.63,0,0,1,29.63,0H58a4.08,4.08,0,0,1,3.88,3.91V6.44a15.3,15.3,0,0,0,1.17,5.93,15.53,15.53,0,0,0,3.36,5,15.38,15.38,0,0,0,5,3.36A15.5,15.5,0,0,0,77.4,22H201.34a15.5,15.5,0,0,0,5.93-1.19,15.38,15.38,0,0,0,5-3.36,15.53,15.53,0,0,0,3.36-5,15.3,15.3,0,0,0,1.17-5.93V4.06h0A4.05,4.05,0,0,1,220.73,0h28.62A29.65,29.65,0,0,1,279,29.67Z"/>

--- a/src/MudBlazor.Docs/Components/LandingPage/PlatformCard.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/PlatformCard.razor
@@ -6,10 +6,10 @@
     </div>
     <div class="d-flex flex-column ml-6">
         <div class="d-flex">
-            <MudText Typo="Typo.h6" Color="Color.Default">Mud</MudText>
-            <MudText Typo="Typo.h6" Color="@Color">@Name</MudText>
+            <MudText Typo="Typo.H6" Color="Color.Default">Mud</MudText>
+            <MudText Typo="Typo.H6" Color="@Color">@Name</MudText>
         </div>
-        <MudText Typo="Typo.body1">@Description</MudText>
+        <MudText Typo="Typo.Body1">@Description</MudText>
     </div>
 </MudPaper>
 @code {

--- a/src/MudBlazor.Docs/Components/MudContributor.razor
+++ b/src/MudBlazor.Docs/Components/MudContributor.razor
@@ -4,8 +4,8 @@
                            <MudAvatar Image="@AvatarLink" Size="Size.Large" Class="mud-elevation-4"/>
                        </CardHeaderAvatar>
                        <CardHeaderContent>
-                           <MudText Typo="Typo.body1">@Firstname @Lastname</MudText>
-                           <MudText Typo="Typo.body2">@Contributor</MudText>
+                           <MudText Typo="Typo.Body1">@Firstname @Lastname</MudText>
+                           <MudText Typo="Typo.Body2">@Contributor</MudText>
                        </CardHeaderContent>
                        <CardHeaderActions>
                            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="@GithubLink" Color="Color.Dark" Target="_blank"/>

--- a/src/MudBlazor.Docs/Components/MudTeamCard.razor
+++ b/src/MudBlazor.Docs/Components/MudTeamCard.razor
@@ -5,8 +5,8 @@
             <MudImage Src="@Memeber.Avatar" />
         </MudAvatar>
         <div class="d-flex flex-column flex-grow-1 px-5 my-2">
-            <MudText Typo="Typo.body1" Style="font-weight:500;">@Memeber.Name</MudText>
-            <MudText Typo="Typo.body2">@Memeber.Github</MudText>
+            <MudText Typo="Typo.Body1" Style="font-weight:500;">@Memeber.Name</MudText>
+            <MudText Typo="Typo.Body2">@Memeber.Github</MudText>
         </div>
         <div class="d-flex flex-sm-column-reverse flex-md-row align-baseline justify-end me-n2 mt-n2">
             @if(Memeber.LinkedIn != null)
@@ -23,7 +23,7 @@
     <div class="d-flex flex-column mt-5">
         <div class="d-flex flex-row align-center">
             <MudIcon Icon="@Icons.Material.Filled.Place" Color="Color.Default" Class="ms-4" />
-            <MudText Typo="Typo.body2" Class="ps-9">@Memeber.From</MudText>
+            <MudText Typo="Typo.Body2" Class="ps-9">@Memeber.From</MudText>
         </div>
     </div>
 </MudPaper>

--- a/src/MudBlazor.Docs/Components/SectionHeader.razor
+++ b/src/MudBlazor.Docs/Components/SectionHeader.razor
@@ -8,7 +8,7 @@
 	}
 	@if (SubTitle != null)
 	{
-		<MudText Typo="Typo.h6">@SubTitle</MudText>
+		<MudText Typo="Typo.H6">@SubTitle</MudText>
 	}
 	@if (Description != null)
 	{

--- a/src/MudBlazor.Docs/Components/SectionHeader.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionHeader.razor.cs
@@ -69,9 +69,9 @@ public partial class SectionHeader
     {
         if (Section.Level >= 1)
         {
-            return Typo.h6;
+            return Typo.H6;
         }
 
-        return Typo.h5;
+        return Typo.H5;
     }
 }

--- a/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
+++ b/src/MudBlazor.Docs/NotificationContent/Announcement_MudBlazorIsHereToStay.razor
@@ -1,6 +1,6 @@
 ﻿
 <DocsPageSection>
-    <MudText Typo="Typo.subtitle1" Class="docs-title-description">I am very excited to finally share this with everyone after several months of work, a few delays and more new things added to the pile of news.</MudText>
+    <MudText Typo="Typo.Subtitle1" Class="docs-title-description">I am very excited to finally share this with everyone after several months of work, a few delays and more new things added to the pile of news.</MudText>
 </DocsPageSection>
 
 <DocsPageSection>
@@ -24,7 +24,7 @@
     </SectionHeader>
     <MudList DisableGutters="true">
         <MudListItem>
-            <MudText Typo="Typo.subtitle1" Inline="true"><b>Mud</b></MudText><MudText Inline="true" Color="Color.Warning"><b>Extensions</b></MudText>
+            <MudText Typo="Typo.Subtitle1" Inline="true"><b>Mud</b></MudText><MudText Inline="true" Color="Color.Warning"><b>Extensions</b></MudText>
             <MudText>MudBlazor extensions platform where users can add their own projects, write documentation and find extensions made by others.</MudText>
         </MudListItem>
     </MudList>
@@ -48,5 +48,5 @@
 
 
 <DocsPageSection>
-    <MudText Typo="Typo.subtitle1" Class="docs-title-description my-8">That's all for now but keep your eyes open for more news in the future and as always, stay muddy!</MudText>
+    <MudText Typo="Typo.Subtitle1" Class="docs-title-description my-8">That's all for now but keep your eyes open for more news in the future and as always, stay muddy!</MudText>
 </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Interactivity/Examples/PointerEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Interactivity/Examples/PointerEventsExample.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudText Class="pointer-events-auto mx-4" Typo="Typo.h5">pointer-events-auto</MudText>
-<MudText Class="pointer-events-none mx-4" Typo="Typo.h5">pointer-events-none</MudText>
+<MudText Class="pointer-events-auto mx-4" Typo="Typo.H5">pointer-events-auto</MudText>
+<MudText Class="pointer-events-none mx-4" Typo="Typo.H5">pointer-events-none</MudText>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingBreakpointExample.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingBreakpointExample.razor
@@ -2,5 +2,5 @@
 
 
 <MudPaper Class="pa-md-6 mx-lg-auto mud-theme-secondary">
-    <MudText Typo="Typo.body1">Adjust screen size to see the changes.</MudText>
+    <MudText Typo="Typo.Body1">Adjust screen size to see the changes.</MudText>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingCenteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingCenteringExample.razor
@@ -2,5 +2,5 @@
 
 
 <MudPaper Class="mx-auto pa-6 mud-theme-success">
-    <MudText Typo="Typo.body1">Centered!</MudText>
+    <MudText Typo="Typo.Body1">Centered!</MudText>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingExample.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingExample.razor
@@ -2,11 +2,11 @@
 
 
 <MudPaper Class="pa-4 mr-16">
-    <MudText Typo="Typo.subtitle2">pa-4 mr-16</MudText>
+    <MudText Typo="Typo.Subtitle2">pa-4 mr-16</MudText>
 </MudPaper>
 <MudPaper Class="pa-4">
-    <MudText Typo="Typo.subtitle2">pa-4</MudText>
+    <MudText Typo="Typo.Subtitle2">pa-4</MudText>
 </MudPaper>
 <MudPaper Class="pa-4 ml-8">
-    <MudText Typo="Typo.subtitle2">pa-4 ml-8</MudText>
+    <MudText Typo="Typo.Subtitle2">pa-4 ml-8</MudText>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingNegativeExample.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/Examples/SpacingNegativeExample.razor
@@ -4,5 +4,5 @@
 <MudPaper Class="mx-auto pa-4 mud-theme-secondary" Style="height:100px; width:150px;">
 </MudPaper>
 <MudPaper Class="mt-n12 mx-auto pa-6 mud-theme-primary" Elevation="12" Style="width: 350px;">
-    <MudText Typo="Typo.body1">This card uses negative top margin!</MudText>
+    <MudText Typo="Typo.Body1">This card uses negative top margin!</MudText>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/SpacingPage.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/SpacingPage.razor
@@ -38,7 +38,7 @@
             </SectionHeader>
             <MudGrid>
                 <MudItem md="6">
-                    <MudText Typo="Typo.h6" Color="Color.Primary">Positive</MudText>
+                    <MudText Typo="Typo.H6" Color="Color.Primary">Positive</MudText>
                     <ul class="mud-typography-body1 my-2 mud-spacing-list">
                         <li><CodeInline>0</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>0</CodeInline></li>
                         <li><CodeInline>1</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>4px</CodeInline></li>
@@ -61,7 +61,7 @@
                     </ul>
                 </MudItem>
                 <MudItem md="6">
-                    <MudText Typo="Typo.h6" Color="Color.Secondary">Negative</MudText>
+                    <MudText Typo="Typo.H6" Color="Color.Secondary">Negative</MudText>
                     <ul class="mud-typography-body1 my-2 mud-spacing-list">
                         <li><CodeInline SecondaryColor="true">n1</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-4px</CodeInline></li>
                         <li><CodeInline SecondaryColor="true">n2</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-8px</CodeInline></li>

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -4,7 +4,7 @@
     <DocsPageHeader Title="Alert" SubTitle="An alert is used to display an important message which is statically embedded in the page content." />
     <DocsPageContent>
         <DocsPageSection>
-            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Note</MudText>
             <MudText>To notify the user with dynamic alerts which overlay the page check out <MudLink Href="/components/snackbar">Snackbar</MudLink>.</MudText>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteClrObjectsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteClrObjectsExample.razor
@@ -24,7 +24,7 @@
         </MudAutocomplete>
     </MudItem>
     <MudItem xs="12" md="12">
-        <MudText Class="mb-n3" Typo="Typo.body2">
+        <MudText Class="mb-n3" Typo="Typo.Body2">
             Selected values: <MudChip>@(value1?.ToString() ?? "Not selected")</MudChip><MudChip>@(value2?.ToString() ?? "Not selected")</MudChip>
         </MudText>
     </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteProgressExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteProgressExample.razor
@@ -23,7 +23,7 @@
         </MudAutocomplete>
     </MudItem>
     <MudItem md="4">
-        <MudText Typo="Typo.h6" GutterBottom="true">Progress options</MudText>
+        <MudText Typo="Typo.H6" GutterBottom="true">Progress options</MudText>
         <MudSelect T="Color" Label="Color" Margin="Margin.Dense" Dense="true" Value="@SelectedColor" ValueChanged="OnColorSelected">
             <MudSelectItem T="Color" Value="@Color.Default">Default</MudSelectItem>
             <MudSelectItem T="Color" Value="@Color.Info">Info</MudSelectItem>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -13,7 +13,7 @@
                          AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" />
     </MudItem>
     <MudItem xs="12" md="12">
-        <MudText Class="mb-n3" Typo="Typo.body2">
+        <MudText Class="mb-n3" Typo="Typo.Body2">
             <MudChip>@(value1 ?? "Not selected")</MudChip><MudChip>@(value2 ?? "Not selected")</MudChip>
         </MudText>
     </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -51,7 +51,7 @@
         </MudForm>
 	</MudItem>
     <MudItem xs="12" md="12">
-        <MudText Class="mb-n3" Typo="Typo.body2">
+        <MudText Class="mb-n3" Typo="Typo.Body2">
             <MudChip>@(choice1.State ?? "Not selected")</MudChip><MudChip>@(choice2.State ?? "Not selected")</MudChip><MudChip>@(choice3.State ?? "Not selected")</MudChip>
         </MudText>
     </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Badge/Examples/BadgeInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Badge/Examples/BadgeInteractiveExample.razor
@@ -5,7 +5,7 @@
 <MudGrid>
     <MudItem md="3">
         <MudPaper Class="pa-4" Elevation="0">
-            <MudText Typo="Typo.h6" GutterBottom="true">Test Options</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Test Options</MudText>
             <MudSelect T="string" Label="Component" Margin="Margin.Dense" Dense="true" Value="@SelectedTestComponent" ValueChanged="OnSelectedTestComponent">
                 <MudSelectItem T="string" Value="@("MudIcon")">MudIcon</MudSelectItem>
                 <MudSelectItem T="string" Value="@("MudButton")">MudButton</MudSelectItem>
@@ -46,7 +46,7 @@
     </MudItem>
     <MudItem md="3">
         <MudPaper Class="pa-4" Elevation="0">
-            <MudText Typo="Typo.h6" GutterBottom="true">Badge Options</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Badge Options</MudText>
             <MudSelect Label="Badge Origin" Margin="Margin.Dense" Dense="true" @bind-Value="Origin">
                 <MudSelectItem Value="Origin.TopLeft">TopLeft</MudSelectItem>
                 <MudSelectItem Value="Origin.TopCenter">TopCenter</MudSelectItem>
@@ -62,7 +62,7 @@
             <MudCheckBox @bind-Value="Overlap" Label="Overlap" Color="Color.Primary" Style="width:100%;" />
             <MudCheckBox @bind-Value="Bordered" Label="Bordered" Color="Color.Primary" Style="width:100%;" />
             <MudCheckBox T="bool" ValueChanged="AddIcon" Label="Icon" Color="Color.Primary" Style="width:100%;" />
-            <MudText Typo="Typo.subtitle2" Class="my-2">Badge Content</MudText>
+            <MudText Typo="Typo.Subtitle2" Class="my-2">Badge Content</MudText>
             <div style="display: flex;">
                 <MudButton OnClick="AddValue" Variant="Variant.Filled" Size="Size.Small" Color="Color.Primary" FullWidth="true" Class="mr-1">Add @AddNumber</MudButton>
                 <MudButton OnClick="ClearContent" Variant="Variant.Filled" Size="Size.Small" Color="Color.Secondary" FullWidth="true" Class="ml-1">Clear</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardCombinedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardCombinedExample.razor
@@ -6,8 +6,8 @@
             <MudAvatar Color="Color.Secondary">I</MudAvatar>
         </CardHeaderAvatar>
         <CardHeaderContent>
-            <MudText Typo="Typo.body1">Istra Croatia</MudText>
-            <MudText Typo="Typo.body2">Peninsula in Europe</MudText>
+            <MudText Typo="Typo.Body1">Istra Croatia</MudText>
+            <MudText Typo="Typo.Body2">Peninsula in Europe</MudText>
         </CardHeaderContent>
         <CardHeaderActions>
             <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" />
@@ -15,7 +15,7 @@
     </MudCardHeader>
     <MudCardMedia Image="images/pilars.jpg" Height="250" />
     <MudCardContent>
-        <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+        <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudIconButton Icon="@Icons.Material.Filled.Favorite" Color="Color.Default" />

--- a/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardHeaderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardHeaderExample.razor
@@ -3,7 +3,7 @@
 <MudCard>
     <MudCardHeader>
         <CardHeaderContent>
-            <MudText Typo="Typo.h6">The Story Book</MudText>
+            <MudText Typo="Typo.H6">The Story Book</MudText>
         </CardHeaderContent>
         <CardHeaderActions>
             <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" />
@@ -11,7 +11,7 @@
     </MudCardHeader>
     <MudCardContent>
         <MudText>This day everything happened.</MudText>
-        <MudText Typo="Typo.body2">The quick, brown fox jumps over a lazy dog.</MudText>
+        <MudText Typo="Typo.Body2">The quick, brown fox jumps over a lazy dog.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudButton Variant="Variant.Text" Color="Color.Primary">Read More</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardMediaExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardMediaExample.razor
@@ -3,9 +3,9 @@
 <MudCard>
     <MudCardMedia Image="images/door.jpg" Height="200" />
     <MudCardContent>
-        <MudText Typo="Typo.h5">Old Paint</MudText>
-        <MudText Typo="Typo.body2">Old paint found on a stone house door.</MudText>
-        <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+        <MudText Typo="Typo.H5">Old Paint</MudText>
+        <MudText Typo="Typo.Body2">Old paint found on a stone house door.</MudText>
+        <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudButton Variant="Variant.Text" Color="Color.Primary">Share</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardOutlinedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardOutlinedExample.razor
@@ -3,7 +3,7 @@
 <MudCard Outlined="true">
     <MudCardContent>
         <MudText>Story of the day</MudText>
-        <MudText Typo="Typo.body2">The quick, brown fox jumps over a lazy dog.</MudText>
+        <MudText Typo="Typo.Body2">The quick, brown fox jumps over a lazy dog.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudButton Variant="Variant.Text" Color="Color.Primary">Learn More</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/Examples/CardSimpleExample.razor
@@ -3,7 +3,7 @@
 <MudCard>
     <MudCardContent>
         <MudText>Story of the day</MudText>
-        <MudText Typo="Typo.body2">The quick, brown fox jumps over a lazy dog.</MudText>
+        <MudText Typo="Typo.Body2">The quick, brown fox jumps over a lazy dog.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudButton Variant="Variant.Text" Color="Color.Primary">Learn More</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample1.razor
@@ -3,7 +3,7 @@
 <div>
     <MudChart ChartType="ChartType.Bar" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
 </div>
-<MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
+<MudText Typo="Typo.H6">Selected portion of the chart: @Index</MudText>
 
 @code {
     private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutExample1.razor
@@ -8,7 +8,7 @@
     <MudButton @onclick="RandomizeData" Variant="Variant.Filled" Class="mx-4">Randomize</MudButton>
     <MudButton OnClick="RemoveDataSize" Variant="Variant.Filled" Color="Color.Secondary">Remove</MudButton>  
 </MudPaper>
-<MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
+<MudText Typo="Typo.H6">Selected portion of the chart: @Index</MudText>
 
 @code {
     private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample1.razor
@@ -4,7 +4,7 @@
     <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px" ChartOptions="@Options"/>
     <MudGrid>
         <MudItem xs="6">
-            <MudText Typo="Typo.body1" Class="py-3">Selected: @(Index < 0 ? "None" : Series[Index].Name)</MudText>
+            <MudText Typo="Typo.Body1" Class="py-3">Selected: @(Index < 0 ? "None" : Series[Index].Name)</MudText>
         </MudItem>
         <MudItem xs="6">
             <MudSlider @bind-Value="Options.LineStrokeWidth" Min="1" Max="10" Color="Color.Info">Line Width: @Options.LineStrokeWidth.ToString()</MudSlider>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/PieExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/PieExample1.razor
@@ -8,7 +8,7 @@
     <MudButton @onclick="RandomizeData" Variant="Variant.Filled" Class="mx-4">Randomize</MudButton>
     <MudButton OnClick="RemoveDataSize" Variant="Variant.Filled" Color="Color.Secondary">Remove</MudButton>  
 </MudPaper>
-<MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
+<MudText Typo="Typo.H6">Selected portion of the chart: @Index</MudText>
 
 @code {
     private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
@@ -3,7 +3,7 @@
 <div>
     <MudChart ChartType="ChartType.StackedBar" ChartSeries="@Series" @bind-SelectedIndex="Index" LegendPosition="@LegendPosition" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
 </div>
-<MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
+<MudText Typo="Typo.H6">Selected portion of the chart: @Index</MudText>
 
 <div>
     <MudRadioGroup T="Position" @bind-SelectedValue="LegendPosition">

--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerExampleUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerExampleUsageExample.razor
@@ -6,7 +6,7 @@
     <MudPaper Class="d-flex">
         <MudColorPicker Rounded="true" Class="rounded-tr-0" PickerVariant="PickerVariant.Static" DisableModeSwitch="true" Value="_pickerColor" ValueChanged="UpdateSelectedColor" />
         <div class="pa-2">
-            <MudText Typo="Typo.h6" Class="mx-1">Gradient Colors</MudText>
+            <MudText Typo="Typo.H6" Class="mx-1">Gradient Colors</MudText>
 
             <MudList Clickable="true" SelectedItemChanged="ChangeSelectedColor">
                 <MudListItem Text="1">

--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPlaygroundExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPlaygroundExample.razor
@@ -8,7 +8,7 @@
     </MudItem>
     <MudItem md="4">
         <MudPaper Height="400px" Class="px-4 pt-2 pb-4">
-            <MudText Typo="Typo.h6">Options</MudText>
+            <MudText Typo="Typo.H6">Options</MudText>
             <MudCheckBox @bind-Value="DisableToolbar" Label="Disable Toolbar" Color="Color.Primary" Dense="true" />
             <MudCheckBox @bind-Value="DisableAlpha" Label="Disable Alpha" Color="Color.Primary" Dense="true" />
             <MudCheckBox @bind-Value="DisableColorField" Label="Disable Color Field" Color="Color.Primary" Dense="true" />

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAdvancedExample.razor
@@ -6,7 +6,7 @@
 <MudDataGrid T="Element" MultiSelection="true" Items="@Elements" SortMode="SortMode.Multiple" Filterable="true" QuickFilter="@_quickFilter"
     Hideable="true" RowClick="@RowClicked" RowContextMenuClick="RowRightClicked" SelectedItemsChanged="@SelectedItemsChanged">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
         <MudTextField @bind-Value="_searchString" Placeholder="Search" Adornment="Adornment.Start" Immediate="true"
             AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
@@ -33,7 +33,7 @@
     <MudExpansionPanel Text="Show Events">
         @foreach (var message in _events)
         {
-            <MudText Typo="@Typo.body2">@message</MudText>
+            <MudText Typo="@Typo.Body2">@message</MudText>
         }
         @if(_events.Count > 0) 
         {

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -17,7 +17,7 @@
         <MudCard>
             <MudCardHeader>
                 <CardHeaderContent>
-                    <MudText Typo="Typo.h6">@context.Item.Name</MudText>
+                    <MudText Typo="Typo.H6">@context.Item.Name</MudText>
                 </CardHeaderContent>
             </MudCardHeader>
             <MudCardContent>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -44,7 +44,7 @@
     <MudExpansionPanel Text="Show Events">
         @foreach (var message in _events)
         {
-            <MudText Typo="@Typo.body2">@message</MudText>
+            <MudText Typo="@Typo.Body2">@message</MudText>
         }
         @if(_events.Count > 0) 
         {

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingExample.razor
@@ -6,7 +6,7 @@
 <MudDataGrid @ref="dataGrid" MultiSelection="true" Items="@Elements" Filterable="true"
     Hideable="true" Groupable="true" GroupExpanded="false" GroupClassFunc="GroupClassFunc">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -7,7 +7,7 @@
     <DocsPageContent>
 
         <DocsPageSection>
-            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Note</MudText>
             <MudText>The Dialog is dependant on <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline></MudText>
             <MudText>Check the <MudLink Href="/getting-started/installation">Installation</MudLink> page for instructions regarding default setup.</MudText>
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogInlineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogInlineExample.razor
@@ -9,7 +9,7 @@
 
 <MudDialog @bind-IsVisible="visible" Options="dialogOptions">
     <TitleContent>
-        <MudText Typo="Typo.h6">
+        <MudText Typo="Typo.H6">
             <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-3" /> Edit rating
         </MudText>
     </TitleContent>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogPassingDataExample_Dialog.razor
@@ -5,7 +5,7 @@
 
 <MudDialog>
     <TitleContent>
-        <MudText Typo="Typo.h6">
+        <MudText Typo="Typo.H6">
             <MudIcon Icon="@Icons.Material.Filled.DeleteForever" Class="mr-3 mb-n1"/>
             Delete server?
         </MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerMiddleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerMiddleExample.razor
@@ -3,7 +3,7 @@
 <MudCard>
     <MudCardHeader>
         <CardHeaderContent>
-            <MudText Typo="Typo.h5">Uranium-235</MudText>
+            <MudText Typo="Typo.H5">Uranium-235</MudText>
         </CardHeaderContent>
     </MudCardHeader>
     <MudCardContent>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerAnchorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerAnchorExample.razor
@@ -4,7 +4,7 @@
     <MudDrawerContainer Class="mud-height-full">
         <MudDrawer @bind-Open="@openStart" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">My App</MudText>
+                <MudText Typo="Typo.H6">My App</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
@@ -14,7 +14,7 @@
         </MudDrawer>
         <MudDrawer @bind-Open="@openEnd" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">Settings</MudText>
+                <MudText Typo="Typo.H6">Settings</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.AccountBox">Profile</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerBreakpointExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerBreakpointExample.razor
@@ -10,7 +10,7 @@
     </MudAppBar>
     <MudDrawer @bind-Open="@open" Breakpoint="@breakpoint" Elevation="1" Variant="@DrawerVariant.Responsive" PreserveOpenState="@preserveOpenState">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">My App</MudText>
+            <MudText Typo="Typo.H6">My App</MudText>
         </MudDrawerHeader>
         <MudNavMenu>
             <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerClippingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerClippingExample.razor
@@ -10,7 +10,7 @@
     </MudAppBar>
     <MudDrawer @bind-Open="@open" ClipMode="clipMode" Elevation="1" Variant="@DrawerVariant.Responsive">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">My App</MudText>
+            <MudText Typo="Typo.H6">My App</MudText>
         </MudDrawerHeader>
         <MudNavMenu>
             <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerLeftRightExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerLeftRightExample.razor
@@ -4,7 +4,7 @@
     <MudDrawerContainer Class="mud-height-full">
         <MudDrawer @bind-Open="@openLeft" Anchor="Anchor.Left" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">My App</MudText>
+                <MudText Typo="Typo.H6">My App</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
@@ -14,7 +14,7 @@
         </MudDrawer>
         <MudDrawer @bind-Open="@openRight" Fixed="false" Anchor="Anchor.Right" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">Settings</MudText>
+                <MudText Typo="Typo.H6">Settings</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.AccountBox">Profile</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerOverlayExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerOverlayExample.razor
@@ -4,7 +4,7 @@
 
 <MudDrawer @bind-Open="@open" DisableOverlay="true" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
-        <MudText Typo="Typo.h6">My App</MudText>
+        <MudText Typo="Typo.H6">My App</MudText>
     </MudDrawerHeader>
     <MudNavMenu>
         <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerPersistentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerPersistentExample.razor
@@ -4,7 +4,7 @@
     <MudDrawerContainer Class="mud-height-full">
         <MudDrawer @bind-Open="@open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">My App</MudText>
+                <MudText Typo="Typo.H6">My App</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Dashboard" IconColor="Color.Inherit">Dashboard</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerResponsiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerResponsiveExample.razor
@@ -11,7 +11,7 @@
     </MudAppBar>
     <MudDrawer @bind-Open="@open" Elevation="1">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">My App</MudText>
+            <MudText Typo="Typo.H6">My App</MudText>
         </MudDrawerHeader>
         <MudNavMenu>
             <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeContainerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeContainerExample.razor
@@ -4,7 +4,7 @@
     <MudDrawerContainer Class="mud-height-full">
         <MudDrawer @bind-Open="@openStart" Width="150px" Fixed="false" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">My App</MudText>
+                <MudText Typo="Typo.H6">My App</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
@@ -14,7 +14,7 @@
         </MudDrawer>
         <MudDrawer @bind-Open="@openEnd" Width="300px" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">Settings</MudText>
+                <MudText Typo="Typo.H6">Settings</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.AccountBox">Profile</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeTemporaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeTemporaryExample.razor
@@ -7,7 +7,7 @@
 
 <MudDrawer @bind-Open="@open" Width="@width" Height="@height" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
-        <MudText Typo="Typo.h6">My App</MudText>
+        <MudText Typo="Typo.H6">My App</MudText>
     </MudDrawerHeader>
     <MudNavMenu>
         <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
@@ -7,7 +7,7 @@
 
 <MudDrawer @bind-Open="@open" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
-        <MudText Typo="Typo.h6">My App</MudText>
+        <MudText Typo="Typo.H6">My App</MudText>
     </MudDrawerHeader>
     <MudNavMenu>
         <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneCanDropStylesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneCanDropStylesExample.razor
@@ -4,13 +4,13 @@
     <ChildContent>
         <div class="d-flex flex-wrap justify-space-between">
             <MudDropZone T="DropItem" Identifier="Fridge" CanDrop="@((item) => false)" Class="rounded-lg border-2 border-solid mud-border-lines-default pa-6 ma-8">
-                <MudText Typo="Typo.h6" Class="mb-4">Fridge</MudText>
+                <MudText Typo="Typo.H6" Class="mb-4">Fridge</MudText>
             </MudDropZone>
             <MudDropZone T="DropItem" Identifier="Dinner" CanDrop="@((item) => item.IsPicked == false && item.IsRotten == false)" Class="rounded-lg border-2 border-solid mud-border-lines-default pa-6 ma-8 flex-grow-1">
-                <MudText Typo="Typo.h6" Class="mb-4">Soup</MudText>
+                <MudText Typo="Typo.H6" Class="mb-4">Soup</MudText>
             </MudDropZone>
             <MudDropZone T="DropItem" Identifier="Trash" CanDrop="@((item) => item.IsPicked == false && item.IsRotten == true)" Class="rounded-lg border-2 border-dashed mud-border-lines-default pa-6 ma-8 flex-grow-1">
-                <MudText Typo="Typo.h6" Class="mb-4">Trash</MudText>
+                <MudText Typo="Typo.H6" Class="mb-4">Trash</MudText>
             </MudDropZone>
         </div>
         <MudToolBar>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDropRulesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDropRulesExample.razor
@@ -4,13 +4,13 @@
     <ChildContent>
         <div class="d-flex flex-wrap justify-space-between">
             <MudDropZone T="DropItem" Identifier="Compost" CanDrop="@((item) => item.Type == ItemType.Compost)" Class="rounded-lg mud-alert-text-success pa-4 ma-4 flex-grow-1">
-                <MudText Typo="Typo.button" Class="ma-2">Compost Bin</MudText>
+                <MudText Typo="Typo.Button" Class="ma-2">Compost Bin</MudText>
             </MudDropZone>
             <MudDropZone T="DropItem" Identifier="Recycle" CanDrop="@((item) => item.Type == ItemType.Recycle)" Class="rounded-lg mud-alert-text-warning pa-4 ma-4 flex-grow-1">
-                <MudText Typo="Typo.button" Class="ma-2">Recycle Bin</MudText>
+                <MudText Typo="Typo.Button" Class="ma-2">Recycle Bin</MudText>
             </MudDropZone>
             <MudDropZone T="DropItem" Identifier="Trash" CanDrop="@((item) => item.Type == ItemType.Trash)" Class="rounded-lg mud-alert-text-info pa-4 ma-4 flex-grow-1">
-                <MudText Typo="Typo.button" Class="ma-2">Trash Bin</MudText>
+                <MudText Typo="Typo.Button" Class="ma-2">Trash Bin</MudText>
             </MudDropZone>
         </div>
         <MudDropZone T="DropItem" Identifier="Street" CanDrop="@((item) => false)" Class="rounded-lg mud-alert-text-normal pa-4 mt-6 mx-4 flex-grow-1 d-flex flex-wrap"/>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
@@ -8,7 +8,7 @@
 		{
 			<MudPaper Elevation="0" Width="224px" MinHeight="400px" Class="pa-4 ma-4 d-flex flex-column mud-background-gray rounded-lg">
 				<MudToolBar DisableGutters="true">
-					<MudText Typo="Typo.subtitle1"><b>@item.Name</b></MudText>
+					<MudText Typo="Typo.Subtitle1"><b>@item.Name</b></MudText>
 					<MudSpacer />
 					<MudMenu Icon="@Icons.Material.Rounded.MoreHoriz" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" ListClass="pa-2 d-flex flex-column" PopoverClass="mud-elevation-25">
 						<MudButton Size="Size.Small" Color="Color.Error" StartIcon="@Icons.Material.Outlined.Delete" OnClick="@( () => DeleteSection(item))">Delete Section</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneNestedZonesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneNestedZonesExample.razor
@@ -8,7 +8,7 @@
              </ChildContent>
              <ItemRenderer>
                  <MudPaper Class="pa-4 my-4">
-                     <MudText Typo="Typo.h6">@context.Name</MudText>
+                     <MudText Typo="Typo.H6">@context.Name</MudText>
                      <MudDropZone T="DropZoneItem" Identifier="@context.Name" AllowReorder Class="rounded mud-background-gray px-4 py-1 ma-4" />
                  </MudPaper>
              </ItemRenderer>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneOverrideExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneOverrideExample.razor
@@ -3,16 +3,16 @@
 <MudDropContainer T="DropItem" DraggingClass="mud-alert-text-warning" ItemDraggingClass="mud-alert-text-warning" Items="_items" ItemsSelector="@((item,dropzone) => item.Identifier == dropzone)" NoDropClass="mud-border-error" ItemDropped="ItemUpdated" Class="d-flex flex-wrap flex-grow-1">
     <ChildContent>
         <MudDropZone T="DropItem" Identifier="Enterprise" DraggingClass="mud-alert-text-info" ItemDraggingClass="mud-alert-text-info" Class="rounded-lg border-2 border-dashed mud-border-lines-default pa-6 ma-8" CanDrop="@((item) => item.Team == "BLUE")">
-            <MudText Typo="Typo.h6" Class="mb-4">USS Enterprise</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">USS Enterprise</MudText>
          </MudDropZone>
         <MudDropZone T="DropItem" Identifier="Air Zone 1" Class="rounded-lg border-2 border-dashed mud-border-lines-default pa-6 ma-8 flex-grow-1">
-            <MudText Typo="Typo.h6" Class="mb-4">Air Zone 1</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">Air Zone 1</MudText>
         </MudDropZone>
         <MudDropZone T="DropItem" Identifier="Air Zone 2" Class="rounded-lg border-2 border-dashed mud-border-lines-default pa-6 ma-8 flex-grow-1">
-            <MudText Typo="Typo.h6" Class="mb-4">Air Zone 2</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">Air Zone 2</MudText>
         </MudDropZone>
         <MudDropZone T="DropItem" Identifier="Danger Zone" DraggingClass="mud-alert-text-error" ItemDraggingClass="mud-alert-text-error" CanDrop="@((item) => item.Team == "RED")" Class="rounded-lg border-2 border-dashed mud-border-lines-default pa-6 ma-8">
-            <MudText Typo="Typo.h6" Class="mb-4">Danger Zone</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">Danger Zone</MudText>
         </MudDropZone>
     </ChildContent>
     <ItemRenderer>

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneUsageExample.razor
@@ -3,10 +3,10 @@
 <MudDropContainer T="DropItem" Items="_items" ItemsSelector="@((item,dropzone) => item.Identifier == dropzone)" ItemDropped="ItemUpdated" Class="d-flex flex-wrap flex-grow-1">
     <ChildContent>
         <MudDropZone T="DropItem" Identifier="Drop Zone 1" Class="rounded mud-background-gray pa-6 ma-8 flex-grow-1">
-            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
          </MudDropZone>
         <MudDropZone T="DropItem" Identifier="Drop Zone 2" Class="rounded mud-background-gray pa-6 ma-8 flex-grow-1">
-            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+            <MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
         </MudDropZone>
     </ChildContent>
     <ItemRenderer>

--- a/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldLabelPlaceholderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldLabelPlaceholderExample.razor
@@ -17,6 +17,6 @@
 
 @code {
     RenderFragment content = null;
-    RenderFragment rf1 = @<MudText Typo="@Typo.h6">I Am Field</MudText>;
+    RenderFragment rf1 = @<MudText Typo="@Typo.H6">I Am Field</MudText>;
     string color="#6cf014";
 }

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
@@ -54,7 +54,7 @@
 
 @if (files != null)
 {
-    <MudText Typo="@Typo.h6">@files.Count() File@(files.Count() == 1 ? "" : "s"):</MudText>
+    <MudText Typo="@Typo.H6">@files.Count() File@(files.Count() == 1 ? "" : "s"):</MudText>
     <MudList>
         @foreach (var file in files)
         {

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropCustomScenarioExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropCustomScenarioExample.razor
@@ -16,7 +16,7 @@
             <MudPaper Height="300px"
                       Outlined="true"
                       Class="@_dragClass">
-                <MudText Typo="Typo.h6">
+                <MudText Typo="Typo.H6">
                     Drag and drop files here or click
                 </MudText>
                 @foreach (var file in _fileNames)

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropWithFormValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropWithFormValidationExample.razor
@@ -28,7 +28,7 @@
                     <MudPaper Height="300px"
                               Outlined="true"
                               Class="@_dragClass">
-                        <MudText Typo="Typo.h6">
+                        <MudText Typo="Typo.H6">
                             Drag and drop files here or click
                         </MudText>
                         @foreach (var file in _model.Files?.Select(file => file.Name) ?? Enumerable.Empty<string>())

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadEventOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadEventOptionsExample.razor
@@ -26,7 +26,7 @@
 
 @if (files != null)
 {
-    <MudText Typo="@Typo.h6">@files.Count() File@(files.Count() == 1 ? "" : "s"):</MudText>
+    <MudText Typo="@Typo.H6">@files.Count() File@(files.Count() == 1 ? "" : "s"):</MudText>
     <MudList>
         @foreach (var file in files)
         {

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -4,16 +4,16 @@
     <DocsPageHeader Title="File Upload">
         <Description>
 
-            <MudText Typo="@Typo.body1" Class="mt-4">
+            <MudText Typo="@Typo.Body1" Class="mt-4">
                 To create a file upload button, two elements are needed: a <CodeInline>label</CodeInline> or <CodeInline>button</CodeInline> and an <CodeInline>input</CodeInline>.
             </MudText>
             <br />
-            <MudText Typo="@Typo.body1">
+            <MudText Typo="@Typo.Body1">
                 When we set the <CodeInline>for</CodeInline> attribute to the same value as the <CodeInline>id</CodeInline> of the input, we enable the input to be triggered by clicking on the label or button. We then hide the input.
             </MudText>
             <br />
 
-            <MudText Typo="@Typo.body1">
+            <MudText Typo="@Typo.Body1">
                 After uploading the files, you will receive an <CodeInline>IReadOnlyList&#60IBrowserFile&#62</CodeInline> or <CodeInline>IBrowserFile</CodeInline> and you will need to manually handle the upload in <CodeInline>HandleFilesChanged</CodeInline>.
                 Instead of using <CodeInline>multiple</CodeInline> to allow multiple files, you set T to <CodeInline>IReadOnlyList&#60IBrowserFile&#62</CodeInline>. Using <CodeInline>IBrowserFile</CodeInline> restricts the component to a single file.
             </MudText>

--- a/src/MudBlazor.Docs/Pages/Components/FocusTrap/FocusTrapPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FocusTrap/FocusTrapPage.razor
@@ -7,7 +7,7 @@
     <DocsPageContent>
 
         <DocsPageSection>
-            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Note</MudText>
             <MudText>The <CodeInline>Dialog</CodeInline> component already contains a focus trap, it is not necessary to add one yourself.</MudText>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/EditFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/EditFormExample.razor
@@ -23,7 +23,7 @@
     </MudItem>
     <MudItem xs="12" sm="5">
         <MudPaper Class="pa-4 mud-height-full">
-            <MudText Typo="Typo.subtitle2">Validation Summary</MudText>
+            <MudText Typo="Typo.Subtitle2">Validation Summary</MudText>
             @if (success)
             {
                 <MudText Color="Color.Success">Success</MudText>
@@ -37,7 +37,7 @@
         </MudPaper>
     </MudItem>
     <MudItem xs="12">
-        <MudText Typo="Typo.body2" Align="Align.Center">
+        <MudText Typo="Typo.Body2" Align="Align.Center">
             Fill out the form correctly to see the success message.
         </MudText>
     </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -36,7 +36,7 @@
     </MudItem>
     <MudItem xs="12" sm="5">
         <MudPaper Class="pa-4 mud-height-full">
-            <MudText Typo="Typo.subtitle2">@($"Errors ({errors.Length})")</MudText>
+            <MudText Typo="Typo.Subtitle2">@($"Errors ({errors.Length})")</MudText>
                 @foreach (var error in errors)
                 {
                     <MudText Color="@Color.Error">@error</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridBuilderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridBuilderExample.razor
@@ -23,7 +23,7 @@
                 <MudItem xs="@breaks[localindex]">
                     <MudPaper Class="d-flex flex-column align-center justify-center mud-width-full py-8">
                         <MudIconButton Icon="@Icons.Material.Filled.KeyboardArrowUp" OnClick="(()=>UpdateBreaks(localindex,1))" Size="Size.Small" />
-                        <MudText Typo="Typo.h6" Align="Align.Center">@breaks[localindex]</MudText>
+                        <MudText Typo="Typo.H6" Align="Align.Center">@breaks[localindex]</MudText>
                         <MudIconButton Icon="@Icons.Material.Filled.KeyboardArrowDown" OnClick="(()=>UpdateBreaks(localindex,-1))" Size="Size.Small" />
                     </MudPaper>
                 </MudItem>

--- a/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithTableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Highlighter/Examples/HighlighterWithTableExample.razor
@@ -5,7 +5,7 @@
 
 <MudTable Items="@GetElements()">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
         <MudTextField @bind-Value="_searchTerm" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0" Immediate="true"></MudTextField>
     </ToolBarContent>

--- a/src/MudBlazor.Docs/Pages/Components/Image/Examples/ImagePlaygroundExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/Examples/ImagePlaygroundExample.razor
@@ -6,7 +6,7 @@
     </MudItem>
     <MudItem xs="12" md="4">
         <MudPaper Class="pa-4 mt-6 mt-lg-16" Elevation="0">
-            <MudText Typo="Typo.h6">Options</MudText>
+            <MudText Typo="Typo.H6">Options</MudText>
             <MudSelect Label="Image" AnchorOrigin="Origin.BottomCenter" Dense="true" Margin="Margin.Dense" @bind-Value="Image" Class="mt-4">
                 <MudSelectItem T="string" Value="@("tractor.jpg")">Tractor</MudSelectItem>
                 <MudSelectItem T="string" Value="@("door.jpg")">Door</MudSelectItem>

--- a/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkSimpleExample.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudLink Href="#">Default</MudLink>
-<MudLink Href="#" Typo="Typo.body2">Different Typography</MudLink>
+<MudLink Href="#" Typo="Typo.Body2">Different Typography</MudLink>
 <MudLink Href="#" Disabled="true">Disabled link</MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListInteractiveExample.razor
@@ -7,7 +7,7 @@
         <MudCheckBox @bind-Value="Gutters" Label="Disable Gutters" Color="Color.Secondary" />
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.h6" GutterBottom="true">Text only</MudText>
+        <MudText Typo="Typo.H6" GutterBottom="true">Text only</MudText>
         <MudPaper Width="100%">
             <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
                 <MudListItem Text="Single List Item" />
@@ -17,7 +17,7 @@
         </MudPaper>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.h6" GutterBottom="true">Icons with text</MudText>
+        <MudText Typo="Typo.H6" GutterBottom="true">Icons with text</MudText>
         <MudPaper Width="100%">
             <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
                 <MudListItem Text="Single List Item" Icon="@Icons.Material.Filled.Bookmark" />
@@ -27,7 +27,7 @@
         </MudPaper>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.h6" GutterBottom="true">Avatar with text</MudText>
+        <MudText Typo="Typo.H6" GutterBottom="true">Avatar with text</MudText>
         <MudPaper Width="100%">
             <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
                 <MudListItem Text="Single List Item" Avatar="@Icons.Material.Filled.Image" />

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorOnMouseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorOnMouseExample.razor
@@ -6,9 +6,9 @@
         <MudCard>
             <MudCardMedia Image="images/door.jpg" Height="200" />
             <MudCardContent>
-                <MudText Typo="Typo.h5">Old Paint</MudText>
-                <MudText Typo="Typo.body2">Old paint found on a stone house door.</MudText>
-                <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+                <MudText Typo="Typo.H5">Old Paint</MudText>
+                <MudText Typo="Typo.Body2">Old paint found on a stone house door.</MudText>
+                <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
             </MudCardContent>
         </MudCard>
     </ActivatorContent>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAdvancedPopoverExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAdvancedPopoverExample.razor
@@ -2,7 +2,7 @@
 
 <MudGrid>
     <MudItem xs="3">
-        <MudText Typo="Typo.h6">Anchor Origin</MudText>
+        <MudText Typo="Typo.H6">Anchor Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
@@ -25,7 +25,7 @@
         </MudBadge>
     </MudItem>
     <MudItem xs="3">
-        <MudText Typo="Typo.h6">Transform Origin</MudText>
+        <MudText Typo="Typo.H6">Transform Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAnchorOriginExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuAnchorOriginExample.razor
@@ -2,14 +2,14 @@
 
 <MudGrid>
     <MudItem xs="12" md="3">
-        <MudText Typo="Typo.h6">Anchor Origin</MudText>
+        <MudText Typo="Typo.H6">Anchor Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomLeft">Bottom-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomRight">Bottom-Right</MudRadio>
         </MudRadioGroup>
-        <MudText Typo="Typo.h6">Transform Origin</MudText>
+        <MudText Typo="Typo.H6">Transform Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter" Disabled="true">Top-Center</MudRadio>
         </MudRadioGroup>
@@ -20,7 +20,7 @@
             <MudMenuItem>2</MudMenuItem>
             <MudMenuItem>3</MudMenuItem>
         </MudMenu>
-        <MudText Typo="Typo.overline">Click the button to see effect</MudText>
+        <MudText Typo="Typo.Overline">Click the button to see effect</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuTransformOriginExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuTransformOriginExample.razor
@@ -2,11 +2,11 @@
 
 <MudGrid>
     <MudItem xs="12" md="3">
-        <MudText Typo="Typo.h6">Anchor Origin</MudText>
+        <MudText Typo="Typo.H6">Anchor Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft" Disabled="true">Top-Left</MudRadio>
         </MudRadioGroup>
-        <MudText Typo="Typo.h6">Transform Origin</MudText>
+        <MudText Typo="Typo.H6">Transform Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column  my-2">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
@@ -18,7 +18,7 @@
             <MudMenuItem>My account</MudMenuItem>
             <MudMenuItem>Logout</MudMenuItem>
         </MudMenu>
-        <MudText Typo="Typo.overline">Click the button to see effect</MudText>
+        <MudText Typo="Typo.Overline">Click the button to see effect</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
@@ -6,7 +6,7 @@
     <DocsPageContent>
 
         <DocsPageSection>
-            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Note</MudText>
             <MudText>The MessageBox depends on <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline></MudText>
             <MudText>Any global configuration done on the MudDialogProvider will affect all MessageBoxes in your application.</MudText>
             <MudText>Check the Dialog <MudLink Href="/components/dialog#configuration">Configuration</MudLink> section for instructions on how to configure your dialogs globally.</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuExample.razor
@@ -2,8 +2,8 @@
 
 <MudPaper Width="250px" Class="py-3" Elevation="0">
     <MudNavMenu>
-        <MudText Typo="Typo.h6" Class="px-4">My Application</MudText>
-        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
+        <MudText Typo="Typo.H6" Class="px-4">My Application</MudText>
+        <MudText Typo="Typo.Body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
         <MudDivider Class="my-2"/>
         <MudNavLink Href="/dashboard">Dashboard</MudNavLink>
         <MudNavLink Href="/servers">Servers</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuIconExample.razor
@@ -5,8 +5,8 @@
 
 <MudPaper Width="250px" Class="d-inline-flex py-3" Elevation="0">
     <MudNavMenu Class="mud-width-full">
-        <MudText Typo="Typo.h6" Class="px-4">Material</MudText>
-        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Icons</MudText>
+        <MudText Typo="Typo.H6" Class="px-4">Material</MudText>
+        <MudText Typo="Typo.Body2" Class="px-4 mud-text-secondary">Icons</MudText>
         <MudDivider Class="my-2" />
         <MudNavLink Href="/dashboard" Icon="@Icons.Material.Filled.Dashboard">Dashboard</MudNavLink>
         <MudNavLink Href="/servers" Icon="@Icons.Material.Filled.Storage">Servers</MudNavLink>
@@ -19,8 +19,8 @@
 </MudPaper>
 <MudPaper Width="250px" Class="d-inline-flex py-3" Elevation="0">
     <MudNavMenu Class="mud-width-full">
-        <MudText Typo="Typo.h6" Class="px-4">Font Awesome</MudText>
-        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Icons</MudText>
+        <MudText Typo="Typo.H6" Class="px-4">Font Awesome</MudText>
+        <MudText Typo="Typo.Body2" Class="px-4 mud-text-secondary">Icons</MudText>
         <MudDivider Class="my-2" />
         <MudNavLink Href="/dashboard" Icon="fas fa-chart-line">Dashboard</MudNavLink>
         <MudNavLink Href="/servers" Icon="fas fa-server">Servers</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuSubGroupExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuSubGroupExample.razor
@@ -2,8 +2,8 @@
 
 <MudPaper Width="250px" Class="d-inline-flex py-3" Elevation="0">
     <MudNavMenu Class="mud-width-full">
-        <MudText Typo="Typo.h6" Class="px-4">My Application</MudText>
-        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
+        <MudText Typo="Typo.H6" Class="px-4">My Application</MudText>
+        <MudText Typo="Typo.Body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
         <MudDivider Class="my-2" />
         <MudNavLink Href="/dashboard" Icon="@Icons.Material.Filled.Dashboard">Dashboard</MudNavLink>
         <MudNavGroup Title="Level 0" Icon="@Icons.Material.Filled.Settings" Expanded="true">

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayLoaderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayLoaderExample.razor
@@ -21,9 +21,9 @@
     {
         <MudCardMedia Image="images/door.jpg" Height="200" />
         <MudCardContent>
-            <MudText Typo="Typo.h5">Old Paint</MudText>
-            <MudText Typo="Typo.body2">Old paint found on a stone house door.</MudText>
-            <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+            <MudText Typo="Typo.H5">Old Paint</MudText>
+            <MudText Typo="Typo.Body2">Old paint found on a stone house door.</MudText>
+            <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
         </MudCardContent>
         <MudCardActions>
             <MudButton Variant="Variant.Text" Color="Color.Primary">Share</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
@@ -4,9 +4,9 @@
 <DocsPage DisplayFooter="true">
     <DocsPageHeader Title="Explore MudBlazor" SubTitle="Discover articles from MudBlazor team.">
         <SpecialHeaderContent>
-            <MudText Typo="Typo.h2" Inline="true" Class="docs-title">Explore&nbsp;</MudText>
-            <MudText Typo="Typo.h2" Inline="true" Color="Color.Primary" Class="docs-title">MudBlazor</MudText>
-            <MudText Typo="Typo.subtitle1" Class="docs-title-description">Discover our library and all components to power your next project.</MudText>
+            <MudText Typo="Typo.H2" Inline="true" Class="docs-title">Explore&nbsp;</MudText>
+            <MudText Typo="Typo.H2" Inline="true" Color="Color.Primary" Class="docs-title">MudBlazor</MudText>
+            <MudText Typo="Typo.Subtitle1" Class="docs-title-description">Discover our library and all components to power your next project.</MudText>
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
@@ -14,8 +14,8 @@
             <MudGrid>
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Foundation</MudText>
-                        <MudText Typo="Typo.subtitle1">Theming, Colors, Typography…</MudText>
+                        <MudText Typo="Typo.H5">Foundation</MudText>
+                        <MudText Typo="Typo.Subtitle1">Theming, Colors, Typography…</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -48,8 +48,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Layout</MudText>
-                        <MudText Typo="Typo.subtitle1">Container, Grid, Surfaces...</MudText>
+                        <MudText Typo="Typo.H5">Layout</MudText>
+                        <MudText Typo="Typo.Subtitle1">Container, Grid, Surfaces...</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -103,8 +103,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Buttons</MudText>
-                        <MudText Typo="Typo.subtitle1">Regular, Icon, Floating...</MudText>
+                        <MudText Typo="Typo.H5">Buttons</MudText>
+                        <MudText Typo="Typo.Subtitle1">Regular, Icon, Floating...</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -144,8 +144,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Inputs</MudText>
-                        <MudText Typo="Typo.subtitle1">Forms, Text Fields, Numeric Fields...</MudText>
+                        <MudText Typo="Typo.H5">Inputs</MudText>
+                        <MudText Typo="Typo.Subtitle1">Forms, Text Fields, Numeric Fields...</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -277,8 +277,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Data Display</MudText>
-                        <MudText Typo="Typo.subtitle1">Lists, Tables, Tabs, Pagination...</MudText>
+                        <MudText Typo="Typo.H5">Data Display</MudText>
+                        <MudText Typo="Typo.Subtitle1">Lists, Tables, Tabs, Pagination...</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -508,8 +508,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Navigation</MudText>
-                        <MudText Typo="Typo.subtitle1">Links, Menus and Navigation</MudText>
+                        <MudText Typo="Typo.H5">Navigation</MudText>
+                        <MudText Typo="Typo.Subtitle1">Links, Menus and Navigation</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -554,8 +554,8 @@
 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Feedback</MudText>
-                        <MudText Typo="Typo.subtitle1">Alerts, Progress, Information</MudText>
+                        <MudText Typo="Typo.H5">Feedback</MudText>
+                        <MudText Typo="Typo.Subtitle1">Alerts, Progress, Information</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -639,8 +639,8 @@
                 
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
-                        <MudText Typo="Typo.h5">Utilities</MudText>
-                        <MudText Typo="Typo.subtitle1">CSS Class Utilities</MudText>
+                        <MudText Typo="Typo.H5">Utilities</MudText>
+                        <MudText Typo="Typo.Subtitle1">CSS Class Utilities</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
@@ -2,7 +2,7 @@
  
 <MudGrid>
     <MudItem xs="3">
-        <MudText Typo="Typo.h6">Anchor Origin</MudText>
+        <MudText Typo="Typo.H6">Anchor Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="AnchorOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
@@ -19,7 +19,7 @@
             <MudBadge Origin="@AnchorOrigin" Color="Color.Primary" Dot="true" Overlap="true" Elevation="4" BadgeClass="ma-2">
                 <MudPaper Elevation="0" Outlined="true" Class="pa-12">
                     <MudPopover OverflowBehavior="OverflowBehavior.FlipNever" Open="true" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="pa-4">
-                        <MudText Typo="Typo.body2" Class="px-4 py-1">The content of the popover</MudText>
+                        <MudText Typo="Typo.Body2" Class="px-4 py-1">The content of the popover</MudText>
                         <div class="@GetLocation()" style="top:0; left:0;">
                             <MudIcon Icon="@GetIcon()" Color="Color.Secondary" Class="" />
                         </div>
@@ -28,7 +28,7 @@
             </MudBadge>
     </MudItem>
     <MudItem xs="3">
-        <MudText Typo="Typo.h6">Transform Origin</MudText>
+        <MudText Typo="Typo.H6">Transform Origin</MudText>
         <MudRadioGroup T="Origin" @bind-SelectedValue="TransformOrigin" Class="d-flex flex-column">
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
             <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressLinearLabelsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressLinearLabelsExample.razor
@@ -2,7 +2,7 @@
 
 
 <MudProgressLinear Color="Color.Info" Size="Size.Large" Value="25" Class="my-7">
-    <MudText Typo="Typo.subtitle1" Color="Color.Dark">
+    <MudText Typo="Typo.Subtitle1" Color="Color.Dark">
         <b>25%</b>
     </MudText>
 </MudProgressLinear>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressLinearVerticalExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressLinearVerticalExample.razor
@@ -4,7 +4,7 @@
     <MudProgressLinear Vertical="true" Color="Color.Primary" Size="Size.Small" Indeterminate="true" />
     <MudProgressLinear Vertical="true" Color="Color.Primary" Size="Size.Medium" Value="@Value" />
     <MudProgressLinear Vertical="true" Color="Color.Primary" Size="Size.Medium" Value="25">
-        <MudText Typo="Typo.subtitle1" Color="Color.Dark"><b>25</b></MudText>
+        <MudText Typo="Typo.Subtitle1" Color="Color.Dark"><b>25</b></MudText>
     </MudProgressLinear>
     <MudProgressLinear Vertical="true" Color="Color.Primary" Size="Size.Small" Buffer="true" Value="@Value" BufferValue="@BufferValue" />
     <MudProgressLinear Vertical="true" Color="Color.Primary" Striped="true" Size="Size.Large" Value="@Value" />

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -13,13 +13,13 @@
         <DocsPageSection>
             <MudGrid>
                 <MudItem md="6">
-                    <MudText Typo="Typo.h6" Color="Color.Primary">Determinate indicators</MudText>
+                    <MudText Typo="Typo.H6" Color="Color.Primary">Determinate indicators</MudText>
                     <MudText>
                         <b>Determinate</b> indicators display how long a process will take. They should be used when the process completion rate can be estimated.
                     </MudText>
                 </MudItem>
                 <MudItem md="6">
-                    <MudText Typo="Typo.h6" Color="Color.Secondary">Indeterminate indicators</MudText>
+                    <MudText Typo="Typo.H6" Color="Color.Secondary">Indeterminate indicators</MudText>
                     <MudText>
                         <b>Indeterminate</b> indicators express an unspecified amount of wait time. They should be used when progress isn't estimable, or when it's not necessary to indicate how long an activity will take.
                     </MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingBindingsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingBindingsExample.razor
@@ -3,7 +3,7 @@
 
 <div class="d-flex flex-column align-center">
     <MudRating @bind-SelectedValue="selectedVal" HoveredValueChanged="HandleHoveredValueChanged" />
-    <MudText Typo="Typo.subtitle2" Class="deep-purple-text mt-2">@LabelText</MudText>
+    <MudText Typo="Typo.Subtitle2" Class="deep-purple-text mt-2">@LabelText</MudText>
 </div>
 
 

--- a/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingTestExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingTestExample.razor
@@ -21,7 +21,7 @@
     <div class="d-flex flex-column align-center my-6">
         <h3>Hover feedback</h3>
         <MudRating @bind-SelectedValue="selectedVal" HoveredValueChanged="HandleHoveredValueChanged" />
-        <MudText Typo="Typo.subtitle1" Class="deep-purple-text">@GetLabelText()</MudText>
+        <MudText Typo="Typo.Subtitle1" Class="deep-purple-text">@GetLabelText()</MudText>
     </div>
 
     <div class="d-flex flex-column align-center my-12">

--- a/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/CustomScrollToTopExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/CustomScrollToTopExample.razor
@@ -2,10 +2,10 @@
 
 <div id="another_unique_identifier" class="ma-0" style="height:300px;overflow: auto;">
     <MudPaper Elevation="0" Height="3500px" Class="d-flex flex-column justify-space-between py-6">
-        <MudText Typo="Typo.h3" Align="Align.Center">Scroll inside this container</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Some initial long text</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Middle text</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Bottom text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Scroll inside this container</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Some initial long text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Middle text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Bottom text</MudText>
         <MudScrollToTop TopOffset="100" Selector="#another_unique_identifier" Style="z-index:2001;">
             <div class="mud-theme-secondary px-3 py-6 mud-elevation-16 rounded-xl fixed" style="bottom:20px;left:20px;">Scroll to top custom button</div>
         </MudScrollToTop>

--- a/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/ScrollToTopExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/ScrollToTopExample.razor
@@ -2,10 +2,10 @@
 
 <div id="unique_id_scroll_section" class="ma-0" style="height:300px;overflow: auto;">
     <MudPaper Elevation="0" Height="3500px" Class="d-flex flex-column justify-space-between py-6">
-        <MudText Typo="Typo.h3" Align="Align.Center">Scroll inside this container</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Some initial long text</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Middle text</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Bottom text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Scroll inside this container</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Some initial long text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Middle text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Bottom text</MudText>
         <MudScrollToTop TopOffset="100"
                         OnScroll="OnScroll"
                         Selector="#unique_id_scroll_section"

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
@@ -12,16 +12,16 @@
 
 <MudGrid Class="mt-3 px-4">
     <MudItem xs="6">
-        <MudText Typo="Typo.subtitle2">Value:</MudText>
-        <MudText Typo="Typo.subtitle2">"</MudText>
-        <MudText Typo="Typo.body2" Class="pl-4">@value</MudText>
-        <MudText Typo="Typo.subtitle2">"</MudText>
+        <MudText Typo="Typo.Subtitle2">Value:</MudText>
+        <MudText Typo="Typo.Subtitle2">"</MudText>
+        <MudText Typo="Typo.Body2" Class="pl-4">@value</MudText>
+        <MudText Typo="Typo.Subtitle2">"</MudText>
     </MudItem>
     <MudItem xs="6">
-        <MudText Typo="Typo.subtitle2">SelectedValues: HashSet&lt;string&gt;</MudText>
-        <MudText Typo="Typo.subtitle2">{</MudText>
-        <MudText Typo="Typo.body2" Class="pl-4">@(string.Join(", ", options.Select(x=>$"\"{x}\"")))</MudText>
-        <MudText Typo="Typo.subtitle2">}</MudText>
+        <MudText Typo="Typo.Subtitle2">SelectedValues: HashSet&lt;string&gt;</MudText>
+        <MudText Typo="Typo.Subtitle2">{</MudText>
+        <MudText Typo="Typo.Body2" Class="pl-4">@(string.Join(", ", options.Select(x=>$"\"{x}\"")))</MudText>
+        <MudText Typo="Typo.Subtitle2">}</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectExample.razor
@@ -9,16 +9,16 @@
 
 <MudGrid Class="mt-6 px-4">
     <MudItem xs="6">
-        <MudText Typo="Typo.subtitle2">Value:</MudText>
-        <MudText Typo="Typo.subtitle2">"</MudText>
-        <MudText Typo="Typo.body2" Class="pl-4">@value</MudText>
-        <MudText Typo="Typo.subtitle2">"</MudText>
+        <MudText Typo="Typo.Subtitle2">Value:</MudText>
+        <MudText Typo="Typo.Subtitle2">"</MudText>
+        <MudText Typo="Typo.Body2" Class="pl-4">@value</MudText>
+        <MudText Typo="Typo.Subtitle2">"</MudText>
     </MudItem>
     <MudItem xs="6">
-        <MudText Typo="Typo.subtitle2">SelectedValues: HashSet&lt;string&gt;</MudText>
-        <MudText Typo="Typo.subtitle2">{</MudText>
-        <MudText Typo="Typo.body2" Class="pl-4">@(string.Join(", ", options.Select(x=>$"\"{x}\"")))</MudText>
-        <MudText Typo="Typo.subtitle2">}</MudText>
+        <MudText Typo="Typo.Subtitle2">SelectedValues: HashSet&lt;string&gt;</MudText>
+        <MudText Typo="Typo.Subtitle2">{</MudText>
+        <MudText Typo="Typo.Body2" Class="pl-4">@(string.Join(", ", options.Select(x=>$"\"{x}\"")))</MudText>
+        <MudText Typo="Typo.Subtitle2">}</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectCustomConverterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectCustomConverterExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudText Typo="Typo.h6" Class="mud-width-full">@(pizza == null ? "Nothing selected." : $"Pizza: {pizza.Name}")</MudText>
+<MudText Typo="Typo.H6" Class="mud-width-full">@(pizza == null ? "Nothing selected." : $"Pizza: {pizza.Name}")</MudText>
 
 <MudSelect T="Pizza" @bind-Value="pizza" ToStringFunc="@converter" Label="Select your pizza" AnchorOrigin="Origin.BottomCenter" Variant="Variant.Outlined" Clearable>
     <MudSelectItem Value="@(new Pizza() { Name="Cardinale"})" />

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
@@ -23,7 +23,7 @@
 </MudSelect>
 
 <div class="d-flex mud-width-full align-center mt-8">
-    <MudText Typo="Typo.subtitle1" Class="mr-2">Selected values: </MudText>
+    <MudText Typo="Typo.Subtitle1" Class="mr-2">Selected values: </MudText>
     <MudChip>@(stringValue ?? "Select fast-food")</MudChip>
     <MudChip Color="Color.Primary">@enumValue</MudChip>
     <MudChip Color="Color.Secondary">@(cultureValue?.DisplayName ?? "Select culture")</MudChip>

--- a/src/MudBlazor.Docs/Pages/Components/Skeleton/Examples/SkeletonPulsateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Skeleton/Examples/SkeletonPulsateExample.razor
@@ -18,9 +18,9 @@
 <MudCard>
     <MudCardMedia Image="images/door.jpg" Height="200" />
     <MudCardContent>
-        <MudText Typo="Typo.h5">Old Paint</MudText>
-        <MudText Typo="Typo.body2">Old paint found on a stone house door.</MudText>
-        <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+        <MudText Typo="Typo.H5">Old Paint</MudText>
+        <MudText Typo="Typo.Body2">Old paint found on a stone house door.</MudText>
+        <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudButton Variant="Variant.Text" Color="Color.Primary">Share</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Skeleton/Examples/SkeletonWaveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Skeleton/Examples/SkeletonWaveExample.razor
@@ -27,8 +27,8 @@
             <MudAvatar>I</MudAvatar>
         </CardHeaderAvatar>
         <CardHeaderContent>
-            <MudText Typo="Typo.body1">Istra Croatia</MudText>
-            <MudText Typo="Typo.body2">Peninsula in Europe</MudText>
+            <MudText Typo="Typo.Body1">Istra Croatia</MudText>
+            <MudText Typo="Typo.Body2">Peninsula in Europe</MudText>
         </CardHeaderContent>
         <CardHeaderActions>
             <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" />
@@ -36,7 +36,7 @@
     </MudCardHeader>
     <MudCardMedia Image="images/pilars.jpg" Height="250" />
     <MudCardContent>
-        <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+        <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
     </MudCardContent>
     <MudCardActions>
         <MudIconButton Icon="@Icons.Material.Filled.Favorite" Color="Color.Default" />

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRequireInteractionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRequireInteractionExample.razor
@@ -7,7 +7,7 @@
     <MudAlert Severity="Severity.Error" Dense="true" Class="rounded-0">Reactor meltdown is imminent!</MudAlert>
     <div class="d-flex flex-column" style="height: 200px;">
         <div class="align-self-center mt-12">
-            <MudText Typo="Typo.h6">Fuel Rod Temperature: @FuelRodTemperature.ToString()C</MudText>
+            <MudText Typo="Typo.H6">Fuel Rod Temperature: @FuelRodTemperature.ToString()C</MudText>
         </div>
         <div class="align-self-center mt-6">
             <MudTooltip Text="Reactor Shutdown">

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
@@ -7,7 +7,7 @@
     <DocsPageContent>
 
         <DocsPageSection>
-            <MudText Typo="Typo.h6" GutterBottom="true">Note</MudText>
+            <MudText Typo="Typo.H6" GutterBottom="true">Note</MudText>
             <MudText>The Snackbar is dependant on <CodeInline Class="docs-code-tertiary">ISnackbar</CodeInline> service and <CodeInline>MudSnackbarProvider</CodeInline>.</MudText>
             <MudText>Check the <MudLink Href="/getting-started/installation">Installation</MudLink> page for instructions regarding default setup.</MudText>
             <MudAlert Severity="Severity.Info" Class="mt-3">To statically embed an important message in a page see <MudLink Href="/components/alert">Alert</MudLink></MudAlert>

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackUsageFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackUsageFormExample.razor
@@ -5,8 +5,8 @@
         <MudStack Row="true">
             <MudAvatar Image="images/mony.jpg" Size="Size.Large" />
             <MudStack Justify="Justify.Center" Spacing="0">
-                <MudText Typo="Typo.body1">Mony Larsson</MudText>
-                <MudText Typo="Typo.body2">onebiteonekill@mony.dog</MudText>
+                <MudText Typo="Typo.Body1">Mony Larsson</MudText>
+                <MudText Typo="Typo.Body2">onebiteonekill@mony.dog</MudText>
             </MudStack>
         </MudStack>
     </MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudSwipeArea OnSwipe="@((d) => _swipeDirection = d)" Style="width: 100%; height: 300px">
-    <MudText Typo="@Typo.body1">@_swipeDirection</MudText>
+    <MudText Typo="@Typo.Body1">@_swipeDirection</MudText>
 </MudSwipeArea>
 
 @code{ SwipeDirection _swipeDirection; }

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsPreventDefaultExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsPreventDefaultExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudSwipeArea @ref="_swipeArea" OnSwipeEnd="HandleSwipeEnd" Style="width: 100%; height: 300px" Sensitivity="_sensitivity" PreventDefault="@_preventDefault">
-    <MudText Typo="@Typo.body1">@($"{_swipeDirection} - Swiped: {_swipeDelta}px")</MudText>
+    <MudText Typo="@Typo.Body1">@($"{_swipeDirection} - Swiped: {_swipeDelta}px")</MudText>
 </MudSwipeArea>
 <MudSwitch @bind-Value="_preventDefault" Color="Color.Primary">Prevent Default</MudSwitch>
 <MudNumericField @bind-Value="_sensitivity" Label="Sensitivity" Min="0" />

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
@@ -4,7 +4,7 @@
     <MudPaper Height="200px" Style="overflow:hidden; position:relative;">
         <MudDrawer @bind-Open="@_drawerOpen" Fixed="false" Elevation="1" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
             <MudDrawerHeader>
-                <MudText Typo="Typo.h6">My App</MudText>
+                <MudText Typo="Typo.H6">My App</MudText>
             </MudDrawerHeader>
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Dashboard" IconColor="Color.Inherit">Store</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableExample.razor
@@ -5,7 +5,7 @@
 
 <MudTable Items="@Elements" Dense="@dense" Hover="@hover" Bordered="@bordered" Striped="@striped" Filter="new Func<Element,bool>(FilterFunc1)" @bind-SelectedItem="selectedItem1">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
         <MudTextField @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
@@ -10,7 +10,7 @@
           OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues"
           RowEditCommit="ItemHasBeenCommitted" IsEditRowSwitchingBlocked="@blockSwitch" ApplyButtonPosition="@applyButtonPosition" EditButtonPosition="@editButtonPosition" EditTrigger="@editTrigger">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
         <MudTextField @bind-Value="searchString" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TablePagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TablePagerExample.razor
@@ -5,7 +5,7 @@
 
 <MudTable Items="@Elements">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
     </ToolBarContent>
     <HeaderContent>
         <MudTh>Nr</MudTh>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRelationalExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRelationalExample.razor
@@ -27,7 +27,7 @@
 	<MudCard Elevation="0">
 	 <MudCardHeader>
 	  <CardHeaderContent>
-	   <MudText Typo="Typo.body1">Address Details for <strong>@context.Name</strong></MudText>
+	   <MudText Typo="Typo.Body1">Address Details for <strong>@context.Name</strong></MudText>
 	  </CardHeaderContent>
 	 </MudCardHeader>
 	 <MudCardContent Class="pa-0">

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
@@ -6,7 +6,7 @@
 <MudTable ServerData="@(new Func<TableState, Task<TableData<Element>>>(ServerReload))"
           Dense="true" Hover="true" @ref="table">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudText Typo="Typo.H6">Periodic Elements</MudText>
         <MudSpacer />
         <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsContentExample.razor
@@ -19,7 +19,7 @@
             </MudTooltip>
         </TabWrapperContent>
         <TabContent>
-            <MudText Typo="Typo.h6">Item Two</MudText>
+            <MudText Typo="Typo.H6">Item Two</MudText>
         </TabContent>
     </MudTabPanel>
     <MudTabPanel Text="Item Three">

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -125,10 +125,10 @@
 		 <DocsPageSection>
             <SectionHeader Title="Advanced Dynamic Tabs">
                 <Description>
-					<MudText Typo="Typo.body2">
+					<MudText Typo="Typo.Body2">
 						Although MudDynamicTabs allows a basic browser like tab experience, the way the style can be influenced is limited 
 					</MudText>
-					<MudText Typo="Typo.body2">
+					<MudText Typo="Typo.Body2">
 						 The Property Header and TabPanelHeader allows you to add any RenderFragment to the tab (Header) 
 						 and to each tab panel (TabPanelHeader). The placement can be influenced by setting values to HeaderPosition or TabPanelHeaderPosition
 					</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -165,7 +165,7 @@
     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
         If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
         you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
-        For more details see <MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
+        For more details see <MudLink Typo="Typo.Body2" Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
     </MudAlert>
     <SectionSubGroups>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineAlignExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineAlignExample.razor
@@ -9,36 +9,36 @@
 <MudTimeline TimelineAlign="_timelineAlign">
     <MudTimelineItem Color="Color.Dark" Elevation="25">
         <ItemOpposite>
-            <MudText Color="Color.Dark" Typo="Typo.h6">Aug 2020</MudText>
+            <MudText Color="Color.Dark" Typo="Typo.H6">Aug 2020</MudText>
         </ItemOpposite>
         <ItemContent>
             <MudPaper Elevation="0" Class="mt-n1">
-                <MudText Color="Color.Dark" Typo="Typo.h6" GutterBottom="true">MudBlazor Emerges</MudText>
-                <MudText Typo="Typo.body2">A repository pops up on GitHub named MudBlazor.</MudText>
-                <MudText Typo="Typo.body2">The development has already started and the most common components can be found already.</MudText>
+                <MudText Color="Color.Dark" Typo="Typo.H6" GutterBottom="true">MudBlazor Emerges</MudText>
+                <MudText Typo="Typo.Body2">A repository pops up on GitHub named MudBlazor.</MudText>
+                <MudText Typo="Typo.Body2">The development has already started and the most common components can be found already.</MudText>
             </MudPaper>
         </ItemContent>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Primary" Elevation="25" TimelineAlign="TimelineAlign.End">
         <ItemOpposite>
-            <MudText Color="Color.Primary" Typo="Typo.h6">Oct 2020</MudText>
+            <MudText Color="Color.Primary" Typo="Typo.H6">Oct 2020</MudText>
         </ItemOpposite>
         <ItemContent>
             <MudPaper Elevation="0" Class="mt-n1">
-                <MudText Color="Color.Primary" Typo="Typo.h6" GutterBottom="true">MudBlazor Unleashed!</MudText>
-                <MudText Typo="Typo.body2">The first version is released and uploaded as v1.0.7.</MudText>
+                <MudText Color="Color.Primary" Typo="Typo.H6" GutterBottom="true">MudBlazor Unleashed!</MudText>
+                <MudText Typo="Typo.Body2">The first version is released and uploaded as v1.0.7.</MudText>
             </MudPaper>
         </ItemContent>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Secondary" Elevation="25">
         <ItemOpposite>
-            <MudText Color="Color.Secondary" Typo="Typo.h6" GutterBottom="true">Nov 2020</MudText>
+            <MudText Color="Color.Secondary" Typo="Typo.H6" GutterBottom="true">Nov 2020</MudText>
         </ItemOpposite>
         <ItemContent>
             <MudPaper Elevation="0" Class="mt-n1">
-                <MudText Color="Color.Secondary" Typo="Typo.h6" GutterBottom="true">First Minor</MudText>
-                <MudText Typo="Typo.body2">MudBlazor gets its first minor with version 1.1.0.</MudText>
-                <MudText Typo="Typo.body2">TimerPicker, AutoComplete and Charts join the library as well as T versions of our inputs and selects.</MudText>
+                <MudText Color="Color.Secondary" Typo="Typo.H6" GutterBottom="true">First Minor</MudText>
+                <MudText Typo="Typo.Body2">MudBlazor gets its first minor with version 1.1.0.</MudText>
+                <MudText Typo="Typo.Body2">TimerPicker, AutoComplete and Charts join the library as well as T versions of our inputs and selects.</MudText>
             </MudPaper>
         </ItemContent>
     </MudTimelineItem>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineDotsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineDotsExample.razor
@@ -25,7 +25,7 @@
     </MudItem>
     <MudItem xs="12" md="4">
         <MudPaper Class="pa-4" Elevation="0">
-            <MudText Typo="Typo.h6">Dot Options</MudText>
+            <MudText Typo="Typo.H6">Dot Options</MudText>
             <MudSelect Label="Color" Dense="true" Margin="Margin.Dense" @bind-Value="DotColor" Class="mt-4">
                 <MudSelectItem T="Color" Value="Color.Default">Default</MudSelectItem>
                 <MudSelectItem T="Color" Value="Color.Primary">Primary</MudSelectItem>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineItemAlignExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineItemAlignExample.razor
@@ -2,25 +2,25 @@
 
 <MudTimeline>
     <MudTimelineItem Color="Color.Info">
-        <MudText Typo="Typo.button">Packaging Process Started</MudText>
-        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 16:33</MudText>
+        <MudText Typo="Typo.Button">Packaging Process Started</MudText>
+        <MudText Typo="Typo.Body2" Class="mud-text-secondary">Yesterday: 16:33</MudText>
     </MudTimelineItem>
     <MudTimelineItem TimelineAlign="TimelineAlign.End">
-        <MudText Typo="Typo.body2">Packaging complete</MudText>
-        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 17:10</MudText>
+        <MudText Typo="Typo.Body2">Packaging complete</MudText>
+        <MudText Typo="Typo.Body2" Class="mud-text-secondary">Yesterday: 17:10</MudText>
     </MudTimelineItem>
     <MudTimelineItem TimelineAlign="TimelineAlign.End">
-        <MudText Typo="Typo.body2">Waiting for pickup</MudText>
-        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 17:15</MudText>
+        <MudText Typo="Typo.Body2">Waiting for pickup</MudText>
+        <MudText Typo="Typo.Body2" Class="mud-text-secondary">Yesterday: 17:15</MudText>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Error">
         <MudAlert Severity="Severity.Error">Package missed last pickup time.</MudAlert>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Success">
-        <MudText Typo="Typo.button">Package picked up by driver</MudText>
-        <MudText Typo="Typo.body2" Class="mud-text-secondary">Today: 17:00</MudText>
+        <MudText Typo="Typo.Button">Package picked up by driver</MudText>
+        <MudText Typo="Typo.Body2" Class="mud-text-secondary">Today: 17:00</MudText>
     </MudTimelineItem>
     <MudTimelineItem TimelineAlign="TimelineAlign.End">
-        <MudText Typo="Typo.button">Package In Transit</MudText>
+        <MudText Typo="Typo.Button">Package In Transit</MudText>
     </MudTimelineItem>
 </MudTimeline>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineItemModifiersExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineItemModifiersExample.razor
@@ -7,9 +7,9 @@
     <MudTimelineItem Size="Size.Medium" Color="Color.Info" Elevation="@(_outlined ? 0 : 25)">
         <MudCard Outlined="@_outlined" Elevation="25">
             <MudCardContent>
-                <MudText Typo="Typo.h6">Kopparberg</MudText>
-                <MudText Typo="Typo.body2">Kopparberg is a locality and the seat of Ljusnarsberg, Örebro County, Sweden, with 4,200 inhabitants in 2015.</MudText>
-                <MudText Typo="Typo.body2">It is famous for Kopparberg Cider, now one of the best selling ciders in the UK and worldwide.</MudText>
+                <MudText Typo="Typo.H6">Kopparberg</MudText>
+                <MudText Typo="Typo.Body2">Kopparberg is a locality and the seat of Ljusnarsberg, Örebro County, Sweden, with 4,200 inhabitants in 2015.</MudText>
+                <MudText Typo="Typo.Body2">It is famous for Kopparberg Cider, now one of the best selling ciders in the UK and worldwide.</MudText>
             </MudCardContent>
         </MudCard>
     </MudTimelineItem>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineOppositeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineOppositeExample.razor
@@ -3,28 +3,28 @@
 <MudTimeline>
     <MudTimelineItem Color="Color.Info" Size="Size.Small">
         <ItemOpposite>
-            <MudText Color="Color.Info" Typo="Typo.h5">1970</MudText>
+            <MudText Color="Color.Info" Typo="Typo.H5">1970</MudText>
         </ItemOpposite>
         <ItemContent>
-            <MudText Color="Color.Info" Typo="Typo.h6" GutterBottom="true">Atom Towns</MudText>
+            <MudText Color="Color.Info" Typo="Typo.H6" GutterBottom="true">Atom Towns</MudText>
             <MudText>Construction of the town of Pripyat, one of 9 “atom towns” begins, to be inhabited by future employees of the nuclear power plants.</MudText>
         </ItemContent>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Success" Size="Size.Small">
         <ItemOpposite>
-            <MudText Color="Color.Success" Typo="Typo.h5">1977</MudText>
+            <MudText Color="Color.Success" Typo="Typo.H5">1977</MudText>
         </ItemOpposite>
         <ItemContent>
-            <MudText Color="Color.Success" Typo="Typo.h6" GutterBottom="true">Operational</MudText>
+            <MudText Color="Color.Success" Typo="Typo.H6" GutterBottom="true">Operational</MudText>
             <MudText>The first of the Chernobyl Nuclear Power Plants four reactors is ready to operate followed by number 2 in 1978.</MudText>
         </ItemContent>
     </MudTimelineItem>
     <MudTimelineItem Color="Color.Error" Size="Size.Small">
         <ItemOpposite>
-            <MudText Color="Color.Error" Typo="Typo.h5">1979</MudText>
+            <MudText Color="Color.Error" Typo="Typo.H5">1979</MudText>
         </ItemOpposite>
         <ItemContent>
-            <MudText Color="Color.Error" Typo="Typo.h6" GutterBottom="true">Pripyat</MudText>
+            <MudText Color="Color.Error" Typo="Typo.H6" GutterBottom="true">Pripyat</MudText>
             <MudText>Pripyat officially proclaimed as a city.<br />The Chernobyl Atomic Power Station reaches its first 10 billion kilowatt-hours of electical output.</MudText>
         </ItemContent>
     </MudTimelineItem>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomContentExample.razor
@@ -7,7 +7,7 @@
                 <MudText Class="ellipsis">Indie Developer</MudText>
                 <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Basic</MudChip>
             </div>
-            <MudText Typo="Typo.subtitle2">Perfect for lone wolves</MudText>
+            <MudText Typo="Typo.Subtitle2">Perfect for lone wolves</MudText>
         </div>
     </MudToggleItem>
     <MudToggleItem Value="@("Pro Edition")">
@@ -16,7 +16,7 @@
                 <MudText Class="ellipsis">Small Team</MudText>
                 <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Pro</MudChip>
             </div>
-            <MudText Typo="Typo.subtitle2">Up to five devs and two interns</MudText>
+            <MudText Typo="Typo.Subtitle2">Up to five devs and two interns</MudText>
         </div>
     </MudToggleItem>
     <MudToggleItem Value="@("Enterprise Edition")">
@@ -25,7 +25,7 @@
                 <MudText Class="ellipsis">Corporation</MudText>
                 <MudChip Color="@(context ? Color.Success : Color.Primary)" Icon="@(context ? Icons.Material.Filled.Check : "")">Enterprise</MudChip>
             </div>
-            <MudText Typo="Typo.subtitle2">Unlimited edition</MudText>
+            <MudText Typo="Typo.Subtitle2">Unlimited edition</MudText>
         </div>
     </MudToggleItem>
 </MudToggleGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
@@ -5,8 +5,8 @@
         <MudIconButton Icon="@Icons.Material.Filled.Delete" />
     </ChildContent>
     <TooltipContent>
-        <MudText Typo="Typo.h6">h6 title</MudText>
-        <MudText Typo="Typo.body2">body2 content</MudText>
+        <MudText Typo="Typo.H6">h6 title</MudText>
+        <MudText Typo="Typo.Body2">body2 content</MudText>
         <MudIcon Icon="@Icons.Material.Filled.Star" />
     </TooltipContent>
 </MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewItemTemplateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewItemTemplateExample.razor
@@ -4,14 +4,14 @@
     <MudTreeView Items="TreeItems" MultiSelection="true" @bind-ActivatedValue="ActivatedValue" @bind-SelectedValues="SelectedValues">
         <ItemTemplate>
             <MudTreeViewItem @bind-Expanded="@context.IsExpanded" Items="@context.TreeItems" Value="@context"
-                             Icon="@context.Icon" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+                             Icon="@context.Icon" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.Caption" />
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>
 
 <div style="width: 100%">
-    <MudText Typo="@Typo.subtitle1">Activated item: @(ActivatedValue?.Title)</MudText>
-    <MudText Typo="@Typo.subtitle1">Sum of selected items: @GetSelectedSum()</MudText>
+    <MudText Typo="@Typo.Subtitle1">Activated item: @(ActivatedValue?.Title)</MudText>
+    <MudText Typo="@Typo.Subtitle1">Sum of selected items: @GetSelectedSum()</MudText>
 </div>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
@@ -15,7 +15,7 @@
     </MudTreeViewItem>
 </MudTreeView>
 
-<MudText Style="width: 100%" Typo="Typo.subtitle1"  Class="mb-n2">Number of selected items: @(SelectedValues?.Count ?? 0)</MudText>
+<MudText Style="width: 100%" Typo="Typo.Subtitle1"  Class="mb-n2">Number of selected items: @(SelectedValues?.Count ?? 0)</MudText>
 
 @code {
     HashSet<string> SelectedValues { get; set; }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewSelectedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewSelectedExample.razor
@@ -12,7 +12,7 @@
     </MudTreeView>
 </MudPaper>
 
-<MudText Style="width: 100%" Typo="@Typo.subtitle1">Selected item: @SelectedValue</MudText>
+<MudText Style="width: 100%" Typo="@Typo.Subtitle1">Selected item: @SelectedValue</MudText>
 
 @code {
     string SelectedValue { get; set; }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -3,7 +3,7 @@
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView ServerData="LoadServerData" Items="TreeItems">
         <ItemTemplate>
-            <MudTreeViewItem Value="@context" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.CanExpand" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+            <MudTreeViewItem Value="@context" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.CanExpand" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.Caption" />
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextGeneralExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextGeneralExample.razor
@@ -1,15 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudText Typo="Typo.h1">h1. Heading</MudText>
-<MudText Typo="Typo.h2">h2. Heading</MudText>
-<MudText Typo="Typo.h3">h3. Heading</MudText>
-<MudText Typo="Typo.h4">h4. Heading</MudText>
-<MudText Typo="Typo.h5">h5. Heading</MudText>
-<MudText Typo="Typo.h6">h6. Heading</MudText>
-<MudText Typo="Typo.subtitle1">subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur</MudText>
-<MudText Typo="Typo.subtitle2">subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur</MudText>
-<MudText Typo="Typo.body1">body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.</MudText>
-<MudText Typo="Typo.body2">body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.</MudText>
-<MudText Typo="Typo.button">BUTTON TEXT</MudText>
-<MudText Typo="Typo.caption">caption text</MudText>
-<MudText Typo="Typo.overline">OVERLINE TEXT</MudText>
+<MudText Typo="Typo.H1">h1. Heading</MudText>
+<MudText Typo="Typo.H2">h2. Heading</MudText>
+<MudText Typo="Typo.H3">h3. Heading</MudText>
+<MudText Typo="Typo.H4">h4. Heading</MudText>
+<MudText Typo="Typo.H5">h5. Heading</MudText>
+<MudText Typo="Typo.H6">h6. Heading</MudText>
+<MudText Typo="Typo.Subtitle1">subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur</MudText>
+<MudText Typo="Typo.Subtitle2">subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur</MudText>
+<MudText Typo="Typo.Body1">body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.</MudText>
+<MudText Typo="Typo.Body2">body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.</MudText>
+<MudText Typo="Typo.Button">BUTTON TEXT</MudText>
+<MudText Typo="Typo.Caption">caption text</MudText>
+<MudText Typo="Typo.Overline">OVERLINE TEXT</MudText>

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Palette.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Palette.razor
@@ -3,7 +3,7 @@
     <DocsPageHeader Title="Palette" SubTitle="The palette is the colors the theme uses for all the components and main layout.">
     </DocsPageHeader>
     <DocsPageSection>
-        <MudText Typo="Typo.h4" Class="py-4">Default Colors</MudText>
+        <MudText Typo="Typo.H4" Class="py-4">Default Colors</MudText>
         <MudGrid>
             <MudItem xs="12" sm="12" md="4">
                 <MudPaper Class="mud-theme-primary">
@@ -110,7 +110,7 @@
                 </MudPaper>
             </MudItem>
         </MudGrid>
-        <MudText Typo="Typo.h4" Class="py-4">Texts</MudText>
+        <MudText Typo="Typo.H4" Class="py-4">Texts</MudText>
         <SectionContent DarkenBackground="true">
             <MudGrid>
                 <MudItem xs="12" sm="12" md="4">

--- a/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
@@ -73,7 +73,7 @@
                         {
                             <MudItem md="6" lg="4" xs="12">
                                 <MudPaper Square="true" Elevation="0" Class="@($"pa-4 rounded-t d-flex shades-text text-white {GetColorClass(color.Color.ToLowerInvariant())}")">
-                                    <MudText Typo="Typo.h6">@color.Color</MudText>
+                                    <MudText Typo="Typo.H6">@color.Color</MudText>
                                 </MudPaper>
                                 @foreach (var shade in MaterialColorShades.Where(i => i.Color == color.Color))
                                 {

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -51,7 +51,7 @@
                         {
                             <button class="docs-icon-panel" @onclick="@(() => SetIconDrawer(icon))">
                                 <MudIcon Icon="@icon.Code" Title="@icon.Name" />
-                                <MudText Typo="Typo.caption">
+                                <MudText Typo="Typo.Caption">
                                     @icon.Name
                                 </MudText>
                             </button>
@@ -67,19 +67,19 @@
 <MudDrawer @bind-Open="@iconDrawerOpen" ClipMode="DrawerClipMode.Always" Anchor="Anchor.End" DisableOverlay="true" Elevation="0" Width="260px" Class="mud-icondrawer" Variant="@DrawerVariant.Temporary">
     <MudToolBar Dense="true" DisableGutters="true" Class="pl-4 py-8">
         <MudIcon Size="Size.Large" Icon="@SelectedIcon.Code" Class="mr-4"/>
-        <MudText Typo="Typo.subtitle1">@SelectedIcon.Name</MudText>
+        <MudText Typo="Typo.Subtitle1">@SelectedIcon.Name</MudText>
         <MudSpacer/>
         <MudIconButton OnClick="@(() => CloseIconDrawer())" Icon="@Icons.Material.Filled.Close" Class="pa-2"></MudIconButton>
     </MudToolBar>
     <div class="px-4">
-        <MudText Typo="Typo.subtitle2">Icon Code</MudText>
+        <MudText Typo="Typo.Subtitle2">Icon Code</MudText>
         <MudPaper Class="mud-iconcode pa-2" Elevation="0">
             @IconCodeOutput
             <div class="d-flex justify-end">
                 <MudIconButton OnClick="CopyTextToClipboard" Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" Class="pa-1 mb-n1 mr-n1" />
             </div>
         </MudPaper>
-        <MudText Typo="Typo.subtitle2">Icon Preview</MudText>
+        <MudText Typo="Typo.Subtitle2">Icon Preview</MudText>
         <MudPaper Class="d-flex justify-center align-center" Elevation="0" Height="228px">
             <MudIcon Size="@PreviewIconSize" Color="@PreviewIconColor" Icon="@SelectedIcon.Code" />
         </MudPaper>

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/MultiMaskExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/MultiMaskExample.razor
@@ -78,5 +78,5 @@
             </MudAlert>
         </MudItem>
     </MudGrid>
-    <MudText Class="mud-text-secondary" Typo="Typo.body2">Example inspired by Cleave.js</MudText>
+    <MudText Class="mud-text-secondary" Typo="Typo.Body2">Example inspired by Cleave.js</MudText>
 </MudElement>

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
@@ -7,8 +7,8 @@
                 <MudAvatar Color="Color.Secondary">@Localizer("CardAvatarLetter")</MudAvatar>
             </CardHeaderAvatar>
             <CardHeaderContent>
-                <MudText Typo="Typo.body1">@Localizer("CardHeader")</MudText>
-                <MudText Typo="Typo.body2">@Localizer("CardSubHeader")</MudText>
+                <MudText Typo="Typo.Body1">@Localizer("CardHeader")</MudText>
+                <MudText Typo="Typo.Body2">@Localizer("CardSubHeader")</MudText>
             </CardHeaderContent>
             <CardHeaderActions>
                 <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Default" />
@@ -16,7 +16,7 @@
         </MudCardHeader>
         <MudCardMedia Image="_content/MudBlazor.Docs/images/pilars.jpg" Height="250" />
         <MudCardContent>
-            <MudText Typo="Typo.body2">@Localizer("CardDescription")</MudText>
+            <MudText Typo="Typo.Body2">@Localizer("CardDescription")</MudText>
         </MudCardContent>
         <MudCardActions>
             <MudIconButton Icon="@Icons.Material.Filled.Favorite" Color="Color.Default" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -121,14 +121,14 @@
             <div class="d-flex flex-row flex-wrap mud-width-full">
                 <MudList Clickable="true" Class="flex-grow-1 flex-shrink-0 mud-paper-outlined rounded py-0 mr-2">
                     <MudListItem Icon="@Icons.Material.Filled.AutoAwesomeMosaic" IconColor="Color.Primary" Class="pl-6" Href="/getting-started/layouts">
-                        <MudText Typo="Typo.body1">Layouts</MudText>
-                        <MudText Typo="Typo.body2">Understand the structure</MudText>
+                        <MudText Typo="Typo.Body1">Layouts</MudText>
+                        <MudText Typo="Typo.Body2">Understand the structure</MudText>
                     </MudListItem>
                 </MudList>
                 <MudList Clickable="true" Class="flex-grow-1 flex-shrink-0 mud-paper-outlined rounded py-0 ml-2">
                     <MudListItem Icon="@Icons.Material.Filled.FilterFrames" IconColor="Color.Secondary" Class="pl-6" Href="/getting-started/wireframes">
-                        <MudText Typo="Typo.body1">Wireframes</MudText>
-                        <MudText Typo="Typo.body2">Copy, paste layouts</MudText>
+                        <MudText Typo="Typo.Body1">Wireframes</MudText>
+                        <MudText Typo="Typo.Body2">Copy, paste layouts</MudText>
                     </MudListItem>
                 </MudList>
             </div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Layouts/LayoutsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Layouts/LayoutsPage.razor
@@ -70,14 +70,14 @@
             <div class="d-flex flex-row flex-wrap mud-width-full">
                 <MudList Clickable="true" Class="flex-grow-1 flex-shrink-0 mud-paper-outlined rounded py-0 mr-2">
                     <MudListItem Icon="@Icons.Material.Filled.FileDownloadDone" IconColor="Color.Success" Class="pl-6" Href="/getting-started/installation">
-                        <MudText Typo="Typo.body1">Installation</MudText>
-                        <MudText Typo="Typo.body2">Getting Started</MudText>
+                        <MudText Typo="Typo.Body1">Installation</MudText>
+                        <MudText Typo="Typo.Body2">Getting Started</MudText>
                     </MudListItem>
                 </MudList>
                 <MudList Clickable="true" Class="flex-grow-1 flex-shrink-0 mud-paper-outlined rounded py-0 ml-2">
                     <MudListItem Icon="@Icons.Material.Filled.FilterFrames" IconColor="Color.Secondary" Class="pl-6" Href="/getting-started/wireframes">
-                        <MudText Typo="Typo.body1">Wireframes</MudText>
-                        <MudText Typo="Typo.body2">Copy, paste layouts</MudText>
+                        <MudText Typo="Typo.Body1">Wireframes</MudText>
+                        <MudText Typo="Typo.Body2">Copy, paste layouts</MudText>
                     </MudListItem>
                 </MudList>
             </div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/BasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/BasicUsageExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudText Typo="Typo.h6">MudBlazor is @Text</MudText>
+<MudText Typo="Typo.H6">MudBlazor is @Text</MudText>
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ButtonOnClick">@ButtonText</MudButton>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/RightClickDrawerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/RightClickDrawerExample.razor
@@ -3,7 +3,7 @@
 <div @oncontextmenu="ClickForDrawer" @oncontextmenu:preventDefault class="d-flex align-center justify-center" style="height: calc(100vh - 64px); background: linear-gradient(90deg, #00C9FF 0%, #92FE9D 100%);">
     <MudDrawer @bind-Open="@drawerOpen" Anchor="@Anchor.Right" Elevation="1" Variant="@DrawerVariant.Temporary" DisableOverlay="true">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">My Drawer</MudText>
+            <MudText Typo="Typo.H6">My Drawer</MudText>
         </MudDrawerHeader>
         <MudCard>
             <MudCardContent>
@@ -16,7 +16,7 @@
         </MudList>
     </MudDrawer>
 
-    <MudText Class="white-text" Typo="Typo.h6">Right Click To Somewhere!</MudText>
+    <MudText Class="white-text" Typo="Typo.H6">Right Click To Somewhere!</MudText>
 </div>
 
 @code{

--- a/src/MudBlazor.Docs/Pages/Getting Started/Usage/UsagePage.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Usage/UsagePage.razor
@@ -16,7 +16,7 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <MudText Typo="Typo.h6" Align="Align.Center" Class="my-16">Check out all the components in our <MudLink Href="/components/alert">docs</MudLink> to find out what's available and how to use them.</MudText>
+            <MudText Typo="Typo.H6" Align="Align.Center" Class="my-16">Check out all the components in our <MudLink Href="/components/alert">docs</MudLink> to find out what's available and how to use them.</MudText>
         </DocsPageSection>
 
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content2WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content2WireframeExample.razor
@@ -5,20 +5,20 @@
 
 
 <MudContainer Class="mt-16">
-    <MudText Typo="Typo.h3" Align="Align.Center" GutterBottom="true">Pricing</MudText>
+    <MudText Typo="Typo.H3" Align="Align.Center" GutterBottom="true">Pricing</MudText>
     <MudText Align="Align.Center">Some long pricing text should go here maybe? who knows what text you would want here, i guess i cant fill it in for you.</MudText>
     <MudGrid Class="mt-8">
         <MudItem xs="12" sm="6" md="4">
             <MudCard Elevation="25" Class="rounded-lg pb-4">
                 <MudCardHeader>
                     <CardHeaderContent>
-                        <MudText Typo="Typo.h5" Align="Align.Center">Beginner</MudText>
+                        <MudText Typo="Typo.H5" Align="Align.Center">Beginner</MudText>
                     </CardHeaderContent>
                 </MudCardHeader>
                 <MudCardContent>
                     <div class="d-flex justify-center">
-                        <MudText Typo="Typo.h3">$5</MudText>
-                        <MudText Typo="Typo.h5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
+                        <MudText Typo="Typo.H3">$5</MudText>
+                        <MudText Typo="Typo.H5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
                     </div>
                     <MudList Class="mx-auto mt-4" Style="width:300px;">
                         <MudListItem Icon="@Icons.Material.Filled.LiveHelp">
@@ -41,13 +41,13 @@
             <MudCard Elevation="25" Class="rounded-lg pb-4">
                 <MudCardHeader>
                     <CardHeaderContent>
-                        <MudText Typo="Typo.h5" Align="Align.Center">Starter</MudText>
+                        <MudText Typo="Typo.H5" Align="Align.Center">Starter</MudText>
                     </CardHeaderContent>
                 </MudCardHeader>
                 <MudCardContent>
                     <div class="d-flex justify-center">
-                        <MudText Typo="Typo.h3">$10</MudText>
-                        <MudText Typo="Typo.h5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
+                        <MudText Typo="Typo.H3">$10</MudText>
+                        <MudText Typo="Typo.H5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
                     </div>
                     <MudList Class="mx-auto mt-4" Style="width:300px;">
                         <MudListItem Icon="@Icons.Material.Filled.LiveHelp">
@@ -70,13 +70,13 @@
             <MudCard Elevation="25" Class="rounded-lg pb-4">
                 <MudCardHeader>
                     <CardHeaderContent>
-                        <MudText Typo="Typo.h5" Align="Align.Center">Professional</MudText>
+                        <MudText Typo="Typo.H5" Align="Align.Center">Professional</MudText>
                     </CardHeaderContent>
                 </MudCardHeader>
                 <MudCardContent>
                     <div class="d-flex justify-center">
-                        <MudText Typo="Typo.h3">$15</MudText>
-                        <MudText Typo="Typo.h5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
+                        <MudText Typo="Typo.H3">$15</MudText>
+                        <MudText Typo="Typo.H5" Class="ml-1 mt-5" Color="Color.Secondary">/Monthly</MudText>
                     </div>
                     <MudList Class="mx-auto mt-4" Style="width:300px;">
                         <MudListItem Icon="@Icons.Material.Filled.LiveHelp">

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
@@ -3,10 +3,10 @@
 @page "/getting-started/wireframes/content3"
 
 <MudContainer Class="mt-16" MaxWidth="MaxWidth.Medium">
-    <MudText Typo="Typo.h3" Align="Align.Center" GutterBottom="true">Checkout</MudText>
+    <MudText Typo="Typo.H3" Align="Align.Center" GutterBottom="true">Checkout</MudText>
     <MudGrid Spacing="6" Class="mt-16">
         <MudItem xs="7">
-            <MudText Typo="Typo.h5" GutterBottom="true">Billing address</MudText>
+            <MudText Typo="Typo.H5" GutterBottom="true">Billing address</MudText>
             <MudGrid>
                 <MudItem xs="12">
                     <MudTextField T="string" Label="Email" />
@@ -38,7 +38,7 @@
             </MudGrid>
         </MudItem>
         <MudItem xs="5">
-            <MudText Typo="Typo.h5" GutterBottom="true">Cart</MudText>
+            <MudText Typo="Typo.H5" GutterBottom="true">Cart</MudText>
             <MudPaper Class="d-flex flex-column" Style="height:100%;" Outlined="true">
                 <MudList Clickable="true">
                     <MudListItem Icon="@Icons.Material.Filled.ContentCut">

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/WireframeContentLayout1.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/WireframeContentLayout1.razor
@@ -12,7 +12,7 @@
     </MudAppBar>
     <MudDrawer @bind-Open="_drawerOpen" Elevation="2">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h5" Class="mt-1">Application</MudText>
+            <MudText Typo="Typo.H5" Class="mt-1">Application</MudText>
         </MudDrawerHeader>
         @*NavMenu*@
     </MudDrawer>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/WireframeContentLayout2.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/WireframeContentLayout2.razor
@@ -6,7 +6,7 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
+        <MudText Typo="Typo.H5" Class="ml-3">Application</MudText>
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
     </MudAppBar>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout1WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout1WireframeExample.razor
@@ -12,7 +12,7 @@
     </MudAppBar>
     <MudDrawer @bind-Open="_drawerOpen" Elevation="2">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h5" Class="mt-1">Application</MudText>
+            <MudText Typo="Typo.H5" Class="mt-1">Application</MudText>
         </MudDrawerHeader>
         @*NavMenu*@
     </MudDrawer>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout2WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout2WireframeExample.razor
@@ -7,7 +7,7 @@
 <MudLayout>
     <MudAppBar Elevation="1">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
-        <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
+        <MudText Typo="Typo.H5" Class="ml-3">Application</MudText>
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
     </MudAppBar>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout3WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout3WireframeExample.razor
@@ -7,7 +7,7 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
+        <MudText Typo="Typo.H5" Class="ml-3">Application</MudText>
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
     </MudAppBar>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/WireframesPage.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/WireframesPage.razor
@@ -20,7 +20,7 @@
                         <div class="wf-content"></div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Drawer left + top appbar</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Drawer left + top appbar</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Layout1WireframeExample"))" />
                         </MudTooltip>
@@ -36,7 +36,7 @@
                         <div class="wf-content"></div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Top appbar with clipped drawer</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Top appbar with clipped drawer</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Layout2WireframeExample"))" />
                         </MudTooltip>
@@ -50,7 +50,7 @@
                         <div class="wf-content"></div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Appbar Only</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Appbar Only</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Layout3WireframeExample"))" />
                         </MudTooltip>
@@ -89,7 +89,7 @@
                         </div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Dashboard Grid</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Dashboard Grid</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Content1WireframeExample"))" />
                         </MudTooltip>
@@ -118,7 +118,7 @@
                         </div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Pricing</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Pricing</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Content2WireframeExample"))" />
                         </MudTooltip>
@@ -159,7 +159,7 @@
                         </div>
                     </div>
                     <div class="d-flex justify-center align-center mt-8 pl-12">
-                        <MudText Typo="Typo.body1" Class="mx-auto">Checkout</MudText>
+                        <MudText Typo="Typo.Body1" Class="mx-auto">Checkout</MudText>
                         <MudTooltip Text="Show/Copy Wireframe">
                             <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="@(e => ToggleOverlay(true, "Content3WireframeExample"))" />
                         </MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -10,12 +10,12 @@
     <ChildContent>
         <MudGrid Class="mb-16 mb-sm-0">
             <MudItem Class="relative" xs="12" md="7" lg="6">
-                <MudText Typo="Typo.h1">The Blazor</MudText>
-                <MudText Typo="Typo.h1" Inline="true" Class="landing-h1-gradient">Component </MudText>
-                <MudText Typo="Typo.h1" Inline="true">Library</MudText>
-                <MudText Typo="Typo.h1">You always wanted</MudText>
+                <MudText Typo="Typo.H1">The Blazor</MudText>
+                <MudText Typo="Typo.H1" Inline="true" Class="landing-h1-gradient">Component </MudText>
+                <MudText Typo="Typo.H1" Inline="true">Library</MudText>
+                <MudText Typo="Typo.H1">You always wanted</MudText>
                 <div class="pl-1 my-4">
-                    <MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
+                    <MudText Typo="Typo.Subtitle1" Class="mud-text-secondary">
                         Trusted by thousands of users, from hobby developers to large enterprises. Use MudBlazor to rapidly build amazing web applications without leaving your loved C# language and toolchain.
                     </MudText>
                 </div>
@@ -37,7 +37,7 @@
 </LandingSection>
 
 <LandingSection Straight="true" Class="pt-0 pb-16">
-    <MudText Typo="Typo.subtitle2" Align="Align.Center" Class="mb-16" Style="color: #8898aa;">
+    <MudText Typo="Typo.Subtitle2" Align="Align.Center" Class="mb-16" Style="color: #8898aa;">
         The continued development and maintenance of MudBlazor is secured by our sponsors
     </MudText>
     <MudGrid Spacing="5" Justify="Justify.Center">
@@ -63,23 +63,23 @@
 </LandingSection>
 
 <LandingSection Straight="true" BackgroundClass="sweet">
-    <MudText Typo="Typo.h6" Color="Color.Primary">Unified platform</MudText>
-    <MudText Typo="Typo.h5">MudBlazor is more than a library</MudText>
+    <MudText Typo="Typo.H6" Color="Color.Primary">Unified platform</MudText>
+    <MudText Typo="Typo.H5">MudBlazor is more than a library</MudText>
     <MudGrid>
         <MudItem xs="12" sm="6">
-            <MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
-                We bring together everything that's required to build amazing Blazor applications that scale from desktop to mobile. Apart from the library itself we also provide <MudText Typo="Typo.subtitle1" Inline="true" Color="Color.Primary">templates, a learning platform, theme manager, demo and example projects as well as an online code editor</MudText> integrated with our documentation and issue tracking. With more to come.
+            <MudText Typo="Typo.Subtitle1" Class="mud-text-secondary">
+                We bring together everything that's required to build amazing Blazor applications that scale from desktop to mobile. Apart from the library itself we also provide <MudText Typo="Typo.Subtitle1" Inline="true" Color="Color.Primary">templates, a learning platform, theme manager, demo and example projects as well as an online code editor</MudText> integrated with our documentation and issue tracking. With more to come.
             </MudText>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
-                We help companies build <MudText Typo="Typo.subtitle1" Inline="true" Color="Color.Primary">amazing apps in record time</MudText> and let them focus on their business instead of buttons, <MudText Typo="Typo.subtitle1" Inline="true" Color="Color.Primary">MudBlazor is battle-tested and one of the fastest-improving platforms</MudText>, and much more.
+            <MudText Typo="Typo.Subtitle1" Class="mud-text-secondary">
+                We help companies build <MudText Typo="Typo.Subtitle1" Inline="true" Color="Color.Primary">amazing apps in record time</MudText> and let them focus on their business instead of buttons, <MudText Typo="Typo.Subtitle1" Inline="true" Color="Color.Primary">MudBlazor is battle-tested and one of the fastest-improving platforms</MudText>, and much more.
             </MudText>
         </MudItem>
     </MudGrid>
 
     <div class="@GetTestimonialClass()">
-        <MudText Typo="Typo.h3" Align="Align.Center" Class="mt-16 mb-8">“Never had such a good time making a site“</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center" Class="mt-16 mb-8">“Never had such a good time making a site“</MudText>
         <div class="absolute z-20 d-flex justify-center align-end mud-width-full mud-height-full">
             <MudButton OnClick="ToggleTestimonials" Color="Color.Primary" Variant="Variant.Filled" DisableElevation="true" Size="Size.Large" Class="mb-12">@(_showTestimonials? "Show less" : "Show more")</MudButton>
         </div>
@@ -91,8 +91,8 @@
                             <MudIcon Class="mt-n4" Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Brian</MudText>
-                            <MudText Typo="Typo.body2">EvoDynamic</MudText>
+                            <MudText Typo="Typo.Subtitle2">Brian</MudText>
+                            <MudText Typo="Typo.Body2">EvoDynamic</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -107,8 +107,8 @@
                             <MudIcon Class="mt-n4" Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Developer Team</MudText>
-                            <MudText Typo="Typo.body2">Wunderminds</MudText>
+                            <MudText Typo="Typo.Subtitle2">Developer Team</MudText>
+                            <MudText Typo="Typo.Body2">Wunderminds</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -123,7 +123,7 @@
                             <MudIcon Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Wave Master</MudText>
+                            <MudText Typo="Typo.Subtitle2">Wave Master</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -140,8 +140,8 @@
                             <MudIcon Class="mt-n4" Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Karakoulak Spyridon</MudText>
-                            <MudText Typo="Typo.body2">Arhs Group</MudText>
+                            <MudText Typo="Typo.Subtitle2">Karakoulak Spyridon</MudText>
+                            <MudText Typo="Typo.Body2">Arhs Group</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -156,8 +156,8 @@
                             <MudIcon Class="mt-n4" Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Hayden Ravenscroft</MudText>
-                            <MudText Typo="Typo.body2">Mail Solutions UK Ltd</MudText>
+                            <MudText Typo="Typo.Subtitle2">Hayden Ravenscroft</MudText>
+                            <MudText Typo="Typo.Body2">Mail Solutions UK Ltd</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -173,8 +173,8 @@
                             <MudIcon Class="mt-n4" Icon="@Icons.Material.Rounded.FormatQuote" Size="Size.Large"/>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.subtitle2">Frederik</MudText>
-                            <MudText Typo="Typo.body2">Xuntar</MudText>
+                            <MudText Typo="Typo.Subtitle2">Frederik</MudText>
+                            <MudText Typo="Typo.Body2">Xuntar</MudText>
                         </CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 px-6 pb-6 mud-typography-body1">
@@ -192,22 +192,22 @@
         <MudItem xs="12" sm="12" md="6">
             <MudGrid>
                 <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Color="Color.Primary">Designed for developers</MudText>
-                    <MudText Typo="Typo.h5" Class="white-text">Developers love to work with MudBlazor</MudText>
-                    <MudText Typo="Typo.subtitle1" Class="my-4">
+                    <MudText Typo="Typo.H6" Color="Color.Primary">Designed for developers</MudText>
+                    <MudText Typo="Typo.H5" Class="white-text">Developers love to work with MudBlazor</MudText>
+                    <MudText Typo="Typo.Subtitle1" Class="my-4">
                         We started MudBlazor with a simple promise, to empower the developer and fully take advantage of what Blazor offers. With MudBlazor you can create exceptional apps without the burden of mastering HTML, CSS and JS and focus your skillset on C#.
                     </MudText>
                 </MudItem>
                 <MudItem xs="12" sm="12" md="6">
                     <MudIcon Icon="@lpIconCode" Size="Size.Large"/>
-                    <MudText Typo="Typo.subtitle2" Class="white-text my-2">TryMudBlazor</MudText>
+                    <MudText Typo="Typo.Subtitle2" Class="white-text my-2">TryMudBlazor</MudText>
                     <MudText>Use the full power of Blazor directly in your browser with TryMudBlazor.</MudText>
                     <MudText>Full fetched editor with IntelliSense, multiple files and save your code.</MudText>
                     <MudLink Class="landing-link my-4" Href="https://try.mudblazor.com/" Taget="_blank">Test online<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
                 </MudItem>
                 <MudItem xs="12" sm="12" md="6">
                     <MudIcon Icon="@lpIconTemplates" Size="Size.Large"/>
-                    <MudText Typo="Typo.subtitle2" Class="white-text my-2">Templates</MudText>
+                    <MudText Typo="Typo.Subtitle2" Class="white-text my-2">Templates</MudText>
                     <MudText>We provide all the default Blazor templates but pre configured with MudBlazor to help you get started faster.</MudText>
                     <MudLink Class="landing-link my-4" Href="https://github.com/MudBlazor/Templates" Taget="_blank">Explore templates<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
                 </MudItem>
@@ -220,8 +220,8 @@
                     <MudCardMedia Image="images/door.jpg" Height="0"/>
                     <MudCardContent>
                         <MudText>Old Paint</MudText>
-                        <MudText Typo="Typo.body2">Old paint found on a stone house door.</MudText>
-                        <MudText Typo="Typo.body2">This photo was taken in a small village in Istra Croatia.</MudText>
+                        <MudText Typo="Typo.Body2">Old paint found on a stone house door.</MudText>
+                        <MudText Typo="Typo.Body2">This photo was taken in a small village in Istra Croatia.</MudText>
                     </MudCardContent>
                     <MudCardActions>
                         <MudButton Variant="Variant.Text" Color="Color.Primary">Share</MudButton>
@@ -235,35 +235,35 @@
 
 <LandingSection>
     <div style="max-width:570px;">
-        <MudText Typo="Typo.h6" Color="Color.Primary">Community</MudText>
-        <MudText Typo="Typo.h5">Join our community</MudText>
-        <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-4">
+        <MudText Typo="Typo.H6" Color="Color.Primary">Community</MudText>
+        <MudText Typo="Typo.H5">Join our community</MudText>
+        <MudText Typo="Typo.Subtitle1" Class="mud-text-secondary mb-4">
             Do you have questions? Do you want to help others? Just talk or get news? Join one of our channels and become part of the MudBlazor community.
         </MudText>
     </div>
     <MudGrid Class="pt-4">
         <MudItem xs="12" sm="6" md="3">
             <MudIcon Icon="@Icons.Custom.Brands.Twitter" Class="twitter"/>
-            <MudText Typo="Typo.subtitle2">Twitter</MudText>
-            <MudText Typo="Typo.body1">For announcements, blog posts, and general MudBlazor stuff.</MudText>
+            <MudText Typo="Typo.Subtitle2">Twitter</MudText>
+            <MudText Typo="Typo.Body1">For announcements, blog posts, and general MudBlazor stuff.</MudText>
             <MudLink Class="landing-link twitter my-4" Href="https://twitter.com/MudBlazor" Target="_blank">Follow us<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
         </MudItem>
         <MudItem xs="12" sm="6" md="3">
             <MudIcon Icon="@Icons.Custom.Brands.Discord" Class="discord"/>
-            <MudText Typo="Typo.subtitle2">Discord</MudText>
-            <MudText Typo="Typo.body1">To get involved in the community, ask questions, help others or just talk.</MudText>
+            <MudText Typo="Typo.Subtitle2">Discord</MudText>
+            <MudText Typo="Typo.Body1">To get involved in the community, ask questions, help others or just talk.</MudText>
             <MudLink Class="landing-link discord my-4" Href="https://discord.gg/mudblazor" Target="_blank">Come and chat<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
         </MudItem>
         <MudItem xs="12" sm="6" md="3">
             <MudIcon Icon="@Icons.Custom.Brands.GitHub" Class="github"/>
-            <MudText Typo="Typo.subtitle2">GitHub</MudText>
-            <MudText Typo="Typo.body1">To file issues, request features, and contribute, check out our GitHub.</MudText>
+            <MudText Typo="Typo.Subtitle2">GitHub</MudText>
+            <MudText Typo="Typo.Body1">To file issues, request features, and contribute, check out our GitHub.</MudText>
             <MudLink Class="landing-link github my-4" Href="https://github.com/MudBlazor/MudBlazor" Target="_blank">Check the code<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
         </MudItem>
         <MudItem xs="12" sm="6" md="3">
             <MudIcon Icon="@Icons.Custom.Brands.StackOverflow" Class="stackoverflow"/>
-            <MudText Typo="Typo.subtitle2">Stack Overflow</MudText>
-            <MudText Typo="Typo.body1">Active on Stack Overflow? Answer or ask question's under our tag.</MudText>
+            <MudText Typo="Typo.Subtitle2">Stack Overflow</MudText>
+            <MudText Typo="Typo.Body1">Active on Stack Overflow? Answer or ask question's under our tag.</MudText>
             <MudLink Class="landing-link stackoverflow my-4" Href="https://stackoverflow.com/tags/mudblazor" Target="_blank">Ask and answer questions<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
         </MudItem>
     </MudGrid>
@@ -272,9 +272,9 @@
 <LandingSection StraightEnd="true" SectionClass="dark-section-text" BackgroundClass="mud-dark">
     <MudGrid>
         <MudItem xs="12" sm="12" md="6">
-            <MudText Typo="Typo.h6" Color="Color.Primary">Global scale</MudText>
-            <MudText Typo="Typo.h5" Class="white-text">MudBlazor is growing quickly</MudText>
-            <MudText Typo="Typo.subtitle1" Class="my-4">
+            <MudText Typo="Typo.H6" Color="Color.Primary">Global scale</MudText>
+            <MudText Typo="Typo.H5" Class="white-text">MudBlazor is growing quickly</MudText>
+            <MudText Typo="Typo.Subtitle1" Class="my-4">
                 We are growing every day, developers from all over the world are using MudBlazor and are engaged with the community.
                 We are dedicated to improving every aspect of MudBlazor to be your number one choice when looking for a Blazor component library.
                 Join us and be part of the library’s success!
@@ -287,37 +287,37 @@
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_nugetPackage?.TotalDownloads)</MudText>
+                    <MudText Typo="Typo.H3" Color="Color.Primary">@NumericExtensions.RoundedToString(_nugetPackage?.TotalDownloads)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDownloads"/>
-                    <MudText Typo="Typo.body1" Class="ml-4">Total Downloads</MudText>
+                    <MudText Typo="Typo.Body1" Class="ml-4">Total Downloads</MudText>
                 </div>
             </div>
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_gitHubRepo?.StargazersCount)</MudText>
+                    <MudText Typo="Typo.H3" Color="Color.Primary">@NumericExtensions.RoundedToString(_gitHubRepo?.StargazersCount)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpGitHub"/>
-                    <MudText Typo="Typo.body1" Class="ml-4">GitHub Stars</MudText>
+                    <MudText Typo="Typo.Body1" Class="ml-4">GitHub Stars</MudText>
                 </div>
             </div>
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                <MudText Typo="Typo.h3" Color="Color.Primary">@_gitHubTotalContributors</MudText>
+                <MudText Typo="Typo.H3" Color="Color.Primary">@_gitHubTotalContributors</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpContributors"/>
-                    <MudText Typo="Typo.body1" Class="ml-4">Contributors</MudText>
+                    <MudText Typo="Typo.Body1" Class="ml-4">Contributors</MudText>
                 </div>
             </div>
         </MudItem>
         <MudItem xs="6" sm="3">
             <div class="global-scale-item">
-                    <MudText Typo="Typo.h3" Color="Color.Primary">@NumericExtensions.RoundedToString(_discordInvite?.ApproximateMemberCount)</MudText>
+                    <MudText Typo="Typo.H3" Color="Color.Primary">@NumericExtensions.RoundedToString(_discordInvite?.ApproximateMemberCount)</MudText>
                 <div class="d-flex align-center">
                     <MudIcon Icon="@lpDiscord"/>
-                    <MudText Typo="Typo.body1" Class="ml-4">Discord Members</MudText>
+                    <MudText Typo="Typo.Body1" Class="ml-4">Discord Members</MudText>
                 </div>
             </div>
         </MudItem>
@@ -327,8 +327,8 @@
 <LandingSection Straight="true" BackgroundClass="surface">
     <div class="lp-grid">
         <div class="lp-grid-item main-description">
-            <MudText Typo="Typo.h5">Ready to get started?</MudText>
-            <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-4">
+            <MudText Typo="Typo.H5">Ready to get started?</MudText>
+            <MudText Typo="Typo.Subtitle1" Class="mud-text-secondary mb-4">
                 Ready to build amazing things? there are several ways to get started. If you are new to web development or blazor in general, the Getting Started section is a great place to start.
             </MudText>
             <div>
@@ -338,7 +338,7 @@
         <div class="lp-grid-item">
             <MudIcon Icon="@lpIconCode"/>
             <div class="lp-border-title">
-                <MudText Typo="Typo.subtitle2">TryMudBlazor</MudText>
+                <MudText Typo="Typo.Subtitle2">TryMudBlazor</MudText>
             </div>
             <MudText>Test MudBlazor directly in your browser, no software or installation needed.</MudText>
             <MudLink Class="landing-link" Href="https://try.mudblazor.com/" Taget="_blank">Test online<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>
@@ -346,7 +346,7 @@
         <div class="lp-grid-item">
             <MudIcon Icon="@lpIconTemplatesFilled"/>
             <div class="lp-border-title">
-                <MudText Typo="Typo.subtitle2">Templates</MudText>
+                <MudText Typo="Typo.Subtitle2">Templates</MudText>
             </div>
             <MudText>Install our pre configured .NET Templates with MudBlazor.</MudText>
             <MudLink Class="landing-link" Href="https://github.com/MudBlazor/Templates" Taget="_blank">Explore templates<MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowRight" Size="Size.Small"/></MudLink>

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor
@@ -10,18 +10,18 @@
         {
             <DocsPageHeader Title="@_message.Title" SubTitle="@_message.Except">
                 <SpecialHeaderContent>
-                    <MudText Typo="Typo.h2" Class="docs-title">@_message.Title&nbsp;</MudText>
-                    <MudText Typo="Typo.subtitle1" Class="docs-title-description">@_message.Except</MudText>
+                    <MudText Typo="Typo.H2" Class="docs-title">@_message.Title&nbsp;</MudText>
+                    <MudText Typo="Typo.Subtitle1" Class="docs-title-description">@_message.Except</MudText>
                     <MudToolBar DisableGutters="true">
                         @foreach (var author in _message.Authors)
                         {
                             <div class="d-flex justify-start align-center mx-1">
                                 <MudAvatar Image="@author.AvatarUlr"/>
-                                <MudText Typo="Typo.subtitle2" Class="mx-2">@author.DisplayName</MudText>
+                                <MudText Typo="Typo.Subtitle2" Class="mx-2">@author.DisplayName</MudText>
                             </div>
                         }
                     </MudToolBar>
-                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">@_message.PublishDate.ToString("MMM dd, yyyy")</MudText>
+                    <MudText Typo="Typo.Subtitle2" Class="mud-text-secondary">@_message.PublishDate.ToString("MMM dd, yyyy")</MudText>
                 </SpecialHeaderContent>
             </DocsPageHeader>
             <DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
@@ -3,8 +3,8 @@
 <DocsPage DisplayFooter="true">
     <DocsPageHeader Title="Announcements" SubTitle="Discover articles from MudBlazor team.">
         <SpecialHeaderContent>
-            <MudText Typo="Typo.h2" Class="docs-title">Announcements&nbsp;</MudText>
-            <MudText Typo="Typo.subtitle1" Class="docs-title-description">Discover articles from MudBlazor team.</MudText>
+            <MudText Typo="Typo.H2" Class="docs-title">Announcements&nbsp;</MudText>
+            <MudText Typo="Typo.Subtitle1" Class="docs-title-description">Discover articles from MudBlazor team.</MudText>
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
@@ -32,9 +32,9 @@
                             <MudCard Class="announcement-card rounded-lg">
                                 <MudCardMedia Image="@message.ImgUrl" Height="175"/>
                                 <MudCardContent Class="pa-4">
-                                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">@message.Category</MudText>
-                                    <MudText Typo="Typo.h6" GutterBottom="true">@message.Title</MudText>
-                                    <MudText Typo="Typo.body2">@message.Except</MudText>
+                                    <MudText Typo="Typo.Subtitle2" Class="mud-text-secondary">@message.Category</MudText>
+                                    <MudText Typo="Typo.H6" GutterBottom="true">@message.Title</MudText>
+                                    <MudText Typo="Typo.Body2">@message.Except</MudText>
                                 </MudCardContent>
                                 <MudCardActions Class="pa-4">
                                     <MudAvatarGroup Max="6" Spacing="3" MaxColor="Color.Primary">
@@ -46,13 +46,13 @@
                                     <div class="mx-4 d-flex flex-column">
                                         @if (message.Authors.Count() > 1)
                                         {
-                                            <MudText Typo="Typo.subtitle2">Multiple Authors</MudText>
-                                            <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">@message.PublishDate.ToString("MMM dd, yyyy")</MudText>
+                                            <MudText Typo="Typo.Subtitle2">Multiple Authors</MudText>
+                                            <MudText Typo="Typo.Subtitle2" Class="mud-text-secondary">@message.PublishDate.ToString("MMM dd, yyyy")</MudText>
                                         }
                                         else
                                         {
-                                            <MudText Typo="Typo.subtitle2">@message.Authors.FirstOrDefault().DisplayName</MudText>
-                                            <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">@message.PublishDate.ToString("MMM dd, yyyy")</MudText>
+                                            <MudText Typo="Typo.Subtitle2">@message.Authors.FirstOrDefault().DisplayName</MudText>
+                                            <MudText Typo="Typo.Subtitle2" Class="mud-text-secondary">@message.PublishDate.ToString("MMM dd, yyyy")</MudText>
                                         }
                                     </div>
                                 </MudCardActions>

--- a/src/MudBlazor.Docs/Pages/Mud/Project/HowItStarted.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/HowItStarted.razor
@@ -3,7 +3,7 @@
 <DocsPage DisplayFooter="true">
     <DocsPageHeader Title="About" />
     <DocsPageContent>
-        <MudText Typo="Typo.h4" GutterBottom="true">How it started</MudText>
+        <MudText Typo="Typo.H4" GutterBottom="true">How it started</MudText>
         <MudText>
             I had a vision for this project, to keep it clean and simple with a modern design that is highly customizable. Simple and easy to use components. More CSS, SASS and no Javascript
             or at least just the absolute necessities if there is something Blazor and CSS cannot do.
@@ -14,7 +14,7 @@
             Blazor is all about.
         </MudText>
 
-        <MudText Typo="Typo.h4" GutterBottom="true" Class="mt-8">I was not alone</MudText>
+        <MudText Typo="Typo.H4" GutterBottom="true" Class="mt-8">I was not alone</MudText>
         <MudText>
             I was almost about to give up, the time it took to make everything myself and the knowledge I lacked made it hard, and the project was far from going public. I started looking around,
             surely there must be another library with the same vision and values out there which I could contribute to instead.
@@ -24,7 +24,7 @@
             both had the same vision. I made a promise to clean up my library and prepare it to go public on GitHub. That guy had been none other than Henon who became co-creator of the project.
         </MudText>
 
-        <MudText Typo="Typo.h4" GutterBottom="true" Class="mt-8">Our Story</MudText>
+        <MudText Typo="Typo.H4" GutterBottom="true" Class="mt-8">Our Story</MudText>
         <MudText>
             From this point on we worked hard to get something ready for what we call "first release" day and night, we covered each others shortcomings
             and suddenly something great was coming along.
@@ -38,7 +38,7 @@
         </div>
         <MudContainer>
         <div class="mud-typography-align-center">
-            <MudText Typo="Typo.h4" Class="my-16">Meet the <MudLink Typo="Typo.h4" Href="/mud/project/team">Team</MudLink></MudText>
+            <MudText Typo="Typo.H4" Class="my-16">Meet the <MudLink Typo="Typo.H4" Href="/mud/project/team">Team</MudLink></MudText>
         </div>
         </MudContainer>
         <MudContainer>

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -19,9 +19,9 @@
                 {
                     <MudItem xs="12" md="4">
                         <div class="docs-sticky-info">
-                            <MudText Typo="Typo.h5" Inline="true">Version </MudText>
-                            <MudText Typo="Typo.h5" Inline="true" Color="Color.Primary"><b>@release.TagName</b></MudText>
-                            <MudText Typo="Typo.subtitle1">Released on @release.PublishedAt.ToString("MMMM dd, yyyy")</MudText>
+                            <MudText Typo="Typo.H5" Inline="true">Version </MudText>
+                            <MudText Typo="Typo.H5" Inline="true" Color="Color.Primary"><b>@release.TagName</b></MudText>
+                            <MudText Typo="Typo.Subtitle1">Released on @release.PublishedAt.ToString("MMMM dd, yyyy")</MudText>
                         </div>
                     </MudItem>
                     <MudItem xs="12" md="8">

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Team.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Team.razor
@@ -4,13 +4,13 @@
 <PageTitle>Meet the team - MudBlazor</PageTitle>
 <DocsPage DisplayFooter="true">
     <MudContainer>
-        <MudText Typo="Typo.h3" GutterBottom="true">Meet the team</MudText>
-        <MudText Typo="Typo.subtitle1">
+        <MudText Typo="Typo.H3" GutterBottom="true">Meet the team</MudText>
+        <MudText Typo="Typo.Subtitle1">
             MudBlazor is not a one-person show. A nice little community has emerged and a couple of highly motivated people are working on improvements and are regularly adding more components.
             Everyone is welcome to join in and contribute to make this library even more awesome than it already is.
         </MudText>
 
-        <MudText Typo="Typo.h4" Class="mt-16" GutterBottom="true" Color="Color.Primary">Core Team</MudText>
+        <MudText Typo="Typo.H4" Class="mt-16" GutterBottom="true" Color="Color.Primary">Core Team</MudText>
         <MudText Class="mb-8">The Core Team who guide, develop and direct the development of MudBlazor.</MudText>
         <MudGrid>
             <MudItem xs="12" md="6">
@@ -20,8 +20,8 @@
                             <MudAvatar Image="https://avatars.githubusercontent.com/u/10367109?v=4" Size="Size.Large" Class="mud-elevation-4" />
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.h6">Jonny Larsson</MudText>
-                            <MudText Typo="Typo.body1" Color="Color.Primary" Style="font-weight:500;">Creator</MudText>
+                            <MudText Typo="Typo.H6">Jonny Larsson</MudText>
+                            <MudText Typo="Typo.Body1" Color="Color.Primary" Style="font-weight:500;">Creator</MudText>
                         </CardHeaderContent>
                         <CardHeaderActions>
                             <MudTooltip Text="LinkedIn" Placement="Placement.Top">
@@ -48,8 +48,8 @@
                             <MudAvatar Image="https://avatars.githubusercontent.com/u/44090?v=4" Size="Size.Large" Class="mud-elevation-4" />
                         </CardHeaderAvatar>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.h6">Meinrad Recheis</MudText>
-                            <MudText Typo="Typo.body1" Color="Color.Primary" Style="font-weight:500;">Co-Creator</MudText>
+                            <MudText Typo="Typo.H6">Meinrad Recheis</MudText>
+                            <MudText Typo="Typo.Body1" Color="Color.Primary" Style="font-weight:500;">Co-Creator</MudText>
                         </CardHeaderContent>
                         <CardHeaderActions>
                             <MudTooltip Text="LinkedIn" Placement="Placement.Top">
@@ -77,7 +77,7 @@
             }
         </MudGrid>
 
-        <MudText Typo="Typo.h4" Class="mt-16" GutterBottom="true" Color="Color.Secondary">Contribution Team</MudText>
+        <MudText Typo="Typo.H4" Class="mt-16" GutterBottom="true" Color="Color.Secondary">Contribution Team</MudText>
         <MudText Class="mb-8">Core Contributors who work closely with the Core Team and are actively working on MudBlazor.</MudText>
 
         <MudGrid>
@@ -89,7 +89,7 @@
             }
         </MudGrid>
         
-        <MudText Typo="Typo.h4" Class="mt-16" GutterBottom="true" Color="Color.Tertiary">Awesome coders</MudText>
+        <MudText Typo="Typo.H4" Class="mt-16" GutterBottom="true" Color="Color.Tertiary">Awesome coders</MudText>
         <MudText Class="mb-8">Who allowed us to use some of their code in MudBlazor.</MudText>
         <MudGrid>
             <MudItem xs="12" md="6">
@@ -108,7 +108,7 @@
                 </MudContributor>      
             </MudItem>
         </MudGrid>
-        <MudText Typo="Typo.h4" Class="mt-16 mb-8">All contributors</MudText>
+        <MudText Typo="Typo.H4" Class="mt-16 mb-8">All contributors</MudText>
         <MudGrid>
             @if (_githubContributors == null)
             {

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -3,7 +3,7 @@
     <MudSpacer/>
     <NavLink ActiveClass="d-flex align-center" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo"/>
-        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
+        <MudText Color="Color.Primary" Typo="Typo.H5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
     <MudSpacer/>
     @if (DisplaySearchBar)
@@ -18,7 +18,7 @@
 <div class="d-none d-md-flex align-center flex-grow-1">
     <NavLink ActiveClass="d-flex align-center me-4" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo"/>
-        <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
+        <MudText Color="Color.Primary" Typo="Typo.H5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
     <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
     <MudButton Href="/getting-started/installation" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.GettingStarted)">Getting Started</MudButton>
@@ -32,25 +32,25 @@
                 <div class="d-flex">
                     <MudText Color="Color.Primary">MudBlazor</MudText>
                 </div>
-                <MudText Typo="Typo.body2">Blazor component library</MudText>
+                <MudText Typo="Typo.Body2">Blazor component library</MudText>
             </MudListItem>
             <MudListItem Href="https://try.mudblazor.com/">
                 <div class="d-flex">
                     <MudText Color="Color.Primary">Try</MudText><MudText>MudBlazor</MudText>
                 </div>
-                <MudText Typo="Typo.body2">Online code editor with Blazor</MudText>
+                <MudText Typo="Typo.Body2">Online code editor with Blazor</MudText>
             </MudListItem>
             <MudListItem Href="https://github.com/MudBlazor/ThemeManager">
                 <div class="d-flex">
                     <MudText>Theme</MudText><MudText Color="Color.Secondary">Manager</MudText>
                 </div>
-                <MudText Typo="Typo.body2">Manage your theme live in your app</MudText>
+                <MudText Typo="Typo.Body2">Manage your theme live in your app</MudText>
             </MudListItem>
             <MudListItem Href="https://github.com/MudBlazor/Templates">
                 <div class="d-flex">
                     <MudText>Templates</MudText>
                 </div>
-                <MudText Typo="Typo.body2">Blazor templates loaded with MudBlazor</MudText>
+                <MudText Typo="Typo.Body2">Blazor templates loaded with MudBlazor</MudText>
             </MudListItem>
         </MudList>
         <MudList Clickable="true" Class="relative">
@@ -62,7 +62,7 @@
                 <MudBadge Class="d-flex mr-16" Content="@_badgeTextSoon" Color="Color.Info" Overlap="true">
                     <MudText>Mud</MudText><MudText Color="Color.Warning">Extensions</MudText>
                 </MudBadge>
-                <MudText Typo="Typo.body2">Official and Community Extensions</MudText>
+                <MudText Typo="Typo.Body2">Official and Community Extensions</MudText>
             </MudListItem>
         </MudList>
     </MudMenu>
@@ -73,7 +73,7 @@
                          AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined"
                          SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
-                <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
+                <MudText>@result.Title</MudText> <MudText Typo="Typo.Body2">@result.SubTitle</MudText>
             </ItemTemplate>
         </MudAutocomplete>
         <MudDivider FlexItem="true" Vertical="true" DividerType="DividerType.Middle" Class="mx-4 my-4"/>
@@ -94,12 +94,12 @@
                          AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async text => await Search(text)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">
-                <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
+                <MudText>@result.Title</MudText> <MudText Typo="Typo.Body2">@result.SubTitle</MudText>
             </ItemTemplate>
         </MudAutocomplete>
 
         @* This text element will always be rendered but it's easier to write it this way *@
-        <MudText Typo="Typo.body2" Class="flex-grow-1 mud-text-secondary" Align="Align.Center">
+        <MudText Typo="Typo.Body2" Class="flex-grow-1 mud-text-secondary" Align="Align.Center">
             @if (!_searchDialogAutocompleteOpen)
             {
                 @("Use the box above to search the docs")

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -2,7 +2,7 @@
 <MudBadge Color="Color.Secondary" Dot="true" Overlap="true" Visible="_newNotificationsAvailable">
     <MudMenu Icon="@Icons.Material.Outlined.Notifications" Color="Color.Inherit" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopCenter" PopoverClass="docs-layout-menu-shadow" ListClass="pa-2 docs-menu-list" LockScroll="true">
         <div class="d-flex justify-space-between align-center px-2">
-            <MudText Typo="Typo.subtitle2">Notifications</MudText>
+            <MudText Typo="Typo.Subtitle2">Notifications</MudText>
             <MudButton Disabled="@(_newNotificationsAvailable == false)" OnClick="MarkNotificationAsRead" StartIcon="@Icons.Material.Filled.DoneAll" Variant="Variant.Text" Color="Color.Primary" Class="ml-16 mr-n2">Mark as read</MudButton>
         </div>
         @if (_messages != null && _newNotificationsAvailable)
@@ -10,8 +10,8 @@
             @foreach (var (message, isRead) in _messages.Take(5))
             {
                 <MudMenuItem Class="px-2 py-0 rounded" Href="@($"/mud/announcements/{message.Id}")">
-                    <MudText Typo="Typo.subtitle2">@message.Title</MudText>
-                    <MudText Typo="Typo.body2">@($"{message.Authors.FirstOrDefault()?.DisplayName} • {message.PublishDate.ToString("MM/dd/yyyy")}")</MudText>
+                    <MudText Typo="Typo.Subtitle2">@message.Title</MudText>
+                    <MudText Typo="Typo.Body2">@($"{message.Authors.FirstOrDefault()?.DisplayName} • {message.PublishDate.ToString("MM/dd/yyyy")}")</MudText>
                 </MudMenuItem>
                 <MudDivider Class="my-2"/>
             }

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -45,7 +45,7 @@
             }
             else if (!_topMenuOpen && LayoutService.GetDocsBasePage(NavigationManager.Uri) == DocsBasePage.GettingStarted)
             {
-                <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Getting Started</b></MudText>
+                <MudText Typo="Typo.Subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Getting Started</b></MudText>
                 <MudNavLink Href="/getting-started/installation">Installation</MudNavLink>
                 <MudNavLink Href="/getting-started/layouts">Layouts</MudNavLink>
                 <MudNavLink Href="/getting-started/usage">Usage</MudNavLink>
@@ -53,7 +53,7 @@
             }
             else if (!_topMenuOpen && LayoutService.GetDocsBasePage(NavigationManager.Uri) == DocsBasePage.DiscoverMore)
             {
-                <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Discover More</b></MudText>
+                <MudText Typo="Typo.Subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Discover More</b></MudText>
                 <MudNavLink Href="/mud/introduction" Class="docs-single-link">What is MudBlazor?</MudNavLink>
                 <MudNavGroup Title="Community" Expanded="true" HideExpandIcon="true">
                     <MudNavLink Href="/mud/community/getting-help">Getting Help</MudNavLink>

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -4,15 +4,15 @@
         <div class="d-flex flex-column mt-4">
             <div class="d-flex align-center my-2">
                 <MudIcon Icon="@Icons.Custom.Brands.MudBlazor" Size="Size.Small" Color="Color.Inherit" Class="mr-2" />
-                <MudText Typo="Typo.body1">MudBlazor</MudText>
+                <MudText Typo="Typo.Body1">MudBlazor</MudText>
             </div>
             <div class="d-flex align-center my-2">
                 <MudIcon Icon="@Icons.Material.Rounded.MapsHomeWork" Size="Size.Small" Color="Color.Inherit" Class="mr-2" />
-                <MudText Typo="Typo.body1">Gardnet AB</MudText>
+                <MudText Typo="Typo.Body1">Gardnet AB</MudText>
             </div>
             <div class="d-flex align-center my-2">
                 <MudIcon Icon="@Icons.Material.Rounded.NearMe" Size="Size.Small" Color="Color.Inherit" Class="mr-2" />
-                <MudText Typo="Typo.body1">Sweden</MudText>
+                <MudText Typo="Typo.Body1">Sweden</MudText>
             </div>
         </div>
         <div class="d-flex mt-4">
@@ -23,30 +23,30 @@
         </div>
     </MudItem>
     <MudItem xs="6" sm="3" Class="d-flex flex-column">
-        <MudText Typo="Typo.subtitle2" Class="mb-3">Community</MudText>
-        <MudLink Href="/mud/community/getting-help" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Getting Help</MudLink>
-        <MudLink Href="/mud/community/reporting-bugs" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Reporting Bugs</MudLink>
-        <MudLink Href="/mud/community/contribution" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Contribute</MudLink>
+        <MudText Typo="Typo.Subtitle2" Class="mb-3">Community</MudText>
+        <MudLink Href="/mud/community/getting-help" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Getting Help</MudLink>
+        <MudLink Href="/mud/community/reporting-bugs" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Reporting Bugs</MudLink>
+        <MudLink Href="/mud/community/contribution" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Contribute</MudLink>
     </MudItem>
     <MudItem xs="6" sm="3" Class="d-flex flex-column">
-        <MudText Typo="Typo.subtitle2" Class="mb-3">Project</MudText>
-        <MudLink Href="/mud/announcements" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Announcements</MudLink>
-        <MudLink Href="/mud/project/how-it-started" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">How it started</MudLink>
-        <MudLink Href="/mud/project/releases" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Releases</MudLink>
-        <MudLink Href="/mud/project/roadmap" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Roadmap</MudLink>
-        <MudLink Href="/mud/project/sponsor" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Sponsors and Backers</MudLink>
-        <MudLink Href="/mud/project/team" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Team and Contributors</MudLink>
+        <MudText Typo="Typo.Subtitle2" Class="mb-3">Project</MudText>
+        <MudLink Href="/mud/announcements" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Announcements</MudLink>
+        <MudLink Href="/mud/project/how-it-started" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">How it started</MudLink>
+        <MudLink Href="/mud/project/releases" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Releases</MudLink>
+        <MudLink Href="/mud/project/roadmap" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Roadmap</MudLink>
+        <MudLink Href="/mud/project/sponsor" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Sponsors and Backers</MudLink>
+        <MudLink Href="/mud/project/team" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Team and Contributors</MudLink>
     </MudItem>
     <MudItem xs="6" sm="3" Class="d-flex flex-column">
-        <MudText Typo="Typo.subtitle2" Class="mb-3">Products</MudText>
-        <MudLink Href="https://mudblazor.com/" Target="_blank" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">MudBlazor</MudLink>
-        <MudLink Href="https://try.mudblazor.com/" Target="_blank" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">TryMudBlazor</MudLink>
-        <MudLink Href="https://github.com/MudBlazor/ThemeManager" Target="_blank" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">ThemeManager</MudLink>
-        <MudLink Href="https://github.com/MudBlazor/Templates" Target="_blank" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Templates</MudLink>
+        <MudText Typo="Typo.Subtitle2" Class="mb-3">Products</MudText>
+        <MudLink Href="https://mudblazor.com/" Target="_blank" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">MudBlazor</MudLink>
+        <MudLink Href="https://try.mudblazor.com/" Target="_blank" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">TryMudBlazor</MudLink>
+        <MudLink Href="https://github.com/MudBlazor/ThemeManager" Target="_blank" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">ThemeManager</MudLink>
+        <MudLink Href="https://github.com/MudBlazor/Templates" Target="_blank" Typo="Typo.Body1" Color="Color.Inherit" Underline="Underline.None">Templates</MudLink>
     </MudItem>
     <MudItem xs="12">
         <MudToolBar DisableGutters="true" Dense="true">
-            <MudText Typo="Typo.body1">@($"Copyright © 2020-{DateTime.Now.Year} MudBlazor.")</MudText>
+            <MudText Typo="Typo.Body1">@($"Copyright © 2020-{DateTime.Now.Year} MudBlazor.")</MudText>
         </MudToolBar>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -2,7 +2,7 @@
 @using System.Text.RegularExpressions
 @using MudBlazor.Docs.Extensions
 
-<MudText Typo="Typo.subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Docs</b></MudText>
+<MudText Typo="Typo.Subtitle1" Class="mt-1 mb-2 ml-2 d-flex d-md-none"><b>Docs</b></MudText>
 <MudNavLink Href="docs/overview" Class="docs-single-link">Overview</MudNavLink>
 <MudNavGroup Title="Components" Expanded="@(_section == "components")" ExpandIcon="@Icons.Material.Filled.ExpandMore">
     @foreach (var item in MenuService.Components)

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -4,18 +4,18 @@
 <MudLayout>
     <MudAppBar Elevation="0">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="DocsDrawerToggle" />
-        <MudText Typo="Typo.h6">@selectedType?.Name</MudText>
+        <MudText Typo="Typo.H6">@selectedType?.Name</MudText>
         <MudSpacer />
         <MudAutocomplete @ref="autocomplete" T="Type" Placeholder="Search" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">
-                <MudText>@result.Name</MudText> <MudText Typo="Typo.body2">@getDescription(result)</MudText>
+                <MudText>@result.Name</MudText> <MudText Typo="Typo.Body2">@getDescription(result)</MudText>
             </ItemTemplate>
         </MudAutocomplete>
         <MudSpacer />
     </MudAppBar>
     <MudDrawer Open="@drawerOpen" DisableOverlay="true" Variant="DrawerVariant.Responsive" ClipMode="DrawerClipMode.Always" Breakpoint="Breakpoint.Sm">
         <MudDrawerHeader>
-            <MudText Typo="Typo.h6">Test Components</MudText>
+            <MudText Typo="Typo.H6">Test Components</MudText>
         </MudDrawerHeader>
         <MudNavMenu>
             @foreach (var type in availableComponentTypes)

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteDisabledItemsTest.razor
@@ -8,7 +8,7 @@
     </ItemTemplate>
     <ItemDisabledTemplate>
         @context
-        <MudText Typo="Typo.subtitle2">Disabled as the state contains the letter 'o'</MudText>
+        <MudText Typo="Typo.Subtitle2">Disabled as the state contains the letter 'o'</MudText>
     </ItemDisabledTemplate>
 </MudAutocomplete>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
@@ -1,6 +1,6 @@
 ﻿<div>
     <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
-    <MudText Typo="Typo.h6">Selected portion of the chart: @Index</MudText>
+    <MudText Typo="Typo.H6">Selected portion of the chart: @Index</MudText>
 </div>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
@@ -8,7 +8,7 @@
 	Groupable="true"
 	GroupExpanded="false">
 	<ToolBarContent>
-		<MudText Typo="Typo.h6">Fruits</MudText>
+		<MudText Typo="Typo.H6">Fruits</MudText>
 		<MudSpacer />
 	</ToolBarContent>
 	<Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandAllCollapseAllTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandAllCollapseAllTest.razor
@@ -8,7 +8,7 @@
     Groupable="true"
     GroupExpanded="false">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Elements</MudText>
+        <MudText Typo="Typo.H6">Elements</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedAsyncTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
     GroupExpanded="true">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseAsyncTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
              GroupExpanded="false">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseServerDataTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseServerDataTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid @ref="dataGrid" T="Fruit" ServerData="ServerDataFunc" Filterable="true" Hideable="true" Groupable="true"
              GroupExpanded="false">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedFalseTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
              GroupExpanded="false">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedServerDataTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedServerDataTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid @ref="dataGrid" T="Fruit" ServerData="ServerDataFunc" Filterable="true" Hideable="true" Groupable="true"
     GroupExpanded="true">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid T="Fruit" @ref="dataGrid" Items="@Fruits" Filterable="true" Hideable="true" Groupable="true"
     GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudText Typo="Typo.H6">Fruits</MudText>
         <MudSpacer />
     </ToolBarContent>
     <Columns>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
@@ -8,7 +8,7 @@
 
 <MudDialog @bind-IsVisible="visible">
     <TitleContent>
-        <MudText Typo="Typo.h6">
+        <MudText Typo="Typo.H6">
             <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-3"/> Edit rating
         </MudText>
     </TitleContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneBasicTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneBasicTest.razor
@@ -7,11 +7,11 @@
 				  ItemDropped="ItemUpdated">
 	<ChildContent>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
 					 DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanDropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCanDropTest.razor
@@ -8,15 +8,15 @@
 				  ItemDropped="ItemUpdated" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
 	<ChildContent>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
 					 ApplyDropClassesOnDragStarted="@SecondColumnAppliesClassesOnDragStarted"
 					 CanDropClass="can-drop-from-zone" NoDropClass="no-drop-class-from-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 3" Class="third-drop-zone" CanDrop=@( (item) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCustomItemSelectorTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneCustomItemSelectorTest.razor
@@ -4,14 +4,14 @@
 	<ChildContent>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
 			<ChildContent>
-				<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+				<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 			</ChildContent>
 			<ItemRenderer>
 				<MudText>@context.Name by Drop Zone 1</MudText>
 			</ItemRenderer>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDisableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDisableTest.razor
@@ -8,10 +8,10 @@
 	<ChildContent>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
 					 ItemIsDisabled="@( (item) => item.Name == "Fourth Item")" DisabledClass="my-zone-based-custom-disabled">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDraggingTestCantDropSecondZoneTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDraggingTestCantDropSecondZoneTest.razor
@@ -8,11 +8,11 @@
 	<ChildContent>
         <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
                      CanDrop=@( (x) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
 					 CanDrop=@( (x) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneVisbilityTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneVisbilityTest.razor
@@ -7,11 +7,11 @@
 				  ItemDropped="ItemUpdated">
 	<ChildContent>
 		<MudDropZone OnlyZone="@HideItemsInFirstDropZone" T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
 					 DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+			<MudText Typo="Typo.H6" Class="mb-4">Drop Zone 2</MudText>
 		</MudDropZone>
 	</ChildContent>
 	<ItemRenderer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadButtonTemplateContextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadButtonTemplateContextTest.razor
@@ -10,7 +10,7 @@
                @ondragend="@ClearDragClass">
     <ButtonTemplate>
         <MudPaper Height="300px" Outlined="true" Class="@_dragClass">
-            <MudText Typo="Typo.h6">Drag and drop files here or click</MudText>
+            <MudText Typo="Typo.H6">Drag and drop files here or click</MudText>
             <MudChip Color="Color.Dark" Text="@File?.Name" />
         </MudPaper>
         <MudToolBar DisableGutters="true"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadAndButtonTemplateContextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadAndButtonTemplateContextTest.razor
@@ -22,7 +22,7 @@
                            @ondragend="@ClearDragClass">
                 <ButtonTemplate>
                     <MudPaper Height="300px" Outlined="true" Class="@_dragClass">
-                        <MudText Typo="Typo.h6">Drag and drop files here or click</MudText>
+                        <MudText Typo="Typo.H6">Drag and drop files here or click</MudText>
                         <MudChip Color="Color.Dark" Text="@_model.File?.Name" />
                     </MudPaper>
                     <MudToolBar DisableGutters="true"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuGroupDisabledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuGroupDisabledTest.razor
@@ -1,5 +1,5 @@
 ﻿<MudNavMenu>
-    <MudText Typo="Typo.subtitle2" Color="Color.Inherit" Class="ml-4 my-3">Templates</MudText>
+    <MudText Typo="Typo.Subtitle2" Color="Color.Inherit" Class="ml-4 my-3">Templates</MudText>
     <MudNavLink Href="/" Icon="@Icons.Material.Outlined.SelectAll">Select Template</MudNavLink>
     <MudNavLink Href="/Admin/Upload" Icon="@Icons.Material.Outlined.Upload">Upload Template</MudNavLink>
     <MudNavGroup  Icon="@Icons.Material.Outlined.AdminPanelSettings" Title="Admin" Disabled="@IsGroupDisabled">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scroll/ScrollToTopTest.razor
@@ -6,14 +6,14 @@
 
 <MudStack Row="true">
     <button type="button" @onclick="ScrollBottom">Scroll bottom</button>
-    <MudText id="scroll_on_top_scroll_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@Scrolled</MudText>
-    <MudText id="scroll_on_top_click_event_raised" Typo="Typo.subtitle1" Align="Align.Center">@Clicked</MudText>
+    <MudText id="scroll_on_top_scroll_event_raised" Typo="Typo.Subtitle1" Align="Align.Center">@Scrolled</MudText>
+    <MudText id="scroll_on_top_click_event_raised" Typo="Typo.Subtitle1" Align="Align.Center">@Clicked</MudText>
 </MudStack>
 <div id="unique_id_scroll_section" class="ma-0" style="height:300px;overflow: auto;">
     <MudPaper Elevation="0" Height="1500px" Class="d-flex flex-column justify-space-between py-6">
-        <MudText id="scroll_on_top_text_must_be_in_view" Typo="Typo.h3" Align="Align.Center">@_text</MudText>
-        <MudText Typo="Typo.h3" Align="Align.Center">Middle text</MudText>
-        <MudText id="scroll_to_top_bottom_text" Typo="Typo.h3" Align="Align.Center">Bottom text</MudText>
+        <MudText id="scroll_on_top_text_must_be_in_view" Typo="Typo.H3" Align="Align.Center">@_text</MudText>
+        <MudText Typo="Typo.H3" Align="Align.Center">Middle text</MudText>
+        <MudText id="scroll_to_top_bottom_text" Typo="Typo.H3" Align="Align.Center">Bottom text</MudText>
         <MudScrollToTop Selector="#unique_id_scroll_section" OnClick="@Click" OnScroll="@Scroll">
             <MudFab Color="@Color.Primary" StartIcon="@Icons.Material.Filled.ArrowCircleUp"/>
         </MudScrollToTop>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest3.razor
@@ -14,7 +14,7 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.body2">MudSelect.Value: "@value"</MudText>
+        <MudText Typo="Typo.Body2">MudSelect.Value: "@value"</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest4.razor
@@ -14,7 +14,7 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.body2">MudSelect.Value: "@value"</MudText>
+        <MudText Typo="Typo.Body2">MudSelect.Value: "@value"</MudText>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReloadSelectItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReloadSelectItemsTest.razor
@@ -10,7 +10,7 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudText Typo="Typo.body2">MudSelect.Value: "@value"</MudText>
+        <MudText Typo="Typo.Body2">MudSelect.Value: "@value"</MudText>
     </MudItem>
 </MudGrid>
 <br>   

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SwipeArea/SwipeAreaOnSwipeEndTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SwipeArea/SwipeAreaOnSwipeEndTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSwipeArea @ref="_swipeArea" OnSwipeEnd="HandleSwipeEnd" Style="width: 100%; height: 300px" Sensitivity="_sensitivity" PreventDefault="@_preventDefault">
-    <MudText Typo="@Typo.body1">@($"{SwipeDirection} - Swiped: {SwipeDelta}px")</MudText>
+    <MudText Typo="@Typo.Body1">@($"{SwipeDirection} - Swiped: {SwipeDelta}px")</MudText>
     </MudSwipeArea>
     <MudSwitch @bind-Checked="@_preventDefault" Color="Color.Primary">Prevent Default</MudSwitch>
     <MudNumericField @bind-Value="_sensitivity" Label="Sensitivity" Min="0" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SwipeArea/SwipeAreaTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SwipeArea/SwipeAreaTest.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSwipeArea OnSwipe="@((d) => _swipeDirection = d)" Style="width: 100%; height: 300px">
-    <MudText Typo="@Typo.body1">@_swipeDirection</MudText>
+    <MudText Typo="@Typo.Body1">@_swipeDirection</MudText>
 </MudSwipeArea>
 
 @code{ 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithHeaderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithHeaderTest.razor
@@ -2,20 +2,20 @@
 <MudTabs HeaderPosition="@TabHeaderPosition" TabPanelHeaderPosition="@TabPanelHeaderPosition">
     <ChildContent>
         <MudTabPanel Text="First Tab" Tag="0">
-            <MudText Typo="Typo.h1">  First Tab Content</MudText>
+            <MudText Typo="Typo.H1">  First Tab Content</MudText>
         </MudTabPanel>
         <MudTabPanel Text="Second Tab" Tag="1">
-            <MudText Typo="Typo.h1">Second Tab Content</MudText>
+            <MudText Typo="Typo.H1">Second Tab Content</MudText>
         </MudTabPanel>
         <MudTabPanel Text="Third Tab" Tag="2">
-            <MudText Typo="Typo.h1">Third Tab Content</MudText>
+            <MudText Typo="Typo.H1">Third Tab Content</MudText>
         </MudTabPanel>
     </ChildContent>
     <Header>
-        <MudText Typo="Typo.caption" Class="test-header-content">Count: @context.Panels.Count</MudText>
+        <MudText Typo="Typo.Caption" Class="test-header-content">Count: @context.Panels.Count</MudText>
     </Header>
     <TabPanelHeader>
-        <MudText Typo="Typo.caption" Class="test-panel-header-content">Index: @context.Tag</MudText>
+        <MudText Typo="Typo.Caption" Class="test-panel-header-content">Index: @context.Tag</MudText>
     </TabPanelHeader>
 </MudTabs>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudText Typo="Typo.h6">Result: @searchString</MudText>
+<MudText Typo="Typo.H6">Result: @searchString</MudText>
 <MudTextField @bind-Value="searchString" T="string" DebounceInterval="500"></MudTextField>
 @code
 {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
@@ -2,7 +2,7 @@
 
 <MudTreeView ExpandOnClick="true" ServerData="LoadServerData" Items="TreeItems" Width="350px">
     <ItemTemplate>
-        <MudTreeViewItem Value="@context" Icon="@context.Icon" CanExpand="@context.CanExpand" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" />
+        <MudTreeViewItem Value="@context" Icon="@context.Icon" CanExpand="@context.CanExpand" Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.Caption" />
     </ItemTemplate>
 </MudTreeView>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
@@ -3,7 +3,7 @@
 <MudTreeView MultiSelection="true" Items="TreeItems" Style="width: 500px;">
     <ItemTemplate>
         <MudTreeViewItem @bind-Activated="@context.IsSelected" @bind-Expanded="@context.IsExpanded" Icon="@context.Icon"
-                         Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" Items="@context.TreeItems" />
+                         Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.Caption" Items="@context.TreeItems" />
     </ItemTemplate>
 </MudTreeView>
 

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -22,6 +22,6 @@
     }
     else
     {
-        <MudText Typo="Typo.body2" Color="Color.Inherit">@ChildContent</MudText>
+        <MudText Typo="Typo.Body2" Color="Color.Inherit">@ChildContent</MudText>
     }
 </MudElement>

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -10,13 +10,13 @@
                 @if(MudChartParent?.CanHideSeries == false)
                 {
                     <span class="mud-chart-legend-marker" style="@($"background-color:{MudChartParent.ChartOptions.ChartPalette.GetValue(item.Index % MudChartParent.ChartOptions.ChartPalette.Count())}")"></span>
-                    <MudText Typo="Typo.body2" Inline="true">@item.Labels</MudText>
+                    <MudText Typo="Typo.Body2" Inline="true">@item.Labels</MudText>
                 }
                 else
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
                         <MudCheckBox Checked="@item.IsVisible" CheckedChanged="@((bool value) => item.HandleCheckboxChangeAsync())"></MudCheckBox>               
-                        <MudText Typo="Typo.body2" Class="ml-1" Inline="true">@item.Labels</MudText>
+                        <MudText Typo="Typo.Body2" Class="ml-1" Inline="true">@item.Labels</MudText>
                     </div> 
                 }                 
             </div>

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -6,7 +6,7 @@
     <div class="mud-table-pagination-spacer"></div>
     @if (!DisableRowsPerPage)
     {
-        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
+        <MudText Typo="Typo.Body2" Class="mud-table-pagination-caption">
             @RowsPerPageString
         </MudText>
         <MudSelect T="string" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true" Disabled="@Disabled">
@@ -16,7 +16,7 @@
             }
         </MudSelect>
     }
-    <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
+    <MudText Typo="Typo.Body2" Class="mud-table-pagination-caption">
         @Info
     </MudText>
     <div class="mud-table-pagination-actions">

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -51,13 +51,13 @@
                                     {
                                         <MudIconButton aria-label="@prevLabel" Icon="@PreviousIcon" OnClick="OnPreviousYearClick" Class="mud-flip-x-rtl" />
                                         <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition" @onclick="OnYearClick" @onclick:stopPropagation="true">
-                                            <MudText Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
+                                            <MudText Typo="Typo.Body1" Align="Align.Center">@calendarYear</MudText>
                                         </button>
                                         <MudIconButton aria-label="@nextLabel" Icon="@NextIcon" OnClick="OnNextYearClick" Class="mud-flip-x-rtl" />
                                     }
                                     else
                                     {
-                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@calendarYear</MudText>
+                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.Body1" Align="Align.Center">@calendarYear</MudText>
                                     }
                                 </div>
                             </div>
@@ -82,25 +82,25 @@
                                     {
                                         <MudIconButton aria-label="@prevLabel" Class="mud-picker-nav-button-prev mud-flip-x-rtl" Icon="@PreviousIcon" OnClick="OnPreviousMonthClick" />
                                         <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition mud-button-month" @onclick="(() => OnMonthClicked(tempMonth))" @onclick:stopPropagation="true">
-                                            <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
+                                            <MudText Typo="Typo.Body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
                                         </button>
                                         <MudIconButton aria-label="@nextLabel" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" />
                                     }
                                     else
                                     {
-                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
+                                        <MudText Class="mud-picker-calendar-header-transition" Typo="Typo.Body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
                                     }
                                 </div>
                                 <div class="mud-picker-calendar-header-day">
                                     @if (ShowWeekNumbers)
                                     {
                                         <div class="mud-picker-calendar-week">
-                                            <MudText Typo="Typo.caption" Class="mud-picker-calendar-week-text"></MudText>
+                                            <MudText Typo="Typo.Caption" Class="mud-picker-calendar-week-text"></MudText>
                                         </div>
                                     }
                                     @foreach (var dayname in GetAbbreviatedDayNames())
                                     {
-                                        <MudText Typo="Typo.caption" Class="mud-day-label">@dayname</MudText>
+                                        <MudText Typo="Typo.Caption" Class="mud-day-label">@dayname</MudText>
                                     }
                                 </div>
                             </div>
@@ -114,7 +114,7 @@
                                         @if (ShowWeekNumbers)
                                         {
                                             <div class="mud-picker-calendar-week">
-                                                <MudText class="mud-picker-calendar-week-text" Typo="Typo.caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
+                                                <MudText class="mud-picker-calendar-week-text" Typo="Typo.Caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
                                             </div>
                                         }
                                         @foreach (var day in GetWeek(tempMonth, tempWeek))

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -537,8 +537,8 @@ namespace MudBlazor
         private Typo GetYearTypo(int year)
         {
             if (year == Culture.Calendar.GetYear(GetMonthStart(0)))
-                return Typo.h5;
-            return Typo.subtitle1;
+                return Typo.H5;
+            return Typo.Subtitle1;
         }
 
         private void OnFormattedDateClick()
@@ -578,8 +578,8 @@ namespace MudBlazor
         private Typo GetMonthTypo(DateTime month)
         {
             if (Culture.Calendar.GetMonth(GetMonthStart(0)) == Culture.Calendar.GetMonth(month))
-                return Typo.h5;
-            return Typo.subtitle1;
+                return Typo.H5;
+            return Typo.Subtitle1;
         }
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -9,7 +9,7 @@
             <div class="@TitleClassname">
                 @if (TitleContent == null)
                 {
-                    <MudText Typo="Typo.h6">@Title</MudText>
+                    <MudText Typo="Typo.H6">@Title</MudText>
                 }
                 else
                 {

--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Link.Appearance)]
-        public Typo Typo { get; set; } = Typo.body1;
+        public Typo Typo { get; set; } = Typo.Body1;
 
         /// <summary>
         /// Controls when the link should have an underline.
@@ -59,7 +59,7 @@ namespace MudBlazor
         public string? Href { get; set; }
 
         /// <summary>
-        /// The target attribute specifies where to open the link, if Href is specified. Possible values: _blank | _self | _parent | _top | <i>framename</i>
+        /// The target attribute specifies where to open the link, if Link is specified. Possible values: _blank | _self | _parent | _top | <i>framename</i>
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Link.Behavior)]

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -180,6 +180,21 @@ namespace MudBlazor
         public bool InitiallyExpanded { get; set; }
 
         /// <summary>
+        /// Command parameter.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        public object CommandParameter { get; set; }
+
+        /// <summary>
+        /// Command executed when the user clicks on an element.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
+        public ICommand Command { get; set; }
+
+        /// <summary>
         /// Display content of this list item. If set, this overrides Text
         /// </summary>
         [Parameter]
@@ -233,6 +248,12 @@ namespace MudBlazor
                         await MudList.SetSelectedValueAsync(Value);
                     }
                     await OnClick.InvokeAsync(eventArgs);
+#pragma warning disable CS0618
+                    if (Command?.CanExecute(CommandParameter) ?? false)
+                    {
+                        Command.Execute(CommandParameter);
+                    }
+#pragma warning restore CS0618
                 }
             }
             else
@@ -262,6 +283,10 @@ namespace MudBlazor
                 {
                     MudList?.SetSelectedValueAsync(this.Value);
                     OnClick.InvokeAsync(ev);
+                    if (Command?.CanExecute(CommandParameter) ?? false)
+                    {
+                        Command.Execute(CommandParameter);
+                    }
                 }
             }
             else
@@ -286,11 +311,11 @@ namespace MudBlazor
         {
             if ((Dense ?? MudList?.Dense) ?? false)
             {
-                _textTypo = Typo.body2;
+                _textTypo = Typo.Body2;
             }
             else if (!((Dense ?? MudList?.Dense) ?? false))
             {
-                _textTypo = Typo.body1;
+                _textTypo = Typo.Body1;
             }
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -5,7 +5,7 @@
     <TitleContent>
         @if (TitleContent is null)
         {
-            <MudText Typo="Typo.h6">@Title</MudText> }
+            <MudText Typo="Typo.H6">@Title</MudText> }
         else
         {
             @TitleContent

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -5,7 +5,7 @@
 <div class="@GetPanelClass()" @attributes="UserAttributes">
     @if (_sections.Count > 1)
     {
-        <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
+        <MudText Typo="Typo.Subtitle1" Class="title" GutterBottom="true">
             @Headline
         </MudText>
         <MudNavMenu Class="pl-4">

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -10,7 +10,7 @@
 <div class="@Classname" style="@Style">
 	@if (ChildContent != null)
 	{
-		<MudText Typo="Typo.body1">@ChildContent</MudText>
+		<MudText Typo="Typo.Body1">@ChildContent</MudText>
 	}
 	<div class="mud-slider-container">
 		@if (Variant == Variant.Filled)
@@ -31,7 +31,7 @@
 							<span class="mud-slider-track-tick" />
 							@if (TickMarkLabels != null && current < TickMarkLabels.Length)
 							{
-								<MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
+								<MudText Class="mud-slider-track-tick-label" Typo="Typo.Body2">@TickMarkLabels[current]</MudText>
 							}
 						</div>
 					}

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -13,12 +13,12 @@
                 @if (TimeEditMode == TimeEditMode.Normal)
                 {
                     <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@HoursButtonClass" OnClick="OnHourClick">@GetHourString()</MudButton>
-                    <MudText Typo="Typo.h2" Class="mud-timepicker-separator">:</MudText>
+                    <MudText Typo="Typo.H2" Class="mud-timepicker-separator">:</MudText>
                     <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@MinuteButtonClass" OnClick="OnMinutesClick">@GetMinuteString()</MudButton>
                 }
                 else
                 {
-                    <MudText Typo="Typo.h2" Class="mud-timepicker-separator">@GetHourString():@GetMinuteString()</MudText>
+                    <MudText Typo="Typo.H2" Class="mud-timepicker-separator">@GetHourString():@GetMinuteString()</MudText>
                 }
             </div>
             @if (AmPm)
@@ -67,7 +67,7 @@
                                 {
                                     var _i = i;
                                     var angle =  (6 - _i) * 30;
-                                    <MudText Class="@GetNumberColor(_i)" Typo="Typo.body2" Style="@GetTransform(angle, 74, 0, 40)">@(_i.ToString("D2"))</MudText>
+                                    <MudText Class="@GetNumberColor(_i)" Typo="Typo.Body2" Style="@GetTransform(angle, 74, 0, 40)">@(_i.ToString("D2"))</MudText>
                                 }
                                 for(int i = 1; i <= 12; ++i)
                                 {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -85,7 +85,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public Typo TextTypo { get; set; } = Typo.body1;
+        public Typo TextTypo { get; set; } = Typo.Body1;
 
         /// <summary>
         /// User class names for the text, separated by space.
@@ -106,7 +106,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public Typo EndTextTypo { get; set; } = Typo.body1;
+        public Typo EndTextTypo { get; set; } = Typo.Body1;
 
         /// <summary>
         /// User class names for the endtext, separated by space.
@@ -157,6 +157,14 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
         public HashSet<T>? Items { get; set; }
+
+        /// <summary>
+        /// Command executed when the user clicks on the CommitEdit Button.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.TreeView.ClickAction)]
+        [Obsolete($"Use {nameof(OnClick)} instead. This will be removed in v7.")]
+        public ICommand? Command { get; set; }
 
         /// <summary>
         /// Expand or collapse treeview item when it has children. Two-way bindable. Note: if you directly set this to
@@ -370,6 +378,12 @@ namespace MudBlazor
             }
 
             await OnClick.InvokeAsync(ev);
+#pragma warning disable CS0618
+            if (Command?.CanExecute(Value) ?? false)
+            {
+                Command.Execute(Value);
+            }
+#pragma warning restore CS0618
         }
 
         protected async Task OnItemDoubleClicked(MouseEventArgs ev)

--- a/src/MudBlazor/Components/Typography/MudText.razor
+++ b/src/MudBlazor/Components/Typography/MudText.razor
@@ -4,46 +4,46 @@
 
 @switch (Typo)
 {
-    case Typo.h1:
+    case Typo.H1:
         <h1 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h1>
         break;
-    case Typo.h2:
+    case Typo.H2:
         <h2 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h2>
         break;
-    case Typo.h3:
+    case Typo.H3:
         <h3 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h3>
         break;
-    case Typo.h4:
+    case Typo.H4:
         <h4 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h4>
         break;
-    case Typo.h5:
+    case Typo.H5:
         <h5 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h5>
         break;
-    case Typo.h6:
+    case Typo.H6:
         <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
         break;
-    case Typo.subtitle1:
+    case Typo.Subtitle1:
         <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
         break;
-    case Typo.subtitle2:
+    case Typo.Subtitle2:
         <h6 @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</h6>
         break;
-    case Typo.body1:
+    case Typo.Body1:
         <p @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</p>
         break;
-    case Typo.body2:
+    case Typo.Body2:
         <p @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</p>
         break;
-    case Typo.button:
+    case Typo.Button:
         <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
-    case Typo.caption:
+    case Typo.Caption:
         <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
-    case Typo.overline:
+    case Typo.Overline:
         <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
-    case Typo.inherit:
+    case Typo.Inherit:
         <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
 }

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -34,7 +34,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Text.Appearance)]
-        public Typo Typo { get; set; } = Typo.body1;
+        public Typo Typo { get; set; } = Typo.Body1;
 
         /// <summary>
         /// Set the text-align on the component.

--- a/src/MudBlazor/Enums/Typo.cs
+++ b/src/MudBlazor/Enums/Typo.cs
@@ -5,32 +5,32 @@ namespace MudBlazor
     public enum Typo
     {
         [Description("inherit")]
-        inherit,
+        Inherit,
         [Description("h1")]
-        h1,
+        H1,
         [Description("h2")]
-        h2,
+        H2,
         [Description("h3")]
-        h3,
+        H3,
         [Description("h4")]
-        h4,
+        H4,
         [Description("h5")]
-        h5,
+        H5,
         [Description("h6")]
-        h6,
+        H6,
         [Description("subtitle1")]
-        subtitle1,
+        Subtitle1,
         [Description("subtitle2")]
-        subtitle2,
+        Subtitle2,
         [Description("body1")]
-        body1,
+        Body1,
         [Description("body2")]
-        body2,
+        Body2,
         [Description("button")]
-        button,
+        Button,
         [Description("caption")]
-        caption,
+        Caption,
         [Description("overline")]
-        overline
+        Overline
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->
I've corrected the casing of the `Typo` enum members.
e.g. `Typo.body1` -> `Typo.Body1`, `Typo.subtitle1` -> `Typo.Subtitle1` and so on.

The attributes are left untouched: `[Description("subtitle1")]` as this will wreak havoc in the Docs.

## How Has This Been Tested?
Visually; Browsing through the Docs and comparing it with the online Docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
