### PR TITLE
RenderQueueService: Changed From Singleton to Scoped

### DIFF
--- a/src/MudBlazor.Docs.WasmHost/Program.cs
+++ b/src/MudBlazor.Docs.WasmHost/Program.cs
@@ -31,7 +31,7 @@ builder.Services.AddScoped(sp =>
 });
 builder.Services.TryAddDocsViewServices();
 //set the capacity max so that content is not queue. Again this is for prerending to serve the entire page back to crawler
-builder.Services.AddSingleton<IRenderQueueService>(new RenderQueueService { Capacity = int.MaxValue });
+builder.Services.AddScoped<IRenderQueueService>(s => new RenderQueueService { Capacity = int.MaxValue });
 
 builder.Services.AddSingleton<ICrawlerIdentifier>(new FileBasedCrawlerIdentifier("CrawlerInfo.json"));
 

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IPopoverService, MockPopoverServiceV2>();
             ctx.Services.AddTransient<IKeyInterceptorFactory, MockKeyInterceptorServiceFactory>();
             ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
-            ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
+            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddTransient<InternalMudLocalizer>();
             ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             ctx.Services.AddScoped(sp => new HttpClient());

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IMudPopoverService, MockPopoverService>();
 #pragma warning restore CS0618
             ctx.Services.AddSingleton<IPopoverService, MockPopoverServiceV2>();
-            ctx.Services.AddSingleton<IRenderQueueService, RenderQueueService>();
+            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
             ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             ctx.Services.AddTransient<InternalMudLocalizer>();
             ctx.Services.AddOptions();


### PR DESCRIPTION
## Description

This small PR changes the `RenderQueueService` (used only by the docs sites) from singleton to scoped to fix a potential issue if the MudBlazor docs site ever uses BSS for rendering.

In BSS, users share instances of singleton objects.  Thus, all users would have shared the same render queue, and the call to `RenderQueue.Clear()` in `DocsPage.OnInitialized()` would have cleared the queue for _all_ users any time _any_ user visited a docs page.   By using scoped, however, each user gets their own render queue.

## How Has This Been Tested?

This was tested by running unit tests, as well as by running documentation projects locally:

* Running **MudBlazor.Docs.WasmHost** and **MudBlazor.Docs.Server** projects
* Visiting a big page with lots of sections such as `MudTabs` and `MudTable`, as well as `MudDataGrid` and `MudDialog`
* Spamming clicks to navigate to pages back and forth to ensure that the page navigates quickly and renders completely.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.

## Notes for Reviewers

This fix only has value if the docs site ever uses BSS, such as when auto-rendering in future .NET versions.  There is no current issue for the WASM site, however, since singleton services in WASM are still a separate instance per tab.