### PR TITLE
Docs: Weight search toward closer matches for more accurate results

### DIFF
--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -65,9 +65,9 @@ namespace MudBlazor.Docs.Services
         {
             var ratio = Fuzz.Ratio(keyword, search);
             var partialOutOfOrderRatio = Fuzz.PartialTokenSortRatio(keyword, search);
-            var finalRatio = Math.Max(ratio, partialOutOfOrderRatio);
+            var averageRatio = (ratio + partialOutOfOrderRatio) / 2;
 
-            return finalRatio;
+            return averageRatio;
         }
 
         private void AddEntry(ApiLinkServiceEntry entry)

--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -32,7 +32,7 @@ namespace MudBlazor.Docs.Services
             text = text.ToLowerInvariant();
 
             // Calculate the ratios of all keywords to the search input.
-            var ratios = new Dictionary<ApiLinkServiceEntry, int>();
+            var ratios = new Dictionary<ApiLinkServiceEntry, double>();
             foreach (var (keyword, entry) in _entries)
             {
                 var ratio = GetSearchMatchRatio(text, keyword);
@@ -61,11 +61,11 @@ namespace MudBlazor.Docs.Services
             );
         }
 
-        private int GetSearchMatchRatio(string search, string keyword)
+        private double GetSearchMatchRatio(string search, string keyword)
         {
             var ratio = Fuzz.Ratio(keyword, search);
             var partialOutOfOrderRatio = Fuzz.PartialTokenSortRatio(keyword, search);
-            var averageRatio = (ratio + partialOutOfOrderRatio) / 2;
+            var averageRatio = (ratio + partialOutOfOrderRatio) / 2.0;
 
             return averageRatio;
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

It was treating partial matches on multi-word results far too equally to actual close matches that were a few letters off.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

After (Left) and Before (right)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/e6f2f93c-57fc-401c-8a04-cbb2d0aa1fe0)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/f3760544-353c-4dcc-a201-53f40daa8fb7)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/cac0d2ec-6fb5-4881-ba69-d8104c4b2e97)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/a0f28dbe-0de9-4e29-b19d-f690f8bb9e72)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/d8978005-289a-4e67-b58a-84812e722c3c)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/15c5be5c-dc08-4af8-a3b4-4782c515ffef)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/8d358709-7d2b-40d8-a9f0-75cd67645d04)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/d2843543-72e6-453d-9c81-8e163d8ac6f8)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/fb75072d-630b-4fc8-8b9e-90a14cc1bf34)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/bdb49b45-571a-4aa8-8524-b07a3277600d)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/ab05f401-26cc-4b79-b061-ab1a45fea518)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
