### PR TITLE
MudColor: Add XML comments and make it serializable with STJ / NewtonsoftJson

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
         private const string CssSelector = ".mud-picker-color-overlay-black .mud-picker-color-overlay";
         private const string _mudToolbarButtonsCssSelector = ".mud-toolbar button";
 
-        private static readonly MudColor[] _mudGridDefaultColors = new MudColor[]
+        private static MudColor[] _mudGridDefaultColors = new MudColor[]
                         {
                 "#FFFFFF","#ebebeb","#d6d6d6","#c2c2c2","#adadad","#999999","#858586","#707070","#5c5c5c","#474747","#333333","#000000",
                 "#133648","#071d53","#0f0638","#2a093b","#370c1b","#541107","#532009","#53350d","#523e0f","#65611b","#505518","#2b3d16",
@@ -54,7 +54,7 @@ namespace MudBlazor.UnitTests.Components
                 "#d2effd","#d6e1fc","#d6c9fa","#e9cbfb","#f3d4df","#f9dcd9","#fae3d8","#fcecd7","#fdf2d8","#fefce0","#f7fade","#e3edd6"
                         };
 
-        private static readonly MudColor[] _mudGridPaletteDefaultColors = new MudColor[]
+        private static MudColor[] _mudGridPaletteDefaultClors = new MudColor[]
                 {
                    "#424242", "#2196f3", "#00c853", "#ff9800", "#f44336",
                   "#f6f9fb", "#9df1fa", "#bdffcf", "#fff0a3", "#ffd254",
@@ -173,7 +173,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ColorPickerView.Should().Be(ColorPickerView.Spectrum);
             comp.Instance.UpdateBindingIfOnlyHSLChanged.Should().BeFalse();
             comp.Instance.Value.Should().Be(_defaultColor);
-            comp.Instance.Palette.Should().BeEquivalentTo(_mudGridPaletteDefaultColors);
+            comp.Instance.Palette.Should().BeEquivalentTo(_mudGridPaletteDefaultClors);
             comp.Instance.DisableDragEffect.Should().BeFalse();
         }
 
@@ -810,10 +810,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
             });
 
-            var expectedColors = _mudGridPaletteDefaultColors;
+            var expectedColors = _mudGridPaletteDefaultClors;
 
             var collectionView = comp.Find(".mud-picker-color-view-collection");
 
@@ -836,10 +836,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
             });
 
-            var expectedColors = _mudGridPaletteDefaultColors;
+            var expectedColors = _mudGridPaletteDefaultClors;
             var collectionView = comp.Find(".mud-picker-color-view-collection");
 
             for (var i = 0; i < collectionView.Children.Length; i++)
@@ -991,12 +991,12 @@ namespace MudBlazor.UnitTests.Components
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
                 p.Add(x => x.Variant, variant);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
             });
 
             await comp.Instance.OpenPicker();
 
-            var expectedColors = _mudGridPaletteDefaultColors;
+            var expectedColors = _mudGridPaletteDefaultClors;
 
             var gridView = comp.Find(".mud-picker-color-view-collection");
             gridView.Children[0].Click();
@@ -1024,7 +1024,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Instance.OpenPicker();
 
-            var expectedColors = view == ColorPickerView.Grid ? _mudGridDefaultColors : _mudGridPaletteDefaultColors;
+            var expectedColors = view == ColorPickerView.Grid ? _mudGridDefaultColors : _mudGridPaletteDefaultClors;
 
             IElement item;
             if (view == ColorPickerView.Grid)

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -150,18 +149,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         private IHtmlInputElement GetColorInput(IRenderedComponent<SimpleColorPickerTest> comp, int index, int expectedCount = 4) => GetColorInputs(comp, expectedCount)[index];
-
-
-        [Test]
-        public void MudColor_Serialization()
-        {
-            var originalMudColor = new MudColor("#f6f9fb");
-
-            var jsonString = JsonSerializer.Serialize(originalMudColor);
-            var deserializeMudColor = JsonSerializer.Deserialize<MudColor>(jsonString);
-
-            deserializeMudColor.Should().Be(originalMudColor);
-        }
 
         [Test]
         public void ColorPickerOpenButtonAriaLabel()

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -40,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         private const string CssSelector = ".mud-picker-color-overlay-black .mud-picker-color-overlay";
         private const string _mudToolbarButtonsCssSelector = ".mud-toolbar button";
 
-        private static MudColor[] _mudGridDefaultColors = new MudColor[]
+        private static readonly MudColor[] _mudGridDefaultColors = new MudColor[]
                         {
                 "#FFFFFF","#ebebeb","#d6d6d6","#c2c2c2","#adadad","#999999","#858586","#707070","#5c5c5c","#474747","#333333","#000000",
                 "#133648","#071d53","#0f0638","#2a093b","#370c1b","#541107","#532009","#53350d","#523e0f","#65611b","#505518","#2b3d16",
@@ -54,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
                 "#d2effd","#d6e1fc","#d6c9fa","#e9cbfb","#f3d4df","#f9dcd9","#fae3d8","#fcecd7","#fdf2d8","#fefce0","#f7fade","#e3edd6"
                         };
 
