### PR TITLE
Optimization: Make PeriodicTableService a Singleton Service

### DIFF
--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -42,7 +42,7 @@ namespace MudBlazor.Docs.Extensions
             services.AddBlazoredLocalStorage();
             services.AddScoped<IUserPreferencesService, UserPreferencesService>();
             services.AddScoped<INotificationService, InMemoryNotificationService>();
-            services.AddScoped<IPeriodicTableService, PeriodicTableService>();
+            services.AddSingleton<IPeriodicTableService, PeriodicTableService>();
             services.AddSingleton<IRenderQueueService, RenderQueueService>();
             services.AddScoped<LayoutService>();
             services.AddGoogleAnalytics("G-PRYNCB61NV");

--- a/src/MudBlazor.Examples.Data/PeriodicTableService.cs
+++ b/src/MudBlazor.Examples.Data/PeriodicTableService.cs
@@ -10,14 +10,14 @@ namespace MudBlazor.Examples.Data
 {
     public class PeriodicTableService : IPeriodicTableService
     {
-        private static readonly Table s_table = null;
-        private static readonly JsonSerializerOptions s_serializerOptions = new() { PropertyNameCaseInsensitive = true };
+        private static readonly Table _table = null;
+        private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNameCaseInsensitive = true };
 
         static PeriodicTableService()
         {
             var key = GetResourceKey(typeof(PeriodicTableService).Assembly, "Elements.json");
             using var stream = typeof(PeriodicTableService).Assembly.GetManifestResourceStream(key);
-            s_table = JsonSerializer.Deserialize<Table>(stream, s_serializerOptions);
+            _table = JsonSerializer.Deserialize<Table>(stream, _serializerOptions);
         }
 
         public static string GetResourceKey(Assembly assembly, string embeddedFile)
@@ -33,7 +33,7 @@ namespace MudBlazor.Examples.Data
         public async Task<IEnumerable<Element>> GetElements(string search = "")
         {
             var elements = new List<Element>();
-            foreach (var elementGroup in s_table.ElementGroups)
+            foreach (var elementGroup in _table.ElementGroups)
             {
                 elements = elements.Concat(elementGroup.Elements).ToList();
             }

--- a/src/MudBlazor.Examples.Data/PeriodicTableService.cs
+++ b/src/MudBlazor.Examples.Data/PeriodicTableService.cs
@@ -11,12 +11,13 @@ namespace MudBlazor.Examples.Data
     public class PeriodicTableService : IPeriodicTableService
     {
         private static readonly Table s_table = null;
+        private static readonly JsonSerializerOptions s_serializerOptions = new() { PropertyNameCaseInsensitive = true };
 
         static PeriodicTableService()
         {
             var key = GetResourceKey(typeof(PeriodicTableService).Assembly, "Elements.json");
             using var stream = typeof(PeriodicTableService).Assembly.GetManifestResourceStream(key);
-            s_table = JsonSerializer.Deserialize<Table>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+            s_table = JsonSerializer.Deserialize<Table>(stream, s_serializerOptions);
         }
 
         public static string GetResourceKey(Assembly assembly, string embeddedFile)

--- a/src/MudBlazor.Examples.Data/PeriodicTableService.cs
+++ b/src/MudBlazor.Examples.Data/PeriodicTableService.cs
@@ -10,6 +10,20 @@ namespace MudBlazor.Examples.Data
 {
     public class PeriodicTableService : IPeriodicTableService
     {
+        private static readonly Table s_table = null;
+
+        static PeriodicTableService()
+        {
+            var key = GetResourceKey(typeof(PeriodicTableService).Assembly, "Elements.json");
+            using var stream = typeof(PeriodicTableService).Assembly.GetManifestResourceStream(key);
+            s_table = JsonSerializer.Deserialize<Table>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+        }
+
+        public static string GetResourceKey(Assembly assembly, string embeddedFile)
+        {
+            return assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(embeddedFile));
+        }
+
         public Task<IEnumerable<Element>> GetElements()
         {
             return GetElements(string.Empty);
@@ -18,23 +32,15 @@ namespace MudBlazor.Examples.Data
         public async Task<IEnumerable<Element>> GetElements(string search = "")
         {
             var elements = new List<Element>();
-            var key = GetResourceKey(typeof(PeriodicTableService).Assembly, "Elements.json");
-            using var stream = typeof(PeriodicTableService).Assembly.GetManifestResourceStream(key);
-            var table = await JsonSerializer.DeserializeAsync<Table>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
-            foreach (var elementGroup in table.ElementGroups)
+            foreach (var elementGroup in s_table.ElementGroups)
             {
                 elements = elements.Concat(elementGroup.Elements).ToList();
             }
 
             if (search == string.Empty)
-                return elements;
+                return await Task.FromResult(elements);
             else
                 return elements.Where(elm => (elm.Sign + elm.Name).Contains(search, StringComparison.InvariantCultureIgnoreCase));
-        }
-
-        public static string GetResourceKey(Assembly assembly, string embeddedFile)
-        {
-            return assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(embeddedFile));
         }
     }
 }


### PR DESCRIPTION
## Description

This small update improves performance of `MudTable` examples by:

* Changing the `PeriodicTableService` from a scoped service into a singleton service 
* Loading `Elements.json` into a static variable once instead of reloading as an instance variable repeatedly

## How Has This Been Tested?

This was tested by running unit tests then interacting with the `MudTable` examples via the `MudBlazor.Docs.Server` and `MudBlazor.Docs.WasmHost` projects to ensure no concurrency issues.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.

## Notes for Reviewers

* This change only affects MudBlazor examples
* This change increases performance of the `PeriodicTableService` but also increases memory use via a new static variable.
