### PR TITLE
MudDialog: Fix content not stretched in fullscreen mode

### DIFF
--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
@@ -19,7 +19,7 @@
          tabindex="-1">
     </div>
 
-    <div class="outline-none"
+    <div class="mud-focus-trap-child-container outline-none"
          tabindex="-1">
         @ChildContent
     </div>

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -15,7 +15,8 @@ namespace MudBlazor
         private bool _shouldRender = true;
 
         protected string Classname =>
-            new CssBuilder("outline-none")
+            new CssBuilder("mud-focus-trap")
+                .AddClass("outline-none")
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -97,6 +97,18 @@
     }
   }
 
+  & > .mud-focus-trap {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    & > .mud-focus-trap-child-container {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+    }
+  }
+
   & .mud-dialog-content {
     position: relative;
     flex: 1 1 auto;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Apparently this was a regression which I expect was caused by the addition of a Focus Trap. The dialog content was expecting a flex parent, but the focus trap intercepted that.

This adds classes to the MudFocusTrap and the container for the child content so you can apply styles and debug the layout easier by default.

With those extra classes I applied flex to the intemediary components to make the dialog content grow as intended. Flex is the easier way to do this.

Resolves #5651
Resolves #6994

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/228ef267-0b82-40d1-a889-520a47b117ec)


After

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/db9f5e93-6479-4ee5-9cc1-f8968a1388f0)


I had to hide the Scroll to Top FAB in those images because for some reason they are visible over the dialog.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