-        private static MudColor[] _mudGridPaletteDefaultClors = new MudColor[]
+        private static readonly MudColor[] _mudGridPaletteDefaultColors = new MudColor[]
                 {
                    "#424242", "#2196f3", "#00c853", "#ff9800", "#f44336",
                   "#f6f9fb", "#9df1fa", "#bdffcf", "#fff0a3", "#ffd254",
@@ -150,6 +151,18 @@ namespace MudBlazor.UnitTests.Components
 
         private IHtmlInputElement GetColorInput(IRenderedComponent<SimpleColorPickerTest> comp, int index, int expectedCount = 4) => GetColorInputs(comp, expectedCount)[index];
 
+
+        [Test]
+        public void MudColor_Serialization()
+        {
+            var originalMudColor = new MudColor("#f6f9fb");
+
+            var jsonString = JsonSerializer.Serialize(originalMudColor);
+            var deserializeMudColor = JsonSerializer.Deserialize<MudColor>(jsonString);
+
+            deserializeMudColor.Should().Be(originalMudColor);
+        }
+
         [Test]
         public void ColorPickerOpenButtonAriaLabel()
         {
@@ -173,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ColorPickerView.Should().Be(ColorPickerView.Spectrum);
             comp.Instance.UpdateBindingIfOnlyHSLChanged.Should().BeFalse();
             comp.Instance.Value.Should().Be(_defaultColor);
-            comp.Instance.Palette.Should().BeEquivalentTo(_mudGridPaletteDefaultClors);
+            comp.Instance.Palette.Should().BeEquivalentTo(_mudGridPaletteDefaultColors);
             comp.Instance.DisableDragEffect.Should().BeFalse();
         }
 
@@ -810,10 +823,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
             });
 
-            var expectedColors = _mudGridPaletteDefaultClors;
+            var expectedColors = _mudGridPaletteDefaultColors;
 
             var collectionView = comp.Find(".mud-picker-color-view-collection");
 
@@ -836,10 +849,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
             });
 
-            var expectedColors = _mudGridPaletteDefaultClors;
+            var expectedColors = _mudGridPaletteDefaultColors;
             var collectionView = comp.Find(".mud-picker-color-view-collection");
 
             for (var i = 0; i < collectionView.Children.Length; i++)
@@ -991,12 +1004,12 @@ namespace MudBlazor.UnitTests.Components
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
                 p.Add(x => x.Variant, variant);
-                p.Add(x => x.Palette, _mudGridPaletteDefaultClors);
+                p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
             });
 
             await comp.Instance.OpenPicker();
 
-            var expectedColors = _mudGridPaletteDefaultClors;
+            var expectedColors = _mudGridPaletteDefaultColors;
 
             var gridView = comp.Find(".mud-picker-color-view-collection");
             gridView.Children[0].Click();
@@ -1024,7 +1037,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Instance.OpenPicker();
 
-            var expectedColors = view == ColorPickerView.Grid ? _mudGridDefaultColors : _mudGridPaletteDefaultClors;
+            var expectedColors = view == ColorPickerView.Grid ? _mudGridDefaultColors : _mudGridPaletteDefaultColors;
 
             IElement item;
             if (view == ColorPickerView.Grid)

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.IO;
+using System.Text;
 using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -33,6 +35,53 @@ namespace MudBlazor.UnitTests.Utilities
             var deserializeMudColor = Newtonsoft.Json.JsonConvert.DeserializeObject<MudColor>(jsonString);
 
             jsonString.Should().Be("{\"R\":246,\"G\":249,\"B\":251,\"A\":255}");
