### PR TITLE
MudVirtualize: Sync With Native Virtualize Parameters

### DIFF
--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -5,11 +5,17 @@
 
 @if (IsEnabled)
 {
-    <Virtualize Items="@Items" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize">
-        @if (ChildContent is not null)
-        {
-            @ChildContent(item)
-        }
+    <Virtualize Items="@Items" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
+        <ItemContent>
+            @if (ChildContent is not null)
+            {
+                @ChildContent(item)
+            }
+        </ItemContent>
+
+        <Placeholder>
+            @Placeholder
+        </Placeholder>
     </Virtualize>
 }
 else

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -6,12 +6,12 @@
 @if (IsEnabled)
 {
     <Virtualize Items="@Items" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
-        <ItemContent>
+        <ChildContent>
             @if (ChildContent is not null)
             {
                 @ChildContent(item)
             }
-        </ItemContent>
+        </ChildContent>
 
         <Placeholder>
             @Placeholder

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 
 namespace MudBlazor
 {
@@ -23,10 +24,22 @@ namespace MudBlazor
         public RenderFragment<T>? ChildContent { get; set; }
 
         /// <summary>
+        /// Gets or sets the template for the items that have not yet been loaded in memory.
+        /// </summary>
+        [Parameter]
+        public RenderFragment? Placeholder { get; set; }
+
+        /// <summary>
         /// Gets or sets the fixed item source.
         /// </summary>
         [Parameter]
         public ICollection<T>? Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function providing items to the list.
+        /// </summary>
+        [Parameter]
+        public ItemsProviderDelegate<T>? ItemsProvider { get; set; }
 
         /// <summary>
         /// Gets or sets a value that determines how many additional items will be rendered
@@ -42,5 +55,11 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public float ItemSize { get; set; } = 50f;
+
+        /// <summary>
+        /// Gets or sets tag name of the HTML element that will be used as virtualization spacer. Default is div.
+        /// </summary>
+        [Parameter]
+        public string SpacerElement { get; set; } = "div";
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Passed native Virtualize parameters `ItemsProvider`, `Placeholder` and `SpacerElement` to the MudVirtualize. Doesn't pass `EmptyContent` parameter because it's .NET 8 only.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
