### PR TITLE
Pickers: change API to async to avoid async void and fire-and-forget

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerActionButtonsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerActionButtonsExample.razor
@@ -2,9 +2,9 @@
 
 <MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date" AutoClose="@autoClose">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudDatePicker>
 <MudSwitch @bind-Value="autoClose" Color="Color.Secondary">AutoClose</MudSwitch>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
@@ -9,9 +9,9 @@
     <MudDateRangePicker Label="Custom start month" StartMonth="@DateTime.Now.AddMonths(-1)" @bind-DateRange="_dateRange" />
     <MudDateRangePicker @ref="_picker" Label="With action buttons" @bind-DateRange="_dateRange" AutoClose="@_autoClose">
         <PickerActions>
-            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-            <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-            <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+            <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+            <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
         </PickerActions>
     </MudDateRangePicker>
     <MudSwitch @bind-Value="_autoClose" Color="Color.Secondary">AutoClose</MudSwitch>

--- a/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerActionButtonsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerActionButtonsExample.razor
@@ -4,9 +4,9 @@
     <MudDateRangePicker @ref="_picker" Label="With action buttons" @bind-DateRange="_dateRange" 
                         AutoClose="@_autoClose" PickerVariant="PickerVariant.Dialog">
         <PickerActions>
-            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-            <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-            <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+            <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+            <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
         </PickerActions>
     </MudDateRangePicker>
     <MudSwitch @bind-Value="_autoClose" Color="Color.Secondary">AutoClose</MudSwitch>

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerActionButtonsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerActionButtonsExample.razor
@@ -1,16 +1,16 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker @ref="_picker" Label="With action buttons" AutoClose="@autoClose">
+<MudTimePicker @ref="_picker" Label="With action buttons" AutoClose="@_autoClose">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudTimePicker>
-<MudSwitch @bind-Value="autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
+<MudSwitch @bind-Value="_autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
 
 @code{
-    MudTimePicker _picker;
-    TimeSpan? time = new TimeSpan(00, 45, 00);
-    private bool autoClose;
+    private MudTimePicker _picker;
+    private readonly TimeSpan? _time = new TimeSpan(00, 45, 00);
+    private bool _autoClose;
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerKeyboardNavigationExample.razor
@@ -1,15 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="time" />
-<MudTimePicker Label="24 hours" @bind-Time="time" />
+<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="_time" />
+<MudTimePicker Label="24 hours" @bind-Time="_time" />
 <MudTimePicker Label="With action buttons">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => context.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => context.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudTimePicker>
 
 @code{
-    TimeSpan? time = new TimeSpan(00, 45, 00);
+    private TimeSpan? _time = new TimeSpan(00, 45, 00);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/SimpleColorPickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/SimpleColorPickerTest.razor
@@ -44,17 +44,16 @@
     {
         await InvokeAsync(() =>
         {
-            _picker.Open();
+            _picker.OpenAsync();
         });
     }
 
     public async Task ClosePicker()
     {
-        await InvokeAsync(() =>
+        await InvokeAsync(async () =>
         {
-            _picker.Close();
+            await _picker.CloseAsync();
         });
     }
-
 }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCloseDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCloseDateRangePickerTest.razor
@@ -3,9 +3,9 @@
 
 <MudDateRangePicker id="picker" @ref="_picker" Label="With action buttons" @bind-DateRange="DateRange" AutoClose=@AutoClose>
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudDateRangePicker>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
@@ -2,9 +2,9 @@
 
 <MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="date">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudDatePicker>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
@@ -2,9 +2,9 @@
 
 <MudDatePicker id="picker" @ref="_picker" Label="With action buttons" PickerVariant="PickerVariant.Static" @bind-Date="date">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudDatePicker>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
@@ -8,9 +8,9 @@
     
     <MudDateRangePicker id="dateRangeLabelTest" @ref="@(_picker)" @bind-DateRange="@(_dateRange)" Label="Select Date Range" Required="true" RequiredError="This field is required!">
         <PickerActions>
-            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
-            <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
-            <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
+            <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+            <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
         </PickerActions>
     </MudDateRangePicker>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -58,6 +58,6 @@ else
     [Parameter] public DateTime? MaxDate { get; set; }
     [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
 
-    public async Task Open() => await InvokeAsync(() => _picker.Open());
-    public async Task Close() => await InvokeAsync(() => _picker.Close());
+    public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
+    public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
@@ -32,7 +32,7 @@ else
     [Parameter] public DateTime? StartMonth { get; set; }
     [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
 
-    public async Task Open() => await InvokeAsync(() => _picker.Open());
-    public async Task Close() => await InvokeAsync(() => _picker.Close());
+    public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
+    public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());
 
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/AutoCompleteTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/AutoCompleteTimePickerTest.razor
@@ -2,9 +2,9 @@
 
 <MudTimePicker Label="With action buttons" @bind-Time="time">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.Clear())">Clear</MudButton>
-        <MudButton OnClick="@(() => context.Close(false))">Cancel</MudButton>
-        <MudButton Id="theCloseButton" Color="Color.Primary" OnClick="@(() => context.Close())">Ok</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => context.ClearAsync())">Clear</MudButton>
+        <MudButton OnClick="@(() => context.CloseAsync(false))">Cancel</MudButton>
+        <MudButton Id="theCloseButton" Color="Color.Primary" OnClick="@(() => context.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudTimePicker>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
@@ -18,6 +18,6 @@
 	[Parameter] public int MinuteSelectionStep { get; set; } = 1;
 
 
-	public async Task Open() => await InvokeAsync(() => _picker.Open());
-	public async Task Close() => await InvokeAsync(() => _picker.Close());
+    public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
+    public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2444,9 +2444,9 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
 
-            await comp.InvokeAsync(() =>
+            await comp.InvokeAsync(async () =>
             {
-                comp.Instance.FilterHiredToggled(true, dataGrid.Instance);
+                await comp.Instance.FilterHiredToggled(true, dataGrid.Instance);
             });
 
             dataGrid.Render();

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -85,8 +85,8 @@ namespace MudBlazor.UnitTests.Components
             var watch = Stopwatch.StartNew();
             for (var i = 0; i < 1000; i++)
             {
-                await comp.InvokeAsync(() => datepicker.Open());
-                await comp.InvokeAsync(() => datepicker.Close());
+                await comp.InvokeAsync(() => datepicker.OpenAsync());
+                await comp.InvokeAsync(() => datepicker.CloseAsync());
             }
             watch.Stop();
             watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
@@ -586,7 +586,7 @@ namespace MudBlazor.UnitTests.Components
             // ---------------------------------------------------------------
             var comp = Context.RenderComponent<PersianDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>();
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
 
             datePicker.Instance.Text.Should().Be("1399/11/26");
         }
@@ -876,7 +876,7 @@ namespace MudBlazor.UnitTests.Components
             var datePicker = comp.FindComponent<MudDatePicker>();
 
             // Open the datepicker
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
 
             // Clicking a day button to select a date
             // It must be a different day than the day of now!
@@ -898,20 +898,20 @@ namespace MudBlazor.UnitTests.Components
 
             // Close the datepicker without submitting the date
             // The date of the datepicker remains equal to now
-            await comp.InvokeAsync(() => datePicker.Instance.Close(false));
+            await comp.InvokeAsync(() => datePicker.Instance.CloseAsync(false));
 
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.Instance.Clear());
+            await comp.InvokeAsync(() => datePicker.Instance.ClearAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
-            await comp.InvokeAsync(() => datePicker.Instance.Close(false));
+            await comp.InvokeAsync(() => datePicker.Instance.CloseAsync(false));
 
             // Change the value of autoclose
             datePicker.Instance.AutoClose = true;
 
             // Open the datepicker
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
 
             // Clicking a day button to select a date
             if (now.Day != 20)
@@ -935,10 +935,10 @@ namespace MudBlazor.UnitTests.Components
                 datePicker.Instance.Date.Should().Be(new DateTime(now.Year, now.Month, 19));
             }
 
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.Instance.Clear());
+            await comp.InvokeAsync(() => datePicker.Instance.ClearAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(0));
         }
 
