### PR TITLE
Docs: Improve navigation UX & Several misc tweaks

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/appbar"
 
 <DocsPage>
-    <DocsPageHeader Title="App Bar" SubTitle="App bar is used to display actions, branding, navigation and screen titles.">
+    <DocsPageHeader Title="App Bar" SubTitle="An app bar is used to display actions, branding, navigation and screen titles.">
         <Description>
             Keeping the app bar persistent while browsing different pages will ease navigation and access to actions for your users.
         </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
@@ -2,11 +2,12 @@
 @page "/docs/overview"
 
 <DocsPage DisplayFooter="true">
-    <DocsPageHeader Title="Explore MudBlazor" SubTitle="Discover articles from MudBlazor team.">
+    <DocsPageHeader Title="Explore MudBlazor">
         <SpecialHeaderContent>
             <MudText Typo="Typo.h2" Inline="true" Class="docs-title">Explore&nbsp;</MudText>
             <MudText Typo="Typo.h2" Inline="true" Color="Color.Primary" Class="docs-title">MudBlazor</MudText>
-            <MudText Typo="Typo.subtitle1" Class="docs-title-description">Discover our library and all components to power your next project.</MudText>
+            <br>
+            <MudText Typo="Typo.subtitle1" Class="docs-title-description">Discover our library and all its components to power your next project.</MudText>
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
@@ -49,7 +50,7 @@
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
                         <MudText Typo="Typo.h5">Layout</MudText>
-                        <MudText Typo="Typo.subtitle1">Container, Grid, Surfaces...</MudText>
+                        <MudText Typo="Typo.subtitle1">Container, Grid, Surfaces…</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -104,7 +105,7 @@
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
                         <MudText Typo="Typo.h5">Buttons</MudText>
-                        <MudText Typo="Typo.subtitle1">Regular, Icon, Floating...</MudText>
+                        <MudText Typo="Typo.subtitle1">Regular, Icon, FAB…</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -145,7 +146,7 @@
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
                         <MudText Typo="Typo.h5">Inputs</MudText>
-                        <MudText Typo="Typo.subtitle1">Forms, Text Fields, Numeric Fields...</MudText>
+                        <MudText Typo="Typo.subtitle1">Forms, Fields, Pickers…</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -278,7 +279,7 @@
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
                         <MudText Typo="Typo.h5">Data Display</MudText>
-                        <MudText Typo="Typo.subtitle1">Lists, Tables, Tabs, Pagination...</MudText>
+                        <MudText Typo="Typo.subtitle1">Lists, Tables, Tabs…</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
@@ -509,7 +510,7 @@
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
                         <MudText Typo="Typo.h5">Navigation</MudText>
-                        <MudText Typo="Typo.subtitle1">Links, Menus and Navigation</MudText>
+                        <MudText Typo="Typo.subtitle1">Links, Menus, Navigation</MudText>
                     </div>
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">

--- a/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
@@ -55,7 +55,7 @@
                 </MudItem>
                 <MudItem xs="12" md="9" Class="mt-16">
                     <div class="explore-mudblazor-items">
-                        <DocsExploreCard Title="AppBar">
+                        <DocsExploreCard Title="App Bar">
                             <MudPaper Elevation="25" Width="100%" Height="68px">
                                 <MudPaper Elevation="0" Width="100%" Height="12px" Square="true" Class="mud-theme-primary rounded-t"/>
                             </MudPaper>
@@ -163,7 +163,7 @@
                                 </MudPaper>
                             </div>
                         </DocsExploreCard>
-                        <DocsExploreCard Title="Checkbox">
+                        <DocsExploreCard Title="Check Box">
                             <MudPaper Elevation="25" Class="pa-2 rounded-lg d-flex justify-center align-center">
                                 <MudIcon Icon="@Icons.Material.Rounded.Check" Color="Color.Primary" Size="Size.Large" />
                             </MudPaper>
