### PR TITLE
MudTable: Added StripedGroups parameter to stripe per group instead of per row.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableStripedGroupExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableStripedGroupExample.razor
@@ -1,0 +1,79 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<style>
+    .mud-table-cell-custom-group {
+        font-weight: 500;
+    }
+
+    .mud-table-cell-custom-group-footer {
+        padding-bottom: 50px;
+        text-align: right;
+    }
+</style>
+
+<MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
+          Items="@Elements"
+          GroupBy="@_groupDefinition"
+          StripedGroups="@StripedGroups"
+          Striped="@Striped">
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <GroupHeaderTemplate>
+        <MudTh Class="mud-table-cell-custom-group" colspan="5">@($"{context.GroupName}: {context.Key}")</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd Style="text-align: right" DataLabel="Molar mass">@context.Molar"</MudTd>
+    </RowTemplate>
+    <GroupFooterTemplate>
+        <MudTh Class="mud-table-cell-custom-group mud-table-cell-custom-group-footer" colspan="5">Total Mass: @context.Items.Sum((e) => e.Molar)</MudTh>
+    </GroupFooterTemplate>
+</MudTable>
+
+<MudSwitch T="bool" ValueChanged="@_handleChangeStripedGroups" Value="@StripedGroups" Color="Color.Primary">StripedGroups</MudSwitch>
+<MudSwitch T="bool" ValueChanged="@_handleChangeStriped" Value="@Striped" Color="Color.Primary">Striped</MudSwitch>
+
+@code {
+    private bool StripedGroups { get; set; } = true;
+    private bool Striped { get; set; }
+
+    private void _handleChangeStripedGroups(bool isChecked)
+    {
+        StripedGroups = isChecked;
+        Striped = false;
+        
+    }
+    
+    private void _handleChangeStriped(bool isChecked)
+    {
+        Striped = isChecked;
+        StripedGroups = false;
+    }
+    
+    private TableGroupDefinition<Element> _groupDefinition = new()
+    {
+        GroupName = "Group",
+        Indentation = false,
+        Expandable = true,
+        IsInitiallyExpanded = false,
+        Selector = (e) => e.Group
+    };
+
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -272,6 +272,18 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Grouping - Striped groups">
+                <Description>
+                    Setting <CodeInline>StripedGroups</CodeInline> on the table will stripe it according to the groups instead of the rows.  <br />
+                    NOTE: StripedGroups should be used instead of Striped, not together with it.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(TableStripedGroupExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TableStripedGroupExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupRowCustomClassnameTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupRowCustomClassnameTest.razor
@@ -1,0 +1,65 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable T="RacingCar" Items="@Cars" GroupBy="@Groups"
+          GroupFooterClass="test-footer-class"
+          GroupHeaderClass="test-header-class" 
+          StripedGroups>
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <GroupHeaderTemplate>
+        <MudTh>@($"{context.GroupName}: {context.Key}")</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <GroupFooterTemplate>
+        <MudTh>Count: @context.Items.Count()</MudTh>
+    </GroupFooterTemplate>
+</MudTable>
+
+@code {
+    private IEnumerable<RacingCar> Cars;
+    
+    TableGroupDefinition<RacingCar> Groups = new()
+    {
+        GroupName = "Brand",
+        Selector = rc => rc.Brand,
+    };
+
+    protected override Task OnInitializedAsync()
+    {
+        Cars = new List<RacingCar>()
+        {
+            new("919 Hybrid", "Porsche", "LMP1"),
+            new("911 RSR", "Porsche", "GTE"),
+            new("911 RS", "Porsche", "GT3"),
+            new("R18 e-tron quattor", "Audi", "LMP1"),
+            new("R8 LMS", "Audi", "GT3"),
+            new ("F488", "Ferrari", "GTE"),
+            new ("SF-1000", "Ferrari", "Formula 1"),
+            new ("Vantage", "Aston Martin", "GTE"),
+            new ("AMR21", "Aston Martin", "Formula 1"),
+        };
+        return base.OnInitializedAsync();
+    }
+
+    public class RacingCar
+    {
+        public RacingCar(string name, string brand, string category)
+        {
+            Name = name;
+            Brand = brand;
+            Category = category;
+        }
+
+        public string Name { get; set; }
+        public string Brand { get; set; }
+        public string Category { get; set; }
+
+        public override string ToString()
+        {
+            return $"({Category}) {Brand} {Name}";
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2383,5 +2383,36 @@ namespace MudBlazor.UnitTests.Components
             selectAllCheckbox.Change(true);
             comp.Find("#counter").TextContent.Should().Be("1");
         }
+        
+        /// <summary>
+        /// StripedGroups should add new classes without interfering with others.
+        /// </summary>
+        [Test]
+        public async Task TestStripedGroupsClasses()
+        {
+            var comp = Context.RenderComponent<TableGroupRowCustomClassnameTest>();
+            
+            // StripedGroups class should be applied correctly when StripedGroups is set to true.
+            var rows = comp.FindAll("tbody tr");
+            
+            // Group header
+            rows[0].ClassName.Should()
+                .Be("mud-table-row test-header-class mud-table-row-group-striped-odd");
+            // Items
+            rows[1].ClassName.Should()
+                .Be("mud-table-row mud-table-row-group-striped-odd");
+            rows[2].ClassName.Should()
+                .Be("mud-table-row mud-table-row-group-striped-odd");
+            rows[3].ClassName.Should()
+                .Be("mud-table-row mud-table-row-group-striped-odd");
+            // Footer
+            rows[4].ClassName.Should()
+                .Be("mud-table-row test-footer-class mud-table-row-group-striped-odd");
+            
+            // New group: Switches to even class
+            rows[5].ClassName.Should()
+                .Be("mud-table-row test-header-class mud-table-row-group-striped-even");
+            
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2383,7 +2383,7 @@ namespace MudBlazor.UnitTests.Components
             selectAllCheckbox.Change(true);
             comp.Find("#counter").TextContent.Should().Be("1");
         }
-        
+
         /// <summary>
         /// StripedGroups should add new classes without interfering with others.
         /// </summary>
@@ -2391,28 +2391,21 @@ namespace MudBlazor.UnitTests.Components
         public async Task TestStripedGroupsClasses()
         {
             var comp = Context.RenderComponent<TableGroupRowCustomClassnameTest>();
-            
+
             // StripedGroups class should be applied correctly when StripedGroups is set to true.
             var rows = comp.FindAll("tbody tr");
-            
+
             // Group header
-            rows[0].ClassName.Should()
-                .Be("mud-table-row test-header-class mud-table-row-group-striped-odd");
+            rows[0].ClassName.Should().Be("mud-table-row test-header-class mud-table-row-group-striped-odd");
             // Items
-            rows[1].ClassName.Should()
-                .Be("mud-table-row mud-table-row-group-striped-odd");
-            rows[2].ClassName.Should()
-                .Be("mud-table-row mud-table-row-group-striped-odd");
-            rows[3].ClassName.Should()
-                .Be("mud-table-row mud-table-row-group-striped-odd");
+            rows[1].ClassName.Should().Be("mud-table-row mud-table-row-group-striped-odd");
+            rows[2].ClassName.Should().Be("mud-table-row mud-table-row-group-striped-odd");
+            rows[3].ClassName.Should().Be("mud-table-row mud-table-row-group-striped-odd");
             // Footer
-            rows[4].ClassName.Should()
-                .Be("mud-table-row test-footer-class mud-table-row-group-striped-odd");
-            
+            rows[4].ClassName.Should().Be("mud-table-row test-footer-class mud-table-row-group-striped-odd");
+
             // New group: Switches to even class
-            rows[5].ClassName.Should()
-                .Be("mud-table-row test-header-class mud-table-row-group-striped-even");
-            
+            rows[5].ClassName.Should().Be("mud-table-row test-header-class mud-table-row-group-striped-even");
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -84,12 +84,22 @@
                 <tbody class="mud-table-body">
                     @if(GroupBy != null)
                     {
+                        var rowIndex = 0;
+                        var stripedGroup = "";
                         @foreach (var group in GroupItemsPage)
                         {
+                            if (StripedGroups)
+                            {
+                                stripedGroup = rowIndex % 2 == 0 ? "even" : "odd";
+                            }
+                            rowIndex++;
+                            
                             <MudTableGroupRow GroupDefinition="GroupBy" Items="group" IsCheckable="MultiSelection" 
                                               HeaderClass="@GroupHeaderClass" HeaderStyle="@GroupHeaderStyle" 
                                               FooterClass="@GroupFooterClass" FooterStyle="@GroupFooterStyle"
-                                              HeaderTemplate="@GroupHeaderTemplate" FooterTemplate="@GroupFooterTemplate" T="T"  />
+                                              HeaderTemplate="@GroupHeaderTemplate" FooterTemplate="@GroupFooterTemplate" T="T"
+                                              StripedGroup="@stripedGroup"
+                                              />
                         }
                     }
                     else

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -90,7 +90,7 @@
                         {
                             if (StripedGroups)
                             {
-                                stripedGroup = rowIndex % 2 == 0 ? "even" : "odd";
+                                stripedGroup = (rowIndex + 1) % 2 == 0 ? "even" : "odd";
                             }
                             rowIndex++;
                             

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -403,6 +403,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Table.Grouping)]
         public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
+        
+        /// <summary>
+        /// If true, the table will be striped per group. Use instead of Striped.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Grouping)]
+        public bool StripedGroups { get; set; }
 
         private IEnumerable<T> _preEditSort;
         private bool _currentRenderFilteredItemsCached;

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -411,14 +411,13 @@ namespace MudBlazor
         [Category(CategoryTypes.Table.Grouping)]
         public bool StripedGroups { get; set; }
 
-        private IEnumerable<T> _preEditSort;
-        private bool _currentRenderFilteredItemsCached;
-        private bool HasPreEditSort => _preEditSort != null;
-
         /// <summary>
         /// For unit testing the filtering cache mechanism.
         /// </summary>
         internal uint FilteringRunCount { get; private set; } = 0;
+        private IEnumerable<T> _preEditSort;
+        private bool _currentRenderFilteredItemsCached;
+        private bool HasPreEditSort => _preEditSort != null;
 
         public IEnumerable<T> FilteredItems
         {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -403,7 +403,7 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Table.Grouping)]
         public RenderFragment<TableGroupData<object, T>> GroupFooterTemplate { get; set; }
-        
+
         /// <summary>
         /// If true, the table will be striped per group. Use instead of Striped.
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -70,12 +70,7 @@ else
     @*FOOTER:*@
     @if (FooterTemplate != null && GroupDefinition != null)
     {
-        var footerClass = FooterClassname;
-        if (!string.IsNullOrEmpty(StripedGroup))
-        {
-            footerClass += $" mud-table-row-group-striped-{StripedGroup}";
-        }
-        <tr class="@footerClass" @onclick="@OnRowClick" style="@FooterStyle" @attributes="@UserAttributes">
+        <tr class="@FooterClassname" @onclick="@OnRowClick" style="@FooterStyle" @attributes="@UserAttributes">
             @if ((GroupDefinition?.IsThisOrParentExpandable ?? false) || (Context?.Table.MultiSelection ?? false))
             {
                 <MudTd/>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -53,18 +53,22 @@ else
             <MudTableGroupRow GroupDefinition="GroupDefinition.InnerGroup" Items="@group" IsCheckable="@IsCheckable"
                               HeaderClass="@HeaderClass" HeaderStyle="@HeaderStyle"
                               FooterClass="@FooterClass" FooterStyle="@FooterStyle"
-                              HeaderTemplate="@HeaderTemplate" FooterTemplate="@FooterTemplate" T="T" @attributes="@UserAttributes" />
+                              HeaderTemplate="@HeaderTemplate" FooterTemplate="@FooterTemplate" T="T" @attributes="@UserAttributes"
+                              StripedGroup="@StripedGroup" />
         }
     }
     else
     {
-        @Table?.RenderRows(Items, (GroupDefinition?.Indentation ?? false) ? $"mud-table-row-group-indented-{GroupDefinition?.Level - 1}" : null, GroupDefinition?.IsThisOrParentExpandable ?? false)
+        var customClass = GroupDefinition?.Indentation ?? false ? $"mud-table-row-group-indented-{GroupDefinition?.Level - 1}" : "";
+        customClass += StripedGroup == "" ? "" : $" mud-table-row-group-striped-{StripedGroup}";
+        @Table?.RenderRows(Items, customClass, GroupDefinition?.IsThisOrParentExpandable ?? false)
     }
 
     @*FOOTER:*@
     @if (FooterTemplate != null && GroupDefinition != null)
     {
-        <tr class="@FooterClassname" @onclick="@OnRowClick" style="@FooterStyle" @attributes="@UserAttributes">
+        var footerClass = FooterClassname + (StripedGroup == "" ? "" : $" mud-table-row-group-striped-{StripedGroup}");
+        <tr class="@footerClass" @onclick="@OnRowClick" style="@FooterStyle" @attributes="@UserAttributes">
             @if ((GroupDefinition?.IsThisOrParentExpandable ?? false) || (Context?.Table.MultiSelection ?? false))
             {
                 <MudTd/>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -60,14 +60,21 @@ else
     else
     {
         var customClass = GroupDefinition?.Indentation ?? false ? $"mud-table-row-group-indented-{GroupDefinition?.Level - 1}" : "";
-        customClass += StripedGroup == "" ? "" : $" mud-table-row-group-striped-{StripedGroup}";
+        if (!string.IsNullOrEmpty(StripedGroup))
+        {
+            customClass += $" mud-table-row-group-striped-{StripedGroup}";
+        }
         @Table?.RenderRows(Items, customClass, GroupDefinition?.IsThisOrParentExpandable ?? false)
     }
 
     @*FOOTER:*@
     @if (FooterTemplate != null && GroupDefinition != null)
     {
-        var footerClass = FooterClassname + (StripedGroup == "" ? "" : $" mud-table-row-group-striped-{StripedGroup}");
+        var footerClass = FooterClassname;
+        if (!string.IsNullOrEmpty(StripedGroup))
+        {
+            footerClass += $" mud-table-row-group-striped-{StripedGroup}";
+        }
         <tr class="@footerClass" @onclick="@OnRowClick" style="@FooterStyle" @attributes="@UserAttributes">
             @if ((GroupDefinition?.IsThisOrParentExpandable ?? false) || (Context?.Table.MultiSelection ?? false))
             {

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
     {
         protected string HeaderClassname => new CssBuilder("mud-table-row")
                                 .AddClass(HeaderClass)
-                                .AddClass(StripedGroup == "" ? "" : $"mud-table-row-group-striped-{StripedGroup}" )
+                                .AddClass(StripedGroup == "" ? "" : $"mud-table-row-group-striped-{StripedGroup}")
                                 .AddClass($"mud-table-row-group-indented-{GroupDefinition?.Level - 1}", (GroupDefinition?.Indentation ?? false) && GroupDefinition?.Level > 1).Build();
 
         protected string FooterClassname => new CssBuilder("mud-table-row")

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
     {
         protected string HeaderClassname => new CssBuilder("mud-table-row")
                                 .AddClass(HeaderClass)
-                                .AddClass(StripedGroup == "" ? "" : $"mud-table-row-group-striped-{StripedGroup}")
+                                .AddClass($"mud-table-row-group-striped-{StripedGroup}", !string.IsNullOrEmpty(StripedGroup))
                                 .AddClass($"mud-table-row-group-indented-{GroupDefinition?.Level - 1}", (GroupDefinition?.Indentation ?? false) && GroupDefinition?.Level > 1).Build();
 
         protected string FooterClassname => new CssBuilder("mud-table-row")
@@ -66,7 +66,7 @@ namespace MudBlazor
 
         [Parameter] public string HeaderStyle { get; set; }
         [Parameter] public string FooterStyle { get; set; }
-        [Parameter] public string StripedGroup { get; set; } = "";
+        [Parameter] public string StripedGroup { get; set; }
 
         /// <summary>
         /// Custom expand icon.

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -66,7 +66,6 @@ namespace MudBlazor
 
         [Parameter] public string HeaderStyle { get; set; }
         [Parameter] public string FooterStyle { get; set; }
-
         [Parameter] public string StripedGroup { get; set; } = "";
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -12,6 +12,7 @@ namespace MudBlazor
     {
         protected string HeaderClassname => new CssBuilder("mud-table-row")
                                 .AddClass(HeaderClass)
+                                .AddClass(StripedGroup == "" ? "" : $"mud-table-row-group-striped-{StripedGroup}" )
                                 .AddClass($"mud-table-row-group-indented-{GroupDefinition?.Level - 1}", (GroupDefinition?.Indentation ?? false) && GroupDefinition?.Level > 1).Build();
 
         protected string FooterClassname => new CssBuilder("mud-table-row")
@@ -65,6 +66,8 @@ namespace MudBlazor
 
         [Parameter] public string HeaderStyle { get; set; }
         [Parameter] public string FooterStyle { get; set; }
+
+        [Parameter] public string StripedGroup { get; set; } = "";
 
         /// <summary>
         /// Custom expand icon.

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
 
         protected string FooterClassname => new CssBuilder("mud-table-row")
                                 .AddClass(FooterClass)
+                                .AddClass($"mud-table-row-group-striped-{StripedGroup}", !string.IsNullOrEmpty(StripedGroup))
                                 .AddClass($"mud-table-row-group-indented-{GroupDefinition?.Level - 1}", (GroupDefinition?.Indentation ?? false) && GroupDefinition?.Level > 1).Build();
 
         protected string ActionsStylename => new StyleBuilder()

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -484,11 +484,11 @@
 }
 
 .mud-table-row-group-striped-even {
-  background-color: var(--mud-palette-surface);
+  background-color: var(--mud-palette-table-striped);
 }
 
 .mud-table-row-group-striped-odd {
-  background-color: var(--mud-palette-table-striped);
+  background-color: var(--mud-palette-surface);
 }
 
 .mud-table-row-expander {

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -483,6 +483,14 @@
   }
 }
 
+.mud-table-row-group-striped-even {
+  background-color: var(--mud-palette-surface);
+}
+
+.mud-table-row-group-striped-odd {
+  background-color: var(--mud-palette-table-striped);
+}
+
 .mud-table-row-expander {
   margin: -12px -2px -12px -12px;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

This adds the parameter `StripedGroups` to the table that can be used togheter with the grouping system to stripe even/odd groups, instead of `Striped` that stripes based on even/odd rows.

Open to improvement suggestions, but this implementation works. I tried to do this using only CSS, but that seems impossible. In the end my CSS + C# implementation got so complex that i decided to scrap it and make this PR instead.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually and simple unit test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

![firefox_tfkP8JKD5r](https://github.com/MudBlazor/MudBlazor/assets/31126885/bc6425f8-3995-4569-9a81-9ab42e64f99f)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