+            deserializeMudColor.Should().Be(originalMudColor);
+        }
+
+        [Test]
+        public void MudColor_Default_Ctor()
+        {
+            var defaultMudColor = new MudColor();
+            var blackMudColor = new MudColor("#000000ff");
+
+            defaultMudColor.R.Should().Be(0);
+            defaultMudColor.G.Should().Be(0);
+            defaultMudColor.B.Should().Be(0);
+            defaultMudColor.A.Should().Be(255);
+            defaultMudColor.H.Should().Be(0);
+            defaultMudColor.L.Should().Be(0);
+            defaultMudColor.S.Should().Be(0);
+            defaultMudColor.APercentage.Should().Be(1);
+            blackMudColor.Should().Be(defaultMudColor);
+        }
+
+        [Test]
+        public void MudColor_XMLDataContract_Serialization()
+        {
+            var dataContractSerializer = new System.Runtime.Serialization.DataContractSerializer(typeof(MudColor));
+
+            MudColor DeserializeXml(string toDeserialize)
+            {
+                using var textReader = new StringReader(toDeserialize);
+                using var reader = System.Xml.XmlReader.Create(textReader);
+
+                return (MudColor)dataContractSerializer.ReadObject(reader);
+            }
+
+            string SerializeXml(MudColor mudColorObject)
+            {
+                using var memoryStream = new MemoryStream();
+                dataContractSerializer.WriteObject(memoryStream, mudColorObject);
+
+                return Encoding.UTF8.GetString(memoryStream.ToArray());
+            }
+
+            var originalMudColor = new MudColor("#f6f9fb");
+
+            var xmlString = SerializeXml(originalMudColor);
+            var deserializeMudColor = DeserializeXml(xmlString);
+
+            xmlString.Should().Be("<MudColor xmlns=\"http://schemas.datacontract.org/2004/07/MudBlazor.Utilities\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:x=\"http://www.w3.org/2001/XMLSchema\"><R i:type=\"x:unsignedByte\" xmlns=\"\">246</R><G i:type=\"x:unsignedByte\" xmlns=\"\">249</G><B i:type=\"x:unsignedByte\" xmlns=\"\">251</B><A i:type=\"x:unsignedByte\" xmlns=\"\">255</A></MudColor>");
             deserializeMudColor.Should().Be(originalMudColor);
         }
 

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -13,6 +13,30 @@ namespace MudBlazor.UnitTests.Utilities
     public class MudColorTests
     {
         [Test]
+        public void MudColor_STJ_Serialization()
+        {
+            var originalMudColor = new MudColor("#f6f9fb");
+
+            var jsonString = System.Text.Json.JsonSerializer.Serialize(originalMudColor);
+            var deserializeMudColor = System.Text.Json.JsonSerializer.Deserialize<MudColor>(jsonString);
+
+            jsonString.Should().Be("{\"R\":246,\"G\":249,\"B\":251,\"A\":255}");
+            deserializeMudColor.Should().Be(originalMudColor);
+        }
+
+        [Test]
+        public void MudColor_Newtonsoft_Serialization()
+        {
+            var originalMudColor = new MudColor("#f6f9fb");
+
+            var jsonString = Newtonsoft.Json.JsonConvert.SerializeObject(originalMudColor);
+            var deserializeMudColor = Newtonsoft.Json.JsonConvert.DeserializeObject<MudColor>(jsonString);
+
+            jsonString.Should().Be("{\"R\":246,\"G\":249,\"B\":251,\"A\":255}");
+            deserializeMudColor.Should().Be(originalMudColor);
+        }
+
+        [Test]
         [TestCase("12315aca", 18, 49, 90, 202)]
         [TestCase("12315a", 18, 49, 90, 255)]
         [TestCase("#12315a", 18, 49, 90, 255)]

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -566,16 +566,20 @@ namespace MudBlazor.UnitTests.Utilities
         {
             MudColor color1 = new(10, 20, 50, 255);
             MudColor color2 = new(10, 20, 50, 255);
+            MudColor color3 = null;
+            MudColor color4 = null;
 
             (color1 == color1).Should().BeTrue();
             (color2 == color2).Should().BeTrue();
             (color1 == color2).Should().BeTrue();
             (color2 == color1).Should().BeTrue();
+            (color3 == color4).Should().BeTrue();
 
             color1.Equals(color1).Should().BeTrue();
             color2.Equals(color2).Should().BeTrue();
             color1.Equals(color2).Should().BeTrue();
             color2.Equals(color1).Should().BeTrue();
+            Equals(color3, color4).Should().BeTrue();
         }
 
         [Test]
@@ -583,12 +587,18 @@ namespace MudBlazor.UnitTests.Utilities
         {
             MudColor color1 = new(10, 20, 50, 255);
             MudColor color2 = new(10, 20, 50, 10);
+            MudColor color3 = null;
 
             (color1 != color2).Should().BeTrue();
             (color2 != color1).Should().BeTrue();
+            (color2 != color3).Should().BeTrue();
+            (color3 != color2).Should().BeTrue();
 
             color1.Equals(color2).Should().BeFalse();
             color2.Equals(color1).Should().BeFalse();
+            color2.Equals(color3).Should().BeFalse();
+            Equals(color3, color2).Should().BeFalse();
+            Equals(color2, color3).Should().BeFalse();
         }
 
 #pragma warning restore CS1718 // Comparison made to same variable

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -6,7 +6,6 @@ using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
-using System.Xml.Linq;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Utilities

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -4,10 +4,14 @@
 
 using System;
 using System.Globalization;
+using System.Text.Json.Serialization;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Utilities
 {
+    /// <summary>
+    /// Specifies different output formats for <seealso cref="MudColor"/>.
+    /// </summary>
     public enum MudColorOutputFormats
     {
         /// <summary>
@@ -32,36 +36,84 @@ namespace MudBlazor.Utilities
         ColorElements
     }
 
+    /// <summary>
+    /// Represents a color with methods to manipulate color values.
+    /// </summary>
     public class MudColor : IEquatable<MudColor>
     {
-        #region Fields and Properties
+        private const double Epsilon = 0.000000000000001;
+        private readonly byte[] _valuesAsByte;
 
-        private const double EPSILON = 0.000000000000001;
-
-        private byte[] _valuesAsByte;
-
+        [JsonIgnore]
         public string Value => $"#{R:x2}{G:x2}{B:x2}{A:x2}";
 
+        /// <summary>
+        /// Gets the red component value of the color.
+        /// </summary>
+        [JsonInclude]
         public byte R => _valuesAsByte[0];
+
+        /// <summary>
+        /// Gets the green component value of the color.
+        /// </summary>
+        [JsonInclude]
         public byte G => _valuesAsByte[1];
+
+        /// <summary>
+        /// Gets the blue component value of the color.
+        /// </summary>
+        [JsonInclude]
         public byte B => _valuesAsByte[2];
+
+        /// <summary>
+        /// Gets the alpha component value of the color.
+        /// </summary>
+        [JsonInclude]
         public byte A => _valuesAsByte[3];
+
+        /// <summary>
+        /// Gets the alpha component value as a percentage (0.0 to 1.0) of the color.
+        /// </summary>
+        [JsonIgnore]
         public double APercentage => Math.Round(A / 255.0, 2);
 
+        /// <summary>
+        /// Gets the hue component value of the color.
+        /// </summary>
+        [JsonIgnore]
         public double H { get; private set; }
+
+        /// <summary>
+        /// Gets the luminance component value of the color.
+        /// </summary>
+        [JsonIgnore]
         public double L { get; private set; }
+
+        /// <summary>
+        /// Gets the saturation component value of the color.
+        /// </summary>
+        [JsonIgnore]
         public double S { get; private set; }
 
-        #endregion
-
-        #region Constructor
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified hue, saturation, luminance, and alpha values.
+        /// </summary>
+        /// <param name="h">The hue component value (0 to 360).</param>
+        /// <param name="s">The saturation component value (0.0 to 1.0).</param>
+        /// <param name="l">The luminance component value (0.0 to 1.0).</param>
+        /// <param name="a">The alpha component value (0 to 1.0).</param>
         public MudColor(double h, double s, double l, double a)
-         : this(h, s, l, (int)((a * 255.0).EnsureRange(255)))
+            : this(h, s, l, (int)(a * 255.0).EnsureRange(255))
         {
-
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified hue, saturation, luminance, and alpha values.
+        /// </summary>
+        /// <param name="h">The hue component value (0 to 360).</param>
+        /// <param name="s">The saturation component value (0.0 to 1.0).</param>
+        /// <param name="l">The luminance component value (0.0 to 1.0).</param>
+        /// <param name="a">The alpha component value (0 to 255).</param>
         public MudColor(double h, double s, double l, int a)
         {
             _valuesAsByte = new byte[4];
@@ -72,7 +124,7 @@ namespace MudBlazor.Utilities
             a = a.EnsureRange(255);
 
             // achromatic argb (gray scale)
-            if (Math.Abs(s) < EPSILON)
+            if (Math.Abs(s) < Epsilon)
             {
                 _valuesAsByte[0] = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255D)));
                 _valuesAsByte[1] = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255D)));
