### PR TITLE
Docs: Add note about `Accept` filter for `FileUpload`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -41,7 +41,19 @@
                 <Description>
                     Allow multiple files with <CodeInline>T="IReadOnlyList&#60IBrowserFile&#62"</CodeInline> or limit the valid file types with <CodeInline>Accept</CodeInline>.
                     To upload more than 10 files, you must specify a <CodeInline>MaximumFileCount</CodeInline>.
+
+                    <MudAlert Class="my-3"
+                              Dense
+                              Severity="Severity.Info">
+                        Note: Some browsers or platforms may require specific values for the <CodeInline>Accept</CodeInline> attribute.
+                        <br>
+                        <br>
+                        In MAUI using an Android device for example, you should use <CodeInline>Accept="image/png, image/jpg"</CodeInline> rather than <CodeInline>Accept=".png, .jpg"</CodeInline>.
+                        <br>
+                        Refer to the <a href="https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/file-picker?view=net-maui-8.0&tabs=android#platform-differences">MAUI docs</a> for more information.
+                    </MudAlert>
                 </Description>
+
             </SectionHeader>
             <SectionContent DarkenBackground="true" ShowCode="false" Code="@nameof(FileUploadMultipleAcceptExample)">
                 <FileUploadMultipleAcceptExample />


### PR DESCRIPTION
## Description
Added a note indicating that different browsers and platforms may require different values for the `Accept` property in `MudFileUpload` (or more specifically the underlying `accept` attribute).

Resolves #8578 

## How Has This Been Tested?
N/A

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

#### Before

![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/de7d935c-324d-4778-bba4-888db5c882c0)

#### After

![image](https://github.com/MudBlazor/MudBlazor/assets/15004223/c3f1aa69-b7b3-4bb0-8b66-a1bb580c88ec)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
