### PR TITLE
MudAlert: Add XML Documentation for Public Members

### DIFF
--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -5,202 +5,209 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
-namespace MudBlazor;
-
 #nullable enable
 
-/// <summary>
-/// Represents an alert used to display an important message which is statically embedded in the page content.
-/// </summary>
-/// <remarks><para>Alerts are useful for calling attention to the user in regards to warnings, errors,
-/// informational messages, and more.  Alerts typically use the <see cref="Severity"/> property to control
-/// the color and icon displayed, but a custom <see cref="Icon"/> and <see cref="CloseIcon"/> can be used, 
-/// or no icon at all via the <see cref="NoIcon"/> and <see cref="ShowCloseIcon"/> properties.  You can 
-/// also use the <see cref="Dense"/> property to take up less space, and <see cref="HorizontalAlignment"/>
-/// to control the horizontal alignment of text.  The <see cref="Variant"/> property can be used to show
-/// outlined, filled, or textual alerts.  The <see cref="Elevation"/> property can be used to make the alert
-/// stand out with a drop shadow.</para>
-/// <para>To notify the user with dynamic alerts which overlay the page, check out the 
-/// <see href="https://mudblazor.com/components/snackbar"/> component.</para>
-/// </remarks>
-public partial class MudAlert : MudComponentBase
+namespace MudBlazor
 {
-    protected string Classname => new CssBuilder("mud-alert")
-      .AddClass($"mud-alert-{Variant.ToDescriptionString()}-{Severity.ToDescriptionString()}")
-      .AddClass($"mud-dense", Dense)
-      .AddClass($"mud-square", Square)
-      .AddClass($"mud-elevation-{Elevation}")
-      .AddClass(Class)
-      .Build();
-
-    protected string ClassPosition => new CssBuilder("mud-alert-position")
-      .AddClass($"justify-sm-{ConvertHorizontalAlignment(ContentAlignment).ToDescriptionString()}")
-      .Build();
-
     /// <summary>
-    /// Gets the horizontal alignment to use based on the current right-to-left setting.
+    /// Represents an alert used to display an important message which is statically embedded in the page content.
     /// </summary>
-    /// <param name="contentAlignment">A <see cref="HorizontalAlignment"/> value.  The alignment to adjust.</param>
-    /// <returns>A <see cref="HorizontalAlignment"/> value.  The adjusted alignment.</returns>
-    private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
+    /// <remarks><para>Alerts are useful for calling attention to the user in regards to warnings, errors,
+    /// informational messages, and more.  Alerts typically use the <see cref="Severity"/> property to control
+    /// the color and icon displayed, but a custom <see cref="Icon"/> and <see cref="CloseIcon"/> can be used, 
+    /// or no icon at all via the <see cref="NoIcon"/> and <see cref="ShowCloseIcon"/> properties.  You can 
+    /// also use the <see cref="Dense"/> property to take up less space, and <see cref="HorizontalAlignment"/>
+    /// to control the horizontal alignment of text.  The <see cref="Variant"/> property can be used to show
+    /// outlined, filled, or textual alerts.  The <see cref="Elevation"/> property can be used to make the alert
+    /// stand out with a drop shadow.</para>
+    /// <para>To notify the user with dynamic alerts which overlay the page, check out the 
+    /// <see href="https://mudblazor.com/components/snackbar"/> component.</para>
+    /// </remarks>
+    public partial class MudAlert : MudComponentBase
     {
-        return contentAlignment switch
+        protected string Classname => new CssBuilder("mud-alert")
+          .AddClass($"mud-alert-{Variant.ToDescriptionString()}-{Severity.ToDescriptionString()}")
+          .AddClass($"mud-dense", Dense)
+          .AddClass($"mud-square", Square)
+          .AddClass($"mud-elevation-{Elevation}")
+          .AddClass(Class)
+          .Build();
+
+        protected string ClassPosition => new CssBuilder("mud-alert-position")
+          .AddClass($"justify-sm-{ConvertHorizontalAlignment(ContentAlignment).ToDescriptionString()}")
+          .Build();
+
+        /// <summary>
+        /// Gets the horizontal alignment to use based on the current right-to-left setting.
+        /// </summary>
+        /// <param name="contentAlignment">A <see cref="HorizontalAlignment"/> value.  The alignment to adjust.</param>
+        /// <returns>A <see cref="HorizontalAlignment"/> value.  The adjusted alignment.</returns>
+        private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
         {
-            HorizontalAlignment.Right => RightToLeft ? HorizontalAlignment.Start : HorizontalAlignment.End,
-            HorizontalAlignment.Left => RightToLeft ? HorizontalAlignment.End : HorizontalAlignment.Start,
-            _ => contentAlignment
-        };
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether Right-to-Left (RTL) mode is enabled.
-    /// </summary>
-    /// <remarks>Defaults to false. When true, text will be displayed right-to-left.</remarks>
-    [CascadingParameter(Name = "RightToLeft")]
-    public bool RightToLeft { get; set; }
-
-    /// <summary>
-    /// Gets or sets the position of the text to the start (Left in LTR and right in RTL).
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
-
-    /// <summary>
-    /// Gets or sets the callback for when the close button has been clicked.
-    /// </summary>
-    [Parameter]
-    public EventCallback<MudAlert> CloseIconClicked { get; set; }
-
-    /// <summary>
-    /// Gets or sets the icon used for the close button.
-    /// </summary>
-    /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only 
-    /// displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether a close icon is displayed.
-    /// </summary>
-    /// <remarks>To customize which icon is displayed for the close icon, set the 
-    /// <see cref="CloseIcon"/> property.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Behavior)]
-    public bool ShowCloseIcon { get; set; }
-
-    /// <summary>
-    /// Gets or sets the size of the drop shadow.
-    /// </summary>
-    /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value 
-    /// of 0 for no shadow.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public int Elevation { set; get; } = 0;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether rounded corners are disabled.
-    /// </summary>
-    /// <remarks>Defaults to false.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public bool Square { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether compact padding will be used.
-    /// </summary>
-    /// <remarks>Defaults to false.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public bool Dense { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether no icon is displayed.
-    /// </summary>
-    /// <remarks>Defaults to false.  To customize the icon, use the <see cref="Icon"/> property.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public bool NoIcon { get; set; }
-
-    /// <summary>
-    /// Gets or sets the severity of the alert.
-    /// </summary>
-    /// <remarks>The severity determines the color and icon used.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Behavior)]
-    public Severity Severity { get; set; } = Severity.Normal;
-
-    /// <summary>
-    /// Gets or sets the display variant to use.
-    /// </summary>
-    /// <remarks>Defaults to Variant.Text. The variant changes the appearance of the alert, such as Text, Outlined, or Filled.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public Variant Variant { get; set; } = Variant.Text;
-
-    /// <summary>
-    /// Gets or sets the content within the alert.
-    /// </summary>
-    /// <remarks>This property allows for custom content to displayed inside of the alert, but it is not required.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Behavior)]
-    public RenderFragment? ChildContent { get; set; }
-
-    /// <summary>
-    /// Gets or sets the icon displayed for this alert.
-    /// </summary>
-    /// <remarks>Defaults to null.  When set, the custom icon will be displayed.  Otherwise, the icon will depend on the <see cref="Severity"/> property.</remarks>
-    [Parameter]
-    [Category(CategoryTypes.Alert.Appearance)]
-    public string? Icon { get; set; }
-
-    protected string? _icon;
-
-    /// <summary>
-    /// Occurs when the close icon has been clicked.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> object.</returns>
-    internal async Task OnCloseIconClickAsync()
-    {
-        await CloseIconClicked.InvokeAsync(this);
-    }
-
-    /// <inheritdoc />
-    [ExcludeFromCodeCoverage] //If we can check this exception can include the coverage again
-    protected override void OnParametersSet()
-    {
-        if (!string.IsNullOrEmpty(Icon))
-        {
-            _icon = Icon;
-        }
-        else
-        {
-            _icon = Severity switch
+            return contentAlignment switch
             {
-                Severity.Normal => Icons.Material.Outlined.EventNote,
-                Severity.Info => Icons.Material.Outlined.Info,
-                Severity.Success => Icons.Custom.Uncategorized.AlertSuccess,
-                Severity.Warning => Icons.Material.Outlined.ReportProblem,
-                Severity.Error => Icons.Material.Filled.ErrorOutline,
-                _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
+                HorizontalAlignment.Right => RightToLeft ? HorizontalAlignment.Start : HorizontalAlignment.End,
+                HorizontalAlignment.Left => RightToLeft ? HorizontalAlignment.End : HorizontalAlignment.Start,
+                _ => contentAlignment
             };
         }
-    }
 
-    /// <summary>
-    /// Occurs when the alert has been clicked.
-    /// </summary>
-    /// <param name="mouseEventArgs">A <see cref="MouseEventArgs"/> object.  The mouse coordinates related to this click.</param>
-    /// <returns>A <see cref="Task"/> object.</returns>
-    internal async Task OnClickHandler(MouseEventArgs mouseEventArgs)
-    {
-        await OnClick.InvokeAsync(mouseEventArgs);
-    }
+        /// <summary>
+        /// Gets or sets a value indicating whether Right-to-Left (RTL) mode is enabled.
+        /// </summary>
+        /// <remarks>Defaults to false. When true, text will be displayed right-to-left.</remarks>
+        [CascadingParameter(Name = "RightToLeft")]
+        public bool RightToLeft { get; set; }
 
-    /// <summary>
-    /// Occurs when the alert has been clicked.
-    /// </summary>
-    [Parameter]
-    public EventCallback<MouseEventArgs> OnClick { get; set; }
+        /// <summary>
+        /// Gets or sets the position of the text to the start (Left in LTR and right in RTL).
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
+
+        /// <summary>
+        /// Gets or sets the callback for when the close button has been clicked.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MudAlert> CloseIconClicked { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon used for the close button.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only 
+        /// displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a close icon is displayed.
+        /// </summary>
+        /// <remarks>To customize which icon is displayed for the close icon, set the 
+        /// <see cref="CloseIcon"/> property.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Behavior)]
+        public bool ShowCloseIcon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the drop shadow.
+        /// </summary>
+        /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value 
+        /// of 0 for no shadow.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public int Elevation { set; get; } = 0;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether rounded corners are disabled.
+        /// </summary>
+        /// <remarks>Defaults to false.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public bool Square { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether compact padding will be used.
+        /// </summary>
+        /// <remarks>Defaults to false.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public bool Dense { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether no icon is displayed.
+        /// </summary>
+        /// <remarks>Defaults to false.  To customize the icon, use the <see cref="Icon"/> property.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public bool NoIcon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the severity of the alert.
+        /// </summary>
+        /// <remarks>The severity determines the color and icon used.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Behavior)]
+        public Severity Severity { get; set; } = Severity.Normal;
+
+        /// <summary>
+        /// Gets or sets the display variant to use.
+        /// </summary>
+        /// <remarks>Defaults to Variant.Text. The variant changes the appearance of the alert, such as Text, Outlined, or Filled.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Gets or sets the content within the alert.
+        /// </summary>
+        /// <remarks>This property allows for custom content to displayed inside of the alert, but it is not required.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Behavior)]
+        public RenderFragment? ChildContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon displayed for this alert.
+        /// </summary>
+        /// <remarks>Defaults to null.  When set, the custom icon will be displayed.  Otherwise, the icon will depend on the <see cref="Severity"/> property.</remarks>
+        [Parameter]
+        [Category(CategoryTypes.Alert.Appearance)]
+        public string? Icon { get; set; }
+
+        protected string? _icon;
+
+        /// <summary>
+        /// Occurs when the close icon has been clicked.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> object.</returns>
+        internal async Task OnCloseIconClickAsync()
+        {
+            if (CloseIconClicked.HasDelegate)
+            {
+                await CloseIconClicked.InvokeAsync(this);
+            }
+        }
+
+        /// <inheritdoc />
+        [ExcludeFromCodeCoverage] //If we can check this exception can include the coverage again
+        protected override void OnParametersSet()
+        {
+            if (!string.IsNullOrEmpty(Icon))
+            {
+                _icon = Icon;
+            }
+            else
+            {
+                _icon = Severity switch
+                {
+                    Severity.Normal => Icons.Material.Outlined.EventNote,
+                    Severity.Info => Icons.Material.Outlined.Info,
+                    Severity.Success => Icons.Custom.Uncategorized.AlertSuccess,
+                    Severity.Warning => Icons.Material.Outlined.ReportProblem,
+                    Severity.Error => Icons.Material.Filled.ErrorOutline,
+                    _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
+                };
+            }
+        }
+
+        /// <summary>
+        /// Occurs when the alert has been clicked.
+        /// </summary>
+        /// <param name="mouseEventArgs">A <see cref="MouseEventArgs"/> object.  The mouse coordinates related to this click.</param>
+        /// <returns>A <see cref="Task"/> object.</returns>
+        internal async Task OnClickHandler(MouseEventArgs mouseEventArgs)
+        {
+            if (OnClick.HasDelegate)
+            {
+                await OnClick.InvokeAsync(mouseEventArgs);
+            }
+        }
+
+        /// <summary>
+        /// Occurs when the alert has been clicked.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClick { get; set; }
+    }
 }

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -67,7 +67,7 @@ namespace MudBlazor
         public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
 
         /// <summary>
