### PR TITLE
DateRangePicker: Fix tests - update selected range to use future dates

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
@@ -9,7 +9,7 @@
 
     protected override Task OnInitializedAsync()
     {
-        DateTimeRange = new DateRange(DateTime.Now.AddDays(-7), DateTime.Now);
+        DateTimeRange = new DateRange(DateTime.Now.AddDays(1), DateTime.Now.AddDays(5));
 
         return base.OnInitializedAsync();
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
@@ -9,7 +9,7 @@
 
     protected override Task OnInitializedAsync()
     {
-        DateRange = new DateRange(DateTime.Now.AddDays(-7).Date, DateTime.Now.Date);
+        DateRange = new DateRange(DateTime.Now.AddDays(1).Date, DateTime.Now.AddDays(5).Date);
 
         return base.OnInitializedAsync();
     }


### PR DESCRIPTION
## Description
By default the initial calendar shows the current month and next month. The existing tests use a range of 7 days in the past to the present day. This resulted in the possibility of the start date being in the previous month when the current day is within the first week of the current month. This causes tests to fail since `mud-range-start-selected` isn't visible (previous month isn't visible, only current and next)

## How Has This Been Tested?
Visually with the test view and with the unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've updated relevant tests.
