### PR TITLE
MudFileUpload: Make FileUploadButtonTemplateContext.ClearAsync required

### DIFF
--- a/src/MudBlazor/Components/FileUpload/FileUploadButtonTemplateContext.cs
+++ b/src/MudBlazor/Components/FileUpload/FileUploadButtonTemplateContext.cs
@@ -26,6 +26,6 @@ public class FileUploadButtonTemplateContext<T>
 
     public class FileUploadButtonTemplateActions
     {
-        public Func<Task> ClearAsync { get; init; } = null!;
+        public required Func<Task> ClearAsync { get; init; }
     }
 }


### PR DESCRIPTION
## Description

This improves https://github.com/MudBlazor/MudBlazor/issues/6535
It was already meant to be always set by the `FileUploadButtonTemplateContext` and the nullable was surpressed with the `null!` annotation, but it's not required anymore with the `required` keyword. Now we can use it because of .net6 drop, we could use it before but it would require a special polifyll.

It slightly breaking in terms if someone used this class by himself, but usually this was totally managed by the `FileUploadButtonTemplateContext`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
