### PR TITLE
ParameterState: Improve hot swappable IEqualityComparer system

### DIFF
--- a/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
+++ b/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
@@ -2,8 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 
 namespace MudBlazor.UnitTests.Comparer;
 

--- a/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
+++ b/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System;
+
+namespace MudBlazor.UnitTests.Comparer;
+
+#nullable enable
+public class DoubleArrayEpsilonEqualityComparer : IEqualityComparer<double[]>
+{
+    private readonly IEqualityComparer<double> _elementComparer;
+
+    public DoubleArrayEpsilonEqualityComparer(IEqualityComparer<double> elementComparer)
+    {
+        _elementComparer = elementComparer ?? throw new ArgumentNullException(nameof(elementComparer));
+    }
+
+    public bool Equals(double[]? x, double[]? y)
+    {
+        if (x == null || y == null)
+        {
+            return x == y;
+        }
+
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x.Length != y.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Length; i++)
+        {
+            if (!_elementComparer.Equals(x[i], y[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(double[] obj)
+    {
+        unchecked
+        {
+            var hash = 17;
+            foreach (var item in obj)
+            {
+                hash = hash * 31 + _elementComparer.GetHashCode(item);
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/State/Builder/RegisterParameterBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/State/Builder/RegisterParameterBuilderTests.cs
@@ -49,7 +49,7 @@ public class RegisterParameterBuilderTests
         parameterState.Value.Should().Be(parameterValue);
         parameterState.HasHandler.Should().BeTrue();
         callBackCalled.Should().BeTrue();
-        parameterState.ComparerFunc().Should().BeOfType<DoubleEpsilonEqualityComparer>();
+        parameterState.Comparer.UnderlyingComparer().Should().BeOfType<DoubleEpsilonEqualityComparer>();
     }
 
     [Test]
@@ -79,7 +79,7 @@ public class RegisterParameterBuilderTests
         parameterState.Metadata.ComparerParameterName.Should().BeNull();
         parameterState.Value.Should().Be(parameterValue);
         parameterState.HasHandler.Should().BeTrue();
-        parameterState.ComparerFunc().Should().BeAssignableTo<EqualityComparer<double>>();
+        parameterState.Comparer.UnderlyingComparer().Should().BeAssignableTo<EqualityComparer<double>>();
     }
 
     [Test]
@@ -107,7 +107,7 @@ public class RegisterParameterBuilderTests
         parameterState.Metadata.ComparerParameterName.Should().BeNull();
         parameterState.Value.Should().Be(parameterValue);
         parameterState.HasHandler.Should().BeTrue();
-        parameterState.ComparerFunc().Should().BeAssignableTo<EqualityComparer<double>>();
+        parameterState.Comparer.UnderlyingComparer().Should().BeAssignableTo<EqualityComparer<double>>();
     }
 
     [Test]
@@ -136,7 +136,7 @@ public class RegisterParameterBuilderTests
         parameterState.Metadata.ComparerParameterName.Should().BeNull();
         parameterState.Value.Should().Be(parameterValue);
         parameterState.HasHandler.Should().BeTrue();
-        parameterState.ComparerFunc().Should().BeOfType<DoubleEpsilonEqualityComparer>();
+        parameterState.Comparer.UnderlyingComparer().Should().BeOfType<DoubleEpsilonEqualityComparer>();
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
@@ -662,7 +662,7 @@ public class ParameterSetTests
             .WithMetadata(new ParameterMetadata(nameof(parameter), null, nameof(comparer)))
             .WithGetParameterValueFunc(() => parameter)
             .WithParameterChangedHandler(parameterChangedHandlerMock)
-            .WithComparer(() => comparer, x=> new DoubleArrayEpsilonEqualityComparer(x))
+            .WithComparer(() => comparer, x => new DoubleArrayEpsilonEqualityComparer(x))
             .Attach();
         var parameterSet = new ParameterSet(parameterState);
 

--- a/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterSetTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +10,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.State.Builder;
+using MudBlazor.UnitTests.Comparer;
 using MudBlazor.UnitTests.State.Mocks;
 using NUnit.Framework;
 
@@ -639,6 +639,38 @@ public class ParameterSetTests
         parameterChangedHandlerMock.Changes.Should().BeEquivalentTo(new[]
         {
             new ParameterChangedEventArgs<double>(ParameterName, Parameter, ParameterNewValue)
+        });
+    }
+
+    [Test(Description = "Tests a very special case described in ParameterStateInternal.HasParameterChanged when comparer is a blazor parameter and changes together with the associated value.")]
+    public async Task SetParametersAsync_FuncCustomComparerTransformAsParameter_Swap()
+    {
+        var comparer = new DoubleEpsilonEqualityComparer(0.0001f);
+        var parameterChangedHandlerMock = new ParameterChangedHandlerMock<double[]>();
+        var parameter = new[] { 10000d };
+        var parameterNewValue = new[] { 10001d };
+        const string ParameterName = nameof(parameter);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { ParameterName, parameterNewValue },
+            { nameof(comparer), new DoubleEpsilonEqualityComparer(0.00001f) }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        // ReSharper disable once AccessToModifiedClosure
+        var parameterState = ParameterAttachBuilder
+            .Create<double[]>()
+            .WithMetadata(new ParameterMetadata(nameof(parameter), null, nameof(comparer)))
+            .WithGetParameterValueFunc(() => parameter)
+            .WithParameterChangedHandler(parameterChangedHandlerMock)
+            .WithComparer(() => comparer, x=> new DoubleArrayEpsilonEqualityComparer(x))
+            .Attach();
+        var parameterSet = new ParameterSet(parameterState);
+
+        // Act && Assert
+        await parameterSet.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+        parameterChangedHandlerMock.Changes.Should().BeEquivalentTo(new[]
+        {
+            new ParameterChangedEventArgs<double[]>(ParameterName, parameter, parameterNewValue)
         });
     }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -28,7 +25,7 @@ namespace MudBlazor
                 .WithParameter(() => SelectedValues)
                 .WithEventCallback(() => SelectedValuesChanged)
                 .WithChangeHandler(OnSelectedValuesChangedAsync)
-                .WithComparer(() => new CollectionComparer<T>(Comparer));
+                .WithComparer(() => Comparer, comparer => new CollectionComparer<T>(comparer));
             registerScope.RegisterParameter<IEqualityComparer<T?>>(nameof(Comparer))
                 .WithParameter(() => Comparer)
                 .WithChangeHandler(OnComparerChangedAsync);

--- a/src/MudBlazor/State/Comparer/IParameterEqualityComparerSwappable.cs
+++ b/src/MudBlazor/State/Comparer/IParameterEqualityComparerSwappable.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.State.Comparer;
+
+#nullable enable
+/// <summary>
+/// Represents an interface for a hot swappable parameter comparer.
+/// </summary>
+/// <typeparam name="T">The type of objects to compare.</typeparam>
+internal interface IParameterEqualityComparerSwappable<T> : IEqualityComparer<T>
+{
+    /// <summary>
+    /// Gets the original unwrapped comparer function.
+    /// </summary>
+    Func<IEqualityComparer<T>> UnderlyingComparer { get; }
+
+    /// <summary>
+    /// Tries to get the comparer from the specified parameter view.
+    /// </summary>
+    /// <param name="parameters">The parameter view to search for the comparer.</param>
+    /// <param name="parameterName">The name of the parameter containing the comparer.</param>
+    /// <param name="result">When this method returns, contains the comparer associated with the specified parameter name, if the parameter was found; otherwise, the default value for the type of the result parameter. This parameter is passed uninitialized.</param>
+    /// <returns><see langword="true"/> if the parameter view contains the comparer with the specified name; otherwise, <see langword="false"/>.</returns>
+    bool TryGetFromParameterView(ParameterView parameters, string parameterName, [MaybeNullWhen(false)] out IEqualityComparer<T> result);
+}

--- a/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
+++ b/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
+
+namespace MudBlazor.State.Comparer;
+
+#nullable enable
+/// <summary>
+/// Represents a hot swappable parameter comparer.
+/// </summary>
+/// <typeparam name="T">The type of objects to compare.</typeparam>
+[DebuggerDisplay("IEqualityComparer = {OriginalComparer}")]
+internal class ParameterEqualityComparerSwappable<T> : IParameterEqualityComparerSwappable<T>
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public Func<IEqualityComparer<T>> UnderlyingComparer { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterEqualityComparerSwappable{T}"/> class with the specified comparer function.
+    /// </summary>
+    /// <remarks>
+    /// This constructor should be used when you have a static <see cref="IEqualityComparer{T}"/> that does not change during the lifetime of a component.
+    /// </remarks>
+    /// <param name="comparer">The static comparer for the parameter.</param>
+    public ParameterEqualityComparerSwappable(IEqualityComparer<T>? comparer)
+        : this(() => comparer ?? EqualityComparer<T>.Default)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterEqualityComparerSwappable{T}"/> class with the specified comparer function.
+    /// </summary>
+    /// <param name="comparerFunc">The function to provide the comparer for the parameter.</param>
+    public ParameterEqualityComparerSwappable(Func<IEqualityComparer<T>>? comparerFunc)
+    {
+        UnderlyingComparer = comparerFunc ?? (() => EqualityComparer<T>.Default);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(T? x, T? y) => UnderlyingComparer().Equals(x, y);
+
+    /// <inheritdoc />
+    public int GetHashCode([DisallowNull] T obj) => UnderlyingComparer().GetHashCode(obj);
+
+    /// <inheritdoc />
+    public bool TryGetFromParameterView(ParameterView parameters, string parameterName, [MaybeNullWhen(false)] out IEqualityComparer<T> result) => parameters.TryGetValue(parameterName, out result);
+
+    [ExcludeFromCodeCoverage]
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private IEqualityComparer<T> OriginalComparer => UnderlyingComparer();
+}

--- a/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
+++ b/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Components;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.State.Comparer;
 
@@ -18,6 +18,7 @@ namespace MudBlazor.State.Comparer;
 [DebuggerDisplay("IEqualityComparer = {OriginalComparer}")]
 internal class ParameterEqualityComparerSwappable<T> : IParameterEqualityComparerSwappable<T>
 {
+    /// <inheritdoc />
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Func<IEqualityComparer<T>> UnderlyingComparer { get; }
 

--- a/src/MudBlazor/State/Comparer/ParameterEqualityComparerTransformSwappable.cs
+++ b/src/MudBlazor/State/Comparer/ParameterEqualityComparerTransformSwappable.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.State.Comparer;
 
 #nullable enable
 /// <summary>
-/// Represents a swappable parameter comparer that can transform from one type to another.
+/// Represents a hot swappable parameter comparer that can transform from one type to another.
 /// </summary>
 /// <typeparam name="TFrom">The type of the comparer to transform from.</typeparam>
 /// <typeparam name="T">The type of objects to compare.</typeparam>
@@ -24,6 +24,7 @@ internal class ParameterEqualityComparerTransformSwappable<TFrom, T> : IParamete
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly Func<IEqualityComparer<TFrom>> _comparerFromFunc;
 
+    /// <inheritdoc />
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Func<IEqualityComparer<T>> UnderlyingComparer => () => _comparerToFunc(_comparerFromFunc());
 

--- a/src/MudBlazor/State/Comparer/ParameterEqualityComparerTransformSwappable.cs
+++ b/src/MudBlazor/State/Comparer/ParameterEqualityComparerTransformSwappable.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.State.Comparer;
+
+#nullable enable
+/// <summary>
+/// Represents a swappable parameter comparer that can transform from one type to another.
+/// </summary>
+/// <typeparam name="TFrom">The type of the comparer to transform from.</typeparam>
+/// <typeparam name="T">The type of objects to compare.</typeparam>
+[DebuggerDisplay("IEqualityComparer = {OriginalComparer}")]
+internal class ParameterEqualityComparerTransformSwappable<TFrom, T> : IParameterEqualityComparerSwappable<T>
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Func<IEqualityComparer<TFrom>, IEqualityComparer<T>> _comparerToFunc;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Func<IEqualityComparer<TFrom>> _comparerFromFunc;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public Func<IEqualityComparer<T>> UnderlyingComparer => () => _comparerToFunc(_comparerFromFunc());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterEqualityComparerTransformSwappable{TFrom, T}"/> class with the specified comparer transformation functions.
+    /// </summary>
+    /// <param name="comparerFromFunc">The function to provide the original comparer.</param>
+    /// <param name="comparerToFunc">The function to transform the original comparer to the target comparer.</param>
+    public ParameterEqualityComparerTransformSwappable(Func<IEqualityComparer<TFrom>> comparerFromFunc, Func<IEqualityComparer<TFrom>, IEqualityComparer<T>> comparerToFunc)
+    {
+        _comparerFromFunc = comparerFromFunc;
+        _comparerToFunc = comparerToFunc;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(T? x, T? y) => UnderlyingComparer().Equals(x, y);
+
+    /// <inheritdoc />
+    public int GetHashCode([DisallowNull] T obj) => UnderlyingComparer().GetHashCode(obj);
+
+    /// <inheritdoc />
+    public bool TryGetFromParameterView(ParameterView parameters, string parameterName, [MaybeNullWhen(false)] out IEqualityComparer<T> result)
+    {
+        if (parameters.TryGetValue<IEqualityComparer<TFrom>>(parameterName, out var newComparer))
+        {
+            var comparer = _comparerToFunc(newComparer);
+            result = comparer;
+
+            return true;
+        }
+
+        result = default;
+
+        return false;
+    }
+
+    [ExcludeFromCodeCoverage]
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private IEqualityComparer<T> OriginalComparer => UnderlyingComparer();
+}


### PR DESCRIPTION
## Description
Solves problem described here: https://github.com/MudBlazor/MudBlazor/pull/8661#issuecomment-2061052057
Adds new overload:
```C#
RegisterParameterBuilder<T> WithComparer<TFrom>(Func<IEqualityComparer<TFrom>> comparerFromFunc, Func<IEqualityComparer<TFrom>, IEqualityComparer<T>> comparerToFunc, [CallerArgumentExpression(nameof(comparerFromFunc))] string? comparerParameterName = null)
```
Example usage:
```C#
.WithComparer(() => Comparer, x => new CollectionComparer<T>(x));
```

## How Has This Been Tested?
New unit test.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
