### PR TITLE
MudDataGrid: Rename `DisableRowsPerPage` to `PageSizeDropDown`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationTest.razor
@@ -5,11 +5,14 @@
         <PropertyColumn Property="x => x.Name" />
     </Columns>
     <PagerContent>
-        <MudDataGridPager />
+        <MudDataGridPager PageSizeDropDown="@PageSizeDropDown" />
     </PagerContent>
 </MudDataGrid>
 
 @code {
+    [Parameter]
+    public bool PageSizeDropDown { get; set; } = true;
+
     private List<Item> _items = new List<Item>();
 
     protected override void OnInitialized()

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -474,14 +474,16 @@ namespace MudBlazor.UnitTests.Components
                 dataGrid.FindAll("input.mud-checkbox-input")[i].Change(true);
                 dataGrid.Instance.SelectedItems.Count.Should().Be(i);
             }
-
-
         }
 
+        [Test]
         public async Task DataGridPaginationTest()
         {
             var comp = Context.RenderComponent<DataGridPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
+            // check that the page size dropdown is shown
+            comp.FindComponents<MudSelect<string>>().Count.Should().Be(1);
+
             dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
 
             // test that we are on the first page of results
@@ -509,6 +511,21 @@ namespace MudBlazor.UnitTests.Components
             // navigate back to the first page programmatically
             await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(Page.First));
             dataGrid.Instance.CurrentPage.Should().Be(0);
+        }
+
+
+        [Test]
+        public async Task DataGridPaginationPageSizeDropDownTest()
+        {
+            var comp = Context.RenderComponent<DataGridPaginationTest>(self => self.Add(x => x.PageSizeDropDown, false));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
+            dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
+
+            // test that we are on the first page of results
+            dataGrid.Find(".mud-table-body td").TextContent.Trim().Should().Be("0");
+
+            // page size drop-down is not shown
+            comp.FindComponents<MudSelect<string>>().Should().BeEmpty();
         }
 
         [Test]
@@ -3733,5 +3750,6 @@ namespace MudBlazor.UnitTests.Components
             rows = dataGrid.FindAll("tr");
             rows.Count.Should().Be(6, because: "1 header row + 4 data rows + 1 footer row");
         }
+
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -4,7 +4,7 @@
 
 <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
     <div class="mud-table-pagination-spacer"></div>
-    @if (!DisableRowsPerPage)
+    @if (PageSizeDropDown)
     {
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -12,40 +13,55 @@ namespace MudBlazor
 {
     public partial class MudDataGridPager<T> : MudComponentBase, IDisposable
     {
-        [CascadingParameter] public MudDataGrid<T> DataGrid { get; set; }
+        [CascadingParameter]
+        public MudDataGrid<T> DataGrid { get; set; }
 
         /// <summary>
         /// Set true to hide the part of the pager which allows to change the page size.
         /// </summary>
-        [Parameter] public bool DisableRowsPerPage { get; set; }
+        [Parameter]
+        public bool PageSizeDropDown { get; set; } = true;
 
         /// <summary>
         /// Set true to disable user interaction with the backward/forward buttons
         /// and the part of the pager which allows to change the page size.
         /// </summary>
-        [Parameter] public bool Disabled { get; set; }
+        [Parameter]
+        public bool Disabled { get; set; }
 
         /// <summary>
         /// Define a list of available page size options for the user to choose from
         /// </summary>
-        [Parameter] public int[] PageSizeOptions { get; set; } = new int[] { 10, 25, 50, 100 };
+        [Parameter]
+        public int[] PageSizeOptions { get; set; } = new int[] { 10, 25, 50, 100 };
 
         /// <summary>
         /// Format string for the display of the current page, which you can localize to your language. Available variables are:
         /// {first_item}, {last_item} and {all_items} which will replaced with the indices of the page's first and last item, as well as the total number of items.
         /// Default: "{first_item}-{last_item} of {all_items}" which is transformed into "0-25 of 77". 
         /// </summary>
-        [Parameter] public string InfoFormat { get; set; } = "{first_item}-{last_item} of {all_items}";
+        [Parameter]
+        public string InfoFormat { get; set; } = "{first_item}-{last_item} of {all_items}";
 
         /// <summary>
         /// The localizable "Rows per page:" text.
         /// </summary>
-        [Parameter] public string RowsPerPageString { get; set; } = "Rows per page:";
+        [Parameter]
+        public string RowsPerPageString { get; set; } = "Rows per page:";
 
-        private string Info => DataGrid == null ? "DataGrid==null" : InfoFormat
-            .Replace("{first_item}", $"{(DataGrid?.CurrentPage * DataGrid.RowsPerPage) + 1}")
-            .Replace("{last_item}", $"{Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount())}")
-            .Replace("{all_items}", $"{DataGrid.GetFilteredItemsCount()}");
+        private string Info
+        {
+            get
+            {
+                if (DataGrid == null)
+                    return "DataGrid==null";
+                Debug.Assert(DataGrid != null);
+                var firstItem = DataGrid.CurrentPage * DataGrid.RowsPerPage + 1;
+                var lastItem = Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount());
+                var allItems = DataGrid?.GetFilteredItemsCount();
+                return InfoFormat.Replace("{first_item}", $"{firstItem}").Replace("{last_item}", $"{lastItem}").Replace("{all_items}", $"{allItems}");
+            }
+        }
 
         private bool BackButtonsDisabled => Disabled || DataGrid is { CurrentPage: 0 };
 
@@ -58,7 +74,10 @@ namespace MudBlazor
 
         private async Task SetRowsPerPageAsync(string size)
         {
-            await DataGrid?.SetRowsPerPageAsync(int.Parse(size));
+            if (DataGrid != null)
+            {
+                await DataGrid.SetRowsPerPageAsync(int.Parse(size));
+            }
         }
 
         protected override async Task OnInitializedAsync()


### PR DESCRIPTION
## Description
We want to move from `DisableSomething` to just `Something` or `EnableSomething` depending on the property. This PR tackles only `DisableRowsPerPage` and renames it to `PageSizeDropDown`. Of course default value and all invocations have been inverted.

See #6131

This feature was not covered by any tests at all, so I added a testcase. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