@@ -488,7 +488,7 @@
                                 <MudPaper Elevation="0" Width="18px" Height="18px" Class="mud-theme-primary rounded-0 mt-n6 z-10" Style="transform:rotate(45deg);"/>
                             </div>
                         </DocsExploreCard>
-                        <DocsExploreCard Title="TreeView">
+                        <DocsExploreCard Title="Tree View">
                             <div class="d-flex flex-column flex-grow-1">
                                 <MudPaper Elevation="25" Width="100%" Class="px-2 py-1 d-flex align-center">
                                     <MudIcon Icon="@Icons.Material.Rounded.KeyboardArrowDown" Color="Color.Primary" Class="my-n2 ml-n2" Size="Size.Small"/>
@@ -672,7 +672,5 @@
 </DocsPage>
 
 @code {
-
     [Inject] IMenuService MenuService { get; set; } 
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -6,7 +6,7 @@
 <DocsPageContent>
 
 <DocsPageSection>
-    <SectionHeader Title="Basic Text Field's">
+    <SectionHeader Title="Basic Text Fields">
         <Description></Description>
     </SectionHeader>
     <SectionContent Code="@nameof(TextFieldBasicExample)" ShowCode="false">
@@ -22,7 +22,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Dense">
-                <Description>With the <CodeInline>margin</CodeInline> prop you can reduce the text field height.</Description>
+                <Description>With the <CodeInline>Margin</CodeInline> property you can reduce the text field height.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TextFieldDenseExample)" ShowCode="false">
                 <TextFieldDenseExample/>
@@ -147,7 +147,7 @@
 </DocsPageSection>
 
 <DocsPageSection>
-    <SectionHeader Title="Clear button">
+    <SectionHeader Title="Clear Button">
         <Description></Description>
     </SectionHeader>
     <SectionContent Code="@nameof(TextFieldClearableAndInputTypeExample)" ShowCode="false">

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -16,7 +16,7 @@
                 <MudText Typo="Typo.h1">You always wanted</MudText>
                 <div class="pl-1 my-4">
                     <MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
-                        Trusted by thousands of users, from hobby developers to large enterprises. Use MudBlazor to rapidly build amazing web applications without leaving your loved C# language and toolchain.
+                        With millions of downloads, from hobby developers to large enterprises, MudBlazor enables you to rapidly build amazing web applications without leaving your beloved C# language and toolchain.
                     </MudText>
                 </div>
                 <div class="d-flex py-4 mb-16 mb-md-0">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -15,8 +15,8 @@
         <MudBlazorLogo Class="docs-mudblazor-logo" />
         <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
-    <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
     <MudButton Href="/getting-started/installation" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.GettingStarted)">Get Started</MudButton>
