### PR TITLE
New Component: Add MudFlexBreak component for forcing flex items onto a new line

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridLineBreakExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridLineBreakExample.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="6">
+        <MudPaper Class="d-flex align-center justify-center mud-width-full py-8">One</MudPaper>
+    </MudItem>
+
+    <MudGridBreak />
+
+    <MudItem xs="6">
+        <MudPaper Class="d-flex align-center justify-center mud-width-full py-8">Two</MudPaper>
+    </MudItem>
+    <MudItem xs="6">
+        <MudPaper Class="d-flex align-center justify-center mud-width-full py-8">Three</MudPaper>
+    </MudItem>
+</MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridLineBreakExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridLineBreakExample.razor
@@ -5,7 +5,7 @@
         <MudPaper Class="d-flex align-center justify-center mud-width-full py-8">One</MudPaper>
     </MudItem>
 
-    <MudGridBreak />
+    <MudFlexBreak />
 
     <MudItem xs="6">
         <MudPaper Class="d-flex align-center justify-center mud-width-full py-8">Two</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
@@ -38,7 +38,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Line Break">
-                <Description>You can force items onto the next line by adding a <CodeInline>MudGridBreak</CodeInline>.</Description>
+                <Description>You can force items onto the next line by adding a <CodeInline>MudFlexBreak</CodeInline>.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridLineBreakExample)" ShowCode="false">
                 <GridLineBreakExample />

--- a/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
@@ -2,7 +2,7 @@
 
 <DocsPage>
     <DocsPageHeader Title="Grid" SubTitle="The grid component helps keep layouts consistent across various screen resolutions and sizes.">
-        <Description>            
+        <Description>
             MudBlazor comes with a 12-point grid system and contains 6 breakpoints that are used for specific screen sizes.<br /><br />
             Read more about <MudLink Href="/features/breakpoints">MudBlazor's breakpoints here.</MudLink>
         </Description>
@@ -13,26 +13,35 @@
             <SectionHeader Title="Spacing">
                 <Description></Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Class="demo-grid-spacing" Code="GridSpacingExample" ShowCode="false">
+            <SectionContent DarkenBackground="true" Class="demo-grid-spacing" Code="@nameof(GridSpacingExample)" ShowCode="false">
                 <GridSpacingExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Basic grid">
+            <SectionHeader Title="Basic Grid">
                 <Description>The column widths apply at all breakpoints, xs and up.</Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="GridBasicExample" ShowCode="false">
+            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridBasicExample)" ShowCode="false">
                 <GridBasicExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Grid with breakpoints">
+            <SectionHeader Title="Grid With Breakpoints">
                 <Description>You can apply multiple column widths, causing the layout to change at the specific break point.</Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="GridWithBreakpointsExample" ShowCode="false">
+            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridWithBreakpointsExample)" ShowCode="false">
                 <GridWithBreakpointsExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Line Break">
+                <Description>You can force items onto the next line by adding a <CodeInline>MudGridBreak</CodeInline>.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridLineBreakExample)" ShowCode="false">
+                <GridLineBreakExample />
             </SectionContent>
         </DocsPageSection>
 
@@ -40,7 +49,7 @@
             <SectionHeader Title="Grid Builder">
                 <Description>Calculate your breakpoints with this tool. Move the slider to add and remove items.</Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="GridBuilderExample" ShowCode="false">
+            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridBuilderExample)" ShowCode="false">
                 <GridBuilderExample />
             </SectionContent>
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackBreakExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/Examples/StackBreakExample.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Outlined="true" Class="border-dashed pa-4">
+    <MudStack Wrap="Wrap.Wrap" Spacing="4" Row Style="width: 500px" AlignItems="AlignItems.Start">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 1</MudButton>
+        <MudFlexBreak />
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 2</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 3</MudButton>
+        <MudFlexBreak />
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 4</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 5</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Style="">Button 6</MudButton>
+    </MudStack>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
@@ -45,6 +45,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Line Break">
+                <Description>You can force items onto the next line by adding a <CodeInline>MudFlexBreak</CodeInline>.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(StackBreakExample)" ShowCode="false">
+                <StackBreakExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Usage Examples">
                 <Description>Here are two simple examples to demonstrate what <CodeInline>@nameof(MudStack)</CodeInline> can be used for.</Description>
             </SectionHeader>

