### PR TITLE
MudPageContentNavigation: Fix automatic highlighting of centered section

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -38,7 +38,7 @@
                 <NavLink class="mode-links ml-2" href="@($"api/{_componentName}")" Match="NavLinkMatch.All">API</NavLink>
             </div>
         }
-        <MudPageContentNavigation SectionClassSelector="docs-section-header" @ref="_contentNavigation" ActivateFirstSectionAsDefault="true"/>
+        <MudPageContentNavigation SectionClassSelector="docs-section-anchor" @ref="_contentNavigation" ActivateFirstSectionAsDefault="true"/>
         @if (_renderAds)
         {
             <MudElement HtmlTag="script" async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CESDLK3E&placement=mudblazorcom" id="_carbonads_js" data-consent-category="carbon"></MudElement>

--- a/src/MudBlazor.Docs/Components/SectionHeader.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionHeader.razor.cs
@@ -20,6 +20,7 @@ public partial class SectionHeader
 
     protected string Classname =>
         new CssBuilder("docs-section-header")
+            .AddClass("docs-section-anchor", !string.IsNullOrWhiteSpace(Title))
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
@@ -40,6 +40,7 @@ namespace MudBlazor.UnitTests.Mocks
         public Task ScrollToSection(string id)
         {
             _scrollHistory.Add(id);
+            FireScrollSectionSectionCenteredEvent(id);
             return Task.FromResult(true);
         }
 
@@ -50,10 +51,10 @@ namespace MudBlazor.UnitTests.Mocks
         }
 
         public Task ScrollToSection(Uri uri) => Task.FromResult(false);
-        public Task StartSpying(string elementsSelector)
+        public Task StartSpying(string containerSelector, string sectionClassSelector)
         {
             SpyingInitiated = true;
-            SpyingClassSelector = elementsSelector;
+            SpyingClassSelector = sectionClassSelector;
 
             return Task.FromResult(false);
         }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -38,7 +38,13 @@ namespace MudBlazor
         public string Headline { get; set; } = "Contents";
 
         /// <summary>
-        /// The css selector used to identify the HTML elements that should be observed for viewport changes
+        /// The CSS selector used to identify the scroll container
+        /// </summary>
+        [Parameter]
+        public string ScrollContainerSelector { get; set; } = "html";
+
+        /// <summary>
+        /// The class name (without .) to identify the HTML elements that should be observed for viewport changes
         /// </summary>
         [Parameter]
         public string SectionClassSelector { get; set; } = string.Empty;
@@ -63,8 +69,6 @@ namespace MudBlazor
 
         private Task OnNavLinkClick(string id)
         {
-            SelectActiveSection(id);
-
             return _scrollSpy is not null
                 ? _scrollSpy.ScrollToSection(id)
                 : Task.CompletedTask;
@@ -172,7 +176,7 @@ namespace MudBlazor
 
                     if (!string.IsNullOrEmpty(SectionClassSelector))
                     {
-                        await _scrollSpy.StartSpying(SectionClassSelector);
+                        await _scrollSpy.StartSpying(ScrollContainerSelector, SectionClassSelector);
                     }
 
                     SelectActiveSection(_scrollSpy.CenteredSection);

--- a/src/MudBlazor/Services/Scroll/ScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpy.cs
@@ -26,9 +26,10 @@ namespace MudBlazor
         /// <summary>
         /// Start spying for scroll events for elements with the specified classes
         /// </summary>
-        /// <param name="elementsSelector">the class name (without .) to identify the containers to spy on</param>
+        /// <param name="containerSelector">the CSS selector to identify the scroll container</param>
+        /// <param name="sectionClassSelector">the CSS class (without .) to identify the section containers to spy on</param>
         /// <returns></returns>
-        public Task StartSpying(string elementsSelector);
+        public Task StartSpying(string containerSelector, string sectionClassSelector);
 
         /// <summary>
         /// Center the viewport to DOM element with the given Id 
@@ -70,7 +71,8 @@ namespace MudBlazor
             _dotNetRef = DotNetObjectReference.Create(this);
         }
 
