### PR TITLE
MudExpansionPanels: Rename `DisableBorders` to `Outlined`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelOutlinedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelOutlinedExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudExpansionPanels DisableBorders="true" Elevation="0">
+<MudExpansionPanels Outlined="false" Elevation="0">
     <MudExpansionPanel Text="Panel One">
         Panel One Content
     </MudExpansionPanel>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
@@ -51,10 +51,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Borders">
-                <Description>The <CodeInline>DisableBorders</CodeInline> property removes all borders around the panel.<br />For a flatter UI design, this might be preferred along with <CodeInline>Elevation</CodeInline> set to 0.</Description>
+                <Description>The <CodeInline>Outlined</CodeInline> property controls the borders around the panel.<br />For a flatter UI design, you might be prefer to set it to <CodeInline>false</CodeInline> along with <CodeInline>Elevation</CodeInline> set to 0.</Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="ExpansionPanelDisableBorderExample" Block="true" FullWidth="true">
-                <ExpansionPanelDisableBorderExample />
+            <SectionContent DarkenBackground="true" Code="@nameof(ExpansionPanelOutlinedExample)" Block="true" FullWidth="true">
+                <ExpansionPanelOutlinedExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -20,7 +20,7 @@ namespace MudBlazor
                 .AddClass("mud-panel-next-expanded", NextPanelExpanded)
                 .AddClass("mud-disabled", Disabled)
                 .AddClass($"mud-elevation-{Parent?.Elevation.ToString()}")
-                .AddClass($"mud-expand-panel-border", Parent?.DisableBorders != true)
+                .AddClass($"mud-expand-panel-border", Parent?.Outlined == true)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -54,11 +54,11 @@ namespace MudBlazor
         public bool DisableGutters { get; set; }
 
         /// <summary>
-        /// If true, the borders around each panel will be removed.
+        /// Determines whether the borders around each panel are shown.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Appearance)]
-        public bool DisableBorders { get; set; }
+        public bool Outlined { get; set; } = true;
 
         /// <summary>
         /// Child content of component.


### PR DESCRIPTION
## Description
We want to move from `DisableSomething` to just `Something` or `EnableSomething` depending on the property. This PR tackles only `DisableBorders` and renames it to `Outlined`. Of course default value and all invocations have been inverted.

See #6131

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
