### PR TITLE
MudTabs: Rename toolbar to tabbar in C# and CSS

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -42,7 +42,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Tabs Position">
-                <Description>The position of the tab toolbar can be changed with the <CodeInline>Position</CodeInline> property.</Description>
+                <Description>The position of the tab bar can be changed with the <CodeInline>Position</CodeInline> property.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TabsPositionExample)" ShowCode="false" Block="true" FullWidth="true">
                 <TabsPositionExample />

--- a/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
@@ -328,7 +328,7 @@
     border-left: 1px solid var(--mud-palette-primary);
   }
 
-  .mud-tabs-toolbar-transparent {
+  .mud-tabs-tabbar-transparent {
     background-color: transparent;
 
     .mud-tab {

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.SetParametersAndRender(builder => builder.Add(tabs => tabs.TabHeaderClass, "testA testB"));
 
-            comp.Find(".mud-tabs-toolbar").ClassList.Should().Contain(new[] { "testA", "testB" });
+            comp.Find(".mud-tabs-tabbar").ClassList.Should().Contain(new[] { "testA", "testB" });
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Instance.SetPanelActive(i);
 
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
 
                 toolbarWrapper.Should().NotBeNull();
 
@@ -228,7 +228,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.SetPanelActive(2);
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
 
             toolbarWrapper.Should().NotBeNull();
 
@@ -262,7 +262,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.SetPanelActive(2);
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
 
             toolbarWrapper.Should().NotBeNull();
 
@@ -302,7 +302,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Instance.SetPanelActive(i);
 
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
 
                 toolbarWrapper.Should().NotBeNull();
 
@@ -408,7 +408,7 @@ namespace MudBlazor.UnitTests.Components
                 scrollButtons.Last().Find("button").Click();
                 expectedTranslation += observer.PanelSize;
 
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
                 toolbarWrapper.Should().NotBeNull();
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -444,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
                 scrollButtons.First().Find("button").Click();
                 expectedTranslation -= observer.PanelSize;
 
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
                 toolbarWrapper.Should().NotBeNull();
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -504,7 +504,7 @@ namespace MudBlazor.UnitTests.Components
             var expectedTranslation = 0.0;
             scrollButtons[0].Find("button").Click();
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -534,7 +534,7 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons[0].Find("button").Click();
             var expectedTranslation = 0.0;
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -564,7 +564,7 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons[1].Find("button").Click();
             var expectedTranslation = 500.0;
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -599,7 +599,7 @@ namespace MudBlazor.UnitTests.Components
             var expectedTranslation = 0.0;
             scrollButtons[0].Find("button").Click();
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -630,7 +630,7 @@ namespace MudBlazor.UnitTests.Components
 
             var expectedTranslation = 0.0;
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -695,7 +695,7 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons.Last().Instance.Disabled.Should().BeTrue();
             comp.Instance.SetPanelActive(6);
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -729,7 +729,7 @@ namespace MudBlazor.UnitTests.Components
 
             scrollButtons.First().Instance.Disabled.Should().BeFalse();
 
-            var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             toolbarWrapper.Should().NotBeNull();
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -759,7 +759,7 @@ namespace MudBlazor.UnitTests.Components
 
             scrollButtons.First().Instance.Disabled.Should().BeFalse();
             {
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
                 toolbarWrapper.Should().NotBeNull();
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -772,7 +772,7 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons.First().Instance.Disabled.Should().BeFalse();
 
             {
-                var toolbarWrapper = comp.Find(".mud-tabs-toolbar-wrapper");
+                var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
                 toolbarWrapper.Should().NotBeNull();
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
@@ -1010,7 +1010,7 @@ namespace MudBlazor.UnitTests.Components
             var additionalClass = position == TabHeaderPosition.After ? "mud-tabs-header-after" : "mud-tabs-header-before";
             headerPanel.ClassList.Should().BeEquivalentTo("mud-tabs-header", additionalClass);
 
-            var tabInnerHeader = comp.Find(".mud-tabs-toolbar-inner");
+            var tabInnerHeader = comp.Find(".mud-tabs-tabbar-inner");
 
             tabInnerHeader.Children.Should().Contain(headerPanel);
             if (position == TabHeaderPosition.After)
@@ -1170,7 +1170,7 @@ namespace MudBlazor.UnitTests.Components
 
             content.TextContent.Should().Be("Selected: Tab One");
 
-            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-toolbar");
+            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-tabbar");
             content.NextElementSibling.ClassList.Should().Contain("mud-tabs-panels");
 
             comp.SetParametersAndRender(p => p.Add(x => x.SelectedIndex, 1));
@@ -1179,7 +1179,7 @@ namespace MudBlazor.UnitTests.Components
 
             content.TextContent.Should().Be("Selected: Tab Two");
 
-            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-toolbar");
+            content.PreviousElementSibling.ClassList.Should().Contain("mud-tabs-tabbar");
             content.NextElementSibling.ClassList.Should().Contain("mud-tabs-panels");
         }
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -3,8 +3,8 @@
 
 <div @attributes="UserAttributes" class="@TabsClassnames" style="@Style">
     <CascadingValue Value="this" IsFixed="true">
-        <div class="@ToolbarClassnames">
-            <div class="mud-tabs-toolbar-inner" style="@MaxHeightStyles">
+        <div class="@TabBarClassnames">
+            <div class="mud-tabs-tabbar-inner" style="@MaxHeightStyles">
                 @if (HeaderPosition == TabHeaderPosition.Before && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
@@ -17,7 +17,7 @@
                         <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
                     </div>
                 }
-                <div @ref="@_tabsContentSize" class="mud-tabs-toolbar-content">
+                <div @ref="@_tabsContentSize" class="mud-tabs-tabbar-content">
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
         private ElementReference _tabsContentSize;
         private double _sliderSize;
         private double _sliderPosition;
-        private double _toolbarContentSize;
+        private double _tabBarContentSize;
         private double _allTabsSize;
         private double _scrollPosition;
 
@@ -467,11 +467,11 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
-        protected string ToolbarClassnames =>
-            new CssBuilder("mud-tabs-toolbar")
+        protected string TabBarClassnames =>
+            new CssBuilder("mud-tabs-tabbar")
             .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
-            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default)
+            .AddClass($"mud-tabs-tabbar-{Color.ToDescriptionString()}", Color != Color.Default)
             .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border)
             .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined)
             .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0)
