### PR TITLE
Docs: Improve appbar UX

### DIFF
--- a/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
@@ -42,14 +42,14 @@
     </div>
     <div class="@ContentClassNames">
         <MudToolBar Gutters="false" Class="mud-text-secondary">
-            <MudTooltip Duration="1000" Text="Toggle Drawer">
+            <MudTooltip Delay="1000" Text="Toggle Drawer">
                 <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@GetIcon()" Color="Color.Inherit" />
             </MudTooltip>
-            <MudTooltip Duration="1000" Text="Search">
+            <MudTooltip Delay="1000" Text="Search">
                 <MudIconButton Icon="@Icons.Material.Outlined.Search" Color="Color.Inherit" />
             </MudTooltip>
             <MudSpacer />
-            <MudTooltip Duration="1000" Text="Notifications">
+            <MudTooltip Delay="1000" Text="Notifications">
                 <MudIconButton Class="mud-text-secondary" Icon="@Icons.Material.Outlined.Notifications"/>
             </MudTooltip>
             <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" PopoverClass="mudblazor-landingpage-scaled-menu mud-elevation-1">

--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Docs.Services
 #nullable enable
     public class ApiLinkService : IApiLinkService
     {
-        private readonly List<ApiLinkServiceEntry> _entries = [];
+        private readonly Dictionary<string, ApiLinkServiceEntry> _entries = [];
 
         public ApiLinkService(IMenuService menuService)
         {
@@ -28,46 +28,68 @@ namespace MudBlazor.Docs.Services
                 return Task.FromResult<IReadOnlyCollection<ApiLinkServiceEntry>>([]);
             }
 
-            // Case doesn't matter.
+            // Case is ignored.
             text = text.ToLowerInvariant();
 
+            // Calculate the ratios of all keywords to the search input.
             var ratios = new Dictionary<ApiLinkServiceEntry, int>();
-            foreach (var entry in _entries)
+            foreach (var (keyword, entry) in _entries)
             {
-                // Strings to include in the search.
-                var keywords = new[] {
-                    entry.Title,
-                    entry.SubTitle,
-                    entry.ComponentName,
-                    entry.Link
-                };
+                var ratio = GetSearchMatchRatio(text, keyword);
 
-                var bestMatchRatio = 0;
-
-                // Find the best result for any keyword and the search string.
-                foreach (var keyword in keywords.Where(k => !string.IsNullOrWhiteSpace(k)).Select(k => k!.ToLowerInvariant()))
+                // Assign the highest ratio so far to the entry.
+                if (ratios.TryGetValue(entry, out var highestRatio))
                 {
-                    var ratio = Fuzz.Ratio(keyword, text);
-                    var partialOutOfOrderRatio = Fuzz.PartialTokenSortRatio(keyword, text);
-
-                    bestMatchRatio = Math.Max(bestMatchRatio, Math.Max(ratio, partialOutOfOrderRatio));
+                    if (ratio > highestRatio)
+                    {
+                        ratios[entry] = ratio;
+                    }
                 }
-
-                ratios.Add(entry, bestMatchRatio);
+                else
+                {
+                    ratios.Add(entry, ratio);
+                }
             }
 
+            // Return the most accurate and highest quality results.
             return Task.FromResult<IReadOnlyCollection<ApiLinkServiceEntry>>(
                 ratios
-                .Where(x => x.Value > 50)
+                .Where(x => x.Value > 75)
                 .OrderByDescending(x => x.Value)
                 .Select(x => x.Key)
                 .ToList()
             );
         }
 
+        private int GetSearchMatchRatio(string search, string keyword)
+        {
+            var ratio = Fuzz.Ratio(keyword, search);
+            var partialOutOfOrderRatio = Fuzz.PartialTokenSortRatio(keyword, search);
+            var finalRatio = Math.Max(ratio, partialOutOfOrderRatio);
+
+            return finalRatio;
+        }
+
+        private void AddEntry(ApiLinkServiceEntry entry)
+        {
+            void AddKeyword(string? k)
+            {
+                if (!string.IsNullOrWhiteSpace(k))
+                {
+                    _entries[k.ToLowerInvariant()] = entry;
+                }
+            }
+
+            AddKeyword(entry.Title);
+            AddKeyword(entry.SubTitle);
+            AddKeyword(entry.ComponentName);
+            AddKeyword(entry.Link);
+        }
+
         public void RegisterPage(string title, string? subtitle, Type? componentType, string? link = null)
         {
             link ??= ApiLink.GetComponentLinkFor(componentType!);
+
             var entry = new ApiLinkServiceEntry
             {
                 Title = title,
@@ -76,7 +98,7 @@ namespace MudBlazor.Docs.Services
                 Link = link
             };
 
-            _entries.Add(entry);
+            AddEntry(entry);
         }
 
         private void RegisterAliases()

