### PR TITLE
MudPicker: Fix code style and naming issues

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerBasicExample.razor
@@ -1,7 +1,8 @@
-﻿@namespace MudBlazor.Docs.Examples
+﻿@using MudBlazor.Utilities
+@namespace MudBlazor.Docs.Examples
 
 <MudColorPicker Label="Basic Color Picker" @bind-Text="_colorValue" Style="@($"color: {_colorValue};")" Placeholder="Select Color" />
 
 @code {
-    private string _colorValue;
+    private string _colorValue = "#000000";
 }

--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerExampleUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerExampleUsageExample.razor
@@ -2,7 +2,7 @@
 @using MudBlazor.Utilities
 
 
-<MudPaper Elevation="0" Class="mud-width-full mud-height-full d-flex justify-center align-end pb-8" MinHeight="600px" Style="@($"background-image:linear-gradient({degrees}deg, {_gradientPrimary.ToString(MudColorOutputFormats.RGBA)} 0%, {_gradientSecondary.ToString(MudColorOutputFormats.RGBA)} 100%);")">
+<MudPaper Elevation="0" Class="mud-width-full mud-height-full d-flex justify-center align-end pb-8" MinHeight="600px" Style="@($"background-image:linear-gradient({_degrees}deg, {_gradientPrimary.ToString(MudColorOutputFormats.RGBA)} 0%, {_gradientSecondary.ToString(MudColorOutputFormats.RGBA)} 100%);")">
     <MudPaper Class="d-flex">
         <MudColorPicker Rounded="true" Class="rounded-tr-0" PickerVariant="PickerVariant.Static" DisableModeSwitch="true" Value="_pickerColor" ValueChanged="UpdateSelectedColor" />
         <div class="pa-2">
@@ -16,18 +16,18 @@
                     <div class="mud-width-full rounded py-4" style="@($"background-color:{_gradientSecondary};")"></div>
                 </MudListItem>
             </MudList>
