### PR TITLE
MudColorPicker: Make color field resizable. Closes: #8717

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
@@ -123,5 +123,14 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Resize Color Field">
+                <Description>The <CodeInline>ColorFieldHeight</CodeInline> and <CodeInline>ColorFieldWidth</CodeInline> properties allows you to adjust the height and width of the color field.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(ColorPickerColorFieldResizeExample)">
+                <ColorPickerColorFieldResizeExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerColorFieldResizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerColorFieldResizeExample.razor
@@ -1,0 +1,13 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudStack>
+  <MudColorPicker ColorFieldHeight="@height" ColorFieldWidth="@width" PickerVariant="PickerVariant.Static" />
+
+  <MudSlider Min="0" Max="300" @bind-Value="height">Height: @height.ToString()</MudSlider>
+  <MudSlider Min="0" Max="500" @bind-Value="width">Width: @width.ToString()</MudSlider>
+</MudStack>
+
+@code {
+  double height { get; set; } = 125;
+  double width { get; set; } = 156;
+}

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -22,7 +22,7 @@
         <MudPickerContent Class="mud-picker-color-content">
             @if(!DisableColorField)
             {
-                <div class="mud-picker-color-picker">
+                <div class="mud-picker-color-picker" style="@($"width: {_maxX}px;height: {_maxY}px;margin-left: auto;margin-right: auto;")">
 					@if (_activeColorPickerView == ColorPickerView.Spectrum)
 					{
                         <div class="mud-picker-color-overlay" style="@($"background-color: {_baseColor.ToString(MudColorOutputFormats.RGB)}")">

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -44,8 +44,8 @@ namespace MudBlazor
             { 5, ((x) => 255, x => 0, x => 255 - x, "rg") },
         };
 
-        private const double _maxY = 250;
-        private const double _maxX = 312;
+        private double _maxY = 250;
+        private double _maxX = 312;
         private const double _selectorSize = 26.0;
 
         private double _selectorX;
@@ -258,6 +258,36 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int ThrottleInterval { get; set; } = 300;
+
+        /// <summary>
+        /// A two-way bindable property representing the height of the color field. If unset, height will default to 250px.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerAppearance)]
+        public double ColorFieldHeight
+        {
+            get => _maxY;
+            set
+            {
+                _maxY = value;
+                UpdateColorSelectorBasedOnRgb();
+            }
+        }
+
+        /// <summary>
+        /// A two-way bindable property representing the width of the color field. If unset, height will default to 312px
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerAppearance)]
+        public double ColorFieldWidth
+        {
+            get => _maxX;
+            set
+            {
+                _maxX = value;
+                UpdateColorSelectorBasedOnRgb();
+            }
+        }
 
         #endregion
 

--- a/src/MudBlazor/Styles/components/_pickercolor.scss
+++ b/src/MudBlazor/Styles/components/_pickercolor.scss
@@ -59,6 +59,7 @@
   padding: 16px;
   display: flex;
   flex-direction: column;
+  align-self: center;
 
   .mud-picker-color-controls-row {
     display: flex;


### PR DESCRIPTION
## Description
Added height/width public properties (that update private _maxX/_maxY) so the color field spectrum can be resized. Before this PR, changing the css for the color field would only visually update the color field, and it would not let you use the full range of colors (details in issue). Also changed color field css to have margin-left/right 50% so the color field is centered.

**When going past the default 312px width the ui elements below the color field are aligned left, do we want a different behaviour? (see in demo gif below)**

Closes #8717 

![MudColorPickerFieldResizeExample](https://github.com/MudBlazor/MudBlazor/assets/22691956/157ad969-70e2-4201-9278-456616b35e76)

## How Has This Been Tested?
Visually tested in docs. Added example on docs page.

![MudColorPickerFieldResizeDemo](https://github.com/MudBlazor/MudBlazor/assets/22691956/d28de894-851d-45a7-95a7-cf60afdd1639)

```
<MudStack>
  <MudColorPicker ColorFieldHeight="@height" ColorFieldWidth="@width" PickerVariant="PickerVariant.Static" />

  <MudSlider Min="0" Max="300" @bind-Value="height">Height: @height.ToString()</MudSlider>
  <MudSlider Min="0" Max="500" @bind-Value="width">Width: @width.ToString()</MudSlider>
</MudStack>

@code {
  double height { get; set; } = 125;
  double width { get; set; } = 156;
}
```

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