--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -54,7 +54,7 @@ namespace MudBlazor.Docs.Services
             // Return the most accurate and highest quality results.
             return Task.FromResult<IReadOnlyCollection<ApiLinkServiceEntry>>(
                 ratios
-                .Where(x => x.Value > 75)
+                .Where(x => x.Value > 65)
                 .OrderByDescending(x => x.Value)
                 .Select(x => x.Key)
                 .ToList()

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -63,7 +63,7 @@
     </MudMenu>
     <MudSpacer />
     <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
-                     AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="600"
+                     AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
                      SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                      ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
         <ItemTemplate Context="result">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -16,8 +16,8 @@
         <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
     <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
-    <MudButton Href="/getting-started/installation" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.GettingStarted)">Getting Started</MudButton>
-    <MudButton Href="/mud/introduction" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.DiscoverMore)">Discover More</MudButton>
+    <MudButton Href="/getting-started/installation" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.GettingStarted)">Get Started</MudButton>
+    <MudButton Href="/mud/introduction" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.DiscoverMore)">Learn More</MudButton>
     <MudMenu Color="Color.Inherit" Variant="Variant.Text" Class="mx-1 px-3" PopoverClass="docs-layout-menu-shadow" ListClass="d-flex px-4 pb-2 docs-appbar-special-menu" LockScroll="true" Label="Products" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
         <MudList Clickable="true">
             <MudListSubheader>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -6,7 +6,7 @@
         <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
     <MudSpacer />
-    <MudTooltip Duration="1000" Text="Search">
+    <MudTooltip Delay="1000" Text="Search">
         <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" Edge="Edge.End" OnClick="@(() => OpenSearchDialog())" />
     </MudTooltip>
 </div>
@@ -64,7 +64,8 @@
     <MudSpacer />
     <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
                      AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined"
-                     SearchFunc="async (text, token) => await Search(text, token)" ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+                     SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
+                     ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
         <ItemTemplate Context="result">
             <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
         </ItemTemplate>
@@ -76,8 +77,9 @@
 <MudDialog @bind-IsVisible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
-                         AutoFocus="true" Placeholder="Search docs" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-                         SearchFunc="async (text, token) => await Search(text, token)" ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
+                         AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                         SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
+                         ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -63,7 +63,7 @@
     </MudMenu>
     <MudSpacer />
     <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
