### PR TITLE
Update "Using our dotnet templates" section

### DIFF
--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationTemplateUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationTemplateUsageExample.razor
@@ -1,3 +1,3 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-dotnet new mudblazor --host wasm --name MyApplication
+dotnet new mudblazor --interactivity WebAssembly --name MyApplication


### PR DESCRIPTION
It seems `host` was replace with `interactivity`.