### PR TITLE
Various Components: Rename DisableGutters to just Gutters

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -20,7 +20,7 @@
     else {
         // Just show copyright and version
         <MudContainer MaxWidth="MaxWidth.Large">
-            <MudToolBar DisableGutters="true" Dense="true">
+            <MudToolBar Gutters="false" Dense="true">
                 <MudText Typo="Typo.body1">Copyright © 2020-@DateTime.Now.Year MudBlazor.</MudText>
                 <MudSpacer/>
                 <MudText Typo="Typo.body1">Powered by .NET @Environment.Version.ToString()</MudText>

--- a/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
@@ -41,7 +41,7 @@
         </MudList>
     </div>
     <div class="@ContentClassNames">
-        <MudToolBar DisableGutters="true" Class="mud-text-secondary">
+        <MudToolBar Gutters="false" Class="mud-text-secondary">
             <MudTooltip Duration="1000" Text="Toggle Drawer">
                 <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@GetIcon()" Color="Color.Inherit" />
             </MudTooltip>

--- a/src/MudBlazor.Docs/Components/NavigationFooter.razor
+++ b/src/MudBlazor.Docs/Components/NavigationFooter.razor
@@ -1,4 +1,4 @@
-﻿<MudToolBar DisableGutters="true" Class="mb-16">
+﻿<MudToolBar Gutters="false" Class="mb-16">
     @if (Previous != null)
     {
         <MudButton Color="Color.Primary"

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
@@ -7,7 +7,7 @@
 		@foreach (var item in _sections)
 		{
 			<MudPaper Elevation="0" Width="224px" MinHeight="400px" Class="pa-4 ma-4 d-flex flex-column mud-background-gray rounded-lg">
-				<MudToolBar DisableGutters="true">
+				<MudToolBar Gutters="false">
 					<MudText Typo="Typo.subtitle1"><b>@item.Name</b></MudText>
 					<MudSpacer />
 					<MudMenu Icon="@Icons.Material.Rounded.MoreHoriz" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" ListClass="pa-2 d-flex flex-column" PopoverClass="mud-elevation-25">

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneMailExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneMailExample.razor
@@ -28,7 +28,7 @@
             </MudList>
             <MudDivider Vertical="true" FlexItem="true" />
             <MudList Dense="true" Clickable="true" Class="d-flex flex-column flex-grow-1 py-0">
-                <MudToolBar DisableGutters="true" Dense="true">
+                <MudToolBar Gutters="false" Dense="true">
                     <MudCheckBox @bind-Value="ToolbarCheckBox"/>
                     <MudIconButton Icon="@Icons.Material.Filled.Refresh"/>
                     <MudIconButton Icon="@Icons.Material.Filled.MoreVert"/>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelPaddingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelPaddingExample.razor
@@ -2,15 +2,15 @@
 
 
 <MudExpansionPanels>
-    <MudExpansionPanel Text="Dense" Dense="true">
-        Dense Content
+    <MudExpansionPanel Text="Dense" Dense Gutters>
+        Dense Content with Gutters
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Gutters" DisableGutters="true">
-        Gutters Content
+    <MudExpansionPanel Text="Gutters" Dense="false" Gutters="false">
+        Content without Gutters
     </MudExpansionPanel>
 </MudExpansionPanels>
-<MudExpansionPanels Dense="true" DisableGutters="true" Class="mt-6">
-    <MudExpansionPanel Text="Dense & Gutters from parent">
-        Dense & Gutters Content
+<MudExpansionPanels Dense Gutters="false" Class="mt-6">
+    <MudExpansionPanel Text="Dense and Gutters setting inherited from parent">
+        Dense Content without Gutters
     </MudExpansionPanel>
 </MudExpansionPanels>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
@@ -42,7 +42,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Padding">
-                <Description>The padding of the panels can be controlled with <CodeInline>DisableGutters</CodeInline> and <CodeInline>Dense</CodeInline>. These can be set individually per panel or applied on all panels by setting them on the parent.</Description>
+                <Description>The padding of the panels can be controlled with <CodeInline>Gutters</CodeInline> and <CodeInline>Dense</CodeInline>. These can be set individually per panel or applied on all panels by setting them on the parent.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="ExpansionPanelPaddingExample" Block="true" FullWidth="true">
                 <ExpansionPanelPaddingExample />

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/DragAndDropFileUploadExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/DragAndDropFileUploadExample.razor
@@ -12,7 +12,7 @@
         <MudChip T="string" Color="Color.Dark" Text="@file" />
     }
 </MudPaper>
-<MudToolBar DisableGutters="true" Class="gap-4">
+<MudToolBar Gutters="false" Class="gap-4">
     <MudButton OnClick="Upload" Disabled="@(!_fileNames.Any())" Color="Color.Primary" Variant="Variant.Filled">Upload</MudButton>
     <MudButton OnClick="ClearAsync" Disabled="@(!_fileNames.Any())" Color="Color.Error" Variant="Variant.Filled">Clear</MudButton>
 </MudToolBar>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropCustomScenarioExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropCustomScenarioExample.razor
@@ -24,7 +24,7 @@
                     <MudChip T="string" Color="Color.Dark" Text="@file" />
                 }
             </MudPaper>
-            <MudToolBar DisableGutters="true"
+            <MudToolBar Gutters="false"
                         Class="relative d-flex justify-end gap-4 z-30">
                 <MudButton HtmlTag="label"
                            Color="Color.Primary"

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropWithFormValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadDragAndDropWithFormValidationExample.razor
@@ -37,7 +37,7 @@
                                      Text="@file" />
                         }
                     </MudPaper>