@@ -1024,7 +1024,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
 
             // Open the datepicker
-            await comp.InvokeAsync(() => datePicker.Instance.Open());
+            await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
 
             // An error should be raised if the datepicker could not be not opened and the days could not generated
             // It means that there would be an exception!
@@ -1075,7 +1075,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => datePicker.Date.Should().Be(new DateTime(2020, 10, 10)));
             comp.WaitForAssertion(() => datePicker.PickerMonth.Should().Be(null));
 
-            await comp.InvokeAsync(() => datePicker.Open());
+            await comp.InvokeAsync(() => datePicker.OpenAsync());
             comp.WaitForAssertion(() => datePicker.PickerMonth.Should().Be(new DateTime(2020, 10, 01)));
         }
 
@@ -1114,13 +1114,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.ToggleOpen());
+            await comp.InvokeAsync(() => datePicker.ToggleOpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.ToggleOpen());
+            await comp.InvokeAsync(() => datePicker.ToggleOpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.ToggleState());
+            await comp.InvokeAsync(() => datePicker.ToggleStateAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             datePicker.Disabled = false;
@@ -1128,7 +1128,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.ToggleState());
+            await comp.InvokeAsync(() => datePicker.ToggleStateAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
         }
 
@@ -1163,7 +1163,7 @@ namespace MudBlazor.UnitTests.Components
 
 
             // Open the datepicker
-            await comp.InvokeAsync(datePicker.Open);
+            await comp.InvokeAsync(datePicker.OpenAsync);
 
             comp.Find("button.mud-button-month").Click();
             comp.WaitForAssertion(() => comp.FindAll("button.mud-picker-month").Any(x => x.IsDisabled()).Should().Be(true));

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -99,8 +99,8 @@ namespace MudBlazor.UnitTests.Components
             var watch = Stopwatch.StartNew();
             for (var i = 0; i < 10000; i++)
             {
-                await comp.InvokeAsync(() => datepicker.Open());
-                await comp.InvokeAsync(() => datepicker.Close());
+                await comp.InvokeAsync(() => datepicker.OpenAsync());
+                await comp.InvokeAsync(() => datepicker.CloseAsync());
             }
             watch.Stop();
             watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
@@ -591,7 +591,7 @@ namespace MudBlazor.UnitTests.Components
             dateRangePickerInstance.ErrorText.Should().BeNullOrWhiteSpace();
 
             // reset value
-            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Clear());
+            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.ClearAsync());
 
             // assert values have benn nulled
             dateRangePickerInstance.Text.Should().BeNullOrEmpty();

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -728,7 +728,7 @@ namespace MudBlazor.UnitTests.Components
             var timePicker = comp.FindComponent<MudTimePicker>();
 
             // Open the timepicker
-            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
             var picker = timePicker.Instance;
 
             // Select 16 hours
@@ -746,17 +746,17 @@ namespace MudBlazor.UnitTests.Components
             // and there are actions which are defined
             picker.Time.Should().Be(new TimeSpan(00, 45, 00));
 
