### PR TITLE
MudAvatar*: Added XML Documentation for Public Members

### DIFF
--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether Right-to-Left (RTL) mode is enabled.
+        /// Gets or sets whether Right-to-Left (RTL) mode is enabled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>. When <c>true</c>, text will be displayed right-to-left.
@@ -81,7 +81,7 @@ namespace MudBlazor
         public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
 
         /// <summary>
-        /// Gets or sets a value indicating whether a close icon is displayed.
+        /// Gets or sets whether a close icon is displayed.
         /// </summary>
         /// <remarks>
         /// To customize which icon is displayed for the close icon, set the <see cref="CloseIcon"/> property.
@@ -101,7 +101,7 @@ namespace MudBlazor
         public int Elevation { set; get; } = 0;
 
         /// <summary>
-        /// Gets or sets a value indicating whether rounded corners are disabled.
+        /// Gets or sets whether rounded corners are disabled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -111,7 +111,7 @@ namespace MudBlazor
         public bool Square { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether compact padding will be used.
+        /// Gets or sets whether compact padding will be used.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -121,7 +121,7 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether no icon is displayed.
+        /// Gets or sets whether no icon is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  To customize the icon, use the <see cref="Icon"/> property.

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -5,76 +5,101 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+    /// <summary>
+    /// Represents a component which displays circular user profile pictures, icons or text.
+    /// </summary>
     partial class MudAvatar : MudComponentBase, IDisposable
     {
-        [CascadingParameter] protected MudAvatarGroup? AvatarGroup { get; set; }
-        protected string Classname =>
-        new CssBuilder("mud-avatar")
-          .AddClass($"mud-avatar-{Size.ToDescriptionString()}")
-          .AddClass($"mud-avatar-rounded", Rounded)
-          .AddClass($"mud-avatar-square", Square)
-          .AddClass($"mud-avatar-{Variant.ToDescriptionString()}")
-          .AddClass($"mud-avatar-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
-          .AddClass($"mud-elevation-{Elevation.ToString()}")
-          .AddClass(AvatarGroup?.GetAvatarSpacing() ?? new CssBuilder(), AvatarGroup != null)
-          .AddClass(Class)
-        .Build();
+        [CascadingParameter] 
+        protected MudAvatarGroup? AvatarGroup { get; set; }
 
-        protected string Stylesname =>
-            new StyleBuilder()
+        protected string Classname => new CssBuilder("mud-avatar")
+            .AddClass($"mud-avatar-{Size.ToDescriptionString()}")
+            .AddClass($"mud-avatar-rounded", Rounded)
+            .AddClass($"mud-avatar-square", Square)
+            .AddClass($"mud-avatar-{Variant.ToDescriptionString()}")
+            .AddClass($"mud-avatar-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
+            .AddClass($"mud-elevation-{Elevation.ToString()}")
+            .AddClass(AvatarGroup?.GetAvatarSpacing() ?? new CssBuilder(), AvatarGroup != null)
+            .AddClass(Class)
+            .Build();
+
+        protected string Stylesname => new StyleBuilder()
             .AddStyle(AvatarGroup?.GetAvatarZindex(this) ?? new StyleBuilder(), AvatarGroup != null)
             .AddStyle(Style)
             .Build();
 
         /// <summary>
-        /// The higher the number, the heavier the drop-shadow.
+        /// Gets or sets the size of the drop shadow.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public int Elevation { set; get; } = 0;
 
         /// <summary>
-        /// If true, border-radius is set to 0.
+        /// Gets or sets whether rounded corners are disabled.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public bool Square { get; set; }
 
         /// <summary>
-        /// If true, border-radius is set to the themes default value.
+        /// Gets or sets whether corners are rounded.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public bool Rounded { get; set; }
 
         /// <summary>
-        /// The color of the component. It supports the theme colors.
+        /// Gets or sets the color of the component. It supports the theme colors.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The Size of the MudAvatar.
+        /// Gets or sets the size of the avatar.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// The variant to use.
+        /// Gets or sets the display variant to use.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Filled" />. The variant changes the appearance of the avatar, such as <c>Text</c>, <c>Outlined</c>, or <c>Filled</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
         public Variant Variant { get; set; } = Variant.Filled;
 
         /// <summary>
-        /// Child content of the component.
+        /// Gets or sets the content within the avatar.
         /// </summary>
+        /// <remarks>
+        /// This property allows for custom content to displayed inside of the avatar, but it is not required.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
+        /// <inheritdoc />
         protected override void OnInitialized()
         {
             base.OnInitialized();
@@ -82,6 +107,9 @@ namespace MudBlazor
             AvatarGroup?.AddAvatar(this);
         }
 
+        /// <summary>
+        /// Releases resources used by this component.
+        /// </summary>
         public void Dispose()
         {
             AvatarGroup?.RemoveAvatar(this);

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
     /// </summary>
     partial class MudAvatar : MudComponentBase, IDisposable
     {
-        [CascadingParameter] 
+        [CascadingParameter]
         protected MudAvatarGroup? AvatarGroup { get; set; }
 
         protected string Classname => new CssBuilder("mud-avatar")
@@ -60,10 +60,10 @@ namespace MudBlazor
         public bool Rounded { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the component. It supports the theme colors.
+        /// Gets or sets the color of the avatar.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default"/>.
+        /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -182,7 +182,7 @@ namespace MudBlazor
             return _avatars.IndexOf(avatar) < Max;
         }
 
-        /// <summary>
+        /// <inheritdoc />
         protected override void OnParametersSet()
         {
             base.OnParametersSet();

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -6,109 +6,140 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+    /// <summary>
+    /// Represents a grouping of multiple <see cref="MudAvatar"/> components.
+    /// </summary>
     partial class MudAvatarGroup : MudComponentBase
     {
         private bool _childrenNeedUpdates = false;
 
-        protected string Classname =>
-            new CssBuilder("mud-avatar-group")
-                .AddClass($"mud-avatar-group-outlined", Outlined)
-                .AddClass($"mud-avatar-group-outlined-{OutlineColor.ToDescriptionString()}", Outlined)
-                .AddClass(Class)
-                .Build();
+        protected string Classname => new CssBuilder("mud-avatar-group")
+            .AddClass($"mud-avatar-group-outlined", Outlined)
+            .AddClass($"mud-avatar-group-outlined-{OutlineColor.ToDescriptionString()}", Outlined)
+            .AddClass(Class)
+            .Build();
 
-        protected string MaxAvatarClassname =>
-            new CssBuilder("mud-avatar-group-max-avatar")
-                .AddClass($"ms-n{Spacing}")
-                .AddClass(MaxAvatarClass)
-                .Build();
+        protected string MaxAvatarClassname => new CssBuilder("mud-avatar-group-max-avatar")
+            .AddClass($"ms-n{Spacing}")
+            .AddClass(MaxAvatarClass)
+            .Build();
 
         /// <summary>
-        /// Spacing between avatars where 0 is none and 16 max.
+        /// Gets or sets the amount of space between avatars, between <c>0</c> and <c>16</c>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>3</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Behavior)]
         public int Spacing { get; set; } = 3;
 
         /// <summary>
-        /// Outlines the grouped avatars to distinguish them, useful when avatars are the same color or uses images.
+        /// Gets or sets whether an outline is displayed for the group.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.  This property is useful to differentiate avatars which are the same color or use images.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public bool Outlined { get; set; } = true;
 
         /// <summary>
-        /// Sets the color of the outline if its used.
+        /// Gets or sets the color of the outline when <see cref="Outlined"/> is <c>true</c>.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public Color OutlineColor { get; set; } = Color.Surface;
 
         /// <summary>
-        /// Elevation of the MaxAvatar the higher the number, the heavier the drop-shadow.
+        /// Gets or sets the size of the drop shadow when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public int MaxElevation { set; get; } = 0;
 
         /// <summary>
-        /// If true, MaxAvatar border-radius is set to 0.
+        /// Gets or sets whether rounded corners are disabled when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> CSS style is set to <c>0</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public bool MaxSquare { get; set; }
 
         /// <summary>
-        /// If true, MaxAvatar will be rounded.
+        /// Gets or sets whether corners are rounded when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public bool MaxRounded { get; set; }
 
         /// <summary>
-        /// Color for the MaxAvatar.
+        /// Gets or sets the color of the avatar when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public Color MaxColor { get; set; } = Color.Default;
 
         /// <summary>
-        /// Size of the MaxAvatar.
+        /// Gets or sets the size of the avatar when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public Size MaxSize { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Variant of the MaxAvatar.
+        /// Gets or sets the display variant to use when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Filled" />. The variant changes the appearance of the avatar, such as <c>Text</c>, <c>Outlined</c>, or <c>Filled</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public Variant MaxVariant { get; set; } = Variant.Filled;
 
         /// <summary>
-        /// Max avatars to show before showing +x avatar, default value 0 has no max.
+        /// Gets or sets the maximum allowed avatars to display.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  When <c>0</c>, no maximum is enforced.  Otherwise, a "+#" avatar is shown for the number of avatars exceeding this number.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Behavior)]
         public int Max { get; set; }
 
         /// <summary>
-        /// Custom class/classes for MaxAvatar
+        /// Gets or sets the CSS class applied when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public string? MaxAvatarClass { get; set; }
 
         /// <summary>
-        /// Template that will be rendered when the number of avatars exceeds the maximum (parameter Max).
+        /// Gets or sets a template used to render avatars when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public RenderFragment<int>? MaxAvatarsTemplate { get; set; }
 
         /// <summary>
-        /// Child content of the component.
+        /// Gets or sets the content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Behavior)]
@@ -151,6 +182,7 @@ namespace MudBlazor
             return _avatars.IndexOf(avatar) < Max;
         }
 
+        /// <summary>
         protected override void OnParametersSet()
         {
             base.OnParametersSet();


### PR DESCRIPTION
## Description

This update adds XML documentation for `MudAvatar` and `MudAvatarGroup`, for all public members.  There is also a minor fix for `MudAlert` to change "a value indicating whether" to just "whether".

## How Has This Been Tested?

This was tested by observing the XML documentation for `MudAvatar` examples, like this:

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/133d7bfb-6891-487f-a295-bb1b77608a5d)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/8731bde6-bcf1-4307-a9e9-399caff39d8e)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/79ac0bc3-4088-4154-9e05-82be5daaaaa0)

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/3d006d20-f68a-420c-986f-7344f7d85835)

... then, for the `MudAlert` component:

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/d8fdfe1f-c6b7-4699-89d6-678938e0f85e)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.

## Notes for Reviewers

* This PR only changes XML documentation.  
* This PR fixes `MudAlert` to change "a value indicating whether" to just "whether".