+    <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
     <MudButton Href="/mud/introduction" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.DiscoverMore)">Learn More</MudButton>
     <MudMenu Color="Color.Inherit" Variant="Variant.Text" Class="mx-1 px-3" PopoverClass="docs-layout-menu-shadow" ListClass="d-flex px-4 pb-2 docs-appbar-special-menu" LockScroll="true" Label="Products" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
         <MudList T="string" Clickable="true">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -20,7 +20,7 @@ public partial class Appbar
     private int _searchDialogReturnedItemsCount;
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
-    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
+    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true, MaxWidth = MaxWidth.False };
     private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
     [
         new ApiLinkServiceEntry

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -17,8 +17,8 @@
             @if (_topMenuOpen == true)
             {
                 <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
-                    <MudNavLink Href="/docs/overview">Docs</MudNavLink>
                     <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
+                    <MudNavLink Href="/docs/overview">Docs</MudNavLink>
                     <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
                     <MudNavGroup Title="Products" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                         <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -31,11 +31,11 @@
     <MudItem xs="6" sm="3" Class="d-flex flex-column">
         <MudText Typo="Typo.subtitle2" Class="mb-3">Project</MudText>
         <MudLink Href="/mud/announcements" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Announcements</MudLink>
-        <MudLink Href="/mud/project/how-it-started" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">How it started</MudLink>
         <MudLink Href="/mud/project/releases" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Releases</MudLink>
         <MudLink Href="/mud/project/roadmap" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Roadmap</MudLink>
-        <MudLink Href="/mud/project/sponsor" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Sponsors and Backers</MudLink>
-        <MudLink Href="/mud/project/team" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Team and Contributors</MudLink>
+        <MudLink Href="/mud/project/sponsor" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Sponsors & Backers</MudLink>
+        <MudLink Href="/mud/project/team" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">Team & Contributors</MudLink>
+        <MudLink Href="/mud/project/how-it-started" Typo="Typo.body1" Color="Color.Inherit" Underline="Underline.None">How it started</MudLink>
     </MudItem>
     <MudItem xs="6" sm="3" Class="d-flex flex-column">
         <MudText Typo="Typo.subtitle2" Class="mb-3">Products and Legal Information</MudText>

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -12,8 +12,8 @@
             <AppbarButtons/>
         </MudToolBar>
         <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
-            <MudNavLink Href="/docs/overview">Docs</MudNavLink>
             <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
+            <MudNavLink Href="/docs/overview">Docs</MudNavLink>
             <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
             <MudNavGroup Title="Products" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                 <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -19,14 +19,14 @@
             <MudNavGroup Title="@item.Name" Expanded="true" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                 @foreach (var subItem in item.GroupComponents)
                 {
-                    string href = $"components/{subItem.Link}";
+                    var href = $"components/{subItem.Link}";
                     <MudNavLink Href="@href">@subItem.Name</MudNavLink>
                 }
             </MudNavGroup>
         }
         else
         {
-            string href = $"components/{item.Link}";
+            var href = $"components/{item.Link}";
             <MudNavLink Href="@href">@item.Name</MudNavLink>
         }
     }
@@ -59,6 +59,7 @@
         <div class="docs-css-utility-header">
             @title
         </div>
+
         @foreach (var link in MenuService.Utilities.Where(x => x.Group == title))
         {
             <MudNavLink Href="@link.Href" Match="NavLinkMatch.All">@link.Title</MudNavLink>
@@ -66,18 +67,15 @@
     }
 </MudNavGroup>
 
-<MudNavGroup Title="Community" Expanded="@(_section is "introduction" or "community")">
+<MudNavGroup Title="Learn More" Expanded="@(_section == "mud")">
     <MudNavLink Href="/mud/introduction">What is MudBlazor?</MudNavLink>
+    <MudNavLink Href="/mud/announcements">Announcements</MudNavLink>
     <MudNavLink Href="/mud/community/getting-help">Getting Help</MudNavLink>
     <MudNavLink Href="/mud/community/reporting-bugs">Reporting Bugs</MudNavLink>
     <MudNavLink Href="/mud/community/contribution">Contribution</MudNavLink>
-</MudNavGroup>
-
-    <MudNavGroup Title="Learn More" Expanded="@(_section is "announcements" or "project")">
-    <MudNavLink Href="/mud/announcements">Announcements</MudNavLink>
-    <MudNavLink Href="/mud/project/how-it-started">How it Started</MudNavLink>
     <MudNavLink Href="/mud/project/releases">Releases</MudNavLink>
     <MudNavLink Href="/mud/project/roadmap">Roadmap</MudNavLink>
     <MudNavLink Href="/mud/project/sponsor">Sponsors & Backers</MudNavLink>
     <MudNavLink Href="/mud/project/team">Team & Contributors</MudNavLink>