@@ -88,31 +140,31 @@ namespace MudBlazor.Utilities
                 var p = (2D * l) - q;
 
                 var hk = h / 360D;
-                var T = new double[3];
-                T[0] = hk + (1D / 3D); // Tr
-                T[1] = hk; // Tb
-                T[2] = hk - (1D / 3D); // Tg
+                var t = new double[3];
+                t[0] = hk + (1D / 3D); // Tr
+                t[1] = hk; // Tb
+                t[2] = hk - (1D / 3D); // Tg
 
                 for (var i = 0; i < 3; i++)
                 {
-                    if (T[i] < 0D)
-                        T[i] += 1D;
-                    if (T[i] > 1D)
-                        T[i] -= 1D;
+                    if (t[i] < 0D)
+                        t[i] += 1D;
+                    if (t[i] > 1D)
+                        t[i] -= 1D;
 
-                    if ((T[i] * 6D) < 1D)
-                        T[i] = p + ((q - p) * 6D * T[i]);
-                    else if ((T[i] * 2D) < 1)
-                        T[i] = q;
-                    else if ((T[i] * 3D) < 2)
-                        T[i] = p + ((q - p) * ((2D / 3D) - T[i]) * 6D);
+                    if ((t[i] * 6D) < 1D)
+                        t[i] = p + ((q - p) * 6D * t[i]);
+                    else if ((t[i] * 2D) < 1)
+                        t[i] = q;
+                    else if ((t[i] * 3D) < 2)
+                        t[i] = p + ((q - p) * ((2D / 3D) - t[i]) * 6D);
                     else
-                        T[i] = p;
+                        t[i] = p;
                 }
 
-                _valuesAsByte[0] = ((int)Math.Round(T[0] * 255D)).EnsureRangeToByte();
-                _valuesAsByte[1] = ((int)Math.Round(T[1] * 255D)).EnsureRangeToByte();
-                _valuesAsByte[2] = ((int)Math.Round(T[2] * 255D)).EnsureRangeToByte();
+                _valuesAsByte[0] = ((int)Math.Round(t[0] * 255D)).EnsureRangeToByte();
+                _valuesAsByte[1] = ((int)Math.Round(t[1] * 255D)).EnsureRangeToByte();
+                _valuesAsByte[2] = ((int)Math.Round(t[2] * 255D)).EnsureRangeToByte();
                 _valuesAsByte[3] = (byte)a;
             }
 
@@ -121,6 +173,14 @@ namespace MudBlazor.Utilities
             L = Math.Round(l, 2);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified red, green, blue, and alpha values.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <param name="a">The alpha component value (0 to 255).</param>
+        [JsonConstructor]
         public MudColor(byte r, byte g, byte b, byte a)
         {
             _valuesAsByte = new byte[4];
@@ -130,33 +190,56 @@ namespace MudBlazor.Utilities
             _valuesAsByte[2] = b;
             _valuesAsByte[3] = a;
 
-            CalculateHSL();
+            CalculateHsl();
         }
 
         /// <summary>
-        /// initialize a new MudColor with new RGB values but keeps the hue value from the color
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified red, green, blue, and alpha values, copying the hue value from the provided color.
         /// </summary>
-        /// <param name="r">R</param>
-        /// <param name="g">G</param>
-        /// <param name="b">B</param>
-        /// <param name="color">Existing color to copy hue value from </param>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <param name="color">The existing color to copy the hue value from.</param>
         public MudColor(byte r, byte g, byte b, MudColor color) : this(r, g, b, color.A)
         {
             H = color.H;
         }
 
-        public MudColor(int r, int g, int b, double alpha) :
-         this(r, g, b, (byte)((alpha * 255.0).EnsureRange(255)))
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified RGB values and alpha component.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <param name="alpha">The alpha component value (0.0 to 1.0).</param>
+        public MudColor(int r, int g, int b, double alpha)
+            : this(r, g, b, (byte)((alpha * 255.0).EnsureRange(255)))
         {
-
         }
 