-            <MudSlider Min="0" Max="360" Step="1" @bind-Value="degrees" Class="px-2">Degrees</MudSlider>
+            <MudSlider Min="0" Max="360" Step="1" @bind-Value="_degrees" Class="px-2">Degrees</MudSlider>
         </div>
     </MudPaper>
 </MudPaper>
 
 
 @code {
-    public MudColor _gradientPrimary = "#594AE2";
-    public MudColor _gradientSecondary = "#FF4081";
-    public MudColor _pickerColor = "#594AE2";
+    private MudColor _gradientPrimary = "#594AE2";
+    private MudColor _gradientSecondary = "#FF4081";
+    private MudColor _pickerColor = "#594AE2";
 
-    int degrees = 90;
+    private int _degrees = 90;
 
     bool _isFirstColor = true;
 

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerActionButtonsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerActionButtonsExample.razor
@@ -1,16 +1,16 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date" AutoClose="@autoClose">
+<MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="_date" AutoClose="@_autoClose">
     <PickerActions>
         <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
         <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
         <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">Ok</MudButton>
     </PickerActions>
 </MudDatePicker>
-<MudSwitch @bind-Value="autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
+<MudSwitch @bind-Value="_autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
 
 @code {
-    MudDatePicker _picker;
-    DateTime? date = DateTime.Today;
-    private bool autoClose;
+    private MudDatePicker _picker;
+    private DateTime? _date = DateTime.Today;
+    private bool _autoClose;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="Basic example" @bind-Date="date"/>
-<MudDatePicker Label="Editable with Placeholder" Editable="true" @bind-Date="date" Placeholder="Select Date" />
-<MudDatePicker Label="Only Calendar" @bind-Date="date" DisableToolbar="true" />
-<MudDatePicker Label="Date Format" @bind-Date="date" DateFormat="dd.MM.yyyy" />
-<MudDatePicker Label="Show week number" ShowWeekNumbers="true" @bind-Date="date" />
-<MudDatePicker Label="Display two months" DisplayMonths="2" TitleDateFormat="dddd, dd MMMM" @bind-Date="date" />
+<MudDatePicker Label="Basic example" @bind-Date="_date"/>
+<MudDatePicker Label="Editable with Placeholder" Editable="true" @bind-Date="_date" Placeholder="Select Date" />
+<MudDatePicker Label="Only Calendar" @bind-Date="_date" DisableToolbar="true" />
+<MudDatePicker Label="Date Format" @bind-Date="_date" DateFormat="dd.MM.yyyy" />
+<MudDatePicker Label="Show week number" ShowWeekNumbers="true" @bind-Date="_date" />
+<MudDatePicker Label="Display two months" DisplayMonths="2" TitleDateFormat="dddd, dd MMMM" @bind-Date="_date" />
 
 @code {
-    DateTime? date = DateTime.Today;
+    private DateTime? _date = DateTime.Today;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerColorExample.razor
@@ -2,6 +2,3 @@
 
 <MudDatePicker PickerVariant="PickerVariant.Static" Color="Color.Success" Rounded="true" Date="@(DateTime.Today.AddDays(1))" />
 <MudDatePicker PickerVariant="PickerVariant.Static" Color="Color.Secondary" Rounded="true" Date="@(DateTime.Today.AddDays(1))" />
-
-
-

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerDisableCustomizeDaysExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerDisableCustomizeDaysExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudDatePicker 
-  Label="Not working days, Sunday in red"   
-  IsDateDisabledFunc="@((DateTime dt)=>((int)dt.DayOfWeek > 0 && (int)dt.DayOfWeek < 6))"
-  AdditionalDateClassesFunc="@((DateTime dt)=>((int)dt.DayOfWeek == 0 ? "red-text text-accent-4" : ""))"/>
+    Label="Not working days, Sunday in red"   
+    IsDateDisabledFunc="@((DateTime dt)=>((int)dt.DayOfWeek > 0 && (int)dt.DayOfWeek < 6))"
+    AdditionalDateClassesFunc="@((DateTime dt)=>((int)dt.DayOfWeek == 0 ? "red-text text-accent-4" : ""))"/>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerElevationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerElevationExample.razor
@@ -2,5 +2,3 @@
 
 <MudDatePicker PickerVariant="PickerVariant.Static" Rounded="true" Elevation="1" Date="@(DateTime.Today.AddDays(1))" />
 <MudDatePicker PickerVariant="PickerVariant.Static" Rounded="true" Elevation="12" Date="@(DateTime.Today.AddDays(1))" />
-
-

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerFixedValuesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerFixedValuesExample.razor
@@ -8,10 +8,10 @@
 <MudDatePicker Label="Day Picker (Fixed Year and Month)" HelperText="@_day?.ToShortDateString()" @bind-Date="_day" FixYear="@DateTime.Today.Year" FixMonth="@DateTime.Today.Month" DateFormat="dd" />
 
 @code { 
-    DateTime? _yearMonth;
-    DateTime? _monthDay;
-    DateTime? _yearDay;
-    DateTime? _year;
-    DateTime? _month;
-    DateTime? _day;
+    private DateTime? _yearMonth;
+    private DateTime? _monthDay;
+    private DateTime? _yearDay;
+    private DateTime? _year;
+    private DateTime? _month;
+    private DateTime? _day;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerGoToDateExample.razor
@@ -1,21 +1,21 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker @ref="_picker" @bind-Date="date" PickerVariant="PickerVariant.Static" MaxDate="maxDate">
+<MudDatePicker @ref="_picker" @bind-Date="_date" PickerVariant="PickerVariant.Static" MaxDate="_maxDate">
     <PickerActions>
-        <MudButton Class="mr-auto align-self-start" OnClick="Today">Today</MudButton>
+        <MudButton Class="mr-auto align-self-start" OnClick="TodayAsync">Today</MudButton>
     </PickerActions>
 </MudDatePicker>
 
 <div class="d-flex flex-column gap-4">
     <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CurrentDate">Move To Current Date</MudButton>
-    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="MudRelease">When First Mud Released?</MudButton>
-    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="GoMaxDateWithoutSubmit">Go To Max Date Without Submit</MudButton>
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="MudReleaseAsync">When First Mud Released?</MudButton>
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="GoMaxDateWithoutSubmitAsync">Go To Max Date Without Submit</MudButton>
 </div>
 
 @code {
-    MudDatePicker _picker;
-    DateTime? date = DateTime.Today.AddDays(210);
-    DateTime? maxDate = new DateTime(2050, 12, 31);
+    private MudDatePicker _picker;
+    private DateTime? _date = DateTime.Today.AddDays(210);
+    private DateTime _maxDate = new DateTime(2050, 12, 31);
 
     protected override void OnAfterRender(bool firstRender)
     {
@@ -25,9 +25,9 @@
         }
     }
 
-    private async Task Today()
+    private Task TodayAsync()
     {
-        await _picker.GoToDate(DateTime.Today);
+        return _picker.GoToDate(DateTime.Today);
     }
 
     private void CurrentDate()
@@ -35,13 +35,13 @@
         _picker.GoToDate();
     }
 
-    private async Task MudRelease()
+    private Task MudReleaseAsync()
     {
-        await _picker.GoToDate(new DateTime(2020, 10, 18));
+        return _picker.GoToDate(new DateTime(2020, 10, 18));
     }
 
-    private async Task GoMaxDateWithoutSubmit()
+    private Task GoMaxDateWithoutSubmitAsync()
     {
-        await _picker.GoToDate(maxDate.Value, false);
+        return _picker.GoToDate(_maxDate, false);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerInternationalizationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerInternationalizationExample.razor
@@ -2,12 +2,12 @@
 @using System.Reflection
 @namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="Current UI Culture" @bind-Date="date" />
-<MudDatePicker Label="Persian" @bind-Date="date" Culture="@GetPersianCulture()" UseShortNames="false" TitleDateFormat="dddd, dd MMMM"/>
-<MudDatePicker Label="Chinese" @bind-Date="date" Culture="@CultureInfo.GetCultureInfo("zh-Hans")" TitleDateFormat="dddd, dd MMMM"/>
+<MudDatePicker Label="Current UI Culture" @bind-Date="_date" />
+<MudDatePicker Label="Persian" @bind-Date="_date" Culture="@GetPersianCulture()" UseShortNames="false" TitleDateFormat="dddd, dd MMMM"/>
+<MudDatePicker Label="Chinese" @bind-Date="_date" Culture="@CultureInfo.GetCultureInfo("zh-Hans")" TitleDateFormat="dddd, dd MMMM"/>
 
 @code {
-    DateTime? date = new DateTime(2021, 02, 14); // 1399-11-26 in Persian calendar
+    private DateTime? _date = new DateTime(2021, 02, 14); // 1399-11-26 in Persian calendar
 
     public CultureInfo GetPersianCulture()
     {
@@ -29,7 +29,7 @@
         formatInfo.ShortDatePattern = "yyyy/MM/dd";
         formatInfo.LongDatePattern = "dddd, dd MMMM,yyyy";
         formatInfo.FirstDayOfWeek = DayOfWeek.Saturday;
-        System.Globalization.Calendar cal = new PersianCalendar();
+        Calendar cal = new PersianCalendar();
         FieldInfo fieldInfo = culture.GetType().GetField("calendar", BindingFlags.NonPublic | BindingFlags.Instance);
         if (fieldInfo != null)
             fieldInfo.SetValue(culture, cal);

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMaskExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMaskExample.razor
@@ -1,11 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="dd.MM.yyyy" Editable="true" @bind-Date="date1" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" />
-<MudDatePicker Label="MM/dd/yyyy" Editable="true" @bind-Date="date2" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" />
-<MudDatePicker Label="yyyy-MM-dd" Editable="true" @bind-Date="date3" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" />
+<MudDatePicker Label="dd.MM.yyyy" Editable="true" @bind-Date="_date1" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" />
+<MudDatePicker Label="MM/dd/yyyy" Editable="true" @bind-Date="_date2" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" />
+<MudDatePicker Label="yyyy-MM-dd" Editable="true" @bind-Date="_date3" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" />
 
 @code {
-    DateTime? date1 = null;
-    DateTime? date2 = DateTime.Today;
-    DateTime? date3 = null;
+    private DateTime? _date1 = null;
+    private DateTime? _date2 = DateTime.Today;
+    private DateTime? _date3 = null;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerReadOnlyExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="Read only" @bind-Date="date" ReadOnly="true"/>
+<MudDatePicker Label="Read only" @bind-Date="_date" ReadOnly="true"/>
 
 @code {
-    DateTime? date = DateTime.Today;
+    private DateTime? _date = DateTime.Today;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerTextParseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerTextParseExample.razor
@@ -1,39 +1,39 @@
 ﻿@using System.Globalization
 @namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="Flexible Date" Editable="true" Date="date" ImmediateText="true" Placeholder="day.month.year" DateFormat="@dateFormat" TextChanged="DatePickerTextChanged" HelperText="@bound" Clearable="true" />
+<MudDatePicker Label="Flexible Date" Editable="true" Date="_date" ImmediateText="true" Placeholder="day.month.year" DateFormat="@_dateFormat" TextChanged="DatePickerTextChanged" HelperText="@_bound" Clearable="true" />
 
 @code {
-    DateTime? date = null;
-    string dateFormat = "dd.MM.yyyy";
-    string bound = "not set";
+    private DateTime? _date = null;
+    private string _dateFormat = "dd.MM.yyyy";
+    private string _bound = "not set";
 
     private void DatePickerTextChanged(string value)
     {
         if (value == null || value.Length < 6)
         {
-            date = null;
+            _date = null;
         }
         else
         {
             string[] formats = { "ddMMyy", "dd.MM.yyyy", "dd.M.yyyy", "d.MM.yyyy", "d.M.yyyy", "dd.MM.yy", "dd.M.yy", "d.MM.yy", "d.M.yy" };
             if (DateTime.TryParseExact(value, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime validDate))
             {
-                date = validDate;
+                _date = validDate;
             }
             else
             {
-                date = null;
+                _date = null;
             }
         }
 
-        if (date.HasValue)
+        if (_date.HasValue)
         {
-            bound = date.Value.ToString(dateFormat); 
+            _bound = _date.Value.ToString(_dateFormat); 
         }
         else
         {
-            bound = "not set";
+            _bound = "not set";
         }
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="time" />
-<MudTimePicker Label="12 hours custom format" AmPm="true" TimeFormat="h:mm tt" @bind-Time="time" />
-<MudTimePicker Label="24 hours" @bind-Time="time" />
+<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="_time" />
+<MudTimePicker Label="12 hours custom format" AmPm="true" TimeFormat="h:mm tt" @bind-Time="_time" />
+<MudTimePicker Label="24 hours" @bind-Time="_time" />
 <MudTimePicker Label="24 hours (editable)" Editable="true" />
 
 @code{
-    TimeSpan? time = new TimeSpan(00, 45, 00);
+    private TimeSpan? _time = new TimeSpan(00, 45, 00);
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerDialogExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerDialogExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker PickerVariant="PickerVariant.Dialog" Label="12 hours" AmPm="true" @bind-Time="time" />
-<MudTimePicker PickerVariant="PickerVariant.Dialog" Label="24 hours" @bind-Time="time" />
+<MudTimePicker PickerVariant="PickerVariant.Dialog" Label="12 hours" AmPm="true" @bind-Time="_time" />
+<MudTimePicker PickerVariant="PickerVariant.Dialog" Label="24 hours" @bind-Time="_time" />
 
 @code{
-    TimeSpan? time = new TimeSpan(00, 45, 00);
+    private TimeSpan? _time = new TimeSpan(00, 45, 00);
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerReadOnlyExample.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="time" ReadOnly="@readOnly" />
-<MudSwitch @bind-Value="readOnly" Color="Color.Tertiary">ReadOnly</MudSwitch>
+<MudTimePicker Label="12 hours" AmPm="true" @bind-Time="_time" ReadOnly="@_readOnly" />
+<MudSwitch @bind-Value="_readOnly" Color="Color.Tertiary">ReadOnly</MudSwitch>
 
 @code{
-    TimeSpan? time = new TimeSpan(00, 45, 00);
-    private bool readOnly;
+    private TimeSpan? _time = new TimeSpan(00, 45, 00);
+    private bool _readOnly;
 
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerStaticExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerStaticExample.razor
@@ -1,11 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudTimePicker PickerVariant="PickerVariant.Static" @bind-Time="time" AmPm="true" />
+<MudTimePicker PickerVariant="PickerVariant.Static" @bind-Time="_time" AmPm="true" />
 <MudHidden Breakpoint="@Breakpoint.Xs">
-    <MudTimePicker PickerVariant="PickerVariant.Static" Orientation="Orientation.Landscape" @bind-Time="time" />
+    <MudTimePicker PickerVariant="PickerVariant.Static" Orientation="Orientation.Landscape" @bind-Time="_time" />
 </MudHidden>
 
 @code{
-    TimeSpan? time = new TimeSpan(13, 37, 00);
+    private TimeSpan? _time = new TimeSpan(13, 37, 00);
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerTimeEditModeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerTimeEditModeExample.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTimePicker Label="Normal" @bind-Time="time" TimeEditMode="TimeEditMode.Normal" />
-<MudTimePicker Label="OnlyHours" @bind-Time="time" TimeEditMode="TimeEditMode.OnlyHours" />
-<MudTimePicker Label="OnlyMinutes" @bind-Time="time" TimeEditMode="TimeEditMode.OnlyMinutes" />
+<MudTimePicker Label="Normal" @bind-Time="_time" TimeEditMode="TimeEditMode.Normal" />
+<MudTimePicker Label="OnlyHours" @bind-Time="_time" TimeEditMode="TimeEditMode.OnlyHours" />
+<MudTimePicker Label="OnlyMinutes" @bind-Time="_time" TimeEditMode="TimeEditMode.OnlyMinutes" />
 
 @code{
 
-    TimeSpan? time = new TimeSpan(13, 37, 00);
+    private TimeSpan? _time = new TimeSpan(13, 37, 00);
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1085,33 +1085,33 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Tab", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Tab", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             datePicker.Disabled = true;
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await comp.InvokeAsync(() => datePicker.ToggleOpenAsync());
@@ -1125,7 +1125,7 @@ namespace MudBlazor.UnitTests.Components
 
             datePicker.Disabled = false;
 
-            await comp.InvokeAsync(() => datePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
             await comp.InvokeAsync(() => datePicker.ToggleStateAsync());

--- a/src/MudBlazor.UnitTests/Components/PickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PickerTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await picker.Instance.SelectRangeAsync(0, 0));
 #pragma warning disable BL0005
             await comp.InvokeAsync(() => picker.Instance.Disabled = true);
-            await comp.InvokeAsync(() => picker.Instance.HandleKeyDown(new KeyboardEventArgs()));
+            await comp.InvokeAsync(() => picker.Instance.OnHandleKeyDownAsync(new KeyboardEventArgs()));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -835,94 +835,94 @@ namespace MudBlazor.UnitTests.Components
             var timePicker = comp.FindComponent<MudTimePicker>().Instance;
             var overlay = comp.FindComponent<MudOverlay>();
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             comp.SetParam("Time", new TimeSpan(02, 00, 00));
             comp.WaitForAssertion(() => comp.Instance.Time.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
             //Enter keys submit, so time should only change with enter
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(02, 00, 00)));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(01, 59, 00)));
             //If IsOpen is false, arrowkeys should now change TimeIntermediate
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
             //Escape key should turn last submitted time
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(01, 59, 00)));
             //Space key should also submit
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = " ", CtrlKey = true, Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", CtrlKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(03, 00, 00)));
 
             comp.SetParam("Time", new TimeSpan(03, 56, 00));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(04, 01, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(03, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", CtrlKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 51, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(07, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(null));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(null));
 
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             //When its disabled, keys should not work
             timePicker.Disabled = true;
             timePicker.FocusAsync().AndForget();
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.HandleKeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await comp.InvokeAsync(() => timePicker.TimeFormat = "hhmm");

--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -408,6 +408,12 @@ namespace MudBlazor
             public const string Appearance = "Appearance";
         }
 
+        public static class Picker
+        {
+            public const string Behavior = "Behavior";
+            public const string Appearance = "Appearance";
+        }
+
         public static class Popover
         {
             public const string Behavior = "Behavior";

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -502,7 +502,7 @@ namespace MudBlazor
             Value = color;
         }
 
-        protected override Task StringValueChanged(string value)
+        protected override Task StringValueChangedAsync(string value)
         {
             SetInputString(value);
             return Task.CompletedTask;
@@ -551,18 +551,18 @@ namespace MudBlazor
             {
                 if (PickerVariant == PickerVariant.Static)
                 {
-                    await AddMouseOverEvent();
+                    await AddMouseOverEventAsync();
                 }
             }
 
             if (_attachedMouseEvent == true)
             {
                 _attachedMouseEvent = false;
-                await AddMouseOverEvent();
+                await AddMouseOverEventAsync();
             }
         }
 
-        private async Task AddMouseOverEvent()
+        private async Task AddMouseOverEventAsync()
         {
             if (DisableDragEffect == true) { return; }
 

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -66,14 +66,14 @@ namespace MudBlazor
                     defaultConverter.Format = value;
                     _dateFormatTouched = true;
                 }
-                DateFormatChanged(value);
+                DateFormatChangedAsync(value);
             }
         }
 
         /// <summary>
         /// Date format value change hook for descendants.
         /// </summary>
-        protected virtual Task DateFormatChanged(string newFormat)
+        protected virtual Task DateFormatChangedAsync(string newFormat)
         {
             return Task.CompletedTask;
         }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -75,13 +75,13 @@ namespace MudBlazor
             }
         }
 
-        protected override Task DateFormatChanged(string newFormat)
+        protected override Task DateFormatChangedAsync(string newFormat)
         {
             Touched = true;
             return SetTextAsync(Converter.Set(_value), false);
         }
 
-        protected override Task StringValueChanged(string value)
+        protected override Task StringValueChangedAsync(string value)
         {
             Touched = true;
             // Update the date property (without updating back the Value property)
@@ -218,16 +218,15 @@ namespace MudBlazor
             var diff = Culture.Calendar.GetYear(date) - Culture.Calendar.GetYear(yearDate);
             var calenderYear = Culture.Calendar.GetYear(date);
             return calenderYear - diff;
-
         }
 
         //To be completed on next PR
-        protected internal override async void HandleKeyDown(KeyboardEventArgs obj)
+        protected internal override async Task OnHandleKeyDownAsync(KeyboardEventArgs args)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            base.HandleKeyDown(obj);
-            switch (obj.Key)
+            await base.OnHandleKeyDownAsync(args);
+            switch (args.Key)
             {
                 case "ArrowRight":
                     if (IsOpen)
@@ -246,11 +245,11 @@ namespace MudBlazor
                     {
                         IsOpen = true;
                     }
-                    else if (obj.AltKey == true)
+                    else if (args.AltKey == true)
                     {
                         IsOpen = false;
                     }
-                    else if (obj.ShiftKey == true)
+                    else if (args.ShiftKey == true)
                     {
 
                     }
@@ -264,7 +263,7 @@ namespace MudBlazor
                     {
                         IsOpen = true;
                     }
-                    else if (obj.ShiftKey == true)
+                    else if (args.ShiftKey == true)
                     {
 
                     }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -10,7 +10,7 @@
                           ErrorText="@ErrorText" Disabled="@GetDisabledState()" Margin="@Margin" Required="@Required"
                           @onclick="async () => { if (!Editable) await ToggleStateAsync(); }" ForId="@FieldId">
                <InputContent>
-                   <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
+                   <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClassname" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
                                    @bind-Value="@RangeText" Disabled="@GetDisabledState()" Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleStateAsync"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin" AdornmentAriaLabel="@AdornmentAriaLabel"
                                    PlaceholderStart="@PlaceholderStart" PlaceholderEnd="@PlaceholderEnd" SeparatorIcon="@SeparatorIcon" Clearable="Clearable"/>

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -159,16 +159,16 @@ namespace MudBlazor
         /// <returns></returns>
         public ValueTask SelectRangeEndAsync(int pos1, int pos2) => _rangeInput.SelectRangeEndAsync(pos1, pos2);
 
-        protected override Task DateFormatChanged(string newFormat)
+        protected override Task DateFormatChangedAsync(string newFormat)
         {
             Touched = true;
             return SetTextAsync(_dateRange?.ToString(Converter), false);
         }
 
-        protected override Task StringValueChanged(string value)
+        protected override Task StringValueChangedAsync(string value)
         {
             Touched = true;
-            // Update the daterange property (without updating back the Value property)
+            // Update the date range property (without updating back the Value property)
             return SetDateRangeAsync(ParseDateRangeValue(value), false);
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -1,4 +1,3 @@
-@using MudBlazor.Internal
 @namespace MudBlazor
 @inherits MudFormComponent<T, string>
 @typeparam T

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -44,7 +44,7 @@
 
     protected virtual RenderFragment Render =>
     @<CascadingValue Value="@this" IsFixed="true">
-        <div class="@PickerClass" id="@_elementId">
+        <div class="@PickerClassname" id="@_elementId">
             @if (PickerVariant != PickerVariant.Static)
             {
                 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
@@ -56,16 +56,16 @@
             @if (PickerVariant == PickerVariant.Inline)
             {
 				<MudPopover Open="IsOpen" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" OverflowBehavior="OverflowBehavior.FlipOnOpen" Paper="false">
-				   <div @ref="_pickerInlineRef" class="@PickerInlineClass">
-					   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-						   <div class="@PickerContainerClass">
+				   <div @ref="_pickerInlineRef" class="@PickerInlineClassname">
+					   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Elevation="@_pickerElevation" Square="@_pickerSquare">
+						   <div class="@PickerContainerClassname">
 							   @if(PickerContent != null){
 								   @PickerContent
 							   }
 						   </div>
 							@if (PickerActions != null)
 							{
-								<div class="@ActionClass">
+								<div class="@ActionsClassname">
 									@PickerActions(this)
 								</div>
 							}
@@ -75,15 +75,15 @@
             }
             else if (PickerVariant == PickerVariant.Static)
             {
-               <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-                   <div class="@PickerContainerClass">
+               <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                   <div class="@PickerContainerClassname">
 					   @if(PickerContent != null){
 						   @PickerContent
 					   }
                    </div>
                     @if (PickerActions != null)
                     {
-                        <div class="@ActionClass">
+                        <div class="@ActionsClassname">
                             @PickerActions(this)
                         </div>
                     }
@@ -92,15 +92,15 @@
             else if(IsOpen && PickerVariant == PickerVariant.Dialog)
             {
                <MudOverlay Visible="IsOpen" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
-                   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-                       <div class="@PickerContainerClass">
+                   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                       <div class="@PickerContainerClassname">
 							@if(PickerContent != null){
 								@PickerContent
 							}
                        </div>
                         @if (PickerActions != null)
                         {
-                            <div class="@ActionClass">
+                            <div class="@ActionsClassname">
                                 @PickerActions(this)
                             </div>
                         }
@@ -114,5 +114,3 @@
         }
     </CascadingValue>;
 }
-
-

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -174,7 +174,7 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool ReadOnly { get; set; }
-        
+
         [CascadingParameter(Name = "ParentReadOnly")]
         private bool ParentReadOnly { get; set; }
         protected bool GetReadOnlyState() => ReadOnly || ParentReadOnly;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -15,23 +14,24 @@ namespace MudBlazor
         public MudPicker() : base(new Converter<T, string>()) { }
         protected MudPicker(Converter<T, string> converter) : base(converter) { }
 
-        [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
+        [Inject]
+        private IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
 
         private string _elementId = "picker" + Guid.NewGuid().ToString().Substring(0, 8);
 
-        protected string PickerClass =>
+        protected string PickerClassname =>
             new CssBuilder("mud-picker")
-                .AddClass($"mud-picker-inline", PickerVariant != PickerVariant.Static)
-                .AddClass($"mud-picker-static", PickerVariant == PickerVariant.Static)
-                .AddClass($"mud-rounded", PickerVariant == PickerVariant.Static && !_pickerSquare)
+                .AddClass("mud-picker-inline", PickerVariant != PickerVariant.Static)
+                .AddClass("mud-picker-static", PickerVariant == PickerVariant.Static)
+                .AddClass("mud-rounded", PickerVariant == PickerVariant.Static && !_pickerSquare)
                 .AddClass($"mud-elevation-{_pickerElevation}", PickerVariant == PickerVariant.Static)
-                .AddClass($"mud-picker-input-button", !Editable && PickerVariant != PickerVariant.Static)
-                .AddClass($"mud-picker-input-text", Editable && PickerVariant != PickerVariant.Static)
-                .AddClass($"mud-disabled", GetDisabledState() && PickerVariant != PickerVariant.Static)
+                .AddClass("mud-picker-input-button", !Editable && PickerVariant != PickerVariant.Static)
+                .AddClass("mud-picker-input-text", Editable && PickerVariant != PickerVariant.Static)
+                .AddClass("mud-disabled", GetDisabledState() && PickerVariant != PickerVariant.Static)
                 .AddClass(Class)
                 .Build();
 
-        protected string PickerPaperClass =>
+        protected string PickerPaperClassname =>
             new CssBuilder("mud-picker")
                 .AddClass("mud-picker-paper")
                 .AddClass("mud-picker-view", PickerVariant == PickerVariant.Inline)
@@ -40,36 +40,26 @@ namespace MudBlazor
                 .AddClass("mud-dialog", PickerVariant == PickerVariant.Dialog)
                 .Build();
 
-        protected string PickerInlineClass =>
+        protected string PickerInlineClassname =>
             new CssBuilder("mud-picker-inline-paper")
                 .Build();
 
-        protected string PickerContainerClass =>
+        protected string PickerContainerClassname =>
             new CssBuilder("mud-picker-container")
                 .AddClass("mud-paper-square", _pickerSquare)
                 .AddClass("mud-picker-container-landscape",
                     Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
                 .Build();
 
-        protected string PickerInputClass =>
-            new CssBuilder("mud-input-input-control").AddClass(Class)
+        protected string PickerInputClassname =>
+            new CssBuilder("mud-input-input-control")
+                .AddClass(Class)
                 .Build();
 
-        protected string ActionClass => new CssBuilder("mud-picker-actions")
-            .AddClass(ClassActions)
-            .Build();
-
-        /// <summary>
-        /// Sets the icon of the input text field
-        /// </summary>
-        [ExcludeFromCodeCoverage]
-        [Parameter]
-        [Obsolete("Use AdornmentIcon instead.", true)]
-        public string InputIcon
-        {
-            get { return AdornmentIcon; }
-            set { AdornmentIcon = value; }
-        }
+        protected string ActionsClassname =>
+            new CssBuilder("mud-picker-actions")
+                .AddClass(ActionsClass)
+                .Build();
 
         /// <summary>
         /// The color of the adornment if used. It supports the theme colors.
@@ -166,7 +156,9 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool Disabled { get; set; }
-        [CascadingParameter(Name = "ParentDisabled")] private bool ParentDisabled { get; set; }
+
+        [CascadingParameter(Name = "ParentDisabled")]
+        private bool ParentDisabled { get; set; }
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
         /// <summary>
@@ -182,7 +174,9 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool ReadOnly { get; set; }
-        [CascadingParameter(Name = "ParentReadOnly")] private bool ParentReadOnly { get; set; }
+        
+        [CascadingParameter(Name = "ParentReadOnly")]
+        private bool ParentReadOnly { get; set; }
         protected bool GetReadOnlyState() => ReadOnly || ParentReadOnly;
 
         /// <summary>
@@ -214,18 +208,6 @@ namespace MudBlazor
         public PickerVariant PickerVariant { get; set; } = PickerVariant.Inline;
 
         /// <summary>
-        ///  Variant of the text input
-        /// </summary>
-        [ExcludeFromCodeCoverage]
-        [Parameter]
-        [Obsolete("Use Variant instead.", true)]
-        public Variant InputVariant
-        {
-            get { return Variant; }
-            set { Variant = value; }
-        }
-
-        /// <summary>
         /// Variant of the text input
         /// </summary>
         [Parameter]
@@ -233,7 +215,7 @@ namespace MudBlazor
         public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        /// Sets if the icon will be att start or end, set to false to disable.
+        /// Sets if the icon will be att start or end, set to None to disable.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
@@ -259,13 +241,6 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerAppearance)]
         public Color Color { get; set; } = Color.Primary;
-
-        /// <summary>
-        /// Changes the cursor appearance.
-        /// </summary>
-        [Obsolete("This is enabled now by default when you use Editable=true. You can remove the parameter.", false)]
-        [Parameter]
-        public bool AllowKeyboardInput { get; set; }
 
         /// <summary>
         /// Fired when the text changes.
@@ -305,7 +280,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerAppearance)]
-        public string ClassActions { get; set; }
+        public string ActionsClass { get; set; }
 
         /// <summary>
         /// Define the action buttons here
@@ -354,7 +329,7 @@ namespace MudBlazor
             {
                 _text = value;
                 if (callback)
-                    await StringValueChanged(_text);
+                    await StringValueChangedAsync(_text);
                 await TextChanged.InvokeAsync(_text);
             }
         }
@@ -362,22 +337,22 @@ namespace MudBlazor
         /// <summary>
         /// Value change hook for descendants.
         /// </summary>
-        protected virtual Task StringValueChanged(string value)
+        protected virtual Task StringValueChangedAsync(string value)
         {
             return Task.CompletedTask;
         }
 
         protected bool IsOpen { get; set; }
 
-        public async Task ToggleOpenAsync()
+        public Task ToggleOpenAsync()
         {
             if (IsOpen)
             {
-                await CloseAsync();
+                return CloseAsync();
             }
             else
             {
-                await OpenAsync();
+                return OpenAsync();
             }
         }
 
@@ -468,11 +443,11 @@ namespace MudBlazor
                 Label = For.GetLabelString();
         }
 
-        private async Task EnsureKeyInterceptor()
+        private async Task EnsureKeyInterceptorAsync()
         {
             if (_keyInterceptor == null)
             {
-                _keyInterceptor = _keyInterceptorFactory.Create();
+                _keyInterceptor = KeyInterceptorFactory.Create();
 
                 await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                 {
@@ -505,11 +480,25 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// 'HandleKeyDown' needed to be async in order to call other async methods. Because
+        /// the HandleKeyDown is virtual and the base needs to be called from overriden methods
+        /// we can't use 'async void'. This would break the synchronous behavior of those
+        /// overriden methods. The KeyInterceptor does not support async behavior, so we have to
+        /// add this hook method for handling the KeyDown event.
+        /// This method can be removed when the KeyInterceptor supports async behavior.
+        /// </summary>
+        /// <param name="args"></param>
+        private async void HandleKeyDown(KeyboardEventArgs args)
+        {
+            await OnHandleKeyDownAsync(args);
+        }
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
-                await EnsureKeyInterceptor();
+                await EnsureKeyInterceptorAsync();
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -538,10 +527,10 @@ namespace MudBlazor
 
             if (PickerVariant == PickerVariant.Inline)
             {
-                await _pickerInlineRef.MudChangeCssAsync(PickerInlineClass);
+                await _pickerInlineRef.MudChangeCssAsync(PickerInlineClassname);
             }
 
-            await EnsureKeyInterceptor();
+            await EnsureKeyInterceptorAsync();
             await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "key+none" });
         }
 
@@ -549,7 +538,7 @@ namespace MudBlazor
         {
             await OnPickerClosedAsync();
 
-            await EnsureKeyInterceptor();
+            await EnsureKeyInterceptorAsync();
             await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "none" });
         }
 
@@ -557,20 +546,17 @@ namespace MudBlazor
 
         protected virtual Task OnPickerClosedAsync() => PickerClosed.InvokeAsync(this);
 
-        protected internal virtual async void HandleKeyDown(KeyboardEventArgs obj)
+        protected internal virtual async Task OnHandleKeyDownAsync(KeyboardEventArgs args)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            switch (obj.Key)
+            switch (args.Key)
             {
                 case "Backspace":
-                    if (obj.CtrlKey == true && obj.ShiftKey == true)
+                    if (args.CtrlKey == true && args.ShiftKey == true)
                     {
                         await ClearAsync();
-                        _value = default(T);
-
-                        // TODO: Probably need to  create a HandleKeyDownAsync that awaits ResetValueAsync()
-                        // Simply replacing Reset() with ResetValueAsync().AndForget() may cause issues in BSS
+                        _value = default;
                         await ResetAsync();
                     }
 

--- a/src/MudBlazor/Components/Picker/MudPickerContent.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerContent.razor
@@ -9,8 +9,8 @@
 @code {
     protected string Classname =>
         new CssBuilder("mud-picker-content")
-          .AddClass(Class)
-        .Build();
+            .AddClass(Class)
+            .Build();
 
     /// <summary>
     /// CSS class that will be applied to the content container

--- a/src/MudBlazor/Components/Picker/MudPickerContent.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerContent.razor
@@ -1,16 +1,26 @@
 ﻿@namespace MudBlazor
 @using MudBlazor.Utilities
 
-<div class="@Classnames" @onclick:stopPropagation="true">
+<div class="@Classname" @onclick:stopPropagation="true">
     @ChildContent
 </div>
 
-@code {
-    protected string Classnames =>
-    new CssBuilder("mud-picker-content")
-      .AddClass(Class)
-    .Build();
 
-    [Parameter] public string Class { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
+@code {
+    protected string Classname =>
+        new CssBuilder("mud-picker-content")
+          .AddClass(Class)
+        .Build();
+
+    /// <summary>
+    /// CSS class that will be applied to the content container
+    /// </summary>
+    [Parameter]
+    public string Class { get; set; }
+
+    /// <summary>
+    /// Child content of component.
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/Picker/MudPickerContent.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerContent.razor
@@ -1,26 +1,6 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
+@inherits MudComponentBase
 
-<div class="@Classname" @onclick:stopPropagation="true">
+<div @attributes="UserAttributes" class="@Classname" Style="@Style" @onclick:stopPropagation="true">
     @ChildContent
 </div>
-
-
-@code {
-    protected string Classname =>
-        new CssBuilder("mud-picker-content")
-            .AddClass(Class)
-            .Build();
-
-    /// <summary>
-    /// CSS class that will be applied to the content container
-    /// </summary>
-    [Parameter]
-    public string Class { get; set; }
-
-    /// <summary>
-    /// Child content of component.
-    /// </summary>
-    [Parameter]
-    public RenderFragment ChildContent { get; set; }
-}

--- a/src/MudBlazor/Components/Picker/MudPickerContent.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPickerContent.razor.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudPickerContent : MudComponentBase
+    {
+        protected string Classname =>
+            new CssBuilder("mud-picker-content")
+                .AddClass(Class)
+                .Build();
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Picker.Behavior)]
+        public RenderFragment ChildContent { get; set; }
+    }
+}

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
@@ -15,7 +15,7 @@
           .AddClass($"mud-theme-{Color.ToDescriptionString()}")
           .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
           .AddClass(Class)
-        .Build();
+          .Build();
 
     /// <summary>
     /// CSS class that will be applied to the toolbar

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
@@ -1,61 +1,9 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
+@inherits MudComponentBase
 
 @if (!DisableToolbar)
 {
-    <MudToolBar Class="@Classname" Style="@Style">
+    <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
         @ChildContent
     </MudToolBar>
-}
-
-
-@code {
-    protected string Classname =>
-        new CssBuilder("mud-picker-toolbar")
-          .AddClass($"mud-theme-{Color.ToDescriptionString()}")
-          .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
-          .AddClass(Class)
-          .Build();
-
-    /// <summary>
-    /// CSS class that will be applied to the toolbar
-    /// </summary>
-    [Parameter]
-    public string Class { get; set; }
-
-    /// <summary>
-    /// CSS style that will be applied to the toolbar
-    /// </summary>
-    [Parameter]
-    public string Style { get; set; }
-    
-    /// <summary>
-    /// Hide toolbar
-    /// </summary>
-    [Parameter]
-    public bool DisableToolbar { get; set; }
-
-    /// <summary>
-    /// Sets the orientation of the toolbar
-    /// </summary>
-    [Parameter]
-    public Orientation Orientation { get; set; }
-    
-    /// <summary>
-    /// Picker container option
-    /// </summary>
-    [Parameter]
-    public PickerVariant PickerVariant { get; set; }
-    
-    /// <summary>
-    /// The color of the toolbar, selected and active. It supports the theme colors
-    /// </summary>
-    [Parameter]
-    public Color Color { get; set; }
-    
-    /// <summary>
-    /// Child content of toolbar
-    /// </summary>
-    [Parameter]
-    public RenderFragment ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor
@@ -3,25 +3,59 @@
 
 @if (!DisableToolbar)
 {
-    <MudToolBar Class="@Classnames" Style="@Style">
+    <MudToolBar Class="@Classname" Style="@Style">
         @ChildContent
     </MudToolBar>
 }
 
 
 @code {
-    protected string Classnames =>
-    new CssBuilder("mud-picker-toolbar")
-      .AddClass($"mud-theme-{Color.ToDescriptionString()}")
-      .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
-      .AddClass(Class)
-    .Build();
+    protected string Classname =>
+        new CssBuilder("mud-picker-toolbar")
+          .AddClass($"mud-theme-{Color.ToDescriptionString()}")
+          .AddClass("mud-picker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
+          .AddClass(Class)
+        .Build();
 
-    [Parameter] public string Class { get; set; }
-    [Parameter] public string Style { get; set; }
-    [Parameter] public bool DisableToolbar { get; set; }
-    [Parameter] public Orientation Orientation { get; set; }
-    [Parameter] public PickerVariant PickerVariant { get; set; }
-    [Parameter] public Color Color { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
+    /// <summary>
+    /// CSS class that will be applied to the toolbar
+    /// </summary>
+    [Parameter]
+    public string Class { get; set; }
+
+    /// <summary>
+    /// CSS style that will be applied to the toolbar
+    /// </summary>
+    [Parameter]
+    public string Style { get; set; }
+    
+    /// <summary>
+    /// Hide toolbar
+    /// </summary>
+    [Parameter]
+    public bool DisableToolbar { get; set; }
+
+    /// <summary>
+    /// Sets the orientation of the toolbar
+    /// </summary>
+    [Parameter]
+    public Orientation Orientation { get; set; }
+    
+    /// <summary>
+    /// Picker container option
+    /// </summary>
+    [Parameter]
+    public PickerVariant PickerVariant { get; set; }
+    
+    /// <summary>
+    /// The color of the toolbar, selected and active. It supports the theme colors
+    /// </summary>
+    [Parameter]
+    public Color Color { get; set; }
+    
+    /// <summary>
+    /// Child content of toolbar
+    /// </summary>
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor;
+
+public partial class MudPickerToolbar : MudComponentBase
+{
+    protected string Classname =>
+        new CssBuilder("mud-picker-toolbar")
+            .AddClass($"mud-theme-{Color.ToDescriptionString()}")
+            .AddClass("mud-picker-toolbar-landscape",
+                Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
+            .AddClass(Class)
+            .Build();
+
+    /// <summary>
+    /// Hide toolbar
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Picker.Behavior)]
+    public bool DisableToolbar { get; set; }
+
+    /// <summary>
+    /// Sets the orientation of the toolbar
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Picker.Appearance)]
+    public Orientation Orientation { get; set; }
+
+    /// <summary>
+    /// Picker container option
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Picker.Appearance)]
+    public PickerVariant PickerVariant { get; set; }
+
+    /// <summary>
+    /// The color of the toolbar, selected and active. It supports the theme colors
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Picker.Appearance)]
+    public Color Color { get; set; }
+
+    /// <summary>
+    /// Child content of toolbar
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Picker.Behavior)]
+    public RenderFragment ChildContent { get; set; }
+}

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -193,7 +193,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<TimeSpan?> TimeChanged { get; set; }
 
-        protected override Task StringValueChanged(string value)
+        protected override Task StringValueChangedAsync(string value)
         {
             Touched = true;
             // Update the time property (without updating back the Value property)
@@ -575,11 +575,11 @@ namespace MudBlazor
             }
         }
 