@@ -479,7 +479,7 @@ namespace MudBlazor
             .Build();
 
         protected string WrapperClassnames =>
-            new CssBuilder("mud-tabs-toolbar-wrapper")
+            new CssBuilder("mud-tabs-tabbar-wrapper")
             .AddClass($"mud-tabs-centered", Centered)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
             .Build();
@@ -586,7 +586,7 @@ namespace MudBlazor
             _nextIcon = RightToLeft ? PrevIcon : NextIcon;
             _prevIcon = RightToLeft ? NextIcon : PrevIcon;
 
-            GetToolbarContentSize();
+            GetTabBarContentSize();
             GetAllTabsSize();
             SetScrollButtonVisibility();
             SetSliderState();
@@ -610,7 +610,7 @@ namespace MudBlazor
         private bool IsSliderPositionDetermined => _activePanelIndex > 0 && _sliderPosition > 0 ||
                                                    _activePanelIndex <= 0;
 
-        private void GetToolbarContentSize() => _toolbarContentSize = GetRelevantSize(_tabsContentSize);
+        private void GetTabBarContentSize() => _tabBarContentSize = GetRelevantSize(_tabsContentSize);
 
         private void GetAllTabsSize()
         {
@@ -659,7 +659,7 @@ namespace MudBlazor
 
         private void SetScrollButtonVisibility()
         {
-            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _toolbarContentSize || _scrollIndex != 0;
+            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _tabBarContentSize || _scrollIndex != 0;
         }
 
         private void ScrollPrev()
@@ -712,7 +712,7 @@ namespace MudBlazor
             var position = GetLengthOfPanelItems(panel, isLast);
             if (isLast)
             {
-                var compare = _toolbarContentSize;
+                var compare = _tabBarContentSize;
                 if (position - compare > 0)
                 {
                     if (!AlwaysShowScrollButtons && _showScrollButtons)
@@ -744,7 +744,7 @@ namespace MudBlazor
 
             var panelToStart = ActivePanel;
             var length = GetPanelLength(panelToStart);
-            if (length >= _toolbarContentSize)
+            if (length >= _tabBarContentSize)
             {
                 _scrollIndex = _panels.IndexOf(panelToStart);
                 ScrollToItem(panelToStart);
@@ -760,13 +760,13 @@ namespace MudBlazor
                     length += GetPanelLength(_panels[panelAfterIndex]);
                 }
 
-                if (length >= _toolbarContentSize)
+                if (length >= _tabBarContentSize)
                 {
                     _scrollIndex = _panels.IndexOf(panelToStart);
                     break;
                 }
 
-                length = _toolbarContentSize - length;
+                length = _tabBarContentSize - length;
 
                 var panelBeforeindex = _activePanelIndex - indexCorrection;
                 if (!IsBeforeFirstPanelIndex(panelBeforeindex))
@@ -784,7 +784,7 @@ namespace MudBlazor
                     break;
                 }
 
-                length = _toolbarContentSize - length;
+                length = _tabBarContentSize - length;
                 panelToStart = _panels[_activePanelIndex - indexCorrection];
 
                 indexCorrection++;
@@ -796,7 +796,7 @@ namespace MudBlazor
 
         private void SetScrollabilityStates()
         {
-            var isEnoughSpace = _allTabsSize <= _toolbarContentSize;
+            var isEnoughSpace = _allTabsSize <= _tabBarContentSize;
 
             if (isEnoughSpace)
             {
@@ -806,7 +806,7 @@ namespace MudBlazor
             else
             {
                 // Disable next button if the last panel is completely visible
-                _nextButtonDisabled = _scrollIndex == _panels.Count - 1 || Math.Abs(_scrollPosition) >= GetLengthOfPanelItems(_panels.Last(), true) - _toolbarContentSize;
+                _nextButtonDisabled = _scrollIndex == _panels.Count - 1 || Math.Abs(_scrollPosition) >= GetLengthOfPanelItems(_panels.Last(), true) - _tabBarContentSize;
                 _prevButtonDisabled = _scrollIndex == 0;
             }
         }

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -24,7 +24,7 @@
     border-radius: var(--mud-default-borderradius);
     overflow: hidden;
 
-    .mud-tabs-toolbar {
+    .mud-tabs-tabbar {
       border-radius: var(--mud-default-borderradius);
     }
 
@@ -34,7 +34,7 @@
   }
 }
 
-.mud-tabs-toolbar {
+.mud-tabs-tabbar {
   position: relative;
   background-color: var(--mud-palette-surface);
 
@@ -67,7 +67,7 @@
   }
 
   &.mud-tabs-vertical {
-    .mud-tabs-toolbar-inner {
+    .mud-tabs-tabbar-inner {
       flex-direction: column;
 
       .mud-tabs-scroll-button {
@@ -86,14 +86,14 @@
     }
   }
 
-  & .mud-tabs-toolbar-inner {
+  & .mud-tabs-tabbar-inner {
     display: flex;
     min-height: 48px;
   }
 }
 
 
-.mud-tabs-toolbar-content {
+.mud-tabs-tabbar-content {
   width: 100%;
   flex: 1 1 auto;
   display: inline-block;
@@ -101,7 +101,7 @@
   white-space: nowrap;
   overflow: hidden;
 
-  & .mud-tabs-toolbar-wrapper {
+  & .mud-tabs-tabbar-wrapper {
     width: max-content;
     position: inherit;
     display: flex;
@@ -210,7 +210,7 @@
 }
 
 @each $color in $mud-palette-colors {
-  .mud-tabs-toolbar-#{$color} {
+  .mud-tabs-tabbar-#{$color} {
     background-color: var(--mud-palette-#{$color});
     color: var(--mud-palette-#{$color}-text);
 
@@ -262,7 +262,7 @@
 }
 
 .mud-dynamic-tabs {
-  .mud-tabs-toolbar {
+  .mud-tabs-tabbar {
     .mud-tab {
       padding: 6px 14px;
 


### PR DESCRIPTION
## Description
See https://github.com/MudBlazor/MudBlazor/pull/6298#issuecomment-1540825627

MudTabs used to name the `Tabbar` as `Toolbar` which is quite misleading. Partially this was resolved in an unbreaking PR #6298 some time ago but the breaking changes were kept for v7. 

## How Has This Been Tested?
unit and visually 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