-            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.Instance.Clear());
+            await comp.InvokeAsync(() => timePicker.Instance.ClearAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
-            await comp.InvokeAsync(() => timePicker.Instance.Close(false));
+            await comp.InvokeAsync(() => timePicker.Instance.CloseAsync(false));
             // Change the value of autoclose
             timePicker.Instance.AutoClose = true;
 
             // Open the timepicker
-            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
             picker = timePicker.Instance;
 
             // Select 16 hours
@@ -773,10 +773,10 @@ namespace MudBlazor.UnitTests.Components
             // Check that the time should be equal to the selection this time!
             picker.Time.Should().Be(new TimeSpan(16, 30, 00));
 
-            await comp.InvokeAsync(() => timePicker.Instance.Open());
+            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.Instance.Clear());
+            await comp.InvokeAsync(() => timePicker.Instance.ClearAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
         }
@@ -789,7 +789,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.FindComponent<MudTimePicker>().Instance;
             comp.WaitForAssertion(() => picker.Time.Should().Be(null));
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.Open());
+            await comp.InvokeAsync(() => picker.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 16 hours
@@ -810,7 +810,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => picker.ReadOnly = true);
 
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.Open());
+            await comp.InvokeAsync(() => picker.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 17 hours
@@ -929,7 +929,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => timePicker.TimeFormat = "hhmm");
 
             timePicker.ReadOnly = true;
-            await comp.InvokeAsync(() => timePicker.Submit());
+            await comp.InvokeAsync(() => timePicker.SubmitAsync());
 
         }
 
@@ -941,7 +941,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.FindComponent<MudTimePicker>().Instance;
             comp.WaitForAssertion(() => picker.Time.Should().Be(null));
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.Open());
+            await comp.InvokeAsync(() => picker.OpenAsync());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             var count = 0;

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -29,7 +29,7 @@
                             <div class="mud-picker-color-overlay mud-picker-color-overlay-white">
                                 <div class="mud-picker-color-overlay mud-picker-color-overlay-black">
                                     <div class="mud-picker-color-overlay" id="@_id" @onclick="OnColorOverlayClick">
-                                        <svg class="mud-picker-color-selector" height="26" width="26" style="transform: @GetSelectorLocation()" @onclick="OnSelectorClicked" @onclick:stopPropagation="true">
+                                        <svg class="mud-picker-color-selector" height="26" width="26" style="transform: @GetSelectorLocation()" @onclick="OnSelectorClickedAsync" @onclick:stopPropagation="true">
                                             <defs>
                                                 <filter id="mud-picker-color-selector-shadow" x="-50%" y="-50%" width="200%" height="200%">
                                                     <feGaussianBlur in="SourceAlpha" stdDeviation="1" />

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -33,7 +33,7 @@
                                 @for (int i = GetMinYear(); i <= GetMaxYear(); i++)
                                 {
                                     var year = i;
-                                    <div class="mud-picker-year" id="@(_componentId + year)" @onclick="(() => OnYearClicked(year))" @onclick:stopPropagation="true">
+                                    <div class="mud-picker-year" id="@(_componentId + year)" @onclick="(async () => await OnYearClickedAsync(year))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetYearTypo(year)" Class="@GetYearClasses(year)">@year</MudText>
                                     </div>
                                 }
@@ -65,7 +65,7 @@
                                 @foreach (var month in GetAllMonths())
                                 {
                                     <button type="button" aria-label="@GetMonthName(month)" disabled="@IsMonthDisabled(month)"
-                                    class="mud-picker-month mud-button-root" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
+                                    class="mud-picker-month mud-button-root" @onclick="(async () => await OnMonthSelectedAsync(month))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
                                     </button>
                                 }
@@ -126,7 +126,7 @@
                                                 var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
                                                 <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
                                                         class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
-                                                        @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
+                                                        @onclick="(async () => { var d = selectedDay; await OnDayClickedAsync(d); })"
                                                         @onclick:stopPropagation="true"
                                                         aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
                                                         onmouseover="@(async () => await HandleMouseoverOnPickerCalendarDayButton(!firstMonthFirstYear ? tempId : tempId + 1))"

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -231,9 +231,9 @@ namespace MudBlazor
 
         protected OpenTo CurrentView;
 
