### PR TITLE
MudMenu: Disable text selection in activator

### DIFF
--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -1,4 +1,4 @@
-﻿.mud-menu {
+.mud-menu {
   display: inline-flex;
   align-self: center;
   position: relative;
@@ -17,5 +17,6 @@
 
   & > div.mud-menu-activator {
     display: contents;
+    user-select: none;
   }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

After #8598 the chip example is now selectable despite being clickable, because the clickable-ness is done on the menu end.
This is especially noticeable when using touch to hold the activator for right clicking.

This resolves it and disables all selection for anything inside the activator, not just chips, to make it a true button.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

https://github.com/MudBlazor/MudBlazor/assets/7112040/177a3d39-dc36-4107-8663-8bfe8694bd63

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
