### PR TITLE
Standardise the use of `IsEnabled` and `Enabled`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverProviderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverProviderTest.razor
@@ -1,5 +1,5 @@
 ﻿
-<CascadingValue Value="ProviderIsEnabled" Name="UsePopoverProvider">
+<CascadingValue Value="ProviderEnabled" Name="UsePopoverProvider">
 	<MudPopoverProvider />
 </CascadingValue>
 
@@ -13,6 +13,6 @@
 @code {
 
 	[Parameter]
-	public bool ProviderIsEnabled { get; set; } = true;
+	public bool ProviderEnabled { get; set; } = true;
 
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Virtualize/VirtualizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Virtualize/VirtualizeTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudVirtualize Items="list" IsEnabled="true">
+<MudVirtualize Items="list" Enabled="true">
     <div class="d-flex mud-width-full">
         @foreach (var s in list)
         {

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -1061,29 +1061,29 @@ namespace MudBlazor.UnitTests.Components
         public void MudPopoverProvider_DefaultValue()
         {
             var provider = new MudPopoverProvider();
-            provider.IsEnabled.Should().BeTrue();
+            provider.Enabled.Should().BeTrue();
         }
 
         [Test]
         public void MudPopoverProvider_RenderElementsBasedOnEnableState()
         {
-            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderIsEnabled, true));
+            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, true));
             comp.Find("#my-content").TextContent.Should().Be("Popover content");
 
             for (var i = 0; i < 3; i++)
             {
-                comp.SetParametersAndRender(p => p.Add(x => x.ProviderIsEnabled, false));
+                comp.SetParametersAndRender(p => p.Add(x => x.ProviderEnabled, false));
                 Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
 
-                comp.SetParametersAndRender(p => p.Add(x => x.ProviderIsEnabled, true));
+                comp.SetParametersAndRender(p => p.Add(x => x.ProviderEnabled, true));
                 comp.Find("#my-content").TextContent.Should().Be("Popover content");
             }
         }
 
         [Test]
-        public void MudPopoverProvider_NoRenderWhenIsEnabledIsFalse()
+        public void MudPopoverProvider_NoRenderWhenEnabledIsFalse()
         {
-            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderIsEnabled, false));
+            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, false));
             Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -230,7 +230,7 @@
 
                                     @if (g.Expanded)
                                     {
-                                        <MudVirtualize IsEnabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                        <MudVirtualize Enabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                             @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var tmpRowIndex = rowIndex; }
@@ -268,7 +268,7 @@
                             else
                             {
                                 var rowIndex = 0;
-                                <MudVirtualize IsEnabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                <MudVirtualize Enabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 
-@if (IsEnabled)
+@if (Enabled)
 {
     <div class="mud-popover-provider">
 	    @foreach (var handler in GetActivePopovers())

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -29,7 +29,7 @@ namespace MudBlazor
         /// PopoverProvider. Set a cascading value with UsePopoverProvider=false to prevent it.
         /// </summary>
         [CascadingParameter(Name = "UsePopoverProvider")]
-        public bool IsEnabled { get; set; } = true;
+        public bool Enabled { get; set; } = true;
 
         public void Dispose()
         {
@@ -42,7 +42,7 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            if (IsEnabled == false)
+            if (Enabled == false)
             {
                 return;
             }
@@ -59,7 +59,7 @@ namespace MudBlazor
         {
             base.OnParametersSet();
 
-            if (!IsEnabled && _isConnectedToService)
+            if (!Enabled && _isConnectedToService)
             {
 #pragma warning disable CS0618
                 //TODO: For backward compatibility with old service. Should be removed in v7 with the _isConnectedToService
@@ -73,7 +73,7 @@ namespace MudBlazor
 
 #pragma warning disable CS0618
             //TODO: For backward compatibility with old service. Whole block should be removed in v7
-            if (IsEnabled && !_isConnectedToService)
+            if (Enabled && !_isConnectedToService)
             {
                 Service.FragmentsChanged -= Service_FragmentsChanged; // make sure to avoid multiple registration
                 Service.FragmentsChanged += Service_FragmentsChanged;
@@ -81,9 +81,9 @@ namespace MudBlazor
             }
 #pragma warning restore CS0618
 
-            // Let's in our new case ignore _isConnectedToService and always update the subscription except IsEnabled = false. The manager is specifically designed for it.
+            // Let's in our new case ignore _isConnectedToService and always update the subscription except Enabled = false. The manager is specifically designed for it.
             // The reason is because If an observer throws an exception during the PopoverCollectionUpdatedNotification, indicating a malfunction, it will be automatically unsubscribed.
-            if (IsEnabled)
+            if (Enabled)
             {
                 PopoverService.Subscribe(this);
             }
@@ -92,7 +92,7 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender && IsEnabled && PopoverService.PopoverOptions.ThrowOnDuplicateProvider)
+            if (firstRender && Enabled && PopoverService.PopoverOptions.ThrowOnDuplicateProvider)
             {
                 if (await PopoverService.GetProviderCountAsync() > 1)
                 {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -97,7 +97,7 @@
                         @if (CurrentPageItems != null && CurrentPageItems.Any())
                         {
                             var rowIndex = 0;
-                                <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable"
@@ -205,7 +205,7 @@
 
          RenderFragment rootNode =
             @<text>
-        <MudVirtualize IsEnabled="@Virtualize" Items="@source?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item" ChildContent="@child()">
+        <MudVirtualize Enabled="@Virtualize" Items="@source?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item" ChildContent="@child()">
         </MudVirtualize>
             </text>;
 

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -3,7 +3,7 @@
 @typeparam T
 @using Microsoft.AspNetCore.Components.Web.Virtualization 
 
-@if (IsEnabled)
+@if (Enabled)
 {
     <Virtualize Items="@Items" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
         <ChildContent>

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         /// Set false to turn off virtualization
         /// </summary>
         [Parameter]
-        public bool IsEnabled { get; set; }
+        public bool Enabled { get; set; }
 
         /// <summary>
         /// Gets or sets the item template for the list.


### PR DESCRIPTION
MudBlazor currently uses the `Enabled` and `IsEnabled` properties. This PR aims to standardise the use of `Enabled`.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudVirtualize**: replace `IsEnabled` with `Enabled`
**MudPopoverProvider**: replace `IsEnabled` with `Enabled`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
