### PR TITLE
MudTabs: Fix overflow when using high border radius values

### DIFF
--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -22,6 +22,7 @@
 
   &.mud-tabs-rounded {
     border-radius: var(--mud-default-borderradius);
+    overflow: hidden;
 
     .mud-tabs-toolbar {
       border-radius: var(--mud-default-borderradius);


### PR DESCRIPTION
## Description
Fixes visual overflow when hovering over rounded MudTabs

## How Has This Been Tested?
visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![image_2024-04-03_16-47-42](https://github.com/MudBlazor/MudBlazor/assets/44732554/c008a32b-d18e-4857-96b0-12c654d21bb6)

After:
![image_2024-04-03_16-48-13](https://github.com/MudBlazor/MudBlazor/assets/44732554/a5bb02d9-2fc9-47a4-bf60-f87681d9f4fb)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
