### PR TITLE
Chip: Remove special palette variables

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -109,8 +109,6 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-palette-table-hover: rgba(0,0,0,0.0392156862745098);",
                 "--mud-palette-divider: rgba(224,224,224,1);",
                 "--mud-palette-divider-light: rgba(0,0,0,0.8);",
-                "--mud-palette-chip-default: rgba(0,0,0,0.0784313725490196);",
-                "--mud-palette-chip-default-hover: rgba(0,0,0,0.11764705882352941);",
                 "--mud-palette-gray-default: #9E9E9E;",
                 "--mud-palette-gray-light: #BDBDBD;",
                 "--mud-palette-gray-lighter: #E0E0E0;",

--- a/src/MudBlazor/Components/ThemeProvider/MudThemingProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemingProvider.razor.cs
@@ -240,9 +240,6 @@ partial class MudThemingProvider : ComponentBase, IDisposable
         theme.AppendLine($"--{Palette}-divider: {palette.Divider};");
         theme.AppendLine($"--{Palette}-divider-light: {palette.DividerLight};");
 
-        theme.AppendLine($"--{Palette}-chip-default: {palette.ChipDefault};");
-        theme.AppendLine($"--{Palette}-chip-default-hover: {palette.ChipDefaultHover};");
-
         theme.AppendLine($"--{Palette}-gray-default: {palette.GrayDefault};");
         theme.AppendLine($"--{Palette}-gray-light: {palette.GrayLight};");
         theme.AppendLine($"--{Palette}-gray-lighter: {palette.GrayLighter};");

--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -98,6 +98,7 @@
 
   &.mud-clickable {
     cursor: pointer;
+    user-select: none;
   }
 
   .mud-chip-icon {
@@ -135,7 +136,6 @@
     display: inline-flex;
     height: 100%;
     max-width: 100%;
-    user-select: none;
   }
 }
 
@@ -144,9 +144,11 @@
   background-color: var(--mud-palette-chip-default);
   --mud-ripple-opacity: var(--mud-ripple-opacity-secondary);
 