-        /// Gets or sets the callback for when the close button has been clicked.
+        /// Occurs when the close button has been clicked.
         /// </summary>
         [Parameter]
         public EventCallback<MudAlert> CloseIconClicked { get; set; }

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -4,167 +4,204 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
+using static System.Net.WebRequestMethods;
 
-namespace MudBlazor
-{
+namespace MudBlazor;
+
 #nullable enable
-    public partial class MudAlert : MudComponentBase
+
+/// <summary>
+/// Represents an alert used to display an important message which is statically embedded in the page content.
+/// </summary>
+/// <remarks><para>Alerts are useful for calling attention to the user in regards to warnings, errors,
+/// informational messages, and more.  Alerts typically use the <see cref="Severity"/> property to control
+/// the color and icon displayed, but a custom <see cref="Icon"/> and <see cref="CloseIcon"/> can be used, 
+/// or no icon at all via the <see cref="NoIcon"/> and <see cref="ShowCloseIcon"/> properties.  You can 
+/// also use the <see cref="Dense"/> property to take up less space, and <see cref="HorizontalAlignment"/>
+/// to control the horizontal alignment of text.  The <see cref="Variant"/> property can be used to show
+/// outlined, filled, or textual alerts.  The <see cref="Elevation"/> property can be used to make the alert
+/// stand out with a drop shadow.</para>
+/// <para>To notify the user with dynamic alerts which overlay the page, check out the 
+/// <see href="https://mudblazor.com/components/snackbar"/> component.</para>
+/// </remarks>
+public partial class MudAlert : MudComponentBase
+{
+    protected string Classname => new CssBuilder("mud-alert")
+      .AddClass($"mud-alert-{Variant.ToDescriptionString()}-{Severity.ToDescriptionString()}")
+      .AddClass($"mud-dense", Dense)
+      .AddClass($"mud-square", Square)
+      .AddClass($"mud-elevation-{Elevation}")
+      .AddClass(Class)
+      .Build();
+
+    protected string ClassPosition => new CssBuilder("mud-alert-position")
+      .AddClass($"justify-sm-{ConvertHorizontalAlignment(ContentAlignment).ToDescriptionString()}")
+      .Build();
+
+    /// <summary>
+    /// Gets the horizontal alignment to use based on the current right-to-left setting.
+    /// </summary>
+    /// <param name="contentAlignment">A <see cref="HorizontalAlignment"/> value.  The alignment to adjust.</param>
+    /// <returns>A <see cref="HorizontalAlignment"/> value.  The adjusted alignment.</returns>
+    private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
     {
-        protected string Classname =>
-        new CssBuilder("mud-alert")
-          .AddClass($"mud-alert-{Variant.ToDescriptionString()}-{Severity.ToDescriptionString()}")
-          .AddClass($"mud-dense", Dense)
-          .AddClass($"mud-square", Square)
-          .AddClass($"mud-elevation-{Elevation}")
-          .AddClass(Class)
-        .Build();
-
-        protected string ClassPosition =>
-        new CssBuilder("mud-alert-position")
-            .AddClass($"justify-sm-{ConvertHorizontalAlignment(ContentAlignment).ToDescriptionString()}")
-        .Build();
-
-        private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
+        return contentAlignment switch
         {
-            return contentAlignment switch
+            HorizontalAlignment.Right => RightToLeft ? HorizontalAlignment.Start : HorizontalAlignment.End,
+            HorizontalAlignment.Left => RightToLeft ? HorizontalAlignment.End : HorizontalAlignment.Start,
+            _ => contentAlignment
+        };
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Right-to-Left (RTL) mode is enabled.
+    /// </summary>
+    /// <remarks>Defaults to false. When true, text will be displayed right-to-left.</remarks>
+    [CascadingParameter(Name = "RightToLeft")]
+    public bool RightToLeft { get; set; }
+
+    /// <summary>
+    /// Gets or sets the position of the text to the start (Left in LTR and right in RTL).
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
+
+    /// <summary>
+    /// Gets or sets the callback for when the close button has been clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MudAlert> CloseIconClicked { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon used for the close button.
+    /// </summary>
+    /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only 
+    /// displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a close icon is displayed.
+    /// </summary>
+    /// <remarks>To customize which icon is displayed for the close icon, set the 
+    /// <see cref="CloseIcon"/> property.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Behavior)]
+    public bool ShowCloseIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the drop shadow.
+    /// </summary>
+    /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value 
+    /// of 0 for no shadow.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public int Elevation { set; get; } = 0;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether rounded corners are disabled.
+    /// </summary>
+    /// <remarks>Defaults to false.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public bool Square { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether compact padding will be used.
+    /// </summary>
+    /// <remarks>Defaults to false.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public bool Dense { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether no icon is displayed.
+    /// </summary>
+    /// <remarks>Defaults to false.  To customize the icon, use the <see cref="Icon"/> property.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public bool NoIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the severity of the alert.
+    /// </summary>
+    /// <remarks>The severity determines the color and icon used.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Behavior)]
+    public Severity Severity { get; set; } = Severity.Normal;
+
+    /// <summary>
+    /// Gets or sets the display variant to use.
+    /// </summary>
+    /// <remarks>Defaults to Variant.Text. The variant changes the appearance of the alert, such as Text, Outlined, or Filled.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public Variant Variant { get; set; } = Variant.Text;
+
+    /// <summary>
+    /// Gets or sets the content within the alert.
+    /// </summary>
+    /// <remarks>This property allows for custom content to displayed inside of the alert, but it is not required.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Behavior)]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon displayed for this alert.
+    /// </summary>
+    /// <remarks>Defaults to null.  When set, the custom icon will be displayed.  Otherwise, the icon will depend on the <see cref="Severity"/> property.</remarks>
+    [Parameter]
+    [Category(CategoryTypes.Alert.Appearance)]
+    public string? Icon { get; set; }
+
+    protected string? _icon;
+
+    /// <summary>
+    /// Occurs when the close icon has been clicked.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> object.</returns>
+    internal async Task OnCloseIconClickAsync()
+    {
+        await CloseIconClicked.InvokeAsync(this);
+    }
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage] //If we can check this exception can include the coverage again
+    protected override void OnParametersSet()
+    {
+        if (!string.IsNullOrEmpty(Icon))
+        {
+            _icon = Icon;
+        }
+        else
+        {
+            _icon = Severity switch
             {
-                HorizontalAlignment.Right => RightToLeft ? HorizontalAlignment.Start : HorizontalAlignment.End,
-                HorizontalAlignment.Left => RightToLeft ? HorizontalAlignment.End : HorizontalAlignment.Start,
-                _ => contentAlignment
+                Severity.Normal => Icons.Material.Outlined.EventNote,
+                Severity.Info => Icons.Material.Outlined.Info,
+                Severity.Success => Icons.Custom.Uncategorized.AlertSuccess,
+                Severity.Warning => Icons.Material.Outlined.ReportProblem,
+                Severity.Error => Icons.Material.Filled.ErrorOutline,
+                _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
             };
         }
-
-        [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
-
-        /// <summary>
-        /// Sets the position of the text to the start (Left in LTR and right in RTL).
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
-
-        /// <summary>
-        /// The callback, when the close button has been clicked.
-        /// </summary>
-        [Parameter] public EventCallback<MudAlert> CloseIconClicked { get; set; }
-
-        /// <summary>
-        /// Define the icon used for the close button.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
-
-        /// <summary>
-        /// Sets if the alert shows a close icon.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Behavior)]
-        public bool ShowCloseIcon { get; set; }
-
-        /// <summary>
-        /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public int Elevation { set; get; } = 0;
-
-        /// <summary>
-        /// If true, rounded corners are disabled.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public bool Square { get; set; }
-
-        /// <summary>
-        /// If true, compact padding will be used.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public bool Dense { get; set; }
-
-        /// <summary>
-        /// If true, no alert icon will be used.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public bool NoIcon { get; set; }
-
-        /// <summary>
-        /// The severity of the alert. This defines the color and icon used.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Behavior)]
-        public Severity Severity { get; set; } = Severity.Normal;
-
-        /// <summary>
-        /// The variant to use.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
-
-        /// <summary>
-        /// Child content of the component.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Behavior)]
-        public RenderFragment? ChildContent { get; set; }
-
-        /// <summary>
-        /// Custom icon, leave unset to use the standard icon which depends on the Severity
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Alert.Appearance)]
-        public string? Icon { get; set; }
-
-        protected string? _icon;
-
-        internal Task OnCloseIconClickAsync()
-        {
-            if (CloseIconClicked.HasDelegate)
-            {
-                return CloseIconClicked.InvokeAsync(this);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        //If we can check this exception can include the coverage again
-        [ExcludeFromCodeCoverage]
-        protected override void OnParametersSet()
-        {
-            if (!string.IsNullOrEmpty(Icon))
-            {
-                _icon = Icon;
-            }
-            else
-            {
-                _icon = Severity switch
-                {
-                    Severity.Normal => Icons.Material.Outlined.EventNote,
-                    Severity.Info => Icons.Material.Outlined.Info,
-                    Severity.Success => Icons.Custom.Uncategorized.AlertSuccess,
-                    Severity.Warning => Icons.Material.Outlined.ReportProblem,
-                    Severity.Error => Icons.Material.Filled.ErrorOutline,
-                    _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
-                };
-            }
-        }
-
-        internal Task OnClickHandler(MouseEventArgs mouseEventArgs)
-        {
-            if (OnClick.HasDelegate)
-            {
-                return OnClick.InvokeAsync(mouseEventArgs);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Raised when the alert is clicked
-        /// </summary>
-        [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
     }
+
+    /// <summary>
+    /// Occurs when the alert has been clicked.
+    /// </summary>
+    /// <param name="mouseEventArgs">A <see cref="MouseEventArgs"/> object.  The mouse coordinates related to this click.</param>
+    /// <returns>A <see cref="Task"/> object.</returns>
+    internal async Task OnClickHandler(MouseEventArgs mouseEventArgs)
+    {
+        await OnClick.InvokeAsync(mouseEventArgs);
+    }
+
+    /// <summary>
+    /// Occurs when the alert has been clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
 }

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -29,8 +29,12 @@ namespace MudBlazor
         /// <summary>
         /// Gets the horizontal alignment to use based on the current right-to-left setting.
         /// </summary>
-        /// <param name="contentAlignment">A <see cref="HorizontalAlignment"/> value.  The alignment to adjust.</param>
-        /// <returns>A <see cref="HorizontalAlignment"/> value.  The adjusted alignment.</returns>
+        /// <param name="contentAlignment">
+        /// A <see cref="HorizontalAlignment"/> value.  The alignment to adjust.
+        /// </param>
+        /// <returns>
+        /// A <see cref="HorizontalAlignment"/> value.  The adjusted alignment.
+        /// </returns>
         private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
         {
             return contentAlignment switch
@@ -44,13 +48,18 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether Right-to-Left (RTL) mode is enabled.
         /// </summary>
-        /// <remarks>Defaults to false. When true, text will be displayed right-to-left.</remarks>
+        /// <remarks>
+        /// Defaults to <c>false</c>. When <c>true</c>, text will be displayed right-to-left.
+        /// </remarks>
         [CascadingParameter(Name = "RightToLeft")]
         public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Gets or sets the position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="HorizontalAlignment.Left"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
@@ -64,7 +73,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the icon used for the close button.
         /// </summary>
-        /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only displayed when the <see cref="ShowCloseIcon"/> property is <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
@@ -72,7 +83,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether a close icon is displayed.
         /// </summary>
-        /// <remarks>To customize which icon is displayed for the close icon, set the <see cref="CloseIcon"/> property.</remarks>
+        /// <remarks>
+        /// To customize which icon is displayed for the close icon, set the <see cref="CloseIcon"/> property.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Behavior)]
         public bool ShowCloseIcon { get; set; }
@@ -80,7 +93,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the size of the drop shadow.
         /// </summary>
-        /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value of 0 for no shadow.</remarks>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public int Elevation { set; get; } = 0;
@@ -88,7 +103,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether rounded corners are disabled.
         /// </summary>
-        /// <remarks>Defaults to false.</remarks>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public bool Square { get; set; }
@@ -96,7 +113,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether compact padding will be used.
         /// </summary>
-        /// <remarks>Defaults to false.</remarks>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public bool Dense { get; set; }
@@ -104,7 +123,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether no icon is displayed.
         /// </summary>
-        /// <remarks>Defaults to false.  To customize the icon, use the <see cref="Icon"/> property.</remarks>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  To customize the icon, use the <see cref="Icon"/> property.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public bool NoIcon { get; set; }
@@ -112,7 +133,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the severity of the alert.
         /// </summary>
-        /// <remarks>The severity determines the color and icon used.</remarks>
+        /// <remarks>
+        /// The severity determines the color and icon used.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Behavior)]
         public Severity Severity { get; set; } = Severity.Normal;
@@ -120,7 +143,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the display variant to use.
         /// </summary>
-        /// <remarks>Defaults to Variant.Text. The variant changes the appearance of the alert, such as Text, Outlined, or Filled.</remarks>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text" />. The variant changes the appearance of the alert, such as <c>Text</c>, <c>Outlined</c>, or <c>Filled</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
@@ -128,7 +153,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the content within the alert.
         /// </summary>
-        /// <remarks>This property allows for custom content to displayed inside of the alert, but it is not required.</remarks>
+        /// <remarks>
+        /// This property allows for custom content to displayed inside of the alert, but it is not required.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Behavior)]
         public RenderFragment? ChildContent { get; set; }
@@ -136,7 +163,9 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the icon displayed for this alert.
         /// </summary>
-        /// <remarks>Defaults to null.  When set, the custom icon will be displayed.  Otherwise, the icon will depend on the <see cref="Severity"/> property.</remarks>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  When set, the custom icon will be displayed.  Otherwise, the icon will depend on the <see cref="Severity"/> property.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public string? Icon { get; set; }
@@ -180,8 +209,12 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when the alert has been clicked.
         /// </summary>
-        /// <param name="mouseEventArgs">A <see cref="MouseEventArgs"/> object.  The mouse coordinates related to this click.</param>
-        /// <returns>A <see cref="Task"/> object.</returns>
+        /// <param name="mouseEventArgs">
+        /// A <see cref="MouseEventArgs"/> object.  The mouse coordinates related to this click.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> object.
+        /// </returns>
         internal async Task OnClickHandler(MouseEventArgs mouseEventArgs)
         {
             if (OnClick.HasDelegate)

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
-using static System.Net.WebRequestMethods;
 
 namespace MudBlazor;
 

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -5,10 +5,10 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
-#nullable enable
-
 namespace MudBlazor
 {
+#nullable enable
+
     /// <summary>
     /// Represents an alert used to display an important message which is statically embedded in the page content.
     /// </summary>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -12,17 +12,6 @@ namespace MudBlazor
     /// <summary>
     /// Represents an alert used to display an important message which is statically embedded in the page content.
     /// </summary>
-    /// <remarks><para>Alerts are useful for calling attention to the user in regards to warnings, errors,
-    /// informational messages, and more.  Alerts typically use the <see cref="Severity"/> property to control
-    /// the color and icon displayed, but a custom <see cref="Icon"/> and <see cref="CloseIcon"/> can be used, 
-    /// or no icon at all via the <see cref="NoIcon"/> and <see cref="ShowCloseIcon"/> properties.  You can 
-    /// also use the <see cref="Dense"/> property to take up less space, and <see cref="HorizontalAlignment"/>
-    /// to control the horizontal alignment of text.  The <see cref="Variant"/> property can be used to show
-    /// outlined, filled, or textual alerts.  The <see cref="Elevation"/> property can be used to make the alert
-    /// stand out with a drop shadow.</para>
-    /// <para>To notify the user with dynamic alerts which overlay the page, check out the 
-    /// <see href="https://mudblazor.com/components/snackbar"/> component.</para>
-    /// </remarks>
     public partial class MudAlert : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-alert")
@@ -75,8 +64,7 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the icon used for the close button.
         /// </summary>
-        /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only 
-        /// displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
+        /// <remarks>Defaults to <see cref="Icons.Material.Filled.Close"/>. This icon is only displayed when the <see cref="ShowCloseIcon"/> property is true.</remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
@@ -84,8 +72,7 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets a value indicating whether a close icon is displayed.
         /// </summary>
-        /// <remarks>To customize which icon is displayed for the close icon, set the 
-        /// <see cref="CloseIcon"/> property.</remarks>
+        /// <remarks>To customize which icon is displayed for the close icon, set the <see cref="CloseIcon"/> property.</remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Behavior)]
         public bool ShowCloseIcon { get; set; }
@@ -93,8 +80,7 @@ namespace MudBlazor
         /// <summary>
         /// Gets or sets the size of the drop shadow.
         /// </summary>
-        /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value 
-        /// of 0 for no shadow.</remarks>
+        /// <remarks>Defaults to 0.  A higher number creates a heavier drop shadow.  Use a value of 0 for no shadow.</remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
         public int Elevation { set; get; } = 0;


### PR DESCRIPTION
## Description

This update adds XML documentation for the `MudAlert` component for all public members.  

## How Has This Been Tested?

This was tested by running unit tests and observing the documentation tooltips shown in Visual Studio 2022 when working with a `MudAlert` component, like this:

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/2b83238e-337b-4045-920b-7b6bf080ddb7)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/c74ad3ea-747b-4f8a-a8ce-31f5adc2f1ca)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/aba90a18-8c7d-4d09-8f58-583e9f543858)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/58c09da1-037c-4d4d-8784-cc65467b36da)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.

## Notes for Reviewers

This PR is the first in an effort to add XML documentation for all components.  This will be a good one to scrutinize heavily to come up with a good standard to follow for other components.   The patterns followed are:

* Following [Microsoft Recommendations for XML Documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags)
* Assuming the audience is new to MudBlazor and should be made aware of features.
* Using a positive tone such as "you can" statements.
* Using "Represents a" as the starting text for classes. 
* Using "Gets or sets" as the starting text of properties
* Using "Gets or sets a value indicating" as the starting text of boolean properties.
* Using "Occurs when" as the starting text of event handlers

Also note that these changes made the API documentation pages bigger  (see 4th screen shot above) since it includes both the Summary and Remarks.  Hopefully that's okay!