-        public MudColor(int r, int g, int b, int alpha) :
-            this((byte)r.EnsureRange(255), (byte)g.EnsureRange(255), (byte)b.EnsureRange(255), (byte)alpha.EnsureRange(255))
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified RGB values and alpha component.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <param name="alpha">The alpha component value (0 to 255).</param>
+        public MudColor(int r, int g, int b, int alpha)
+            : this((byte)r.EnsureRange(255), (byte)g.EnsureRange(255), (byte)b.EnsureRange(255), (byte)alpha.EnsureRange(255))
         {
-
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified string representation of a color.
+        /// </summary>
+        /// <param name="value">The string representation of a color.</param>
+        /// <remarks>
+        /// The color can be represented in various formats, including hexadecimal (with or without alpha), RGB, and RGBA.
+        /// Examples of valid color strings:
+        /// - Hexadecimal format: "#ab2a3d", "#ab2a3dff"
+        /// - RGB format: "rgb(12,15,40)"
+        /// - RGBA format: "rgba(12,15,40,0.42)"
+        /// </remarks>
         public MudColor(string value)
         {
             value = value.Trim().ToLower();
@@ -171,10 +254,10 @@ namespace MudBlazor.Utilities
 
                 _valuesAsByte = new byte[]
                 {
-                    byte.Parse(parts[0],CultureInfo.InvariantCulture),
-                    byte.Parse(parts[1],CultureInfo.InvariantCulture),
-                    byte.Parse(parts[2],CultureInfo.InvariantCulture),
-                    (byte)Math.Max(0, Math.Min(255, 255 * double.Parse(parts[3],CultureInfo.InvariantCulture))),
+                    byte.Parse(parts[0], CultureInfo.InvariantCulture),
+                    byte.Parse(parts[1], CultureInfo.InvariantCulture),
+                    byte.Parse(parts[2], CultureInfo.InvariantCulture),
+                    (byte)Math.Max(0, Math.Min(255, 255 * double.Parse(parts[3], CultureInfo.InvariantCulture))),
                 };
             }
             else if (value.StartsWith("rgb"))
@@ -184,18 +267,18 @@ namespace MudBlazor.Utilities
                 {
                     throw new ArgumentException("invalid color format");
                 }
+
                 _valuesAsByte = new byte[]
                 {
-                    byte.Parse(parts[0],CultureInfo.InvariantCulture),
-                    byte.Parse(parts[1],CultureInfo.InvariantCulture),
-                    byte.Parse(parts[2],CultureInfo.InvariantCulture),
-                    255
+                    byte.Parse(parts[0], CultureInfo.InvariantCulture),
+                    byte.Parse(parts[1], CultureInfo.InvariantCulture),
+                    byte.Parse(parts[2], CultureInfo.InvariantCulture), 255
                 };
             }
             else
             {
 
-                if (value.StartsWith("#"))
+                if (value.StartsWith('#'))
                 {
                     value = value.Substring(1);
                 }
@@ -203,10 +286,10 @@ namespace MudBlazor.Utilities
                 switch (value.Length)
                 {
                     case 3:
-                        value = new string(new char[8] { value[0], value[0], value[1], value[1], value[2], value[2], 'F', 'F' });
+                        value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], 'F', 'F' });
                         break;
                     case 4:
-                        value = new string(new char[8] { value[0], value[0], value[1], value[1], value[2], value[2], value[3], value[3] });
+                        value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], value[3], value[3] });
                         break;
                     case 6:
                         value += "FF";
@@ -214,7 +297,7 @@ namespace MudBlazor.Utilities
                     case 8:
                         break;
                     default:
-                        throw new ArgumentException("not a valid color", nameof(value));
+                        throw new ArgumentException(@"Not a valid color", nameof(value));
                 }
 
                 _valuesAsByte = new byte[]
@@ -225,81 +308,200 @@ namespace MudBlazor.Utilities
                     GetByteFromValuePart(value,6),
                 };
             }
-            CalculateHSL();
+
+            CalculateHsl();
         }
 
-
-
-        #endregion
-
-        #region Methods
-
-        private void CalculateHSL()
-        {
-            var h = 0D;
-            var s = 0D;
-            double l;
-
-            // normalize red, green, blue values
-            var r = R / 255D;
-            var g = G / 255D;
-            var b = B / 255D;
-
-            var max = Math.Max(r, Math.Max(g, b));
-            var min = Math.Min(r, Math.Min(g, b));
-
-            // hue
-            if (Math.Abs(max - min) < EPSILON)
-                h = 0D; // undefined
-            else if ((Math.Abs(max - r) < EPSILON)
-                    && (g >= b))
-                h = (60D * (g - b)) / (max - min);
-            else if ((Math.Abs(max - r) < EPSILON)
-                    && (g < b))
-                h = ((60D * (g - b)) / (max - min)) + 360D;
-            else if (Math.Abs(max - g) < EPSILON)
-                h = ((60D * (b - r)) / (max - min)) + 120D;
-            else if (Math.Abs(max - b) < EPSILON)
-                h = ((60D * (r - g)) / (max - min)) + 240D;
-
-            // luminance
-            l = (max + min) / 2D;
-
-            // saturation
-            if ((Math.Abs(l) < EPSILON)
-                    || (Math.Abs(max - min) < EPSILON))
-                s = 0D;
-            else if ((0D < l)
-                    && (l <= .5D))
-                s = (max - min) / (max + min);
-            else if (l > .5D)
-                s = (max - min) / (2D - (max + min)); //(max-min > 0)?
-
-            H = Math.Round(h.EnsureRange(360), 0);
-            S = Math.Round(s.EnsureRange(1), 2);
-            L = Math.Round(l.EnsureRange(1), 2);
-        }
-
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified hue value while keeping the saturation, luminance, and alpha values unchanged.
+        /// </summary>
+        /// <param name="h">The hue component value (0 to 360).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified hue value.</returns>
         public MudColor SetH(double h) => new(h, S, L, A);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified saturation value while keeping the hue, luminance, and alpha values unchanged.
+        /// </summary>
+        /// <param name="s">The saturation component value (0.0 to 1.0).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified saturation value.</returns>
         public MudColor SetS(double s) => new(H, s, L, A);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified luminance value while keeping the hue, saturation, and alpha values unchanged.