-        protected override void OnPickerOpened()
+        protected override async Task OnPickerOpenedAsync()
         {
-            base.OnPickerOpened();
+            await base.OnPickerOpenedAsync();
             if (Editable == true && Text != null)
             {
                 DateTime? a = Converter.Get(Text);
@@ -264,7 +264,7 @@ namespace MudBlazor
         {
             var monthStartDate = _picker_month ?? DateTime.Today.StartOfMonth(Culture);
             // Return the min supported datetime of the calendar when this is year 1 and first month!
-            if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+            if (_picker_month is { Year: 1, Month: 1 })
             {
                 return Culture.Calendar.MinSupportedDateTime;
             }
@@ -334,16 +334,16 @@ namespace MudBlazor
             return nextView;
         }
 
-        protected virtual async void SubmitAndClose()
+        protected virtual async Task SubmitAndCloseAsync()
         {
             if (PickerActions == null)
             {
-                Submit();
+                await SubmitAsync();
 
                 if (PickerVariant != PickerVariant.Static)
                 {
                     await Task.Delay(ClosingDelay);
-                    Close(false);
+                    await CloseAsync(false);
                 }
             }
         }
@@ -353,13 +353,13 @@ namespace MudBlazor
         /// <summary>
         /// User clicked on a day
         /// </summary>
-        protected abstract void OnDayClicked(DateTime dateTime);
+        protected abstract Task OnDayClickedAsync(DateTime dateTime);
 
         /// <summary>
         /// user clicked on a month
         /// </summary>
         /// <param name="month"></param>
-        protected virtual void OnMonthSelected(DateTime month)
+        protected virtual Task OnMonthSelectedAsync(DateTime month)
         {
             PickerMonth = month;
             var nextView = GetNextView();
@@ -367,13 +367,15 @@ namespace MudBlazor
             {
                 CurrentView = (OpenTo)nextView;
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
         /// user clicked on a year
         /// </summary>
         /// <param name="year"></param>
-        protected virtual void OnYearClicked(int year)
+        protected virtual Task OnYearClickedAsync(int year)
         {
             var current = GetMonthStart(0);
             PickerMonth = new DateTime(year, current.Month, 1, Culture.Calendar);
@@ -382,6 +384,8 @@ namespace MudBlazor
             {
                 CurrentView = (OpenTo)nextView;
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using System.Xml;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
@@ -102,17 +101,17 @@ namespace MudBlazor
             return b.Build();
         }
 
-        protected override async void OnDayClicked(DateTime dateTime)
+        protected override async Task OnDayClickedAsync(DateTime dateTime)
         {
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
-                await Task.Run(() => InvokeAsync(Submit));
+                await Task.Run(() => InvokeAsync(SubmitAsync));
 
                 if (PickerVariant != PickerVariant.Static)
                 {
                     await Task.Delay(ClosingDelay);
-                    Close(false);
+                    await CloseAsync(false);
                 }
             }
         }
@@ -121,7 +120,7 @@ namespace MudBlazor
         /// user clicked on a month
         /// </summary>
         /// <param name="month"></param>
-        protected override void OnMonthSelected(DateTime month)
+        protected override async Task OnMonthSelectedAsync(DateTime month)
         {
             PickerMonth = month;
             var nextView = GetNextView();
@@ -132,7 +131,7 @@ namespace MudBlazor
                     new DateTime(month.Year, month.Month, _selectedDate.Value.Day, _selectedDate.Value.Hour, _selectedDate.Value.Minute, _selectedDate.Value.Second, _selectedDate.Value.Millisecond, _selectedDate.Value.Kind)
                     //We can assume day here, as it was not set yet. If a fix value is set, it will be overriden in Submit
                     : new DateTime(month.Year, month.Month, 1);
-                SubmitAndClose();
+                await SubmitAndCloseAsync();
             }
             else
             {
@@ -144,7 +143,7 @@ namespace MudBlazor
         /// user clicked on a year
         /// </summary>
         /// <param name="year"></param>
-        protected override void OnYearClicked(int year)
+        protected override async Task OnYearClickedAsync(int year)
         {
             var current = GetMonthStart(0);
             PickerMonth = new DateTime(year, Culture.Calendar.GetMonth(current), 1, Culture.Calendar);
@@ -156,7 +155,7 @@ namespace MudBlazor
                     new DateTime(_selectedDate.Value.Year, _selectedDate.Value.Month, _selectedDate.Value.Day, _selectedDate.Value.Hour, _selectedDate.Value.Minute, _selectedDate.Value.Second, _selectedDate.Value.Millisecond, _selectedDate.Value.Kind)
                     //We can assume month and day here, as they were not set yet
                     : new DateTime(year, 1, 1, Culture.Calendar);
-                SubmitAndClose();
+                await SubmitAndCloseAsync();
             }
             else
             {
@@ -164,14 +163,14 @@ namespace MudBlazor
             }
         }
 
-        protected override void OnOpened()
+        protected override Task OnOpenedAsync()
         {
             _selectedDate = null;
 
-            base.OnOpened();
+            return base.OnOpenedAsync();
         }
 
-        protected internal override async void Submit()
+        protected internal override async Task SubmitAsync()
         {
             if (GetReadOnlyState())
                 return;
@@ -191,14 +190,14 @@ namespace MudBlazor
             _selectedDate = null;
         }
 
-        public override async void Clear(bool close = true)
+        public override async Task ClearAsync(bool close = true)
         {
             _selectedDate = null;
             await SetDateAsync(null, true);
 
             if (AutoClose == true)
             {
-                Close(false);
+                await CloseAsync(false);
             }
         }
 
@@ -223,7 +222,7 @@ namespace MudBlazor
         }
 
         //To be completed on next PR
-        protected internal override void HandleKeyDown(KeyboardEventArgs obj)
+        protected internal override async void HandleKeyDown(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
@@ -275,18 +274,18 @@ namespace MudBlazor
                     }
                     break;
                 case "Escape":
-                    ReturnDateBackUp();
+                    await ReturnDateBackUpAsync();
                     break;
                 case "Enter":
                 case "NumpadEnter":
                     if (!IsOpen)
                     {
-                        Open();
+                        await OpenAsync();
                     }
                     else
                     {
-                        Submit();
-                        Close();
+                        await SubmitAsync();
+                        await CloseAsync();
                         _inputReference?.SetText(Text);
                     }
                     break;
@@ -295,12 +294,12 @@ namespace MudBlazor
                     {
                         if (!IsOpen)
                         {
-                            Open();
+                            await OpenAsync();
                         }
                         else
                         {
-                            Submit();
-                            Close();
+                            await SubmitAsync();
+                            await CloseAsync();
                             _inputReference?.SetText(Text);
                         }
                     }
@@ -310,10 +309,7 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        private void ReturnDateBackUp()
-        {
-            Close();
-        }
+        private Task ReturnDateBackUpAsync() => CloseAsync();
 
         /// <summary>
         /// Scrolls to the date.

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -8,10 +8,10 @@
     protected override RenderFragment InputContent=> 
         @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@Error" 
                           ErrorText="@ErrorText" Disabled="@GetDisabledState()" Margin="@Margin" Required="@Required"
-                          @onclick="() => { if (!Editable) ToggleState(); }" ForId="@FieldId">
+                          @onclick="async () => { if (!Editable) await ToggleStateAsync(); }" ForId="@FieldId">
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
-                                   @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
+                                   @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleStateAsync"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"
                                    Clearable="Clearable"/>
                </InputContent>

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -151,10 +151,7 @@ namespace MudBlazor
             return SetDateRangeAsync(ParseDateRangeValue(value), false);
         }
 
-        protected override bool HasValue(DateTime? value)
-        {
-            return null != value && value.HasValue;
-        }
+        protected override bool HasValue(DateTime? value) => value is not null;
 
         private DateRange ParseDateRangeValue(string value)
         {
@@ -166,10 +163,11 @@ namespace MudBlazor
             return DateRange.TryParse(start, end, Converter, out var dateRange) ? dateRange : null;
         }
 
-        protected override void OnPickerClosed()
+        protected override Task OnPickerClosedAsync()
         {
             _firstDate = null;
-            base.OnPickerClosed();
+
+            return base.OnPickerClosedAsync();
         }
 
         private bool CheckDateRange(DateTime day, Func<DateTime, DateTime, bool> compareStart, Func<DateTime, DateTime, bool> compareEnd)
@@ -247,7 +245,7 @@ namespace MudBlazor
             return b.Build();
         }
 
-        protected override async void OnDayClicked(DateTime dateTime)
+        protected override async Task OnDayClickedAsync(DateTime dateTime)
         {
             if (_firstDate == null || _firstDate > dateTime || _secondDate != null)
             {
@@ -259,23 +257,23 @@ namespace MudBlazor
             _secondDate = dateTime;
             if (PickerActions == null || AutoClose)
             {
-                Submit();
+                await SubmitAsync();
 
                 if (PickerVariant != PickerVariant.Static)
                 {
                     await Task.Delay(ClosingDelay);
-                    Close(false);
+                    await CloseAsync(false);
                 }
             }
         }
 
-        protected override void OnOpened()
+        protected override Task OnOpenedAsync()
         {
             _secondDate = null;
-            base.OnOpened();
+            return base.OnOpenedAsync();
         }
 
-        protected internal override async void Submit()
+        protected internal override async Task SubmitAsync()
         {
             if (GetReadOnlyState())
                 return;
@@ -288,11 +286,11 @@ namespace MudBlazor
             _secondDate = null;
         }
 
-        public override void Clear(bool close = true)
+        public override Task ClearAsync(bool close = true)
         {
             DateRange = null;
             _firstDate = _secondDate = null;
-            base.Clear();
+            return base.ClearAsync(close);
         }
 
         protected override string GetTitleDateString()
@@ -317,8 +315,6 @@ namespace MudBlazor
             var diff = Culture.Calendar.GetYear(date) - Culture.Calendar.GetYear(yearDate);
             var calenderYear = Culture.Calendar.GetYear(date);
             return calenderYear - diff;
-
         }
-
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -25,7 +25,7 @@
              ReadOnly="@(!Editable || GetReadOnlyState())" 
              Disabled="@GetDisabledState()"
              DisableUnderLine="@DisableUnderLine"
-             OnAdornmentClick="ToggleState" 
+             OnAdornmentClick="ToggleStateAsync" 
              Adornment="@Adornment"
              AdornmentIcon="@AdornmentIcon" 
              AdornmentColor="@AdornmentColor" 
@@ -37,7 +37,7 @@
              Error="@Error" 
              ErrorText="@ErrorText"
              Clearable="@(GetReadOnlyState() ? false : Clearable)"
-             OnClearButtonClick="@(() => Clear())"
+             OnClearButtonClick="@(async () => await ClearAsync())"
              @onclick="OnClickAsync" />;
 
     protected virtual RenderFragment PickerContent => null;
@@ -91,7 +91,7 @@
             }
             else if(IsOpen && PickerVariant == PickerVariant.Dialog)
             {
-               <MudOverlay Visible="IsOpen" OnClick="CloseOverlay" DarkBackground="true" Class="mud-overlay-dialog">
+               <MudOverlay Visible="IsOpen" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
                    <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
                        <div class="@PickerContainerClass">
 							@if(PickerContent != null){
@@ -110,7 +110,7 @@
         </div>
         @if (PickerVariant == PickerVariant.Inline)
         {
-            <MudOverlay Visible="IsOpen" OnClick="CloseOverlay" LockScroll="false" />
+            <MudOverlay Visible="IsOpen" OnClick="CloseOverlayAsync" LockScroll="false" />
         }
     </CascadingValue>;
 }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -12,7 +12,7 @@
             <div class="mud-timepicker-hourminute mud-ltr">
                 @if (TimeEditMode == TimeEditMode.Normal)
                 {
-                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@HoursButtonClass" OnClick="OnHourClick">@GetHourString()</MudButton>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@HoursButtonClass" OnClick="OnHourClickAsync">@GetHourString()</MudButton>
                     <MudText Typo="Typo.h2" Class="mud-timepicker-separator">:</MudText>
                     <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@MinuteButtonClass" OnClick="OnMinutesClick">@GetMinuteString()</MudButton>
                 }
@@ -24,15 +24,15 @@
             @if (AmPm)
             {
                 <div class="mud-timepicker-ampm">
-                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@AmButtonClass" OnClick="OnAmClicked">AM</MudButton>
-                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@PmButtonClass" OnClick="OnPmClicked">PM</MudButton>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@AmButtonClass" OnClick="OnAmClickedAsync">AM</MudButton>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@PmButtonClass" OnClick="OnPmClickedAsync">PM</MudButton>
                 </div>
             }
         </MudPickerToolbar>
         <MudPickerContent>
             <div class="mud-picker-time-container">
                 <div class="mud-picker-time-clock">
-                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onmousedown="OnMouseDown" @onmouseup="OnMouseUp">
+                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onmousedown="OnMouseDown" @onmouseup="OnMouseUpAsync">
                         <div class="@GetClockPinColor()"></div>
                         <div class="@GetClockPointerColor()" style="height: @GetPointerHeight(); transform: @GetPointerRotation()">
                             <div class="@GetClockPointerThumbColor()"></div>
@@ -50,7 +50,7 @@
                                 for(int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(() => OnMouseClickHour(_i))" @onmouseover="(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
+                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(async () => await OnMouseClickHourAsync(_i))" @onmouseover="(async () => await OnMouseOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
                                 }
                             }
                             else
@@ -73,8 +73,8 @@
                                 {
                                     var _i = i;
                                     <div class="mud-picker-stick" style="@($"transform: rotateZ({_i * 30}deg);")">
-                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(() => OnMouseClickHour(_i))" @onmouseover="(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
-                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(() => OnMouseClickHour((_i + 12) % 24))" @onmouseover="(() => OnMouseOverHour((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(async () => await OnMouseClickHourAsync(_i))" @onmouseover="(async () => await OnMouseOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(async () => await OnMouseClickHourAsync((_i + 12) % 24))" @onmouseover="(async () => await OnMouseOverHourAsync((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
                                     </div>
                                 }
                             }
@@ -90,7 +90,7 @@
                             @for (int i = 0; i < 60; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(() => OnMouseClickMinute(_i))" @onmouseover="(() => OnMouseOverMinute(_i))" @onclick:stopPropagation="true"></div>
+                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(async () => await OnMouseClickMinuteAsync(_i))" @onmouseover="(async () => await OnMouseOverMinuteAsync(_i))" @onclick:stopPropagation="true"></div>
                             }
                         </div>
                     </div>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -202,9 +202,9 @@ namespace MudBlazor
 
         //The last line cannot be tested
         [ExcludeFromCodeCoverage]
-        protected override void OnPickerOpened()
+        protected override async Task OnPickerOpenedAsync()
         {
-            base.OnPickerOpened();
+            await base.OnPickerOpenedAsync();
             _currentView = TimeEditMode switch
             {
                 TimeEditMode.Normal => OpenTo,
@@ -214,21 +214,26 @@ namespace MudBlazor
             };
         }
 
-        protected internal override void Submit()
+        protected internal override Task SubmitAsync()
         {
             if (GetReadOnlyState())
-                return;
+            {
+                return Task.CompletedTask;
+            }
+
             Time = TimeIntermediate;
+
+            return Task.CompletedTask;
         }
 
-        public override async void Clear(bool close = true)
+        public override async Task ClearAsync(bool close = true)
         {
             TimeIntermediate = null;
             await SetTimeAsync(null, true);
 
-            if (AutoClose == true)
+            if (AutoClose)
             {
-                Close(false);
+                await CloseAsync(false);
             }
         }
 
@@ -247,86 +252,86 @@ namespace MudBlazor
             return $"{Math.Min(59, Math.Max(0, TimeIntermediate.Value.Minutes)):D2}";
         }
 
-        private void UpdateTime()
+        private async Task UpdateTimeAsync()
         {
             _lastSelectedHour = _timeSet.Hour;
             TimeIntermediate = new TimeSpan(_timeSet.Hour, _timeSet.Minute, 0);
             if ((PickerVariant == PickerVariant.Static && PickerActions == null) || (PickerActions != null && AutoClose))
             {
-                Submit();
+               await SubmitAsync();
             }
         }
 
-        private void OnHourClick()
+        private async Task OnHourClickAsync()
         {
             _currentView = OpenTo.Hours;
-            FocusAsync().AndForget();
+            await FocusAsync();
         }
 
-        private void OnMinutesClick()
+        private async Task OnMinutesClick()
         {
             _currentView = OpenTo.Minutes;
-            FocusAsync().AndForget();
+            await FocusAsync();
         }
 
-        private void OnAmClicked()
+        private async Task OnAmClickedAsync()
         {
             _timeSet.Hour %= 12;  // "12:-- am" is "00:--" in 24h
-            UpdateTime();
-            FocusAsync().AndForget();
+            await UpdateTimeAsync();
+            await FocusAsync();
         }
 
-        private void OnPmClicked()
+        private async Task OnPmClickedAsync()
         {
             if (_timeSet.Hour <= 12) // "12:-- pm" is "12:--" in 24h
                 _timeSet.Hour += 12;
             _timeSet.Hour %= 24;
-            UpdateTime();
-            FocusAsync().AndForget();
+            await UpdateTimeAsync();
+            await FocusAsync();
         }
 
         protected string ToolbarClass =>
-        new CssBuilder("mud-picker-timepicker-toolbar")
-          .AddClass($"mud-picker-timepicker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
-          .AddClass(Class)
-        .Build();
+            new CssBuilder("mud-picker-timepicker-toolbar")
+                .AddClass($"mud-picker-timepicker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
+                .AddClass(Class)
+                .Build();
 
         protected string HoursButtonClass =>
-        new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Minutes)
-        .Build();
+            new CssBuilder("mud-timepicker-button")
+                .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Minutes)
+                .Build();
 
         protected string MinuteButtonClass =>
-        new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Hours)
-        .Build();
+            new CssBuilder("mud-timepicker-button")
+                .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Hours)
+                .Build();
 
         protected string AmButtonClass =>
-        new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", !IsAm) // gray it out
-        .Build();
+            new CssBuilder("mud-timepicker-button")
+                .AddClass($"mud-timepicker-toolbar-text", !IsAm) // gray it out
+                .Build();
 
         protected string PmButtonClass =>
-        new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", !IsPm) // gray it out
-        .Build();
+            new CssBuilder("mud-timepicker-button")
+                .AddClass($"mud-timepicker-toolbar-text", !IsPm) // gray it out
+                .Build();
 
         private string HourDialClass =>
-        new CssBuilder("mud-time-picker-hour")
-          .AddClass($"mud-time-picker-dial")
-          .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Hours)
-          .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Hours)
-        .Build();
+            new CssBuilder("mud-time-picker-hour")
+                .AddClass($"mud-time-picker-dial")
+                .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Hours)
+                .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Hours)
+                .Build();
 
         private string MinuteDialClass =>
-        new CssBuilder("mud-time-picker-minute")
-          .AddClass($"mud-time-picker-dial")
-          .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Minutes)
-          .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
-        .Build();
+            new CssBuilder("mud-time-picker-minute")
+                .AddClass($"mud-time-picker-dial")
+                .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Minutes)
+                .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
+                .Build();
 
