### PR TITLE
Docs: Add TitleContent to first Dialog example for completeness

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -28,7 +28,7 @@
                     </MudAlert>
                 </Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogUsageExample"), new CodeFile("Dialog.razor", "DialogUsageExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogUsageExample)), new CodeFile("Dialog.razor", nameof(DialogUsageExample_Dialog))})">
                 <DialogUsageExample />
             </SectionContent>
         </DocsPageSection>
@@ -54,7 +54,7 @@
                             Below we pass along the DialogOptions class when we open the dialog, this can be done per dialog or you can predefine a bunch of them that you use for specific cases in your system.<br />
                         </Description>
                     </SectionHeader>
-                    <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogOptionsExample"), new CodeFile("Dialog.razor", "DialogOptionsExample_Dialog")})">
+                    <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogOptionsExample)), new CodeFile("Dialog.razor", nameof(DialogOptionsExample_Dialog))})">
                         <DialogOptionsExample />
                     </SectionContent>
                 </DocsPageSection>
@@ -65,7 +65,7 @@
                             The title and the options can also be modified from the dialog component itself by calling <CodeInline>SetTitle</CodeInline> and <CodeInline>SetOptions</CodeInline> on the <CodeInline>MudDialogInstance</CodeInline> object.
                         </Description>
                     </SectionHeader>
-                    <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogSetOptionsExample"), new CodeFile("Dialog.razor", "DialogSetOptionsExample_Dialog")})">
+                    <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogSetOptionsExample)), new CodeFile("Dialog.razor", nameof(DialogSetOptionsExample_Dialog))})">
                         <DialogSetOptionsExample />
                     </SectionContent>
                 </DocsPageSection>
@@ -77,7 +77,7 @@
             <SectionHeader Title="Templating and Passing Simple Data">
                 <Description>In this section, we will demonstrate how you can build one dialog and reuse it for multiple purposes.</Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogTemplateExample"), new CodeFile("Dialog.razor", "DialogTemplateExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogTemplateExample)), new CodeFile("Dialog.razor", nameof(DialogTemplateExample_Dialog))})">
                 <DialogTemplateExample />
             </SectionContent>
         </DocsPageSection>
@@ -86,7 +86,7 @@
             <SectionHeader Title="Passing Data">
                 <Description>Here is a little more advanced use case. We will use the same dialog but feed it with different server data and then mimic a delete operation.</Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogPassingDataExample"), new CodeFile("Dialog.razor", "DialogPassingDataExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogPassingDataExample)), new CodeFile("Dialog.razor", nameof(DialogPassingDataExample_Dialog))})">
                 <DialogPassingDataExample />
             </SectionContent>
         </DocsPageSection>
@@ -95,7 +95,7 @@
             <SectionHeader Title="Scrollable Dialog">
                 <Description>Quick example on how to give your dialog scrollable content.</Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogScrollableExample"), new CodeFile("Dialog.razor", "DialogScrollableExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogScrollableExample)), new CodeFile("Dialog.razor", nameof(DialogScrollableExample_Dialog))})">
                 <DialogScrollableExample />
             </SectionContent>
         </DocsPageSection>
@@ -104,7 +104,7 @@
             <SectionHeader Title="Blurry Dialog">
                 <Description>Dialog background can be changed via <CodeInline>BackgroundClass</CodeInline> dialog option.</Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogBlurryExample"), new CodeFile("Dialog.razor", "DialogBlurryExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogBlurryExample)), new CodeFile("Dialog.razor", nameof(DialogBlurryExample_Dialog))})">
                 <DialogBlurryExample />
             </SectionContent>
         </DocsPageSection>
@@ -130,7 +130,7 @@
                     an inline dialog.
                 </Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogNestedInlineExample"), new CodeFile("Dialog.razor", "DialogNestedInlineExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogNestedInlineExample)), new CodeFile("Dialog.razor", nameof(DialogNestedInlineExample_Dialog))})">
                 <DialogNestedInlineExample />
             </SectionContent>
         </DocsPageSection>
@@ -143,7 +143,7 @@
                     This example also shows how to open a second dialog and cancel all dialogs at once.
                 </Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogNestedExample"), new CodeFile("Dialog.razor", "DialogNestedExample_Dialog"), new CodeFile("Dialog2.razor", "DialogNestedExample_Dialog2")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogNestedExample)), new CodeFile("Dialog.razor", nameof(DialogNestedExample_Dialog)), new CodeFile("Dialog2.razor", nameof(DialogNestedExample_Dialog2))})">
                 <DialogNestedExample />
             </SectionContent>
         </DocsPageSection>
@@ -156,7 +156,7 @@
                     <MudText><CodeInline>Escape</CodeInline> key to close dialog. Closing a dialog by pressing escape has to be enabled by setting option <CodeInline>CloseOnEscapekey=true</CodeInline></MudText>
                 </Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogKeyboardNavigationExample"), new CodeFile("Dialog.razor", "DialogKeyboardNavigationExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogKeyboardNavigationExample)), new CodeFile("Dialog.razor", nameof(DialogKeyboardNavigationExample_Dialog))})">
                 <DialogKeyboardNavigationExample />
             </SectionContent>
         </DocsPageSection>
@@ -167,7 +167,7 @@
                     Dialog uses the FocusTrap-Component to keep the keyboard-focus within. By default, the first element is focused With <CodeInline>DefaultFocus</CodeInline> you can change the behaviour to, for example, focus the last element.
                 </Description>
             </SectionHeader>
-            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", "DialogFocusExample"), new CodeFile("Dialog.razor","DialogFocusExample_Dialog")})">
+            <SectionContent Codes="@(new[] {new CodeFile("Page.razor", nameof(DialogFocusExample)), new CodeFile("Dialog.razor",nameof(DialogFocusExample_Dialog))})">
                 <DialogFocusExample />
             </SectionContent>
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample_Dialog.razor
@@ -1,6 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudDialog>
+    <TitleContent>
+        Dialog Title
+    </TitleContent>
     <DialogContent>
         Dialog Content
     </DialogContent>


### PR DESCRIPTION
## Description

This improves the dialog docs by adding TitleContent to first example for completeness. 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
