### PR TITLE
MudCheckBox: Add state CSS classes for easier testing

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -28,9 +28,9 @@ namespace MudBlazor.UnitTests.Components
                 .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-false");
             Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
                 .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-null");
-            var comp =Context.RenderComponent<MudCheckBox<bool?>>(self => self
+            var comp = Context.RenderComponent<MudCheckBox<bool?>>(self => self
                 .Add(x => x.Value, null)
-                .Add(x=>x.TriState, true));
+                .Add(x => x.TriState, true));
             comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
             comp.Find("input").Change(true);
             comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -14,6 +14,32 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class CheckBoxTests : BunitTest
     {
+
+        [Test]
+        public void CheckBox_Test_BooleanStateSelectors()
+        {
+            // the state of the checkbox should manifest itself in the classes
+            // mud-checkbox-true, mud-checkbox-false, mud-checkbox-null applied to the span
+            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, false))
+                .Find(".mud-checkbox .mud-checkbox-false").Should().NotBe(null);
+            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+                .Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+                .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-false");
+            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+                .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-null");
+            var comp =Context.RenderComponent<MudCheckBox<bool?>>(self => self
+                .Add(x => x.Value, null)
+                .Add(x=>x.TriState, true));
+            comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
+            comp.Find("input").Change(true);
+            comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find("input").Change(false);
+            comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-false");
+            comp.Find("input").Change("");
+            comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
+        }
+
         /// <summary>
         /// single checkbox, initialized false, check -  uncheck
         /// </summary>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -36,6 +36,9 @@ namespace MudBlazor
                 .AddClass($"mud-ripple mud-ripple-checkbox", Ripple && !GetReadOnlyState() && !GetDisabledState())
                 .AddClass($"mud-disabled", GetDisabledState())
                 .AddClass($"mud-readonly", GetReadOnlyState())
+                .AddClass($"mud-checkbox-true", BoolValue == true)
+                .AddClass($"mud-checkbox-false", BoolValue == false)
+                .AddClass($"mud-checkbox-null", BoolValue is null)
                 .Build();
 
         /// <summary>


### PR DESCRIPTION
## Description
Testing with checkboxes is a pain. I want to add this to mudcheckbox
```c#
                .AddClass($"mud-checkbox-true", BoolValue == true)
                .AddClass($"mud-checkbox-false", BoolValue == false)
                .AddClass($"mud-checkbox-null", BoolValue is null)

```
otherwise I'd have to compare icon geometry
I did it before but it is far from ideal
the classes have no CSS. but could be used by the user as a selector as well

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