-  @media(hover: hover) and (pointer: fine) {
-    &:hover:not(.mud-disabled) {
-      background-color: var(--mud-palette-chip-default-hover);
+  &.mud-clickable {
+    @media(hover: hover) and (pointer: fine) {
+      &:hover:not(.mud-disabled) {
+        background-color: var(--mud-palette-chip-default-hover);
+      }
     }
   }
 
@@ -160,9 +162,11 @@
       --mud-ripple-color: var(--mud-palette-#{$color}-text) !important;
       background-color: var(--mud-palette-#{$color});
 
-      @media(hover: hover) and (pointer: fine) {
-        &:hover:not(.mud-disabled) {
-          background-color: var(--mud-palette-#{$color}-darken);
+      &.mud-clickable {
+        @media(hover: hover) and (pointer: fine) {
+          &:hover:not(.mud-disabled) {
+            background-color: var(--mud-palette-#{$color}-darken);
+          }
         }
       }
 
@@ -177,9 +181,11 @@
   color: var(--mud-palette-text-primary);
   border: 1px solid var(--mud-palette-lines-inputs);
 
-  @media(hover: hover) and (pointer: fine) {
-    &:hover:not(.mud-disabled) {
-      background-color: var(--mud-palette-action-default-hover);
+  &.mud-clickable {
+    @media(hover: hover) and (pointer: fine) {
+      &:hover:not(.mud-disabled) {
+        background-color: var(--mud-palette-action-default-hover);
+      }
     }
   }
 
@@ -193,9 +199,11 @@
       --mud-ripple-color: var(--mud-palette-#{$color}) !important;
       border: 1px solid var(--mud-palette-#{$color});
 
-      @media(hover: hover) and (pointer: fine) {
-        &:hover:not(.mud-disabled) {
-          background-color: var(--mud-palette-#{$color}-hover);
+      &.mud-clickable {
+        @media(hover: hover) and (pointer: fine) {
+          &:hover:not(.mud-disabled) {
+            background-color: var(--mud-palette-#{$color}-hover);
+          }
         }
       }
 
@@ -224,9 +232,11 @@
   color: var(--mud-palette-text-primary);
   background-color: var(--mud-palette-chip-default);
 
-  @media(hover: hover) and (pointer: fine) {
-    &:hover:not(.mud-disabled) {
-      background-color: var(--mud-palette-chip-default-hover);
+  &.mud-clickable {
+    @media(hover: hover) and (pointer: fine) {
+      &:hover:not(.mud-disabled) {
+        background-color: var(--mud-palette-chip-default-hover);
+      }
     }
   }
 
@@ -240,9 +250,11 @@
       --mud-ripple-color: var(--mud-palette-#{$color}) !important;
       background-color: var(--mud-palette-#{$color}-hover);
 
-      @media(hover: hover) and (pointer: fine) {
-        &:hover:not(.mud-disabled) {
-          background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+      &.mud-clickable {
+        @media(hover: hover) and (pointer: fine) {
+          &:hover:not(.mud-disabled) {
+            background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+          }
         }
       }
 

--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -141,19 +141,19 @@
 
 .mud-chip-filled {
   color: var(--mud-palette-text-primary);
-  background-color: var(--mud-palette-chip-default);
+  background-color: var(--mud-palette-action-disabled-background);
   --mud-ripple-opacity: var(--mud-ripple-opacity-secondary);
 
   &.mud-clickable {
     @media(hover: hover) and (pointer: fine) {
       &:hover:not(.mud-disabled) {
-        background-color: var(--mud-palette-chip-default-hover);
+        background-color: var(--mud-palette-action-disabled);
       }
     }
   }
 
   &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-    background-color: var(--mud-palette-chip-default-hover);
+    background-color: var(--mud-palette-action-disabled);
   }
 
   @each $color in $mud-palette-colors {
@@ -230,18 +230,18 @@
 
 .mud-chip-text {
   color: var(--mud-palette-text-primary);
-  background-color: var(--mud-palette-chip-default);
+  background-color: var(--mud-palette-action-default-hover);
 
   &.mud-clickable {
     @media(hover: hover) and (pointer: fine) {
       &:hover:not(.mud-disabled) {
-        background-color: var(--mud-palette-chip-default-hover);
+        background-color: var(--mud-palette-action-disabled-background);
       }
     }
   }
 
   &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-    background-color: var(--mud-palette-chip-default-hover);
+    background-color: var(--mud-palette-action-disabled-background);
   }
 
   @each $color in $mud-palette-colors {

--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -2,7 +2,6 @@
 
 .mud-chip {
   border: none;
-  cursor: default;
   display: inline-flex;
   max-width: 100%;
   outline: 0;
@@ -150,10 +149,10 @@
         background-color: var(--mud-palette-chip-default-hover);
       }
     }
-  }
 
-  &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-    background-color: var(--mud-palette-chip-default-hover);
+    &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+      background-color: var(--mud-palette-chip-default-hover);
+    }
   }
 
   @each $color in $mud-palette-colors {
@@ -168,10 +167,10 @@
             background-color: var(--mud-palette-#{$color}-darken);
           }
         }
-      }
 
-      &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-        background-color: var(--mud-palette-#{$color}-darken);
+        &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+          background-color: var(--mud-palette-#{$color}-darken);
+        }
       }
     }
   }
@@ -187,10 +186,10 @@
         background-color: var(--mud-palette-action-default-hover);
       }
     }
-  }
 
-  &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-    background-color: var(--mud-palette-action-default-hover);
+    &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+      background-color: var(--mud-palette-action-default-hover);
+    }
   }
 
   @each $color in $mud-palette-colors {
@@ -205,10 +204,10 @@
             background-color: var(--mud-palette-#{$color}-hover);
           }
         }
-      }
 
-      &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-        background-color: var(--mud-palette-#{$color}-hover);
+        &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+          background-color: var(--mud-palette-#{$color}-hover);
+        }
       }
 
       &.mud-chip-selected {
@@ -238,10 +237,10 @@
         background-color: var(--mud-palette-chip-default-hover);
       }
     }
-  }
 
-  &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-    background-color: var(--mud-palette-chip-default-hover);
+    &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+      background-color: var(--mud-palette-chip-default-hover);
+    }
   }
 
   @each $color in $mud-palette-colors {
@@ -256,10 +255,10 @@
             background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
           }
         }
-      }
 
-      &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
-        background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+        &:focus-visible:not(.mud-disabled), &:active:not(.mud-disabled) {
+          background-color: rgba(var(--mud-palette-#{$color}-rgb), 0.12);
+        }
       }
     }
   }

--- a/src/MudBlazor/Themes/Models/Palette.cs
+++ b/src/MudBlazor/Themes/Models/Palette.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MudBlazor.Utilities;
+﻿using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -221,16 +220,6 @@ namespace MudBlazor
         /// Gets or sets the light color for dividers.
         /// </summary>
         public virtual MudColor DividerLight { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.8).ToString(MudColorOutputFormats.RGBA);
-
-        /// <summary>
-        /// Gets or sets the default color for chips.
-        /// </summary>
-        public virtual MudColor ChipDefault { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.08).ToString(MudColorOutputFormats.RGBA);
-
-        /// <summary>
-        /// Gets or sets the default hover color for chips.
-        /// </summary>
-        public virtual MudColor ChipDefaultHover { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.12).ToString(MudColorOutputFormats.RGBA);
 
         /// <summary>
         /// Gets or sets the darkened value of the primary color.

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -88,11 +88,5 @@ namespace MudBlazor
 
         /// <inheritdoc />
         public override MudColor DividerLight { get; set; } = "rgba(255,255,255, 0.06)";
-
-        /// <inheritdoc />
-        public override MudColor ChipDefault { get; set; } = "rgba(255,255,255, 0.16)";
-
-        /// <inheritdoc />
-        public override MudColor ChipDefaultHover { get; set; } = "rgba(255,255,255, 0.24)";
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Controversial, but I don't like how MudChip is one of the only components that has its own color properties, especially when it's only for the default chip. I was inspired to revert that after seeing #8529.

If someone customizes their palette the typical way, their chips will look out of place because it deviates from the global style.

Open to other ideas including this PR being denied if it's not the right move.

- Reverts most of https://github.com/MudBlazor/MudBlazor/pull/7406/commits/b681da1f80962678505c002cbcd8ac25e7c80990
- Resolves https://github.com/MudBlazor/MudBlazor/issues/8529

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

---

Can't see the selected chips:

https://github.com/MudBlazor/MudBlazor/assets/7112040/f84d2c2f-1ff4-4ef9-93f5-5d4e7ffef07f

After:

https://github.com/MudBlazor/MudBlazor/assets/7112040/4c8ee8c1-c09c-4404-ae60-1e8435a318bb


https://github.com/MudBlazor/MudBlazor/assets/7112040/e8721024-884f-4d71-88a5-1649988de3ab



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
