### PR TITLE
MudSlider: Fix tick count calculation for certain cases. Fixes #8713

### DIFF
--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -172,9 +172,9 @@ namespace MudBlazor
         {
             if (TickMarks)
             {
-                var min = Convert.ToDouble(Min);
-                var max = Convert.ToDouble(Max);
-                var step = Convert.ToDouble(Step);
+                var min = Convert.ToDecimal(Min);
+                var max = Convert.ToDecimal(Max);
+                var step = Convert.ToDecimal(Step);
 
                 _tickMarkCount = 1 + (int)((max - min) / step);
             }


### PR DESCRIPTION
## Description
Used ToDecimal instead of ToDouble because for certain values the double/int math would have rounding errors (see related issue for details). Fixes #8713 

## How Has This Been Tested?
Visually tested on docs.

## Type of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

**Before:**
![Screenshot_20240415_042123](https://github.com/MudBlazor/MudBlazor/assets/22691956/cc8494ca-890d-4894-b514-b3af3e5b0006)

**After:**
![Screenshot_20240415_042240](https://github.com/MudBlazor/MudBlazor/assets/22691956/4e739e4f-7149-4845-a4b2-52c9bfe7dbe7)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
