### PR TITLE
MudNavMenu: Use `nav` instead of `div` for better accessibility

### DIFF
--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@Classname" style="@Style">
+<nav @attributes="UserAttributes" class="@Classname" style="@Style">
     @ChildContent
-</div>
+</nav>


### PR DESCRIPTION
## Description

Fixes: #7222 

The original issue requested an override on `MudDrawer` for the `aside` tag. However, according to MDN (and other frameworks), having navigation blocks inside of `aside` is not an issue, but navigation blocks **should** always be inside of a `nav` tag. The logical solution for me then is to have `MudNavMenu` translate into `nav` rather than `div`.

## How Has This Been Tested?
Visually tested and confirmed with other major accessibility focused sites:

Drawer documentation post-fix:

![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/8061c927-3ab9-414f-aede-9ace9d99700e)

MDN:
![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/e43dcfbc-f33e-4fe0-a28a-54120da52f2a)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Potentially breaking if users expect a `div` tag in `MudNavMenu` and have custom styling around that expectation.

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