-                     AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined"
+                     AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="600"
                      SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                      ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
         <ItemTemplate Context="result">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -133,8 +133,7 @@ public partial class Appbar
     {
         if (string.IsNullOrWhiteSpace(text))
         {
-            // the user just clicked the autocomplete open, show the most popular pages as search result according to our analytics data
-            // ordered by popularity
+            // The user just opened the popover so show the most popular pages according to our analytics data as search results.
             return Task.FromResult<IReadOnlyCollection<ApiLinkServiceEntry>>(_apiLinkServiceEntries);
         }
 

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -27,7 +27,7 @@ public partial class Appbar
         {
             Title = "Installation",
             Link = "getting-started/installation",
-            SubTitle = "Getting started with MudBlazor fast and easy."
+            SubTitle = "Get started with MudBlazor fast and easy."
         },
 
         new ApiLinkServiceEntry

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -1,5 +1,5 @@
 ﻿@using MudBlazor.Docs.Enums
-<MudTooltip Duration="1000" Text="Notifications">
+<MudTooltip Delay="1000" Text="Notifications">
     <MudBadge Color="Color.Secondary" Dot="true" Overlap="true" Visible="_newNotificationsAvailable">
         <MudMenu Icon="@Icons.Material.Outlined.Notifications" Color="Color.Inherit" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopCenter" PopoverClass="docs-layout-menu-shadow" ListClass="pa-2 docs-menu-list" LockScroll="true">
             <div class="d-flex justify-space-between align-center px-2">
@@ -27,12 +27,12 @@
         </MudMenu>
     </MudBadge>
 </MudTooltip>
-<MudTooltip Duration="1000" Text="@(LayoutService.IsRTL ? "Switch to left-to-right" : "Switch to right-to-left")">
+<MudTooltip Delay="1000" Text="@(LayoutService.IsRTL ? "Left-to-right" : "Right-to-left")">
     <MudIconButton Icon="@(LayoutService.IsRTL ? @Icons.Material.Filled.FormatTextdirectionLToR : @Icons.Material.Filled.FormatTextdirectionRToL)" OnClick="@LayoutService.ToggleRightToLeft" Color="Color.Inherit" />
 </MudTooltip>
-<MudTooltip Duration="1000" Text="@(DarkLightModeButtonText)">
+<MudTooltip Delay="1000" Text="@(DarkLightModeButtonText)">
     <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightModeAsync" />
 </MudTooltip>
-<MudTooltip Duration="1000" Text="GitHub Repository">
+<MudTooltip Delay="1000" Text="GitHub">
     <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" />
 </MudTooltip>

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -20,9 +20,9 @@ public partial class AppbarButtons
 
     public string DarkLightModeButtonText => LayoutService.CurrentDarkLightMode switch
     {
-        DarkLightMode.Dark => "Switch to System mode",
-        DarkLightMode.Light => "Switch to Dark mode",
-        _ => "Switch to Light mode"
+        DarkLightMode.Dark => "System mode",
+        DarkLightMode.Light => "Dark mode",
+        _ => "Light mode"
     };
 
     public string DarkLightModeButtonIcon => LayoutService.CurrentDarkLightMode switch

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -25,8 +25,8 @@
             {
                 <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
                     <MudNavLink Href="/docs/overview">Docs</MudNavLink>
-                    <MudNavLink Href="/getting-started/installation">Getting Started</MudNavLink>
-                    <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Discover More</MudNavLink>
+                    <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
+                    <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
                     <MudNavGroup Title="Products" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                         <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>
                         <MudNavLink Href="https://try.mudblazor.com/">TryMudBlazor</MudNavLink>

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -13,8 +13,8 @@
         </MudToolBar>
         <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
             <MudNavLink Href="/docs/overview">Docs</MudNavLink>
-            <MudNavLink Href="/getting-started/installation">Getting Started</MudNavLink>
-            <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Discover More</MudNavLink>
+            <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
+            <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
             <MudNavGroup Title="Products" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                 <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>
                 <MudNavLink Href="https://try.mudblazor.com/">TryMudBlazor</MudNavLink>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Improve the UX of the docs appbar by
- making the tooltips work on a delay and making their text less verbose
- improving the quality of the search results and expanding the height of the popover
- removing the debounce which made the search feel sluggish
- reword the main buttons so they obstruct small screens less

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->


### Use the Delay property in MudToolTip which I believe was originally intended


https://github.com/MudBlazor/MudBlazor/assets/7112040/c6a02c93-116f-49c3-9830-694f8540855e


https://github.com/MudBlazor/MudBlazor/assets/7112040/24e0296c-f3b2-4d0f-b4f9-73e2a0126ff0



### Make tooltips less wordy to look sleeker and fit better

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/649010ea-55bb-42d0-9444-f01630dc1db9)


![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/7c8b0136-9ce9-4019-8eb8-77993715b675)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/bae051cb-a01f-4c07-a87c-9a84bd7a0be1)


![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/ec42e4db-1d5a-4d81-83d8-21ac551d5dc1)



### Remove debounce on search and optimize the code

The search looked slower on the docs than other websites, so to improve the feel of the website the debounce was removed. Very little processing power went into this, but the code was revamped to avoid allocations to prepare for the extra calls anyway.


https://github.com/MudBlazor/MudBlazor/assets/7112040/e721b303-3e83-44f1-936b-ef4a83e5bb0f


https://github.com/MudBlazor/MudBlazor/assets/7112040/2ff08f83-56ba-4fba-963d-f527b2f80b41


https://github.com/MudBlazor/MudBlazor/assets/7112040/62fc7e60-51e4-41e3-a896-58218474953f



### Show fewer inaccurate search results (50 -> 65 min ratio)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/19ce58fb-c633-4917-918b-e7142e533c0b)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/c9303598-97b0-4e71-a8c8-384e8106af38)


### Make the text in the search dialog the same as home ("Search docs" -> "Search")

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/750df338-d918-45f8-9cae-484a18b3e147)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/393ff1bb-c366-46c3-91df-961f7c036542)

### Increase search height to be less cramped

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/b268ddb4-618e-46dc-860a-88f323a80d63)


![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/9b6d2ea6-4af2-42da-a61c-69aab980f91d)


### Change `Getting Started` and `Discover More` to fit better and be easier to understand

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/a8cd10ec-ec22-4b41-a831-b5437f57e77a)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/f446a96d-e4fc-403b-8968-7890b4abaf9b)



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