--- a/src/MudBlazor/Components/Grid/MudFlexBreak.razor
+++ b/src/MudBlazor/Components/Grid/MudFlexBreak.razor
@@ -9,13 +9,12 @@
 
 @code {
 #nullable enable
-
+    /// <summary>
+    /// Space separated class names
+    /// </summary>
     protected string Classname =>
-    new CssBuilder("mud-grid-break")
+    new CssBuilder("mud-flex-break")
         .AddClass(Class)
         .Build();
-
-    [CascadingParameter]
-    private MudGrid? Parent { get; set; }
 }
 

--- a/src/MudBlazor/Components/Grid/MudGridBreak.razor
+++ b/src/MudBlazor/Components/Grid/MudGridBreak.razor
@@ -8,12 +8,14 @@
 </div>
 
 @code {
+#nullable enable
+
     protected string Classname =>
-        new CssBuilder("mud-grid-break")
+    new CssBuilder("mud-grid-break")
         .AddClass(Class)
         .Build();
 
     [CascadingParameter]
-    private MudGrid Parent { get; set; }
+    private MudGrid? Parent { get; set; }
 }
 

--- a/src/MudBlazor/Components/Grid/MudGridBreak.razor
+++ b/src/MudBlazor/Components/Grid/MudGridBreak.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor
+@using MudBlazor.Utilities
+@using MudBlazor.Extensions
+@inherits MudComponentBase
+
+<div @attributes="UserAttributes" class="@Classname" style="@Style">
+    @* The empty div is used as the break with help from class styles *@
+</div>
+
+@code {
+    protected string Classname =>
+        new CssBuilder("mud-grid-break")
+        .AddClass(Class)
+        .Build();
+
+    [CascadingParameter]
+    private MudGrid Parent { get; set; }
+}
+

--- a/src/MudBlazor/Styles/components/_grid.scss
+++ b/src/MudBlazor/Styles/components/_grid.scss
@@ -1,15 +1,15 @@
 @import '../abstracts/variables';
 
+.mud-flex-break {
+  flex-basis: 100%;
+  width: 0;
+}
+
 .mud-grid {
   width: 100%;
   display: flex;
   flex-wrap: wrap;
   box-sizing: border-box;
-}
-
-.mud-flex-break {
-  flex-basis: 100%;
-  width: 0;
 }
 
 .mud-grid-item {

--- a/src/MudBlazor/Styles/components/_grid.scss
+++ b/src/MudBlazor/Styles/components/_grid.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-grid {
   width: 100%;
@@ -7,11 +7,15 @@
   box-sizing: border-box;
 }
 
+.mud-grid-break {
+  flex-basis: 100%;
+  width: 0;
+}
+
 .mud-grid-item {
   margin: 0;
   box-sizing: border-box;
 }
-
 
 .mud-grid-spacing-xs-1 {
   width: calc(100% + 8px);

--- a/src/MudBlazor/Styles/components/_grid.scss
+++ b/src/MudBlazor/Styles/components/_grid.scss
@@ -7,7 +7,7 @@
   box-sizing: border-box;
 }
 
-.mud-grid-break {
+.mud-flex-break {
   flex-basis: 100%;
   width: 0;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #6712 by adding a `MudFlexBreak` component that can be used in any flexbox layout, such as MudGrid or MudStack, in order to force items onto the next line, similar to `<br>`.

It's very simple to add because we already use flexbox in the grid.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Grid

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/23411c12-2787-4df8-b7ab-2f786e91ecee)

Stack
![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/e0116844-b283-4168-8cd6-a909ea787ce9)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
