### PR TITLE
Docs: Fix contributor GitHub icon colors in dark mode

### DIFF
--- a/src/MudBlazor.Docs/Components/MudContributor.razor
+++ b/src/MudBlazor.Docs/Components/MudContributor.razor
@@ -1,23 +1,25 @@
-﻿               <MudCard Elevation="4">
-                   <MudCardHeader>
-                       <CardHeaderAvatar>
-                           <MudAvatar Image="@AvatarLink" Size="Size.Large" Class="mud-elevation-4"/>
-                       </CardHeaderAvatar>
-                       <CardHeaderContent>
-                           <MudText Typo="Typo.body1">@Firstname @Lastname</MudText>
-                           <MudText Typo="Typo.body2">@Contributor</MudText>
-                       </CardHeaderContent>
-                       <CardHeaderActions>
-                           <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="@GithubLink" Color="Color.Dark" Target="_blank"/>
-                       </CardHeaderActions>
-                   </MudCardHeader>
-                   @if (ChildContent != null)
-                   {
-                       <MudCardContent Class="pt-0">
-                           @ChildContent
-                       </MudCardContent>
-                   }
-               </MudCard>
+﻿<MudCard Elevation="4">
+    <MudCardHeader>
+        <CardHeaderAvatar>
+            <MudAvatar Size="Size.Large" Class="mud-elevation-4">
+                <MudImage Src="@AvatarLink" />
+            </MudAvatar>
+        </CardHeaderAvatar>
+        <CardHeaderContent>
+            <MudText Typo="Typo.body1">@Firstname @Lastname</MudText>
+            <MudText Typo="Typo.body2">@Contributor</MudText>
+        </CardHeaderContent>
+        <CardHeaderActions>
+            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="@GithubLink" Color="Color.Inherit" Target="_blank"/>
+        </CardHeaderActions>
+    </MudCardHeader>
+    @if (ChildContent != null)
+    {
+        <MudCardContent Class="pt-0">
+            @ChildContent
+        </MudCardContent>
+    }
+</MudCard>
 
 @code {
     [Parameter] public string AvatarLink { get; set; }

--- a/src/MudBlazor.Docs/Components/MudTeamCard.razor
+++ b/src/MudBlazor.Docs/Components/MudTeamCard.razor
@@ -1,5 +1,4 @@
-﻿
-<MudPaper Elevation="4" Class="pa-4">
+﻿<MudPaper Elevation="4" Class="pa-4">
     <div class="d-flex flex-row">
         <MudAvatar Size="Size.Large" Class="mud-elevation-4">
             <MudImage Src="@Memeber.Avatar" />
@@ -16,13 +15,13 @@
                 </MudTooltip>
             }
             <MudTooltip Text="GitHub" Placement="Placement.Top" Class="d-flex">
-                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="@("https://github.com/"+Memeber.Github)" Color="Color.Dark" Target="_blank" />
+                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="@("https://github.com/"+Memeber.Github)" Color="Color.Inherit" Target="_blank" />
             </MudTooltip>
         </div>
     </div>
     <div class="d-flex flex-column mt-5">
         <div class="d-flex flex-row align-center">
-            <MudIcon Icon="@Icons.Material.Filled.Place" Color="Color.Default" Class="ms-4" />
+            <MudIcon Icon="@Icons.Material.Filled.Place" Color="Color.Inherit" Class="ms-4" />
             <MudText Typo="Typo.body2" Class="ps-9">@Memeber.From</MudText>
         </div>
     </div>

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Team.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Team.razor
@@ -17,7 +17,9 @@
                 <MudCard Elevation="4">
                     <MudCardHeader>
                         <CardHeaderAvatar>
-                            <MudAvatar Image="https://avatars.githubusercontent.com/u/10367109?v=4" Size="Size.Large" Class="mud-elevation-4" />
+                            <MudAvatar Size="Size.Large" Class="mud-elevation-4">
+                                <MudImage Src="https://avatars.githubusercontent.com/u/10367109?v=4" />
+                            </MudAvatar>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
                             <MudText Typo="Typo.h6">Jonny Larsson</MudText>