-                    <MudToolBar DisableGutters="true"
+                    <MudToolBar Gutters="false"
                                 Class="relative d-flex justify-end gap-4 z-30">
                         <MudButton HtmlTag="label"
                                    Color="Color.Primary"

--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListInteractiveExample.razor
@@ -9,7 +9,7 @@
     <MudItem xs="12" md="6">
         <MudText Typo="Typo.h6" GutterBottom="true">Text only</MudText>
         <MudPaper Width="100%">
-            <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
+            <MudList Clickable="@Clickable" Dense="@Dense" Gutters="@Gutters">
                 <MudListItem Text="Single List Item" />
                 <MudListItem Text="Single List Item" />
                 <MudListItem Text="Single List Item" />
@@ -19,7 +19,7 @@
     <MudItem xs="12" md="6">
         <MudText Typo="Typo.h6" GutterBottom="true">Icons with text</MudText>
         <MudPaper Width="100%">
-            <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
+            <MudList Clickable="@Clickable" Dense="@Dense" Gutters="@Gutters">
                 <MudListItem Text="Single List Item" Icon="@Icons.Material.Filled.Bookmark" />
                 <MudListItem Text="Single List Item" Icon="@Icons.Material.Filled.Bookmark" IconColor="Color.Primary" />
                 <MudListItem Text="Single List Item" Icon="@Icons.Material.Filled.Bookmark" IconColor="Color.Secondary" />
@@ -29,7 +29,7 @@
     <MudItem xs="12" md="6">
         <MudText Typo="Typo.h6" GutterBottom="true">Avatar with text</MudText>
         <MudPaper Width="100%">
-            <MudList Clickable="@Clickable" Dense="@Dense" DisableGutters="@Gutters">
+            <MudList Clickable="@Clickable" Dense="@Dense" Gutters="@Gutters">
                 <MudListItem Text="Single List Item" Avatar="@Icons.Material.Filled.Image" />
                 <MudListItem Text="Single List Item" Avatar="@Icons.Material.Filled.Image" IconColor="Color.Dark" />
                 <MudListItem Text="Single List Item" Avatar="@Icons.Material.Filled.Image" IconColor="Color.Error" />

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayLoaderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayLoaderExample.razor
@@ -32,7 +32,7 @@
     }
 </MudCard>
 
-<MudToolBar DisableGutters="true">
+<MudToolBar Gutters="false">
     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenOverlay" EndIcon="@Icons.Material.Filled.Refresh">Refresh Data</MudButton>
     <MudSpacer/>
     <MudButton Variant="Variant.Filled" OnClick="ResetExample">Reset Example</MudButton>

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -65,7 +65,7 @@
 </DocsPage>
 
 <MudDrawer @bind-Open="@iconDrawerOpen" ClipMode="DrawerClipMode.Always" Anchor="Anchor.End" DisableOverlay="true" Elevation="0" Width="260px" Class="mud-icondrawer" Variant="@DrawerVariant.Temporary">
-    <MudToolBar Dense="true" DisableGutters="true" Class="pl-4 py-8">
+    <MudToolBar Dense="true" Gutters="false" Class="pl-4 py-8">
         <MudIcon Size="Size.Large" Icon="@SelectedIcon.Code" Class="mr-4"/>
         <MudText Typo="Typo.subtitle1">@SelectedIcon.Name</MudText>
         <MudSpacer/>

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor
@@ -12,7 +12,7 @@
                 <SpecialHeaderContent>
                     <MudText Typo="Typo.h2" Class="docs-title">@_message.Title&nbsp;</MudText>
                     <MudText Typo="Typo.subtitle1" Class="docs-title-description">@_message.Except</MudText>