+        /// </summary>
+        /// <param name="l">The luminance component value (0.0 to 1.0).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified luminance value.</returns>
         public MudColor SetL(double l) => new(H, S, l, A);
 
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified red component value while keeping the green, blue, and alpha values unchanged.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified red component value.</returns>
         public MudColor SetR(int r) => new(r, G, B, A);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified green component value while keeping the red, blue, and alpha values unchanged.
+        /// </summary>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified green component value.</returns>
         public MudColor SetG(int g) => new(R, g, B, A);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified blue component value while keeping the red, green, and alpha values unchanged.
+        /// </summary>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified blue component value.</returns>
         public MudColor SetB(int b) => new(R, G, b, A);
 
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified alpha value while keeping the red, green, blue values unchanged.
+        /// </summary>
+        /// <param name="a">The alpha component value (0 to 255).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified alpha component value.</returns>
         public MudColor SetAlpha(int a) => new(R, G, B, a);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance with the specified alpha value while keeping the red, green, blue values unchanged.
+        /// </summary>
+        /// <param name="a">The alpha component value (0.0 to 1.0).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the specified alpha component value.</returns>
         public MudColor SetAlpha(double a) => new(R, G, B, a);
 
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance by adjusting the luminance component value by the specified amount.
+        /// </summary>
+        /// <param name="amount">The amount to adjust the luminance by (-1.0 to 1.0).</param>
+        /// <returns>A new <see cref="MudColor"/> instance with the adjusted luminance.</returns>
         public MudColor ChangeLightness(double amount) => new(H, S, Math.Max(0, Math.Min(1, L + amount)), A);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance by lightening the color.
+        /// </summary>
+        /// <param name="amount">The amount to lighten the color by.</param>
+        /// <returns>A new <see cref="MudColor"/> instance that is lighter than the original color.</returns>
         public MudColor ColorLighten(double amount) => ChangeLightness(+amount);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance by darkening the color.
+        /// </summary>
+        /// <param name="amount">The amount to darken the color by.</param>
+        /// <returns>A new <see cref="MudColor"/> instance that is darker than the original color.</returns>
         public MudColor ColorDarken(double amount) => ChangeLightness(-amount);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance by lightening the color using the RGB algorithm.
+        /// </summary>
+        /// <returns>A new <see cref="MudColor"/> instance that is lighter than the original color.</returns>
         public MudColor ColorRgbLighten() => ColorLighten(0.075);
+
+        /// <summary>
+        /// Creates a new <see cref="MudColor"/> instance by darkening the color using the RGB algorithm.
+        /// </summary>
+        /// <returns>A new <see cref="MudColor"/> instance that is darker than the original color.</returns>
         public MudColor ColorRgbDarken() => ColorDarken(0.075);
 