-        private bool IsAm => _timeSet.Hour >= 00 && _timeSet.Hour < 12; // am is 00:00 to 11:59
-        private bool IsPm => _timeSet.Hour >= 12 && _timeSet.Hour < 24; // pm is 12:00 to 23:59
+        private bool IsAm => _timeSet.Hour is >= 00 and < 12; // am is 00:00 to 11:59
+        private bool IsPm => _timeSet.Hour is >= 12 and < 24; // pm is 12:00 to 23:59
 
         private string GetClockPinColor()
         {
@@ -455,12 +460,12 @@ namespace MudBlazor
         /// <summary>
         /// Sets Mouse Down bool to false if mouse is inside the clock mask.
         /// </summary>
-        private void OnMouseUp(MouseEventArgs e)
+        private async Task OnMouseUpAsync(MouseEventArgs e)
         {
             if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
             {
                 MouseDown = false;
-                SubmitAndClose();
+                await SubmitAndCloseAsync();
             }
 
             MouseDown = false;
@@ -486,26 +491,26 @@ namespace MudBlazor
         /// <summary>
         /// If MouseDown is true enables "dragging" effect on the clock pin/stick.
         /// </summary>
-        private void OnMouseOverHour(int value)
+        private async Task OnMouseOverHourAsync(int value)
         {
             if (MouseDown)
             {
                 _timeSet.Hour = HourAmPm(value);
-                UpdateTime();
+                await UpdateTimeAsync();
             }
         }
 
         /// <summary>
         /// On click for the hour "sticks", sets the hour.
         /// </summary>
-        private void OnMouseClickHour(int value)
+        private async Task OnMouseClickHourAsync(int value)
         {
             _timeSet.Hour = HourAmPm(value);
 
             if (_currentView == OpenTo.Hours
                 || _timeSet.Hour != _lastSelectedHour)
             {
-                UpdateTime();
+                await UpdateTimeAsync();
             }
 
             if (TimeEditMode == TimeEditMode.Normal)
@@ -514,32 +519,32 @@ namespace MudBlazor
             }
             else if (TimeEditMode == TimeEditMode.OnlyHours)
             {
-                SubmitAndClose();
+               await SubmitAndCloseAsync();
             }
         }
 
         /// <summary>
         /// On mouse over for the minutes "sticks", sets the minute.
         /// </summary>
-        private void OnMouseOverMinute(int value)
+        private async Task OnMouseOverMinuteAsync(int value)
         {
             if (MouseDown)
             {
                 value = RoundToStepInterval(value);
                 _timeSet.Minute = value;
-                UpdateTime();
+                await UpdateTimeAsync();
             }
         }
 
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private void OnMouseClickMinute(int value)
+        private async Task OnMouseClickMinuteAsync(int value)
         {
             value = RoundToStepInterval(value);
             _timeSet.Minute = value;
-            UpdateTime();
-            SubmitAndClose();
+            await UpdateTimeAsync();
+            await SubmitAndCloseAsync();
         }
 
         private int RoundToStepInterval(int value)
@@ -556,21 +561,21 @@ namespace MudBlazor
             return value;
         }
 
