### PR TITLE
Docs: Make code copy button always visible

### DIFF
--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -125,6 +125,22 @@
       right: 8px;
       background-color: transparent;
     }
+    /*Show only on hover if on desktop*/
+    /*TODO: Show if code is focused*/
+    @media(hover: hover) and (pointer: fine) {
+      .copy-code-button {
+        color: rgba(5, 0, 51, 0.0);
+        transition: color 250ms cubic-bezier(.4, 0, .2, 1) 0ms;
+        background-color: unset;
+      }
+
+      &:hover {
+        .copy-code-button {
+          color: var(--mud-palette-text-secondary) !important;
+          background-color: transparent;
+        }
+      }
+    }
 
     .docs-section-source-container {
       max-height: 0;

--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -123,24 +123,7 @@
       position: absolute;
       bottom: 8px;
       right: 8px;
-      color: rgba(5, 0, 51, 0.0);
-      transition: color 250ms cubic-bezier(.4, 0, .2, 1) 0ms;
-    }
-
-    @media(hover: hover) and (pointer: fine) {
-      &:hover {
-        .copy-code-button {
-          color: var(--mud-palette-text-secondary) !important;
-          background-color: transparent;
-        }
-      }
-    }
-
-    &:active {
-      .copy-code-button {
-        color: var(--mud-palette-text-secondary) !important;
-        background-color: transparent;
-      }
+      background-color: transparent;
     }
 
     .docs-section-source-container {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

The copy code button is now always visible no matter whether you are focused, hovering, active, or anything else. This is most impactful for copying code on mobile where you can't hover.

Find the same behavior at:
- [MUI](https://mui.com/material-ui/react-snackbar/)
- [Bootstrap](https://getbootstrap.com/docs/5.3/getting-started/introduction/)
- [AntBlazor](https://antblazor.com/en-US/components/button)
- [react.fluentui](https://react.fluentui.dev/?path=/docs/components-accordion--default)
- GitHub code blocks

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/84efb94b-268b-472c-9f77-d6a8bf029c98)



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
