### PR TITLE
MudComponentBase: UserAttributes cannot be null

### DIFF
--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -70,8 +70,8 @@ namespace MudBlazor
         /// <summary>
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>
-        public string FieldId => (UserAttributes != null && UserAttributes.TryGetValue("id", out var id) && id != null)
-                    ? (id.ToString() ?? $"mudinput-{Guid.NewGuid()}")
+        public string FieldId => UserAttributes.TryGetValue("id", out var id) && id != null
+                    ? id.ToString() ?? $"mudinput-{Guid.NewGuid()}"
                     : $"mudinput-{Guid.NewGuid()}";
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description
I noticed a warning that `FieldId` is checking for `UserAttributes` null, while the `UserAttributes` is not annotated as nullable.
I actually don't know if the `CaptureUnmatchedValues` can be null? Can the user override it by passing a null?
As a safe measure I added that it's nullable and checked everywhere for null that reads `UserAttributes`
As bonus `MudRTLProvider` is using `ParameterState`.
@henon let me know if `UserAttributes` is always initialized, then we should just remove the `UserAttributes != null` check.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