-        protected async void SubmitAndClose()
+        protected async Task SubmitAndCloseAsync()
         {
             if (PickerActions == null || AutoClose)
             {
-                Submit();
+                await SubmitAsync();
 
                 if (PickerVariant != PickerVariant.Static)
                 {
                     await Task.Delay(ClosingDelay);
-                    Close(false);
+                    await CloseAsync(false);
                 }
             }
         }
 
-        protected internal override void HandleKeyDown(KeyboardEventArgs obj)
+        protected internal override async void HandleKeyDown(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
@@ -582,23 +587,23 @@ namespace MudBlazor
                     {
                         if (obj.CtrlKey == true)
                         {
-                            ChangeHour(1);
+                            await ChangeHourAsync(1);
                         }
                         else if (obj.ShiftKey == true)
                         {
                             if (_timeSet.Minute > 55)
                             {
-                                ChangeHour(1);
+                                await ChangeHourAsync(1);
                             }
-                            ChangeMinute(5);
+                            await ChangeMinuteAsync(5);
                         }
                         else
                         {
                             if (_timeSet.Minute == 59)
                             {
-                                ChangeHour(1);
+                               await ChangeHourAsync(1);
                             }
-                            ChangeMinute(1);
+                            await ChangeMinuteAsync(1);
                         }
                     }
                     break;
@@ -607,23 +612,23 @@ namespace MudBlazor
                     {
                         if (obj.CtrlKey == true)
                         {
-                            ChangeHour(-1);
+                            await ChangeHourAsync(-1);
                         }
                         else if (obj.ShiftKey == true)
                         {
                             if (_timeSet.Minute < 5)
                             {
-                                ChangeHour(-1);
+                                await ChangeHourAsync(-1);
                             }
-                            ChangeMinute(-5);
+                            await ChangeMinuteAsync(-5);
                         }
                         else
                         {
                             if (_timeSet.Minute == 0)
                             {
-                                ChangeHour(-1);
+                                await ChangeHourAsync(-1);
                             }
-                            ChangeMinute(-1);
+                            await ChangeMinuteAsync(-1);
                         }
                     }
                     break;
@@ -638,11 +643,11 @@ namespace MudBlazor
                     }
                     else if (obj.ShiftKey == true)
                     {
-                        ChangeHour(5);
+                        await ChangeHourAsync(5);
                     }
                     else
                     {
-                        ChangeHour(1);
+                       await ChangeHourAsync(1);
                     }
                     break;
                 case "ArrowDown":
