### PR TITLE
Docs: Fix DarkLightMode button out of sync

### DIFF
--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -76,7 +76,7 @@ public class LayoutService
 
     private void OnMajorUpdateOccurred() => MajorUpdateOccurred?.Invoke(this, EventArgs.Empty);
 
-    public async Task CycleDarkLightMode()
+    public async Task CycleDarkLightModeAsync()
     {
         switch (CurrentDarkLightMode)
         {

--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -4,13 +4,11 @@
 
 using System;
 using System.Threading.Tasks;
+using MudBlazor.Docs.Enums;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services.UserPreferences;
 
 namespace MudBlazor.Docs.Services;
-
-using MudBlazor.Docs.Enums;
-
 public class LayoutService
 {
     private readonly IUserPreferencesService _userPreferencesService;
@@ -18,12 +16,11 @@ public class LayoutService
     private bool _systemPreferences;
 
     public bool IsRTL { get; private set; }
-    public DarkLightMode DarkModeToggle = DarkLightMode.System;
+    public DarkLightMode CurrentDarkLightMode { get; private set; } = DarkLightMode.System;
 
     public bool IsDarkMode { get; private set; }
 
     public MudTheme CurrentTheme { get; private set; }
-
 
     public LayoutService(IUserPreferencesService userPreferencesService)
     {
@@ -38,16 +35,20 @@ public class LayoutService
     public async Task ApplyUserPreferences(bool isDarkModeDefaultTheme)
     {
         _systemPreferences = isDarkModeDefaultTheme;
+
         _userPreferences = await _userPreferencesService.LoadUserPreferences();
+
         if (_userPreferences != null)
         {
-            IsDarkMode = _userPreferences.DarkLightTheme switch
+            CurrentDarkLightMode = _userPreferences.DarkLightTheme;
+            IsDarkMode = CurrentDarkLightMode switch
             {
                 DarkLightMode.Dark => true,
                 DarkLightMode.Light => false,
                 DarkLightMode.System => isDarkModeDefaultTheme,
                 _ => IsDarkMode
             };
+
             IsRTL = _userPreferences.RightToLeft;
         }
         else
@@ -61,39 +62,41 @@ public class LayoutService
     public Task OnSystemPreferenceChanged(bool newValue)
     {
         _systemPreferences = newValue;
-        if (DarkModeToggle == DarkLightMode.System)
+
+        if (CurrentDarkLightMode == DarkLightMode.System)
         {
             IsDarkMode = newValue;
-            OnMajorUpdateOccured();
+            OnMajorUpdateOccurred();
         }
+
         return Task.CompletedTask;
     }
 
-    public event EventHandler MajorUpdateOccured;
+    public event EventHandler MajorUpdateOccurred;
 
-    private void OnMajorUpdateOccured() => MajorUpdateOccured?.Invoke(this, EventArgs.Empty);
+    private void OnMajorUpdateOccurred() => MajorUpdateOccurred?.Invoke(this, EventArgs.Empty);
 
-    public async Task ToggleDarkMode()
+    public async Task CycleDarkLightMode()
     {
-        switch (DarkModeToggle)
+        switch (CurrentDarkLightMode)
         {
             case DarkLightMode.System:
-                DarkModeToggle = DarkLightMode.Light;
+                CurrentDarkLightMode = DarkLightMode.Light;
                 IsDarkMode = false;
                 break;
             case DarkLightMode.Light:
-                DarkModeToggle = DarkLightMode.Dark;
+                CurrentDarkLightMode = DarkLightMode.Dark;
                 IsDarkMode = true;
                 break;
             case DarkLightMode.Dark:
-                DarkModeToggle = DarkLightMode.System;
+                CurrentDarkLightMode = DarkLightMode.System;
                 IsDarkMode = _systemPreferences;
                 break;
         }
 
-        _userPreferences.DarkLightTheme = DarkModeToggle;
+        _userPreferences.DarkLightTheme = CurrentDarkLightMode;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
-        OnMajorUpdateOccured();
+        OnMajorUpdateOccurred();
     }
 
     public async Task ToggleRightToLeft()
@@ -101,13 +104,13 @@ public class LayoutService
         IsRTL = !IsRTL;
         _userPreferences.RightToLeft = IsRTL;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
-        OnMajorUpdateOccured();
+        OnMajorUpdateOccurred();
     }
 
     public void SetBaseTheme(MudTheme theme)
     {
         CurrentTheme = theme;
-        OnMajorUpdateOccured();
+        OnMajorUpdateOccurred();
     }
 
     public DocsBasePage GetDocsBasePage(string uri)

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -30,8 +30,8 @@
 <MudTooltip Duration="1000" Text="@(LayoutService.IsRTL ? "Switch to left-to-right" : "Switch to right-to-left")">
     <MudIconButton Icon="@(LayoutService.IsRTL ? @Icons.Material.Filled.FormatTextdirectionLToR : @Icons.Material.Filled.FormatTextdirectionRToL)" OnClick="@LayoutService.ToggleRightToLeft" Color="Color.Inherit" />
 </MudTooltip>
-<MudTooltip Duration="1000" Text="@(LayoutService.DarkModeToggle == DarkLightMode.System ? "Switch to Light mode" : LayoutService.DarkModeToggle == DarkLightMode.Dark ? "Switch to System mode" : "Switch to Dark mode")">
-    <MudIconButton Icon="@(LayoutService.DarkModeToggle == DarkLightMode.System ? @Icons.Material.Filled.AutoMode : LayoutService.DarkModeToggle == DarkLightMode.Dark ? @Icons.Material.Rounded.LightMode : @Icons.Material.Outlined.DarkMode)" Color="Color.Inherit" OnClick="@LayoutService.ToggleDarkMode" />
+<MudTooltip Duration="1000" Text="@(DarkLightModeButtonText)">
+    <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightMode" />
 </MudTooltip>
 <MudTooltip Duration="1000" Text="GitHub Repository">
     <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" />

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -31,7 +31,7 @@
     <MudIconButton Icon="@(LayoutService.IsRTL ? @Icons.Material.Filled.FormatTextdirectionLToR : @Icons.Material.Filled.FormatTextdirectionRToL)" OnClick="@LayoutService.ToggleRightToLeft" Color="Color.Inherit" />
 </MudTooltip>
 <MudTooltip Duration="1000" Text="@(DarkLightModeButtonText)">
-    <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightMode" />
+    <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightModeAsync" />
 </MudTooltip>
 <MudTooltip Duration="1000" Text="GitHub Repository">
     <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" />

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -2,13 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Docs.Extensions;
-using MudBlazor.Docs.Models;
+using MudBlazor.Docs.Enums;
 using MudBlazor.Docs.Services;
 using MudBlazor.Docs.Services.Notifications;
 
@@ -20,6 +17,20 @@ public partial class AppbarButtons
     [Inject] private LayoutService LayoutService { get; set; }
     private IDictionary<NotificationMessage, bool> _messages = null;
     private bool _newNotificationsAvailable = false;
+
+    public string DarkLightModeButtonText => LayoutService.CurrentDarkLightMode switch
+    {
+        DarkLightMode.Dark => "Switch to System mode",
+        DarkLightMode.Light => "Switch to Dark mode",
+        _ => "Switch to Light mode"
+    };
+
+    public string DarkLightModeButtonIcon => LayoutService.CurrentDarkLightMode switch
+    {
+        DarkLightMode.Dark => Icons.Material.Rounded.AutoMode,
+        DarkLightMode.Light => Icons.Material.Outlined.DarkMode,
+        _ => Icons.Material.Filled.LightMode
+    };
 
     private async Task MarkNotificationAsRead()
     {
@@ -38,5 +49,4 @@ public partial class AppbarButtons
 
         await base.OnAfterRenderAsync(firstRender);
     }
-
 }

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.Docs.Shared
 
         protected override void OnInitialized()
         {
-            LayoutService.MajorUpdateOccured += LayoutServiceOnMajorUpdateOccured;
+            LayoutService.MajorUpdateOccurred += LayoutServiceOnMajorUpdateOccured;
             base.OnInitialized();
         }
 
@@ -44,7 +44,7 @@ namespace MudBlazor.Docs.Shared
 
         public void Dispose()
         {
-            LayoutService.MajorUpdateOccured -= LayoutServiceOnMajorUpdateOccured;
+            LayoutService.MajorUpdateOccurred -= LayoutServiceOnMajorUpdateOccured;
         }
 
         private void LayoutServiceOnMajorUpdateOccured(object sender, EventArgs e) => StateHasChanged();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Live version: If you're in light mode and you refresh, it'll make you switch to the light theme again to go to Dark or System.
This fixes it so the actual mode is loaded correctly from `_userPreferences` instead of just whether or not dark mode is enabled.

Could have literally just been one line:
```cs
DarkModeToggle = _userPreferences.DarkLightTheme;
```
But I wanted to do some refactoring

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->


https://github.com/MudBlazor/MudBlazor/assets/7112040/0985f5f6-60cf-49b5-82c1-291192846911



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
