### PR TITLE
MudButton: fix focus style button when open dialog

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -52,7 +52,7 @@
     }
   }
 
-  &:focus-visible, &:active {
+  &:focus-visible, &:focus, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
 }
@@ -82,7 +82,7 @@
         }
       }
 
-      &:focus-visible, &:active {
+      &:focus-visible, &:focus, &:active {
         background-color: var(--mud-palette-#{$color}-hover);
       }
     }
@@ -109,7 +109,7 @@
     }
   }
 
-  &:focus-visible, &:active {
+  &:focus-visible, &:focus, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
 
@@ -126,7 +126,7 @@
         }
       }
 
-      &:focus-visible, &:active {
+      &:focus-visible, &:focus, &:active {
         border: 1px solid var(--mud-palette-#{$color});
         background-color: var(--mud-palette-#{$color}-hover);
       }
@@ -185,7 +185,7 @@
         }
       }
 
-      &:focus-visible, &:active {
+      &:focus-visible, &:focus, &:active {
         background-color: var(--mud-palette-#{$color}-darken);
       }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## Description
The style file for the MudButton components has been updated to include the :focus and :focus-visible pseudo-classes, applying them to the respective buttons.

## How Has This Been Tested?
I made a style modification to ensure that the focus on the button is correctly applied when the dialog opens.

This modification addresses several issues, such as:
https://github.com/MudBlazor/MudBlazor/issues/4283
https://github.com/MudBlazor/MudBlazor/issues/8451



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

Before: 

https://github.com/MudBlazor/MudBlazor/assets/79289665/16df6948-94d7-459b-b290-3b0fe947b336



After: 
https://github.com/MudBlazor/MudBlazor/assets/79289665/e0609b70-9899-48c0-90de-61f2d585b468
https://github.com/MudBlazor/MudBlazor/assets/79289665/6877c9d1-dd11-496f-bdbf-9cd41498c8b5
https://github.com/MudBlazor/MudBlazor/assets/79289665/07386ced-3695-427b-bacd-10e03e15cabd




## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