@@ -652,26 +657,26 @@ namespace MudBlazor
                     }
                     else if (obj.ShiftKey == true)
                     {
-                        ChangeHour(-5);
+                       await ChangeHourAsync(-5);
                     }
                     else
                     {
-                        ChangeHour(-1);
+                       await ChangeHourAsync(-1);
                     }
                     break;
                 case "Escape":
-                    ReturnTimeBackUp();
+                    await ReturnTimeBackUpAsync();
                     break;
                 case "Enter":
                 case "NumpadEnter":
                     if (!IsOpen)
                     {
-                        Open();
+                        await OpenAsync();
                     }
                     else
                     {
-                        Submit();
-                        Close();
+                        await SubmitAsync();
+                        await CloseAsync();
                         _inputReference?.SetText(Text);
                     }
                     break;
@@ -680,12 +685,12 @@ namespace MudBlazor
                     {
                         if (!IsOpen)
                         {
-                            Open();
+                            await OpenAsync();
                         }
                         else
                         {
-                            Submit();
-                            Close();
+                            await SubmitAsync();
+                            await CloseAsync();
                             _inputReference?.SetText(Text);
                         }
                     }
@@ -695,21 +700,23 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        protected void ChangeMinute(int val)
+        protected Task ChangeMinuteAsync(int val)
         {
             _currentView = OpenTo.Minutes;
             _timeSet.Minute = (_timeSet.Minute + val + 60) % 60;
-            UpdateTime();
+
+            return UpdateTimeAsync();
         }
 