@@ -28,15 +30,15 @@
                                 <MudIconButton Icon="@Icons.Custom.Brands.LinkedIn" Href="https://www.linkedin.com/in/jonny-larsson-b72480161/" Target="_blank" Color="Color.Primary" Edge="Edge.End" />
                             </MudTooltip>
                             <MudTooltip Text="GitHub" Placement="Placement.Top">
-                                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="https://github.com/Garderoben" Color="Color.Dark" Target="_blank" />
+                                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="https://github.com/Garderoben" Color="Color.Inherit" Target="_blank" />
                             </MudTooltip>
                         </CardHeaderActions>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 pb-1">
                         <MudList Dense="true">
-                            <MudListItem Icon="@Icons.Custom.Brands.GitHub" Text="Garderoben" />
-                            <MudListItem Icon="@Icons.Material.Filled.Place" Text="Örebro, Sweden" />
-                            <MudListItem Icon="@Icons.Material.Filled.Translate" Text="Swedish, English" />
+                            <MudListItem Icon="@Icons.Custom.Brands.GitHub" Text="Garderoben" IconColor="Color.Default" />
+                            <MudListItem Icon="@Icons.Material.Filled.Place" Text="Örebro, Sweden" IconColor="Color.Default" />
+                            <MudListItem Icon="@Icons.Material.Filled.Translate" Text="Swedish, English" IconColor="Color.Default" />
                         </MudList>
                     </MudCardContent>
                 </MudCard>
@@ -45,7 +47,9 @@
                 <MudCard Elevation="4">
                     <MudCardHeader>
                         <CardHeaderAvatar>
-                            <MudAvatar Image="https://avatars.githubusercontent.com/u/44090?v=4" Size="Size.Large" Class="mud-elevation-4" />
+                            <MudAvatar Size="Size.Large" Class="mud-elevation-4">
+                                <MudImage Src="https://avatars.githubusercontent.com/u/44090?v=4" />
+                            </MudAvatar>
                         </CardHeaderAvatar>
                         <CardHeaderContent>
                             <MudText Typo="Typo.h6">Meinrad Recheis</MudText>
@@ -56,15 +60,15 @@
                                 <MudIconButton Icon="@Icons.Custom.Brands.LinkedIn" Href="https://www.linkedin.com/in/meinrad-recheis-6a9885171/" Target="_blank" Color="Color.Primary" Edge="Edge.End" />
                             </MudTooltip>
                             <MudTooltip Text="GitHub" Placement="Placement.Top">
-                                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="https://github.com/henon" Color="Color.Dark" Target="_blank" />
+                                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Href="https://github.com/henon" Color="Color.Inherit" Target="_blank" />
                             </MudTooltip>
                         </CardHeaderActions>
                     </MudCardHeader>
                     <MudCardContent Class="pt-0 pb-1">
                         <MudList Dense="true">
-                            <MudListItem Icon="@Icons.Custom.Brands.GitHub" Text="Henon" />
-                            <MudListItem Icon="@Icons.Material.Filled.Place" Text="Vienna, Austria" />
-                            <MudListItem Icon="@Icons.Material.Filled.Translate" Text="German, English, Chinese" />
+                            <MudListItem Icon="@Icons.Custom.Brands.GitHub" Text="Henon" IconColor="Color.Default" />
+                            <MudListItem Icon="@Icons.Material.Filled.Place" Text="Vienna, Austria" IconColor="Color.Default" />
+                            <MudListItem Icon="@Icons.Material.Filled.Translate" Text="German, English, Chinese" IconColor="Color.Default" />
                         </MudList>
                     </MudCardContent>
                 </MudCard>


### PR DESCRIPTION
## Description
GitHub icons are barely visible in dark mode.

## How Has This Been Tested?
Tested visually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Before:
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/08565e0f-6256-4072-864d-d57fe55ea48b)

![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/ec4ffdae-6225-4db7-9825-f54af779c883)

After:
![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/39db13ff-561d-470a-828f-e13a0a2bc8c1)

![image](https://github.com/MudBlazor/MudBlazor/assets/4596077/fdf9eb89-de03-4920-ba94-04514a516093)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