-        protected internal override async void HandleKeyDown(KeyboardEventArgs obj)
+        protected internal override async Task OnHandleKeyDownAsync(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            base.HandleKeyDown(obj);
+            await base.OnHandleKeyDownAsync(obj);
             switch (obj.Key)
             {
                 case "ArrowRight":


### PR DESCRIPTION
## Description
resolves #8489
resolves #8482

- Add missing Async suffix
- Fixed naming for `Classname` properties
- explicit modifiers
- removed obsolete code
- Fix async behavior in HandleKeyDown event

### Public API changes

#### MudColorPicker

- StringValueChanged -> StringValueChangedAsync

#### MudBaseDatePicker

- DateFormatChanged -> DateFormatChangedAsync

#### MudDatePicker

- DateFormatChanged -> DateFormatChangedAsync
- StringValueChanged -> StringValueChangedAsync
- HandleKeyDown -> OnHandleKeyDownAsync

#### MudDateRangePicker

- DateFormatChanged -> DateFormatChangedAsync
- StringValueChanged -> StringValueChangedAsync

#### MudPicker

- PickerClass -> PickerClassname
- PickerPaperClass -> PickerPaperClassname
- PickerInlineClass -> 1PickerInlineClassname
- PickerContainerClass -> PickerContainerClassname
- PickerInputClass -> PickerInputClassname
- ActionClass -> ActionsClassname
- InputIcon (removed obsolete) -> AdornmentIcon
- InputVariant (removed obsolete) -> Variant
- AllowKeyboardInput (removed, unused)
- ClassActions -> ActionsClass
- StringValueChange -> StringValueChangedAsync
- HandleKeyDown -> OnHandleKeyDownAsync

#### MudPickerContent

- Classnames -> Classname

#### MudPickerToolbar

- Classnames -> Classname

#### MudTimePicker

- StringValueChanged -> StringValueChangedAsync
- HandleKeyDown -> OnHandleKeyDownAsync

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested the Server Docs pages
Unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