+    <MudNavLink Href="/mud/project/how-it-started">How it Started</MudNavLink>
 </MudNavGroup>

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -16,7 +16,7 @@
     {
         if (item.IsNavGroup)
         {
-            <MudNavGroup Title="@item.Name" Expanded="@(IsSubGroupExpanded(item))" ExpandIcon="@Icons.Material.Filled.ExpandMore">
+            <MudNavGroup Title="@item.Name" Expanded="true" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                 @foreach (var subItem in item.GroupComponents)
                 {
                     string href = $"components/{subItem.Link}";

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
@@ -29,20 +29,5 @@ namespace MudBlazor.Docs.Shared
             _componentLink = NavMan.GetComponentLink();
             StateHasChanged();
         }
-
-        bool IsSubGroupExpanded(MudComponent item)
-        {
-            #region comment about is subgroup expanded
-            //if the route contains any of the links of the subgroup, then the subgroup
-            //should be expanded
-            //Example:
-            //subgroup: form inputs & controls
-            //the subgroup "form inputs & controls" should be open if the current page has in the route
-            //a component included in the subgroup elements, that in this case are autocomplete, form, field,
-            //radio, select...
-            //this route `/components/autocomplete` should open the subgroup "form inputs..."
-            #endregion
-            return item.GroupComponents.Any(i => i.Link == _componentLink);
-        }
     }
 }

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
@@ -1,7 +1,5 @@
-﻿using System.Linq;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Extensions;
-using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
 
 namespace MudBlazor.Docs.Shared

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -5,16 +5,17 @@
 <div class="@GetPanelClass()" @attributes="UserAttributes">
     @if (_sections.Count > 1)
     {
-        <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
-            @Headline
-        </MudText>
         <MudNavMenu Class="pl-4">
+            <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
+                @Headline
+            </MudText>
+
             @foreach (var docSection in _sections.OrderBy(x => x.LevelSortingValue))
             {
                 <MudNavLink @key="docSection.Id" Match="NavLinkMatch.All" Class="@GetNavLinkClass(docSection)" @onclick="@(e => OnNavLinkClick(docSection.Id))">
                     @docSection.Title
                 </MudNavLink>
-			}
+            }
         </MudNavMenu>
     }
 </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Resolves part of #1671
Makes the components in subgroups first class citizens with the rest of the components by expanding them by default. The groups should just be for organization. Now you can use Ctrl+F effectively and rely less on the mouse since the search doesn't have a hotkey!

Many other small tweaks and fixes seen below.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

### Nav subgroups expand on load for easier access

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/e6cc8148-7bd4-40ba-8d00-548c9705aaa7" width="300">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/83d8b085-472c-4eba-ace6-d98765643020" width="300">

### "Explore MudBlazor" on two lines like v6

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/e35ce64f-fd42-47d0-a04e-0d495a2b5eb3" width="600">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/290b3806-9110-4713-839f-d06c016eb9fb" width="600">

### Merge "Community" and "Learn More" and re-order to be more relevant (+ fix auto-expand)

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/1e2b5d9f-4e6a-44e8-8e00-90b3f11588ac" width="300">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/0b65b716-8e14-4d8d-9d63-cc412fffb00e" width="300">

### Order of top nav now flows the same as the side nav

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/275f7de9-ef90-49a0-a3c5-9eb229171fba" width="600">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/916cec4d-79cd-4e7f-abfb-0890d2b90e7c" width="600">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/605b4446-6fe6-4d20-9738-55c4ac60abdd" width="300">

### Align "Contents" above right nav further right

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/d53b465d-7ce6-4c78-a574-ca723b4cb2fe" width="300">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/8b6d987e-5d5b-420c-a588-9ec61ed45bdc" width="300">

### Emphasize current popularity (8 million downloads)

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/c5b83630-7935-4c1f-8dc7-4583a97be816" width="600">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/11e94697-3002-4c77-b313-3fd4723ebf3e" width="600">

### Don't restrict width of mobile search popup (fit more content on the small screen)

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/78541be7-ad16-4bd8-859d-d5627aa50743" width="600">

<img src="https://github.com/MudBlazor/MudBlazor/assets/7112040/454dc4e4-602c-49c2-8097-969f0c7ea642" width="600">

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
