### PR TITLE
Button: Don't apply :focus effect on mobile so it's not sticky

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -47,12 +47,12 @@
   --mud-ripple-color: var(--mud-palette-text-primary);
 
   @media(hover: hover) and (pointer: fine) {
-    &:hover {
+    &:hover, &:focus {
       background-color: var(--mud-palette-action-default-hover);
     }
   }
 
-  &:focus-visible, &:focus, &:active {
+  &:focus-visible, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
 }
@@ -77,12 +77,12 @@
       --mud-ripple-color: var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover {
+        &:hover, &:focus {
           background-color: var(--mud-palette-#{$color}-hover);
         }
       }
 
-      &:focus-visible, &:focus, &:active {
+      &:focus-visible, &:active {
         background-color: var(--mud-palette-#{$color}-hover);
       }
     }
@@ -104,12 +104,12 @@
   }
 
   @media(hover: hover) and (pointer: fine) {
-    &:hover {
+    &:hover, &:focus {
       background-color: var(--mud-palette-action-default-hover);
     }
   }
 
-  &:focus-visible, &:focus, &:active {
+  &:focus-visible, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
 
@@ -120,13 +120,13 @@
       border: 1px solid var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover {
+        &:hover, &:focus {
           border: 1px solid var(--mud-palette-#{$color});
           background-color: var(--mud-palette-#{$color}-hover);
         }
       }
 
-      &:focus-visible, &:focus, &:active {
+      &:focus-visible, &:active {
         border: 1px solid var(--mud-palette-#{$color});
         background-color: var(--mud-palette-#{$color}-hover);
       }
@@ -180,12 +180,12 @@
       background-color: var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover {
+        &:hover, &:focus {
           background-color: var(--mud-palette-#{$color}-darken);
         }
       }
 
-      &:focus-visible, &:focus, &:active {
+      &:focus-visible, &:active {
         background-color: var(--mud-palette-#{$color}-darken);
       }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes a regression of #8256 caused by #8575.
See it in action by tapping the button using dev tools (not click).

Not the best solution but it's actively causing a problem and I'm really not sure how else to do it as simple as this.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before: tapping a button would keep the tap effect visible indefinitely, like the old way.
After: tapping the button only applies the effect while the tap is held, like after the sticky PR.
See the original sticky PR for examples.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