-        #endregion
+        /// <summary>
+        /// Checks whether the HSL (Hue, Saturation, Luminance) values of this <see cref="MudColor"/> instance have changed compared to another <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="value">The <see cref="MudColor"/> instance to compare HSL values with.</param>
+        /// <returns>True if the HSL values have changed; otherwise, false.</returns>
+        public bool HslChanged(MudColor value)
+        {
+            var comparer = DoubleEpsilonEqualityComparer.Default;
 
-        #region Helper
+            return !comparer.Equals(H, value.H) || !comparer.Equals(S, value.S) || !comparer.Equals(L, value.L);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is MudColor color && Equals(color);
+
+        /// <summary>
+        /// Determines whether this <see cref="MudColor"/> instance is equal to another <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="other">The <see cref="MudColor"/> instance to compare.</param>
+        /// <returns>True if the instances are equal; otherwise, false.</returns>
+        public bool Equals(MudColor other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return
+                _valuesAsByte[0] == other._valuesAsByte[0] &&
+                _valuesAsByte[1] == other._valuesAsByte[1] &&
+                _valuesAsByte[2] == other._valuesAsByte[2] &&
+                _valuesAsByte[3] == other._valuesAsByte[3];
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="MudColor"/> instances are equal.
+        /// </summary>
+        /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
+        /// <param name="rhs">The second <see cref="MudColor"/> instance to compare.</param>
+        /// <returns>True if the instances are equal; otherwise, false.</returns>
+        public static bool operator ==(MudColor lhs, MudColor rhs)
+        {
+            var lhsIsNull = ReferenceEquals(null, lhs);
+            var rhsIsNull = ReferenceEquals(null, rhs);
+            if (lhsIsNull && rhsIsNull)
+            {
+                return true;
+            }
+
+            if (lhsIsNull || rhsIsNull)
+            {
+                return false;
+            }
+
+            return lhs.Equals(rhs);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode() => _valuesAsByte[0] + _valuesAsByte[1] + _valuesAsByte[2] + _valuesAsByte[3];
+
+        /// <inheritdoc />
+        public override string ToString() => ToString(MudColorOutputFormats.RGBA);
+
+        /// <summary>
+        /// Returns the string representation of the color in the specified format.
+        /// </summary>
+        /// <param name="format">The format to represent the color.</param>
+        /// <returns>A string representing the color.</returns>
+        public string ToString(MudColorOutputFormats format) => format switch
+        {
+            MudColorOutputFormats.Hex => Value.Substring(0, 7),
+            MudColorOutputFormats.HexA => Value,
+            MudColorOutputFormats.RGB => $"rgb({R},{G},{B})",
+            MudColorOutputFormats.RGBA => $"rgba({R},{G},{B},{(A / 255.0).ToString(CultureInfo.InvariantCulture)})",
+            MudColorOutputFormats.ColorElements => $"{R},{G},{B}",
+            _ => Value,
+        };
+
+        /// <summary>
+        /// Determines whether two <see cref="MudColor"/> instances are not equal.
+        /// </summary>
+        /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
+        /// <param name="rhs">The second <see cref="MudColor"/> instance to compare.</param>
+        /// <returns>True if the instances are not equal; otherwise, false.</returns>
+        public static bool operator !=(MudColor lhs, MudColor rhs) => !(lhs == rhs);
+
+        /// <summary>
+        /// Converts a string representation of a color to a <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="input">The string representation of the color.</param>
+        /// <returns>A new <see cref="MudColor"/> instance representing the color.</returns>
+        public static implicit operator MudColor(string input) => new(input);
+
+        /// <summary>
+        /// Converts a <see cref="MudColor"/> instance to its string representation.
+        /// </summary>
+        /// <param name="color">The MudColor instance to convert.</param>
+        /// <returns>The string representation of the color.</returns>
+        public static explicit operator string(MudColor color) => color == null ? string.Empty : color.Value;
+
+        private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new char[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 
         private static string[] SplitInputIntoParts(string value)
         {
@@ -311,74 +513,65 @@ namespace MudBlazor.Utilities
             {
                 parts[i] = parts[i].Trim();
             }
+
             return parts;
         }
 
-        private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new char[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
-
-        public bool HslChanged(MudColor value) => H != value.H || S != value.S || L != value.L;
-
-        #endregion
-
-        #region operators and object members
-
-        public static implicit operator MudColor(string input) => new(input);
-        //public static implicit operator string(MudColor input) => input == null ? string.Empty : input.Value;
-
-        public static explicit operator string(MudColor color) => color == null ? string.Empty : color.Value;
-
-        public override string ToString() => ToString(MudColorOutputFormats.RGBA);
-
-        public string ToString(MudColorOutputFormats format) => format switch
+        private void CalculateHsl()
         {
-            MudColorOutputFormats.Hex => Value.Substring(0, 7),
-            MudColorOutputFormats.HexA => Value,
-            MudColorOutputFormats.RGB => $"rgb({R},{G},{B})",
-            MudColorOutputFormats.RGBA => $"rgba({R},{G},{B},{(A / 255.0).ToString(CultureInfo.InvariantCulture)})",
-            MudColorOutputFormats.ColorElements => $"{R},{G},{B}",
-            _ => Value,
-        };
+            var h = 0D;
+            var s = 0D;
 
-        public override bool Equals(object obj) => obj is MudColor color && Equals(color);
+            // normalize red, green, blue values
+            var r = R / 255D;
+            var g = G / 255D;
+            var b = B / 255D;
 
-        public bool Equals(MudColor other)
-        {
-            if (ReferenceEquals(other, null)) { return false; }
+            var max = Math.Max(r, Math.Max(g, b));
+            var min = Math.Min(r, Math.Min(g, b));
 
-            return
-                _valuesAsByte[0] == other._valuesAsByte[0] &&
-                _valuesAsByte[1] == other._valuesAsByte[1] &&
-                _valuesAsByte[2] == other._valuesAsByte[2] &&
-                _valuesAsByte[3] == other._valuesAsByte[3];
-        }
-
-        public override int GetHashCode() => _valuesAsByte[0] + _valuesAsByte[1] + _valuesAsByte[2] + _valuesAsByte[3];
-
-        public static bool operator ==(MudColor lhs, MudColor rhs)
-        {
-            var lhsIsNull = ReferenceEquals(null, lhs);
-            var rhsIsNull = ReferenceEquals(null, rhs);
-            if (lhsIsNull && rhsIsNull)
+            // hue
+            if (Math.Abs(max - min) < Epsilon)
             {
-                return true;
+                h = 0D; // undefined
             }
-            else
+            else if ((Math.Abs(max - r) < Epsilon) && (g >= b))
             {
-                if ((lhsIsNull || rhsIsNull))
-                {
-                    return false;
-                }
-                else
-                {
-                    return lhs.Equals(rhs);
-                }
+                h = (60D * (g - b)) / (max - min);
             }
+            else if ((Math.Abs(max - r) < Epsilon) && (g < b))
+            {
+                h = ((60D * (g - b)) / (max - min)) + 360D;
+            }
+            else if (Math.Abs(max - g) < Epsilon)
+            {
+                h = ((60D * (b - r)) / (max - min)) + 120D;
+            }
+            else if (Math.Abs(max - b) < Epsilon)
+            {
+                h = ((60D * (r - g)) / (max - min)) + 240D;
+            }
+
+            // luminance
+            var l = (max + min) / 2D;
+
+            // saturation
+            if (Math.Abs(l) < Epsilon || (Math.Abs(max - min) < Epsilon))
+            {
+                s = 0D;
+            }
+            else if ((0D < l) && (l <= .5D))
+            {
+                s = (max - min) / (max + min);
+            }
+            else if (l > .5D)
+            {
+                s = (max - min) / (2D - (max + min)); //(max-min > 0)?
+            }
+
+            H = Math.Round(h.EnsureRange(360), 0);
+            S = Math.Round(s.EnsureRange(1), 2);
+            L = Math.Round(l.EnsureRange(1), 2);
         }
-
-        public static bool operator !=(MudColor lhs, MudColor rhs) => !(lhs == rhs);
-
-        #endregion
-
-
     }
 }

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -6,10 +6,14 @@ using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Utilities
 {
+#nullable enable
     /// <summary>
     /// Specifies different output formats for <seealso cref="MudColor"/>.
     /// </summary>
@@ -426,14 +430,14 @@ namespace MudBlazor.Utilities
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is MudColor color && Equals(color);
+        public override bool Equals(object? obj) => obj is MudColor color && Equals(color);
 
         /// <summary>
         /// Determines whether this <see cref="MudColor"/> instance is equal to another <see cref="MudColor"/> instance.
         /// </summary>
         /// <param name="other">The <see cref="MudColor"/> instance to compare.</param>
         /// <returns>True if the instances are equal; otherwise, false.</returns>
-        public bool Equals(MudColor other)
+        public bool Equals(MudColor? other)
         {
             if (ReferenceEquals(other, null))
             {
@@ -453,16 +457,19 @@ namespace MudBlazor.Utilities
         /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
         /// <param name="rhs">The second <see cref="MudColor"/> instance to compare.</param>
         /// <returns>True if the instances are equal; otherwise, false.</returns>
-        public static bool operator ==(MudColor lhs, MudColor rhs)
+        public static bool operator ==(MudColor? lhs, MudColor? rhs)
         {
-            var lhsIsNull = ReferenceEquals(null, lhs);
-            var rhsIsNull = ReferenceEquals(null, rhs);
-            if (lhsIsNull && rhsIsNull)
+            if (lhs is null && rhs is null)
             {
                 return true;
             }
 
-            if (lhsIsNull || rhsIsNull)
+            if (ReferenceEquals(lhs, rhs))
+            {
+                return true;
+            }
+
+            if (lhs is null || rhs is null)
             {
                 return false;
             }
@@ -511,7 +518,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="color">The MudColor instance to convert.</param>
         /// <returns>The string representation of the color.</returns>
-        public static explicit operator string(MudColor color) => color == null ? string.Empty : color.Value;
+        public static explicit operator string(MudColor? color) => color == null ? string.Empty : color.Value;
 
         private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new char[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using System.Xml.Linq;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Utilities
@@ -39,7 +41,8 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Represents a color with methods to manipulate color values.
     /// </summary>
-    public class MudColor : IEquatable<MudColor>
+    [Serializable]
+    public class MudColor : ISerializable, IEquatable<MudColor>
     {
         private const double Epsilon = 0.000000000000001;
         private readonly byte[] _valuesAsByte;
@@ -94,6 +97,16 @@ namespace MudBlazor.Utilities
         /// </summary>
         [JsonIgnore]
         public double S { get; private set; }
+
+        /// <summary>
+        /// Deserialization constructor for <see cref="MudColor"/>.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/>> containing the serialized data.</param>
+        /// <param name="context">The <see cref="StreamingContext"/>>.</param>
+        protected MudColor(SerializationInfo info, StreamingContext context) :
+            this(info.GetByte(nameof(R)), info.GetByte(nameof(G)), info.GetByte(nameof(B)), info.GetByte(nameof(A)))
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MudColor"/> class with the specified hue, saturation, luminance, and alpha values.
@@ -249,7 +262,7 @@ namespace MudBlazor.Utilities
                 var parts = SplitInputIntoParts(value);
                 if (parts.Length != 4)
                 {
-                    throw new ArgumentException("invalid color format");
+                    throw new ArgumentException("Invalid color format.");
                 }
 
                 _valuesAsByte = new byte[]
@@ -265,7 +278,7 @@ namespace MudBlazor.Utilities
                 var parts = SplitInputIntoParts(value);
                 if (parts.Length != 3)
                 {
-                    throw new ArgumentException("invalid color format");
+                    throw new ArgumentException("Invalid color format.");
                 }
 
                 _valuesAsByte = new byte[]
@@ -297,7 +310,7 @@ namespace MudBlazor.Utilities
                     case 8:
                         break;
                     default:
-                        throw new ArgumentException(@"Not a valid color", nameof(value));
+                        throw new ArgumentException(@"Not a valid color.", nameof(value));
                 }
 
                 _valuesAsByte = new byte[]
@@ -572,6 +585,15 @@ namespace MudBlazor.Utilities
             H = Math.Round(h.EnsureRange(360), 0);
             S = Math.Round(s.EnsureRange(1), 2);
             L = Math.Round(l.EnsureRange(1), 2);
+        }
+
+        /// <inheritdoc />
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(R), R);
+            info.AddValue(nameof(G), G);
+            info.AddValue(nameof(B), B);
+            info.AddValue(nameof(A), A);
         }
     }
 }

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -6,9 +6,6 @@ using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
-using System.Xml;
-using System.Xml.Schema;
-using System.Xml.Serialization;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Utilities
@@ -109,6 +106,18 @@ namespace MudBlazor.Utilities
         protected MudColor(SerializationInfo info, StreamingContext context) :
             this(info.GetByte(nameof(R)), info.GetByte(nameof(G)), info.GetByte(nameof(B)), info.GetByte(nameof(A)))
         {
+        }
+
+        /// <summary>
+        /// Constructs a default instance of <see cref="MudColor"/> with default values (black with full opacity).
+        /// </summary>
+        public MudColor()
+        {
+            _valuesAsByte = new byte[4];
+            _valuesAsByte[0] = 0;
+            _valuesAsByte[1] = 0;
+            _valuesAsByte[2] = 0;
+            _valuesAsByte[3] = 255;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7688
Fixes: https://github.com/MudBlazor/MudBlazor/issues/3095

This makes it compatible only with STJ.
I know other Serializers exists like `Newtonsoft.Json`, `YamlDotNet`, and many other binary ones.
But I think think most customers are using the built in - STJ, and the issues were specifically talking about it. I think advanced user can workaround it with custom converters.

## How Has This Been Tested?
New unit tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