-                    <MudToolBar DisableGutters="true">
+                    <MudToolBar Gutters="false">
                         @foreach (var author in _message.Authors)
                         {
                             <div class="d-flex justify-start align-center mx-1">

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -8,7 +8,7 @@
     </MudAppBar>
     <MudDrawer Open="@_drawerOpen" OpenChanged="OnDrawerOpenChanged" ClipMode="DrawerClipMode.Docked" Elevation="0" Breakpoint="Breakpoint.Md">
         <div class="d-block d-md-none">
-            <MudToolBar Dense="true" DisableGutters="true" Class="docs-gray-bg">
+            <MudToolBar Dense="true" Gutters="false" Class="docs-gray-bg">
                 @if (_topMenuOpen == false)
                 {
                     <MudIconButton Icon="@Icons.Material.Rounded.ArrowBack" Color="Color.Inherit" OnClick="@((e) => OpenTopMenu())"/>

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -45,7 +45,7 @@
         <MudLink Href="https://github.com/MudBlazor/Templates" Target="_blank" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Templates</MudLink>
     </MudItem>
     <MudItem xs="12">
-        <MudToolBar DisableGutters="true" Dense="true">
+        <MudToolBar Gutters="false" Dense="true">
             <MudText Typo="Typo.body1">@($"Copyright © 2020-{DateTime.Now.Year} MudBlazor")</MudText>
         </MudToolBar>
     </MudItem>

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -6,7 +6,7 @@
         <Appbar DrawerToggleCallback="ToggleDrawer" />
     </MudAppBar>
     <MudDrawer @bind-Open="@_drawerOpen" Elevation="25" Variant="@DrawerVariant.Temporary">
-        <MudToolBar Dense="true" DisableGutters="true" Class="px-1 docs-gray-bg">
+        <MudToolBar Dense="true" Gutters="false" Class="px-1 docs-gray-bg">
             <MudIconButton Icon="@Icons.Material.Rounded.Close" Color="Color.Inherit" OnClick="@ToggleDrawer" />
             <MudSpacer/>
             <AppbarButtons/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadButtonTemplateContextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadButtonTemplateContextTest.razor
@@ -13,7 +13,7 @@
             <MudText Typo="Typo.h6">Drag and drop files here or click</MudText>
             <MudChip T="string" Color="Color.Dark" Text="@File?.Name" />
         </MudPaper>
-        <MudToolBar DisableGutters="true"
+        <MudToolBar Gutters="false"
                     Class="relative d-flex justify-end gap-4 z-30">
             <MudButton HtmlTag="label"
                        for="@context.Id">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadAndButtonTemplateContextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithFileUploadAndButtonTemplateContextTest.razor
@@ -25,7 +25,7 @@
                         <MudText Typo="Typo.h6">Drag and drop files here or click</MudText>
                         <MudChip T="string" Color="Color.Dark" Text="@_model.File?.Name" />
                     </MudPaper>
-                    <MudToolBar DisableGutters="true"
+                    <MudToolBar Gutters="false"
                                 Class="relative d-flex justify-end gap-4 z-30">
                         <MudButton HtmlTag="label"
                                    for="@context.Id">

--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -95,7 +95,7 @@ namespace MudBlazor
     ///       - <i>Appearance</i> - Changing these properties doesn't change behavior of the component and behavior of the application, but only changes the appearance
     ///                             of the component irrelevant to the understanding of the application by a user. So in some way they are less important than the "Behavior"
     ///                             category, because they are only used to adjust the look of the application. Example properties are: a) <c>Elevation</c>, <c>Outlined</c>,
-    ///                             <c>Square</c>, <c>Rounded</c>, <c>DisableGutters</c>, <c>Dense</c>, <c>Ripple</c>; b) size, color, and typography of the item
+    ///                             <c>Square</c>, <c>Rounded</c>, <c>Gutters</c>, <c>Dense</c>, <c>Ripple</c>; b) size, color, and typography of the item
     ///                             and its subelements; c) CSS classes and styles of subelements; d) icons with the default value already set (because most often changing its value
     ///                             doesn't change passed information).<br/>
     ///       - <i>Common</i>     - Properties defined in <see cref="MudComponentBase"/>.

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -3,7 +3,7 @@
 @if (Bottom)
 {
 <footer @attributes="UserAttributes" class="@Classname" style="@Style">
-    <MudToolBar Dense="@Dense" DisableGutters="@DisableGutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+    <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
         @ChildContent
     </MudToolBar>
 </footer>
@@ -11,7 +11,7 @@
 else
 {
 <header @attributes="UserAttributes" class="@Classname" style="@Style">
-    <MudToolBar Dense="@Dense" DisableGutters="@DisableGutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+    <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
         @ChildContent
     </MudToolBar>
 </header>

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -43,11 +43,11 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// If true, the left and right padding is removed from the appbar.
+        /// If true, left and right padding is added to the appbar. Default is true
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AppBar.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         /// <summary>
         /// The color of the component. It supports the theme colors.

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
 
         protected string PanelContentClassname =>
             new CssBuilder("mud-expand-panel-content")
-                .AddClass("mud-expand-panel-gutters", DisableGutters || Parent?.DisableGutters == true)
+                .AddClass("mud-expand-panel-disable-gutters", !Gutters && Parent?.Gutters != true)
                 .AddClass("mud-expand-panel-dense", Dense || Parent?.Dense == true)
                 .Build();
 
@@ -73,11 +73,11 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// If true, the left and right padding is removed from <see cref="ChildContent"/>.
+        /// If true, left and right padding is added to the <see cref="ChildContent"/>. Default is true .
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         /// <summary>
         /// Raised when IsExpanded changes.

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -47,11 +47,11 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// If true, the left and right padding is removed from all panels' <see cref="ChildContent"/>.
+        /// If true, left and right padding is added to all panels' <see cref="ChildContent"/>. Default is true
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         /// <summary>
         /// If true, the borders around each panel will be removed.

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -53,11 +53,11 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// If true, the left and right padding is removed on all list items.
+        /// If true, left and right padding is added to all list items. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         /// <summary>
         /// If true, will disable the list item if it has onclick.

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
         protected string Classname =>
         new CssBuilder("mud-list-item")
           .AddClass("mud-list-item-dense", (Dense ?? MudList?.Dense) ?? false)
-          .AddClass("mud-list-item-gutters", !DisableGutters && !(MudList?.DisableGutters == true))
+          .AddClass("mud-list-item-gutters", Gutters || MudList?.Gutters == true)
           .AddClass("mud-list-item-clickable", MudList?.Clickable)
           .AddClass("mud-ripple", MudList?.Clickable == true && Ripple && !Disabled)
           .AddClass($"mud-selected-item mud-{MudList?.Color.ToDescriptionString()}-text mud-{MudList?.Color.ToDescriptionString()}-hover", _selected && !Disabled)
@@ -143,11 +143,11 @@ namespace MudBlazor
         public bool? Dense { get; set; }
 
         /// <summary>
-        /// If true, the left and right padding is removed.
+        /// If true, left and right padding is added. Default is true
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         /// <summary>
         /// Expand or collapse nested list. Two-way bindable. Note: if you directly set this to

--- a/src/MudBlazor/Components/List/MudListSubheader.razor.cs
+++ b/src/MudBlazor/Components/List/MudListSubheader.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
     {
         protected string Classname =>
         new CssBuilder("mud-list-subheader")
-           .AddClass("mud-list-subheader-gutters", !DisableGutters)
+           .AddClass("mud-list-subheader-gutters", Gutters)
            .AddClass("mud-list-subheader-inset", Inset)
           .AddClass(Class)
         .Build();
@@ -17,9 +17,12 @@ namespace MudBlazor
         [Category(CategoryTypes.List.Behavior)]
         public RenderFragment ChildContent { get; set; }
 
+        /// <summary>
+        /// If true, left and right padding is added. Default is true
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool DisableGutters { get; set; }
+        public bool Gutters { get; set; } = true;
 
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]

--- a/src/MudBlazor/Components/ToolBar/MudToolBar.razor
+++ b/src/MudBlazor/Components/ToolBar/MudToolBar.razor
@@ -12,7 +12,7 @@
     protected string Classname =>
         new CssBuilder("mud-toolbar")
             .AddClass("mud-toolbar-dense", Dense)
-            .AddClass("mud-toolbar-gutters", !DisableGutters)
+            .AddClass("mud-toolbar-gutters", Gutters)
             .AddClass("mud-toolbar-wrap-content", WrapContent)
             .AddClass(Class)
             .Build();
@@ -25,11 +25,11 @@
     public bool Dense { get; set; }
 
     /// <summary>
-    /// If true, disables gutter padding.
+    /// If true, left and right padding is added. Default is true
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.ToolBar.Appearance)]
-    public bool DisableGutters { get; set; }
+    public bool Gutters { get; set; } = true;
 
     /// <summary>
     /// Child content of component.

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -102,7 +102,7 @@
     flex: 1 1 auto;
     max-width: 100%;
 
-    &.mud-expand-panel-gutters {
+    &.mud-expand-panel-disable-gutters {
       padding-left: 0px;
       padding-right: 0px;
     }


### PR DESCRIPTION
## Description
We want to move from `DisableSomething` to just `Something` or `EnableSomething` depending on the property. This PR tackles only `DisableGutters` and renames it to just `Gutters`. Of course default value and all invocations have been inverted.

See #6131

If you wonder what `Gutters` are (I didn't know), its apparently a term for left-right padding.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