-        protected void ChangeHour(int val)
+        protected Task ChangeHourAsync(int val)
         {
             _currentView = OpenTo.Hours;
             _timeSet.Hour = (_timeSet.Hour + val + 24) % 24;
-            UpdateTime();
+
+            return UpdateTimeAsync();
         }
 
-        protected void ReturnTimeBackUp()
+        protected async Task ReturnTimeBackUpAsync()
         {
             if (Time == null)
             {
@@ -719,7 +726,8 @@ namespace MudBlazor
             {
                 _timeSet.Hour = Time.Value.Hours;
                 _timeSet.Minute = Time.Value.Minutes;
-                UpdateTime();
+
+                await UpdateTimeAsync();
             }
         }
 


### PR DESCRIPTION
## Description
The public API that changed, private api is not included in the list

#### MudColorPicker:

- OnPickerClosed -> OnPickerClosedAsync

####  MudBaseDatePicker:

- OnPickerOpened -> OnPickerOpenedAsync
- OnDayClicked -> OnDayClickedAsync
- OnMonthSelected -> OnMonthSelectedAsync
- OnYearClicked -> OnYearClickedAsync

#### MudDatePicker:

- OnDayClicked -> OnDayClickedAsync
- OnMonthSelected -> OnMonthSelectedAsync
- OnYearClicked -> OnYearClickedAsync
- OnOpened -> OnOpenedAsync
- Submit -> SubmitAsync
- Clear -> ClearAsync

#### MudDateRangePicker:

- OnDayClicked -> OnDayClickedAsync
- OnOpened -> OnOpenedAsync
- Submit -> SubmitAsync
- Clear -> ClearAsync

#### MudPicker:

- ToggleOpen -> ToggleOpenAsync
- Close -> CloseAsync
- Open -> OpenAsync
- Submit -> SubmitAsync
- Clear -> ClearAsync
- ToggleState -> ToggleStateAsync
- OnOpened -> OnOpenedAsync
- OnClosed -> OnClosedAsync
- OnPickerOpened -> OnPickerOpenedAsync
- OnPickerClosed -> OnPickerClosedAsync
- ResetValue -> ResetValueAsync

#### MudTimePicker:

- OnPickerOpened -> OnPickerOpenedAsync
- Submit -> SubmitAsync
- Clear -> ClearAsync
- SubmitAndClose -> SubmitAndCloseAsync
- ChangeMinute -> ChangeMinuteAsync
- ChangeHour -> ChangeHourAsync
- ReturnTimeBackUp -> ReturnTimeBackUpAsync

## How Has This Been Tested?
Brief visual testing via doc.
I think existing current text should cover most of the things.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