-        public async Task StartSpying(string containerSelector) => await _js.InvokeVoidAsync("mudScrollSpy.spying", containerSelector, _dotNetRef);
+        public async Task StartSpying(string containerSelector, string sectionClassSelector) =>
+            await _js.InvokeVoidAsync("mudScrollSpy.spying", _dotNetRef, containerSelector, sectionClassSelector);
 
         [JSInvokable]
         public void SectionChangeOccured(string id)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
fixes #8588

### fixing auto-highlighting

When clicking on a section link in the TOC, navigation to the section works like this:
- the clicked section link is highlighted
- auto-highlighting of the centered secion is disabled
- the section is smoothly scrolled into view
- the arrival at the target section is detected
- auto-highlighting is enabled again

The advantages of this approach are:
- the clicked section is guaranteed to be selected/highlighted
- there is immediate feedback to the user that their intent to jump to the clicked section has been acknowledged
  (the trade-off is eventual consistency with the current scroll position)

Unfortunately there are two bugs in this implementation due to the fact that the target section will not always be reached:
- the scroll spy breaks when navigating to a section that cannot be centered by scrolling (i.e. tiny sections at the top or bottom, cf. #8588)
- the scroll spy breaks when aborting the automatic scroll-into-view via manual scrolling
The first issue could be fixed by detecting when the top or bottom has been reached, but I don't think there is a way to detect manual abortion of automatic scrolling.

The proposed solution is to keep highlighting the currently centered section, even while automatically scrolling.
I think the user feedback is different, but just as natural because the smooth transition between scroll positions is consistently in sync with the highlighted section, whether the scrolling is automatic or manual.
This is also how Mozilla does it in their documentation, probably for good reasons:
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop

The disadvantage is that the clicked section is not guaranteed to be selected/highlighted, even when it was successfully scrolled into view. But this is also more consistent with automatic highlighting while scrolling manually.

![mud-scroll](https://github.com/MudBlazor/MudBlazor/assets/9403243/d0ea479a-fa81-4348-96bd-9d8a689bb726)

### criteria for highlighting the correct section

Another problem with the current behavior is that sometimes a section is highlighted that is not even in view.
For example on https://mudblazor.com/api/datagrid scroll upwards from EventCallbacks. The EventCallbacks section link stays highlighted until the middle of the long Properties section is reached. This is because currently the section header nearest to the current scroll position (center of scroll-container) is detected, and in the bottom half of the Properties section, the next section header, which is EventCallbacks, is nearer.

The proposed solution is to select the nearest/last (bottom-most) section header above the current scroll position (center of scroll-container), unless all section headers are below, in which case the nearest/first (top-most) is selected. That way, in the example, the EventCallbacks section is only selected if it takes up more than about half of the scroll-container.

### sections without navigation link

The problem in the previous example on https://mudblazor.com/api/datagrid can only be seen when scrolling upwards. The reason why the Properties section stays highlighted until the end while scrolling downwards, is that while scrolling through the Properties section, most of the time, the nearest section header belongs to a subsection (Misc/Common). Since these subsections have no navigation link in the TOC, they don't trigger a change of highlighted section.

This is not an issue with MudPageContentNavigation itself, and has been fixed by introducing a new class selector `docs-section-anchor` only for sections that should appear in the TOC. The switch from a section to the next while scroling down now occurs always at the same position as the switch back when scrolling upwards.

### support for elements on the page as scrolling area

Allow passing a CSS selector to identify the element that is the scrolling area, unless that is the browser viewport as per default (or when passing the root element `html`).
Unfortunately, there is a difference in the handling of both cases.
See e.g. https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#scrolling-area-origin


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
This has been tested manually with the MudBlazor.Docs.Server project.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
