### PR TITLE
Update _fab.scss

### DIFF
--- a/src/MudBlazor/Styles/components/_fab.scss
+++ b/src/MudBlazor/Styles/components/_fab.scss
@@ -106,11 +106,11 @@
 
   &.mud-fab-size-large {
     width: auto;
-    height: 48px;
+    height: 56px;
     padding: 0 16px;
-    min-width: 48px;
+    min-width: 56px;
     min-height: auto;
-    border-radius: 24px;
+    border-radius: 28px;
 
     .mud-fab-label {
       gap: 8px;
@@ -119,10 +119,10 @@
 
   &.mud-fab-size-small {
     width: auto;
-    height: 34px;
+    height: 40px;
     padding: 0 12px;
-    min-width: 34px;
-    border-radius: 17px;
+    min-width: 40px;
+    border-radius: 20px;
 
     .mud-fab-label {
       gap: 4px;
@@ -131,10 +131,10 @@
 
   &.mud-fab-size-medium {
     width: auto;
-    height: 40px;
+    height: 48px;
     padding: 0 16px;
-    min-width: 40px;
-    border-radius: 20px;
+    min-width: 48px;
+    border-radius: 24px;
 
     .mud-fab-label {
       gap: 8px;


### PR DESCRIPTION
Updated the mud-fab-extended classes width and height to match the one in the normal mud-fab class.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Currently a FAB with a `Label` set, i.e. a `mud-fab-extended`, will not match the sizing of the standard, non-extended, FAB.

![image](https://github.com/MudBlazor/MudBlazor/assets/13120514/20658b54-7db5-478b-9984-e67a2bb2df31)

The `height`, `min-width`, and `border-radius` of an extended FAB should be equal to the standard FAB's `height`, `width`, and `border-radius` respectively.

## How Has This Been Tested?

This is a visual change it's pretty straightforward. See below for screenshots.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

Before:

![image](https://github.com/MudBlazor/MudBlazor/assets/13120514/afa891ef-459f-4135-b32c-140b65dcb632)

After:

![image](https://github.com/MudBlazor/MudBlazor/assets/13120514/e2b54faa-aa9a-41ac-8ba6-c7de1b6dc02c)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
