### PR TITLE
Button: Revert sticky focus style

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -47,7 +47,7 @@
   --mud-ripple-color: var(--mud-palette-text-primary);
 
   @media(hover: hover) and (pointer: fine) {
-    &:hover, &:focus {
+    &:hover {
       background-color: var(--mud-palette-action-default-hover);
     }
   }
@@ -77,7 +77,7 @@
       --mud-ripple-color: var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover, &:focus {
+        &:hover {
           background-color: var(--mud-palette-#{$color}-hover);
         }
       }
@@ -104,7 +104,7 @@
   }
 
   @media(hover: hover) and (pointer: fine) {
-    &:hover, &:focus {
+    &:hover {
       background-color: var(--mud-palette-action-default-hover);
     }
   }
@@ -120,7 +120,7 @@
       border: 1px solid var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover, &:focus {
+        &:hover {
           border: 1px solid var(--mud-palette-#{$color});
           background-color: var(--mud-palette-#{$color}-hover);
         }
@@ -180,7 +180,7 @@
       background-color: var(--mud-palette-#{$color});
 
       @media(hover: hover) and (pointer: fine) {
-        &:hover, &:focus {
+        &:hover {
           background-color: var(--mud-palette-#{$color}-darken);
         }
       }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Currently if you click a button, it will apply the `:focus` style and keep it there until you click somewhere else. This was done in #8575 to make the dialog show focus on the right button but should be reverted until we figure out a better way of applying only the `focus-visible` pseudo class or at least not leaving the button pressed style indefinitely.

https://github.com/MudBlazor/MudBlazor/assets/7112040/2779cda0-955d-4332-8848-d52a3f7f13f8

Reverts #8575 #8709 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
