### PR TITLE
Docs: Revert landing page search bar to icon

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -62,14 +62,23 @@
         </MudList>
     </MudMenu>
     <MudSpacer />
-    <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
-                     AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
-                     SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
-                     ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
-        <ItemTemplate Context="result">
-            <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
-        </ItemTemplate>
-    </MudAutocomplete>
+    @if (DisplaySearchBar)
+    {
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
+                         AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
+                         SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
+                         ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+            <ItemTemplate Context="result">
+                <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
+            </ItemTemplate>
+        </MudAutocomplete>
+    }
+    else
+    {
+        <MudTooltip Delay="1000" Text="Search">
+            <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" Edge="Edge.End" OnClick="@(() => OpenSearchDialog())" />
+        </MudTooltip>
+    }
     <MudDivider FlexItem="true" Vertical="true" DividerType="DividerType.Middle" Class="my-4" />
     <AppbarButtons />
 </div>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -20,7 +20,7 @@ public partial class Appbar
     private int _searchDialogReturnedItemsCount;
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
-    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true, MaxWidth = MaxWidth.False };
+    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
     private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
     [
         new ApiLinkServiceEntry
@@ -116,6 +116,9 @@ public partial class Appbar
 
     [Parameter]
     public EventCallback<MouseEventArgs> DrawerToggleCallback { get; set; }
+
+    [Parameter]
+    public bool DisplaySearchBar { get; set; } = true;
 
     private async void OnSearchResult(ApiLinkServiceEntry entry)
     {

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -3,7 +3,7 @@
 
 <MudLayout Class="mudblazor-landingpage">
     <MudAppBar Class="landing-appbar" Elevation="0">
-        <Appbar DrawerToggleCallback="ToggleDrawer" />
+        <Appbar DrawerToggleCallback="ToggleDrawer" DisplaySearchBar="false" />
     </MudAppBar>
     <MudDrawer @bind-Open="@_drawerOpen" Elevation="25" Variant="@DrawerVariant.Temporary">
         <MudToolBar Dense="true" Gutters="false" Class="px-1 docs-gray-bg">

--- a/src/MudBlazor.Docs/Theme/Theme.cs
+++ b/src/MudBlazor.Docs/Theme/Theme.cs
@@ -151,8 +151,8 @@ namespace MudBlazor.Docs
             Dark = "#110E2D",
             DarkLighten = "#1A1643",
             GrayDefault = "#4B5563",
-            GrayLight = "#e8e8e8",
-            GrayLighter = "#f9f9f9",
+            GrayLight = "#9CA3AF",
+            GrayLighter = "#adbdccff",
         };
         private static readonly PaletteDark LandingPageDarkPalette = new()
         {
@@ -163,8 +163,6 @@ namespace MudBlazor.Docs
             Background = "#151521",
             Dark = "#111019",
             DarkLighten = "#1A1643",
-            GrayLight = "#2a2833",
-            GrayLighter = "#1e1e2d",
             TextPrimary = "#ffffff",
             TextSecondary = "#92929f",
             TextDisabled = "#ffffff33",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail any why -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310 -->

Original design was preferred and since the auto-focus in the dialog was fixed, it's the same number of clicks to search anyway.

Ideally we want a keyboard shortcut for this in the future: https://github.com/MudBlazor/MudBlazor/pull/7268/#issuecomment-2054120627

Reverts part of #8515 and Closes #8596

This also reverts the change in #8682 to the size of the search dialog since now it's no longer exclusive to small screens.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please provide high quality gif, webm, or mp4 -->

v6, v7 dev, v7 this PR (notice the URLs)

https://github.com/MudBlazor/MudBlazor/assets/7112040/2427cf1a-88d2-4441-9dd2-29d3904981e9



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
