### PR TITLE
CssBuilder, StyleBuilder: Fix method with optional parameter is hidden by overload

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/BuilderExtensions.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BuilderExtensions.cs
@@ -6,33 +6,37 @@ using MudBlazor.Utilities;
 
 namespace UtilityTests
 {
+#nullable enable
+    /// <summary>
+    /// Provides extension methods for <see cref="CssBuilder"/> to handle null rendering scenarios.
+    /// </summary>
     public static class BuilderExtensions
     {
         /// <summary>
-        /// Used to convert a CssBuilder into a null when it is empty.
+        /// Converts a <see cref="CssBuilder"/> into null if it is empty.
         /// Usage: class=null causes the attribute to be excluded when rendered.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <returns>string</returns>
-        public static string NullIfEmpty(this CssBuilder builder) =>
+        /// <param name="builder">The <see cref="CssBuilder"/> instance.</param>
+        /// <returns>A null string if the builder is empty; otherwise, the built string.</returns>
+        public static string? NullIfEmpty(this CssBuilder builder) =>
             string.IsNullOrEmpty(builder.ToString()) ? null : builder.ToString();
 
         /// <summary>
-        /// Used to convert a StyleBuilder into a null when it is empty.
+        /// Converts a <see cref="StyleBuilder"/> into null if it is empty.
         /// Usage: style=null causes the attribute to be excluded when rendered.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <returns>string</returns>
-        public static string NullIfEmpty(this StyleBuilder builder) =>
+        /// <param name="builder">The <see cref="StyleBuilder"/> instance.</param>
+        /// <returns>A null string if the builder is empty; otherwise, the built string.</returns>
+        public static string? NullIfEmpty(this StyleBuilder builder) =>
             string.IsNullOrEmpty(builder.ToString()) ? null : builder.ToString();
 
         /// <summary>
-        /// Used to convert a string.IsNullOrEmpty into a null when it is empty.
+        /// Converts a string into null if it is empty.
         /// Usage: attribute=null causes the attribute to be excluded when rendered.
         /// </summary>
-        /// <returns>string</returns>
-        public static string NullIfEmpty(this string s) =>
+        /// <param name="s">The input string.</param>
+        /// <returns>A null string if the input string is null or empty; otherwise, the input string.</returns>
+        public static string? NullIfEmpty(this string s) =>
             string.IsNullOrEmpty(s) ? null : s;
-
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -15,6 +15,20 @@ namespace UtilityTests
     public class CssBuilderTests
     {
         [Test]
+        public void Default_Returns_Instance_With_Prop_And_Value()
+        {
+            // Arrange
+            var prop = "color";
+            var value = "red";
+
+            // Act
+            var styleBuilder = StyleBuilder.Default(prop, value).Build();
+
+            // Assert
+            styleBuilder.Should().Be("color:red;");
+        }
+
+        [Test]
         public void Default_Returns_Instance_With_Value()
         {
             // Arrange
@@ -136,16 +150,54 @@ namespace UtilityTests
         public void AddClass_With_CssBuilder_And_Condition_Func_Adds_Class_Correctly()
         {
             // Arrange
-            const bool conditionResult = true;
+            const bool ConditionResult = true;
             var nestedBuilder = new CssBuilder().AddClass("nested-class");
 
             // Act
             var cssBuilder = new CssBuilder()
-                .AddClass(nestedBuilder, () => conditionResult)
-                .AddClass(nestedBuilder, () => !conditionResult);
+                .AddClass(nestedBuilder, () => ConditionResult)
+                .AddClass(nestedBuilder, () => !ConditionResult);
 
             // Assert
             cssBuilder.Build().Should().Be("nested-class");
+        }
+
+        [Test]
+        public void AddClass_With_Value_Function_When_Null()
+        {
+            // Arrange
+            string? ValueFunction() => "class1";
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClass(ValueFunction, null);
+
+            // Assert
+            cssBuilder.Build().Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddClass_With_CssBuilder_When_Null()
+        {
+            // Arrange
+            var nestedBuilder = new CssBuilder().AddClass("nested-class");
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClass(nestedBuilder, null);
+
+            // Assert
+            cssBuilder.Build().Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddClassFromAttributes_With_Null_Dictionary()
+        {
+            // Act
+            var cssBuilder = new CssBuilder().AddClassFromAttributes(null);
+
+            // Assert
+            cssBuilder.Build().Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -10,165 +10,260 @@ using NUnit.Framework;
 
 namespace UtilityTests
 {
+#nullable enable
+    [TestFixture]
     public class CssBuilderTests
     {
         [Test]
-        public void ShouldConstructWithDefaultValue()
+        public void Default_Returns_Instance_With_Value()
         {
-            //arrange
-            var classToRender = CssBuilder.Default("item-one").Build();
+            // Arrange
+            var value = "test-class";
 
-            //assert
-            classToRender.Should().Be("item-one");
+            // Act
+            var cssBuilder = CssBuilder.Default(value).Build();
+
+            // Assert
+            cssBuilder.Should().Be("test-class");
         }
 
+        [Test]
+        public void Empty_Returns_Instance_With_Empty_Value()
+        {
+            // Act
+            var cssBuilder = CssBuilder.Empty();
+
+            // Assert
+            cssBuilder.Build().Should().BeEmpty();
+        }
 
         [Test]
-        public void ShouldConstructWithEmpty()
+        public void Empty_Returns_Instance_With_Null_Value()
         {
-            //arrange
+            // Act
             var classToRender = CssBuilder.Empty().NullIfEmpty();
 
-            //assert
+            // Assert
             classToRender.Should().BeNull();
         }
 
         [Test]
-        public void ShouldBuildConditionalCssClasses()
+        public void AddClass_Adds_Class_Correctly()
         {
-            //arrange
-            var hasTwo = false;
-            var hasThree = true;
-            Func<bool> hasFive = () => false;
+            // Arrange
+            var cssBuilder = new CssBuilder();
 
-            //act
+            // Act
+            cssBuilder.AddClass("class1");
+            cssBuilder.AddClass("class2");
+            cssBuilder.AddClass("class3");
+
+            // Assert
+            cssBuilder.Build().Should().Be("class1 class2 class3");
+        }
+
+        [Test]
+        public void AddClass_With_Condition_Adds_Class_Correctly()
+        {
+            // Arrange
+            const bool HasTwo = false;
+            const bool HasThree = true;
+            static bool HasFive() => false;
+
+            // Act
             var classToRender = new CssBuilder("item-one")
-                            .AddClass("item-two", when: hasTwo)
-                            .AddClass("item-three", when: hasThree)
+                            .AddClass("item-two", when: HasTwo)
+                            .AddClass("item-three", when: HasThree)
                             .AddClass("item-four")
-                            .AddClass("item-five", when: hasFive)
+                            .AddClass("item-five", when: HasFive)
                             .Build();
-            //assert
+
+
+            // Assert
             classToRender.Should().Be("item-one item-three item-four");
         }
-        [Test]
-        public void ShouldBuildConditionalCssBuilderClasses()
-        {
-            //arrange
-            var hasTwo = false;
-            var hasThree = true;
-            Func<bool> hasFive = () => false;
 
-            //act
-            var classToRender = new CssBuilder("item-one")
-                            .AddClass("item-two", when: hasTwo)
+        [Test]
+        public void AddClass_With_Condition_Func_Adds_Class_Correctly()
+        {
+            // Arrange
+            var cssBuilder = new CssBuilder();
+            static bool Condition1() => true;
+            static bool Condition2() => false;
+
+            // Act
+            cssBuilder.AddClass("class1", Condition1);
+            cssBuilder.AddClass("class2", Condition2);
+            cssBuilder.AddClass("class3", Condition1);
+
+            // Assert
+            cssBuilder.Build().Should().Be("class1 class3");
+        }
+
+        [Test]
+        public void AddClass_With_Value_And_Condition_Func_Adds_Class_Correctly()
+        {
+            // Arrange
+            const bool ConditionResult = true;
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClass("class1", () => ConditionResult)
+                .AddClass("class2", () => !ConditionResult)
+                .AddClass("class3", () => ConditionResult);
+
+            // Assert
+            cssBuilder.Build().Should().Be("class1 class3");
+        }
+
+        [Test]
+        public void AddClass_With_Value_Function_And_Condition_Func_Adds_Class_Correctly()
+        {
+            // Arrange
+            const bool ConditionResult = true;
+            Func<string?> valueFunction = () => "class1";
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClass(valueFunction, () => ConditionResult)
+                .AddClass(valueFunction, () => !ConditionResult);
+
+            // Assert
+            cssBuilder.Build().Should().Be("class1");
+        }
+
+        [Test]
+        public void AddClass_With_CssBuilder_And_Condition_Func_Adds_Class_Correctly()
+        {
+            // Arrange
+            const bool conditionResult = true;
+            var nestedBuilder = new CssBuilder().AddClass("nested-class");
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClass(nestedBuilder, () => conditionResult)
+                .AddClass(nestedBuilder, () => !conditionResult);
+
+            // Assert
+            cssBuilder.Build().Should().Be("nested-class");
+        }
+
+        [Test]
+        public void Should_Build_Conditional_CssBuilder_Classes()
+        {
+            // Arrange
+            const bool HasTwo = false;
+            const bool HasThree = true;
+            static bool HasFive() => false;
+
+            // Act
+            var cssBuilder = new CssBuilder("item-one")
+                            .AddClass("item-two", when: HasTwo)
                             .AddClass(new CssBuilder("item-three")
                                             .AddClass("item-foo", false)
                                             .AddClass("item-sub-three"),
-                                            when: hasThree)
+                                            when: HasThree)
                             .AddClass("item-four")
-                            .AddClass("item-five", when: hasFive)
+                            .AddClass("item-five", when: HasFive)
                             .Build();
-            //assert
-            classToRender.Should().Be("item-one item-three item-sub-three item-four");
-        }
-        [Test]
-        public void ShouldBuildEmptyClasses()
-        {
-            //arrange
-            var shouldShow = false;
 
-            //act
-            var classToRender = new CssBuilder()
-                            .AddClass("some-class", shouldShow)
+            // Assert
+            cssBuilder.Should().Be("item-one item-three item-sub-three item-four");
+        }
+
+        [Test]
+        public void Should_Build_Empty_Classes()
+        {
+            // Arrange
+            const bool ShouldShow = false;
+
+            // Act
+            var cssBuilder = new CssBuilder()
+                            .AddClass("some-class", ShouldShow)
                             .Build();
-            //assert
-            classToRender.Should().Be(string.Empty);
+
+            // Assert
+            cssBuilder.Should().Be(string.Empty);
         }
 
         [Test]
-        public void ShouldBuildClassesWithFunc()
+        public void Should_Build_Classes_WithFunc()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
 
-                //act
-                var classToRender = new CssBuilder("item-one")
-                                .AddClass(() => attributes["class"].ToString(), when: attributes.ContainsKey("class"))
-                                .Build();
-                //assert
-                classToRender.Should().Be("item-one my-custom-class-1");
-            }
+            // Act
+            var cssBuilder = new CssBuilder("item-one")
+                .AddClass(() => attributes["class"].ToString(), when: attributes.ContainsKey("class"))
+                .Build();
+
+            // Assert
+            cssBuilder.Should().Be("item-one my-custom-class-1");
         }
 
         [Test]
-        public void ShouldBuildClassesFromAttributes()
+        public void Should_Build_Classes_FromAttributes()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
 
-                //act
-                var classToRender = new CssBuilder("item-one")
-                                .AddClassFromAttributes(attributes)
-                                .Build();
-                //assert
-                classToRender.Should().Be("item-one my-custom-class-1");
-            }
+            // Act
+            var cssBuilder = new CssBuilder("item-one")
+                .AddClassFromAttributes(attributes)
+                .Build();
+
+            // Assert
+            cssBuilder.Should().Be("item-one my-custom-class-1");
         }
 
         [Test]
-        public void ShouldNotThrowWhenNullFor_BuildClassesFromAttributes()
+        public void Should_NotThrow_WhenNull_For_BuildClasses_FromAttributes()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = null;
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object>? attributes = null;
 
-                //act
-                var classToRender = new CssBuilder("item-one")
-                                .AddClassFromAttributes(attributes)
-                                .Build();
-                //assert
-                classToRender.Should().Be("item-one");
-            }
+            // Act
+            var cssBuilder = new CssBuilder("item-one")
+                .AddClassFromAttributes(attributes)
+                .Build();
+
+            // Assert
+            cssBuilder.Should().Be("item-one");
         }
 
         [Test]
         public void ForceNullForWhitespace_BuildClassesFromAttributes()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = null;
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object>? attributes = null;
 
-                //act
-                var classToRender = new CssBuilder()
-                                .AddClassFromAttributes(attributes)
-                                .NullIfEmpty();
-                //assert
-                classToRender.Should().BeNull();
-            }
+            // Act
+            var cssBuilder = new CssBuilder()
+                .AddClassFromAttributes(attributes)
+                .NullIfEmpty();
+
+            // Assert
+            cssBuilder.Should().BeNull();
         }
 
         [Test]
-        public void ShouldNotThrowNoKeyExceptionWithDictionary()
+        public void Should_NotThrowNoKeyException_WithDictionary()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "foo", "bar" } };
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "foo", "bar" } };
 
-                //act
-                var classToRender = new CssBuilder("item-one")
-                                .AddClass(() => attributes["string"].ToString(), when: attributes.ContainsKey("class"))
-                                .Build();
-                //assert
-                classToRender.Should().Be("item-one");
-            }
+            // Act
+            var classToRender = new CssBuilder("item-one")
+                .AddClass(() => attributes["string"].ToString(), when: attributes.ContainsKey("class"))
+                .Build();
+
+            // Assert
+            classToRender.Should().Be("item-one");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;
 
 namespace UtilityTests
 {
+#nullable enable
     [TestFixture]
     public class StyleBuilderTests
     {
@@ -57,6 +59,66 @@ namespace UtilityTests
 
             // Assert
             styleBuilder.Build().Should().Be("font-weight:bold;");
+        }
+
+        [Test]
+        public void AddStyle_With_Value_And_Null_Condition()
+        {
+            // Arrange
+            const string Prop = "color";
+            const string Value = "red";
+
+            // Act
+            var styleBuilder = new StyleBuilder()
+                .AddStyle(Prop, Value, null);
+
+            // Assert
+            styleBuilder.Build().Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddStyle_With_Value_And_Condition_Func_Adds_Style_Conditionally()
+        {
+            // Arrange
+            const string Prop = "font-size";
+            const string Value = "12px";
+            bool Condition() => true;
+
+            // Act
+            var styleBuilder = new StyleBuilder()
+                .AddStyle(Prop, Value, Condition);
+
+            // Assert
+            styleBuilder.Build().Should().Be("font-size:12px;");
+        }
+
+        [Test]
+        public void AddStyle_With_Func_Value_And_Null_Condition()
+        {
+            // Arrange
+            const string Prop = "color";
+            string? Value() => "red";
+
+            // Act
+            var styleBuilder = new StyleBuilder()
+                .AddStyle(Prop, Value, null);
+
+            // Assert
+            styleBuilder.Build().Should().BeEmpty();
+        }
+
+        [Test]
+        public void AddStyle_With_Condition_Func_Null_Condition()
+        {
+            // Arrange
+            var nestedBuilder = new StyleBuilder().AddStyle("font-weight", "bold");
+
+            // Act
+            var styleBuilder = new StyleBuilder()
+                .AddStyle(nestedBuilder, null);
+
+            // Assert
+            styleBuilder.Build().Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -5,12 +5,64 @@ using NUnit.Framework;
 
 namespace UtilityTests
 {
+    [TestFixture]
     public class StyleBuilderTests
     {
         [Test]
+        public void AddStyle_With_Condition_Func_And_Nullable_Value_Adds_Style_Correctly()
+        {
+            // Arrange
+            var styleBuilder = new StyleBuilder();
+
+            // Act
+            styleBuilder.AddStyle("color", "red", true);
+            styleBuilder.AddStyle("font-size", "12px", false);
+            styleBuilder.AddStyle("background-color", () => "blue", true);
+            styleBuilder.AddStyle("border", () => "1px solid black", false);
+
+            // Assert
+            styleBuilder.Build().Should().Be("color:red;background-color:blue;");
+        }
+
+        [Test]
+        public void AddStyle_With_Func_Value_And_Condition_Adds_Style_Correctly()
+        {
+            // Arrange
+            var styleBuilder = new StyleBuilder();
+            static bool Condition1() => true;
+            static bool Condition2() => false;
+
+            // Act
+            styleBuilder.AddStyle("color", () => "red", Condition1);
+            styleBuilder.AddStyle("font-size", () => "12px", Condition2);
+            styleBuilder.AddStyle("background-color", () => "blue", Condition1);
+            styleBuilder.AddStyle("border", () => "1px solid black", Condition2);
+
+            // Assert
+            styleBuilder.Build().Should().Be("color:red;background-color:blue;");
+        }
+
+        [Test]
+        public void AddStyle_With_Builder_And_Condition_Func_Adds_Style_Correctly()
+        {
+            // Arrange
+            var styleBuilder = new StyleBuilder();
+            var nestedBuilder1 = new StyleBuilder().AddStyle("font-weight", "bold");
+            var nestedBuilder2 = new StyleBuilder().AddStyle("text-decoration", "underline");
+            static bool Condition() => true;
+
+            // Act
+            styleBuilder.AddStyle(nestedBuilder1, Condition);
+            styleBuilder.AddStyle(nestedBuilder2, () => false);
+
+            // Assert
+            styleBuilder.Build().Should().Be("font-weight:bold;");
+        }
+
+        [Test]
         public void ShouldBuildConditionalInlineStyles()
         {
-            //arrange
+            // Arrange
             var hasBorder = true;
             var isOnTop = false;
             var top = 2;
@@ -18,22 +70,22 @@ namespace UtilityTests
             var left = 4;
             var right = 20;
 
-            //act
-            var classToRender = new StyleBuilder("background-color", "DodgerBlue")
+            // Act
+            var styleBuilder = new StyleBuilder("background-color", "DodgerBlue")
                             .AddStyle("border-width", $"{top}px {right}px {bottom}px {left}px", when: hasBorder)
                             .AddStyle("z-index", "999", when: isOnTop)
                             .AddStyle("z-index", "-1", when: !isOnTop)
                             .AddStyle("padding", "35px")
                             .Build();
-            //assert
-            classToRender.Should().Be("background-color:DodgerBlue;border-width:2px 20px 10px 4px;z-index:-1;padding:35px;");
+
+            // Assert
+            styleBuilder.Should().Be("background-color:DodgerBlue;border-width:2px 20px 10px 4px;z-index:-1;padding:35px;");
         }
 
         [Test]
         public void ShouldBuildConditionalInlineStylesFromAttributes()
         {
-
-            //arrange
+            // Arrange
             var hasBorder = true;
             var isOnTop = false;
             var top = 2;
@@ -41,36 +93,40 @@ namespace UtilityTests
             var left = 4;
             var right = 20;
 
-            //act
-            var styleToRender = new StyleBuilder("background-color", "DodgerBlue")
+            // Act
+            var styleBuilder1 = new StyleBuilder("background-color", "DodgerBlue")
                             .AddStyle("border-width", $"{top}px {right}px {bottom}px {left}px", when: hasBorder)
                             .AddStyle("z-index", "999", when: isOnTop)
                             .AddStyle("z-index", "-1", when: !isOnTop)
                             .AddStyle("padding", "35px")
                             .Build();
 
-            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "style", styleToRender } };
+            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "style", styleBuilder1 } };
 
-            var classToRender = new StyleBuilder().AddStyleFromAttributes(attributes).Build();
-            //assert
-            classToRender.Should().Be("background-color:DodgerBlue;border-width:2px 20px 10px 4px;z-index:-1;padding:35px;");
+            var styleBuilder2 = new StyleBuilder().AddStyleFromAttributes(attributes).Build();
+
+            // Assert
+            styleBuilder2.Should().Be("background-color:DodgerBlue;border-width:2px 20px 10px 4px;z-index:-1;padding:35px;");
         }
 
         [Test]
         public void ShouldAddExistingStyle()
         {
-            var styleToRender = StyleBuilder.Empty()
+            // Arrange
+            var styleBuilder = StyleBuilder.Empty()
                 .AddStyle("background-color:DodgerBlue;")
                 .AddStyle("padding", "35px")
                 .Build();
 
-            var styleToRenderFromDefaultConstructor = StyleBuilder.Default(styleToRender).Build();
+            // Act
+            var styleToRenderFromDefaultConstructor = StyleBuilder.Default(styleBuilder).Build();
 
+            // Assert
             // Double ;; is valid HTML.
             // The CSS syntax allows for empty declarations, which means that you can add leading and trailing semicolons as you like. For instance, this is valid CSS
             // .foo { ;;;display:none;;;color:black;;; }
             // Trimming is possible, but is it worth the operations for a non-issue?
-            styleToRender.Should().Be("background-color:DodgerBlue;;padding:35px;");
+            styleBuilder.Should().Be("background-color:DodgerBlue;;padding:35px;");
             styleToRenderFromDefaultConstructor.Should().Be("background-color:DodgerBlue;;padding:35px;;");
 
         }
@@ -78,32 +134,32 @@ namespace UtilityTests
         [Test]
         public void ShouldNotAddEmptyStyle()
         {
-            var styleToRender = StyleBuilder.Empty().AddStyle("");
+            // Act
+            var styleBuilder = StyleBuilder.Empty().AddStyle("");
 
-            styleToRender.NullIfEmpty().Should().BeNull();
-
+            // Assert
+            styleBuilder.NullIfEmpty().Should().BeNull();
         }
 
         [Test]
         public void ShouldAddNestedStyles()
         {
-
-
+            // Act
             var child = StyleBuilder.Empty()
                 .AddStyle("background-color", "DodgerBlue")
                 .AddStyle("padding", "35px");
 
-            var styleToRender = StyleBuilder.Empty()
+            var styleBuilder = StyleBuilder.Empty()
                 .AddStyle(child)
                 .AddStyle("z-index", "-1")
                 .Build();
 
+            // Assert
             // Double ;; is valid HTML.
             // The CSS syntax allows for empty declarations, which means that you can add leading and trailing semicolons as you like. For instance, this is valid CSS
             // .foo { ;;;display:none;;;color:black;;; }
             // Trimming is possible, but is it worth the operations for a non-issue?
-            styleToRender.Should().Be("background-color:DodgerBlue;padding:35px;z-index:-1;");
-
+            styleBuilder.Should().Be("background-color:DodgerBlue;padding:35px;z-index:-1;");
         }
 
         [Test]
@@ -118,7 +174,8 @@ namespace UtilityTests
             //bool HasOverline = false;
             //bool HasStrikeout = true;
 
-            var styleToRender = StyleBuilder.Empty()
+            // Act
+            var styleBuilder = StyleBuilder.Empty()
                 .AddStyle("text-decoration", v => v
                             .AddValue("underline", true)
                             .AddValue("overline", false)
@@ -127,75 +184,75 @@ namespace UtilityTests
                 .AddStyle("z-index", "-1")
                 .Build();
 
+            // Assert
             // Double ;; is valid HTML.
             // The CSS syntax allows for empty declarations, which means that you can add leading and trailing semicolons as you like. For instance, this is valid CSS
             // .foo { ;;;display:none;;;color:black;;; }
             // Trimming is possible, but is it worth the operations for a non-issue?
-            styleToRender.Should().Be("text-decoration:underline line-through;z-index:-1;");
+            styleBuilder.Should().Be("text-decoration:underline line-through;z-index:-1;");
 
         }
 
         [Test]
         public void ShouldBuildStyleWithFunc()
         {
-            {
-                //arrange
-                // Simulates Razor Components attribute splatting feature
-                IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
+            // Arrange
+            // Simulates Razor Components attribute splatting feature
+            IReadOnlyDictionary<string, object> attributes = new Dictionary<string, object> { { "class", "my-custom-class-1" } };
 
-                //act
-                var styleToRender = StyleBuilder.Empty()
-                                .AddStyle("background-color", () => attributes["style"].ToString(), when: attributes.ContainsKey("style"))
-                                .AddStyle("background-color", "black")
-                                .Build();
-                //assert
-                styleToRender.Should().Be("background-color:black;");
-            }
+            // Act
+            var styleBuilder = StyleBuilder.Empty()
+                .AddStyle("background-color", () => attributes["style"].ToString(), when: attributes.ContainsKey("style"))
+                .AddStyle("background-color", "black")
+                .Build();
+
+            // Assert
+            styleBuilder.Should().Be("background-color:black;");
         }
 
         [Test]
         public void ShouldAddStyleWithFunc()
         {
             // Arrange
-            string styleToAdd = "background-color: green";
+            var styleToAdd = "background-color: green";
 
             // Act
-            string styleToRender = StyleBuilder.Empty()
-                                               .AddStyle(styleToAdd, () => true)
-                                               .Build();
+            var styleBuilder = StyleBuilder.Empty()
+                .AddStyle(styleToAdd, () => true)
+                .Build();
 
             // Assert
-            styleToRender.Should().Be("background-color: green;");
+            styleBuilder.Should().Be("background-color: green;");
         }
 
         [Test]
         public void ShouldAddConditionalStyle()
         {
             // Arrange
-            string styleToAdd = "background-color: green";
+            var styleToAdd = "background-color: green";
 
             // Act
-            string styleToRender = StyleBuilder.Empty()
-                                   .AddStyle(styleToAdd, true)
-                                   .Build();
+            var styleBuilder = StyleBuilder.Empty()
+                .AddStyle(styleToAdd, true)
+                .Build();
 
             // Assert
-            styleToRender.Should().Be("background-color: green;");
+            styleBuilder.Should().Be("background-color: green;");
         }
 
         [Test]
         public void ShouldAddConditionalStyleWithNullFunc()
         {
             // Arrange
-            string styleToAdd = "background-color: green";
+            var styleToAdd = "background-color: green";
 
             // Act
-            string styleToRender = StyleBuilder.Empty()
-                                   .AddStyle(styleToAdd, when: null)
-                                   .Build();
+            var styleBuilder = StyleBuilder.Empty()
+                .AddStyle(styleToAdd, when: null)
+                .Build();
 
             // Assert
-            styleToRender.Should().Be(string.Empty);
+            styleBuilder.Should().Be(string.Empty);
         }
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -22,7 +22,7 @@ namespace MudBlazor.Utilities
         /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public static CssBuilder Default(string value) => new(value);
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace MudBlazor.Utilities
         /// <remarks>
         /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
         /// </remarks>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public static CssBuilder Empty() => new();
 
         /// <summary>
@@ -41,13 +41,14 @@ namespace MudBlazor.Utilities
         /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder(string? value) => _stringBuffer = value;
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next class or value added to the builder.
         /// </summary>
         /// <param name="value">The string value to add.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddValue(string? value)
         {
             _stringBuffer += value;
@@ -58,7 +59,7 @@ namespace MudBlazor.Utilities
         /// Adds a CSS class to the builder with a space separator.
         /// </summary>
         /// <param name="value">The CSS class to add.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(string? value) => AddValue(" " + value);
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">The CSS class to conditionally add.</param>
         /// <param name="when">The nullable condition in which the CSS class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(string? value, bool when) => when ? AddClass(value) : this;
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">CSS Class to conditionally add.</param>
         /// <param name="when">Nullable condition in which the CSS Class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(string? value, bool? when) => when == true ? AddClass(value) : this;
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">The CSS class to conditionally add.</param>
         /// <param name="when">The condition in which the CSS class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(string? value, Func<bool>? when) => AddClass(value, when is not null && when());
 
         /// <summary>
@@ -90,7 +91,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">The function that returns a CSS class to conditionally add.</param>
         /// <param name="when">The condition in which the CSS class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(Func<string?> value, bool when = true) => when ? AddClass(value()) : this;
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">The function that returns a CSS class to conditionally add.</param>
         /// <param name="when">The condition in which the CSS class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(Func<string?> value, Func<bool>? when = null) => AddClass(value, when != null && when());
 
         /// <summary>
@@ -106,7 +107,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="builder">The CssBuilder to conditionally add.</param>
         /// <param name="when">The condition in which the CssBuilder is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(CssBuilder builder, bool when = true) => when ? AddClass(builder.Build()) : this;
 
         /// <summary>
@@ -114,7 +115,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="builder">The CssBuilder to conditionally add.</param>
         /// <param name="when">The condition in which the CSS class is added.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(CssBuilder builder, Func<bool>? when = null) => AddClass(builder, when is not null && when());
 
         /// <summary>
@@ -122,7 +123,7 @@ namespace MudBlazor.Utilities
         /// This is a null-safe operation.
         /// </summary>
         /// <param name="additionalAttributes">Additional attribute splat parameters.</param>
-        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClassFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
             return additionalAttributes is null

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -8,133 +8,134 @@ using System.Collections.Generic;
 namespace MudBlazor.Utilities
 {
 #nullable enable
+    /// <summary>
+    /// Represents a builder for creating CSS classes used in a component.
+    /// </summary>
     public struct CssBuilder
     {
-        private string _stringBuffer;
+        private string? _stringBuffer;
 
         /// <summary>
-        /// Creates a CssBuilder used to define conditional CSS classes used in a component.
-        /// Call Build() to return the completed CSS Classes as a string. 
+        /// Creates a new instance of CssBuilder with the specified initial value.
         /// </summary>
-        /// <param name="value"></param>
+        /// <remarks>
+        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// </remarks>
+        /// <param name="value">The initial CSS class value.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
         public static CssBuilder Default(string value) => new(value);
 
         /// <summary>
-        /// Creates an Empty CssBuilder used to define conditional CSS classes used in a component.
-        /// Call Build() to return the completed CSS Classes as a string. 
+        /// Creates an empty instance of CssBuilder.
         /// </summary>
+        /// <remarks>
+        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// </remarks>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
         public static CssBuilder Empty() => new();
 
         /// <summary>
-        /// Creates a CssBuilder used to define conditional CSS classes used in a component.
-        /// Call Build() to return the completed CSS Classes as a string. 
+        /// Initializes a new instance of the CssBuilder class with the specified initial value.
         /// </summary>
-        /// <param name="value"></param>
-        public CssBuilder(string value) => _stringBuffer = value;
+        /// <remarks>
+        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// </remarks>
+        /// <param name="value">The initial CSS class value.</param>
+        public CssBuilder(string? value) => _stringBuffer = value;
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next class or value added to the builder.
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddValue(string value)
+        /// <param name="value">The string value to add.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddValue(string? value)
         {
             _stringBuffer += value;
             return this;
         }
 
         /// <summary>
-        /// Adds a CSS Class to the builder with space separator.
+        /// Adds a CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="value">CSS Class to add</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value) => AddValue(" " + value);
+        /// <param name="value">The CSS class to add.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(string? value) => AddValue(" " + value);
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="value">CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, bool when) => when ? AddClass(value) : this;
+        /// <param name="value">The CSS class to conditionally add.</param>
+        /// <param name="when">The nullable condition in which the CSS class is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(string? value, bool when) => when ? AddClass(value) : this;
 
         /// <summary>
         /// Adds a conditional CSS Class to the builder with space separator.
         /// </summary>
         /// <param name="value">CSS Class to conditionally add.</param>
         /// <param name="when">Nullable condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, bool? when) => when == true ? AddClass(value) : this;
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(string? value, bool? when) => when == true ? AddClass(value) : this;
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="value">CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, Func<bool>? when) => AddClass(value, when is not null && when());
+        /// <param name="value">The CSS class to conditionally add.</param>
+        /// <param name="when">The condition in which the CSS class is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(string? value, Func<bool>? when) => AddClass(value, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="value">Function that returns a CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(Func<string> value, bool when = true) => when ? AddClass(value()) : this;
+        /// <param name="value">The function that returns a CSS class to conditionally add.</param>
+        /// <param name="when">The condition in which the CSS class is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(Func<string?> value, bool when = true) => when ? AddClass(value()) : this;
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="value">Function that returns a CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(Func<string> value, Func<bool>? when = null) => AddClass(value, when != null && when());
+        /// <param name="value">The function that returns a CSS class to conditionally add.</param>
+        /// <param name="when">The condition in which the CSS class is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
+        public CssBuilder AddClass(Func<string?> value, Func<bool>? when = null) => AddClass(value, when != null && when());
 
         /// <summary>
-        /// Adds a conditional nested CssBuilder to the builder with space separator.
+        /// Adds a conditional nested CssBuilder to the builder with a space separator.
         /// </summary>
-        /// <param name="builder">CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
+        /// <param name="builder">The CssBuilder to conditionally add.</param>
+        /// <param name="when">The condition in which the CssBuilder is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
         public CssBuilder AddClass(CssBuilder builder, bool when = true) => when ? AddClass(builder.Build()) : this;
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with a space separator.
         /// </summary>
-        /// <param name="builder">CSS Class to conditionally add.</param>
-        /// <param name="when">Condition in which the CSS Class is added.</param>
-        /// <returns>CssBuilder</returns>
+        /// <param name="builder">The CssBuilder to conditionally add.</param>
+        /// <param name="when">The condition in which the CSS class is added.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
         public CssBuilder AddClass(CssBuilder builder, Func<bool>? when = null) => AddClass(builder, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional CSS Class when it exists in a dictionary to the builder with space separator.
-        /// Null safe operation.
+        /// Adds a conditional CSS class when it exists in a dictionary to the builder with a space separator.
+        /// This is a null-safe operation.
         /// </summary>
-        /// <param name="additionalAttributes">Additional Attribute splat parameters</param>
-        /// <returns>CssBuilder</returns>
+        /// <param name="additionalAttributes">Additional attribute splat parameters.</param>
+        /// <returns>The <see cref="CssBuilder"/>> instance.</returns>
         public CssBuilder AddClassFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
-            if (additionalAttributes is null)
-            {
-                return this;
-            }
-
-            if (additionalAttributes.TryGetValue("class", out var result))
-            {
-                var stringResult = result.ToString();
-                if (stringResult is not null)
-                {
-                    return AddClass(stringResult);
-                }
-            }
-
-            return this;
+            return additionalAttributes is null
+                ? this
+                : additionalAttributes.TryGetValue("class", out var result)
+                    ? AddClass(result.ToString())
+                    : this;
         }
 
         /// <summary>
-        /// Finalize the completed CSS Classes as a string.
+        /// Finalizes the completed CSS classes as a string.
         /// </summary>
-        /// <returns>string</returns>
+        /// <returns>The string representation of the CSS classes.</returns>
         public string Build()
         {
             // String buffer finalization code

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -7,9 +7,10 @@ using System.Collections.Generic;
 
 namespace MudBlazor.Utilities
 {
+#nullable enable
     public struct CssBuilder
     {
-        private string stringBuffer;
+        private string _stringBuffer;
 
         /// <summary>
         /// Creates a CssBuilder used to define conditional CSS classes used in a component.
@@ -29,7 +30,7 @@ namespace MudBlazor.Utilities
         /// Call Build() to return the completed CSS Classes as a string. 
         /// </summary>
         /// <param name="value"></param>
-        public CssBuilder(string value) => stringBuffer = value;
+        public CssBuilder(string value) => _stringBuffer = value;
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next class or value added to the builder.
@@ -38,7 +39,7 @@ namespace MudBlazor.Utilities
         /// <returns>CssBuilder</returns>
         public CssBuilder AddValue(string value)
         {
-            stringBuffer += value;
+            _stringBuffer += value;
             return this;
         }
 
@@ -55,7 +56,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">CSS Class to conditionally add.</param>
         /// <param name="when">Condition in which the CSS Class is added.</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, bool when = true) => when ? AddClass(value) : this;
+        public CssBuilder AddClass(string value, bool when) => when ? AddClass(value) : this;
 
         /// <summary>
         /// Adds a conditional CSS Class to the builder with space separator.
@@ -63,7 +64,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">CSS Class to conditionally add.</param>
         /// <param name="when">Nullable condition in which the CSS Class is added.</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, bool? when = true) => when == true ? AddClass(value) : this;
+        public CssBuilder AddClass(string value, bool? when) => when == true ? AddClass(value) : this;
 
         /// <summary>
         /// Adds a conditional CSS Class to the builder with space separator.
@@ -71,7 +72,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">CSS Class to conditionally add.</param>
         /// <param name="when">Condition in which the CSS Class is added.</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(string value, Func<bool> when = null) => AddClass(value, when != null && when());
+        public CssBuilder AddClass(string value, Func<bool>? when) => AddClass(value, when is not null && when());
 
         /// <summary>
         /// Adds a conditional CSS Class to the builder with space separator.
@@ -87,7 +88,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">Function that returns a CSS Class to conditionally add.</param>
         /// <param name="when">Condition in which the CSS Class is added.</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(Func<string> value, Func<bool> when = null) => AddClass(value, when != null && when());
+        public CssBuilder AddClass(Func<string> value, Func<bool>? when = null) => AddClass(value, when != null && when());
 
         /// <summary>
         /// Adds a conditional nested CssBuilder to the builder with space separator.
@@ -103,7 +104,7 @@ namespace MudBlazor.Utilities
         /// <param name="builder">CSS Class to conditionally add.</param>
         /// <param name="when">Condition in which the CSS Class is added.</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClass(CssBuilder builder, Func<bool> when = null) => AddClass(builder, when != null && when());
+        public CssBuilder AddClass(CssBuilder builder, Func<bool>? when = null) => AddClass(builder, when is not null && when());
 
         /// <summary>
         /// Adds a conditional CSS Class when it exists in a dictionary to the builder with space separator.
@@ -111,9 +112,24 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="additionalAttributes">Additional Attribute splat parameters</param>
         /// <returns>CssBuilder</returns>
-        public CssBuilder AddClassFromAttributes(IReadOnlyDictionary<string, object> additionalAttributes) =>
-            additionalAttributes == null ? this :
-            additionalAttributes.TryGetValue("class", out var c) ? AddClass(c.ToString()) : this;
+        public CssBuilder AddClassFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
+        {
+            if (additionalAttributes is null)
+            {
+                return this;
+            }
+
+            if (additionalAttributes.TryGetValue("class", out var result))
+            {
+                var stringResult = result.ToString();
+                if (stringResult is not null)
+                {
+                    return AddClass(stringResult);
+                }
+            }
+
+            return this;
+        }
 
         /// <summary>
         /// Finalize the completed CSS Classes as a string.
@@ -122,11 +138,11 @@ namespace MudBlazor.Utilities
         public string Build()
         {
             // String buffer finalization code
-            return stringBuffer != null ? stringBuffer.Trim() : string.Empty;
+            return _stringBuffer is not null ? _stringBuffer.Trim() : string.Empty;
         }
 
         // ToString should only and always call Build to finalize the rendered string.
+        /// <inheritdoc />
         public override string ToString() => Build();
-
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.Utilities
         /// Creates a new instance of CssBuilder with the specified initial value.
         /// </summary>
         /// <remarks>
-        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// Call <see cref="Build"/> to return the completed CSS classes as a string. 
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
@@ -29,7 +29,7 @@ namespace MudBlazor.Utilities
         /// Creates an empty instance of CssBuilder.
         /// </summary>
         /// <remarks>
-        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// Call <see cref="Build"/> to return the completed CSS classes as a string. 
         /// </remarks>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public static CssBuilder Empty() => new();
@@ -38,7 +38,7 @@ namespace MudBlazor.Utilities
         /// Initializes a new instance of the CssBuilder class with the specified initial value.
         /// </summary>
         /// <remarks>
-        /// Call <see cref="Build"/> to return the completed CSS Classes as a string. 
+        /// Call <see cref="Build"/> to return the completed CSS classes as a string. 
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
@@ -71,10 +71,10 @@ namespace MudBlazor.Utilities
         public CssBuilder AddClass(string? value, bool when) => when ? AddClass(value) : this;
 
         /// <summary>
-        /// Adds a conditional CSS Class to the builder with space separator.
+        /// Adds a conditional CSS class to the builder with space separator.
         /// </summary>
-        /// <param name="value">CSS Class to conditionally add.</param>
-        /// <param name="when">Nullable condition in which the CSS Class is added.</param>
+        /// <param name="value">CSS class to conditionally add.</param>
+        /// <param name="when">Nullable condition in which the CSS class is added.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClass(string? value, bool? when) => when == true ? AddClass(value) : this;
 

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -100,7 +100,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">The function that returns a CSS class to conditionally add.</param>
         /// <param name="when">The condition in which the CSS class is added.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
-        public CssBuilder AddClass(Func<string?> value, Func<bool>? when = null) => AddClass(value, when != null && when());
+        public CssBuilder AddClass(Func<string?> value, Func<bool>? when = null) => AddClass(value, when is not null && when());
 
         /// <summary>
         /// Adds a conditional nested CssBuilder to the builder with a space separator.

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -7,9 +7,10 @@ using System.Collections.Generic;
 
 namespace MudBlazor.Utilities
 {
+#nullable enable
     public struct StyleBuilder
     {
-        private string stringBuffer;
+        private string _stringBuffer;
 
         /// <summary>
         /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
@@ -34,7 +35,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value"></param>
-        public StyleBuilder(string prop, string value) => stringBuffer = $"{prop}:{value};";
+        public StyleBuilder(string prop, string value) => _stringBuffer = $"{prop}:{value};";
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
@@ -47,16 +48,16 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="style">The style to add</param>
         /// <param name="when">The condition</param>
-        /// <returns>The stylebuilder</returns>
-        public StyleBuilder AddStyle(string style, bool when = true) => when ? AddStyle(style) : this;
+        /// <returns>The <see cref="StyleBuilder"/></returns>
+        public StyleBuilder AddStyle(string style, bool when) => when ? AddStyle(style) : this;
 
         /// <summary>
         /// Adds a conditional style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="style">The style to add</param>
         /// <param name="when">The condition as function</param>
-        /// <returns>The stylebuilder</returns>
-        public StyleBuilder AddStyle(string style, Func<bool> when) => AddStyle(style, when is not null && when());
+        /// <returns>The <see cref="StyleBuilder"/></returns>
+        public StyleBuilder AddStyle(string style, Func<bool>? when) => AddStyle(style, when is not null && when());
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next style or value added to the builder.
@@ -65,12 +66,12 @@ namespace MudBlazor.Utilities
         /// <returns>StyleBuilder</returns>
         private StyleBuilder AddRaw(string style)
         {
-            stringBuffer += style;
+            _stringBuffer += style;
             return this;
         }
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value">Style to add</param>
@@ -78,17 +79,17 @@ namespace MudBlazor.Utilities
         public StyleBuilder AddStyle(string prop, string value) => AddRaw($"{prop}:{value};");
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value">Style to conditionally add.</param>
         /// <param name="when">Condition in which the style is added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, string value, bool when = true) => when ? AddStyle(prop, value) : this;
+        public StyleBuilder AddStyle(string prop, string value, bool when) => when ? AddStyle(prop, value) : this;
 
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value">Style to conditionally add.</param>
@@ -97,22 +98,22 @@ namespace MudBlazor.Utilities
         public StyleBuilder AddStyle(string prop, Func<string> value, bool when = true) => when ? AddStyle(prop, value()) : this;
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value">Style to conditionally add.</param>
         /// <param name="when">Condition in which the style is added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, string value, Func<bool> when = null) => AddStyle(prop, value, when != null && when());
+        public StyleBuilder AddStyle(string prop, string value, Func<bool>? when) => AddStyle(prop, value, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="value">Style to conditionally add.</param>
         /// <param name="when">Condition in which the style is added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, Func<string> value, Func<bool> when = null) => AddStyle(prop, value(), when != null && when());
+        public StyleBuilder AddStyle(string prop, Func<string> value, Func<bool>? when = null) => AddStyle(prop, value(), when is not null && when());
 
         /// <summary>
         /// Adds a conditional nested StyleBuilder to the builder with separator and closing semicolon.
@@ -127,18 +128,18 @@ namespace MudBlazor.Utilities
         /// <param name="builder">Style Builder to conditionally add.</param>
         /// <param name="when">Condition in which the style is added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(StyleBuilder builder, bool when = true) => when ? AddRaw(builder.Build()) : this;
+        public StyleBuilder AddStyle(StyleBuilder builder, bool when) => when ? AddRaw(builder.Build()) : this;
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="builder">Style Builder to conditionally add.</param>
         /// <param name="when">Condition in which the styles are added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(StyleBuilder builder, Func<bool> when = null) => AddStyle(builder, when != null && when());
+        public StyleBuilder AddStyle(StyleBuilder builder, Func<bool>? when) => AddStyle(builder, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon..
+        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// A ValueBuilder action defines a complex set of values for the property.
         /// </summary>
         /// <param name="prop"></param>
@@ -157,9 +158,24 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="additionalAttributes">Additional Attribute splat parameters</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyleFromAttributes(IReadOnlyDictionary<string, object> additionalAttributes) =>
-            additionalAttributes == null ? this :
-            additionalAttributes.TryGetValue("style", out var c) ? AddRaw(c.ToString()) : this;
+        public StyleBuilder AddStyleFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
+        {
+            if (additionalAttributes is null)
+            {
+                return this;
+            }
+
+            if (additionalAttributes.TryGetValue("style", out var result))
+            {
+                var resultString = result.ToString();
+                if (resultString is not null)
+                {
+                    return AddRaw(resultString);
+                }
+            }
+
+            return this;
+        }
 
 
         /// <summary>
@@ -169,10 +185,11 @@ namespace MudBlazor.Utilities
         public string Build()
         {
             // String buffer finalization code
-            return stringBuffer != null ? stringBuffer.Trim() : string.Empty;
+            return _stringBuffer != null ? _stringBuffer.Trim() : string.Empty;
         }
 
         // ToString should only and always call Build to finalize the rendered string.
+        /// <inheritdoc />
         public override string ToString() => Build();
     }
 }

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -8,62 +8,82 @@ using System.Collections.Generic;
 namespace MudBlazor.Utilities
 {
 #nullable enable
+    /// <summary>
+    /// Represents a builder for creating in-line styles used in a component.
+    /// </summary>
     public struct StyleBuilder
     {
         private string? _stringBuffer;
 
         /// <summary>
-        /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
+        /// Creates a new instance of StyleBuilder with the specified property and value.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value"></param>
+        /// <remarks>
+        /// Call <see cref="Build"/>> to return the completed style as a string.
+        /// </remarks>
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public static StyleBuilder Default(string prop, string value) => new(prop, value);
 
         /// <summary>
-        /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
+        /// Creates a new instance of StyleBuilder with the specified style.
         /// </summary>
-        /// <param name="style"></param>
-        public static StyleBuilder Default(string style) => Empty().AddStyle(style);
+        /// <remarks>
+        /// Call <see cref="Build"/>> to return the completed style as a string.
+        /// </remarks>
+        /// <param name="style">The CSS style.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public static StyleBuilder Default(string? style) => Empty().AddStyle(style);
 
         /// <summary>
-        /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
+        /// Creates an empty instance of StyleBuilder.
         /// </summary>
+        /// <remarks>
+        /// Call <see cref="Build"/>> to return the completed style as a string.
+        /// </remarks>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public static StyleBuilder Empty() => new();
 
         /// <summary>
-        /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
+        /// Initializes a new instance of the StyleBuilder class with the specified property and value.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value"></param>
+        /// <remarks>
+        /// Call <see cref="Build"/>> to return the completed style as a string.
+        /// </remarks>
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder(string prop, string value) => _stringBuffer = $"{prop}:{value};";
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="style"></param>
+        /// <param name="style">The style to add.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw($"{style};") : this;
 
         /// <summary>
-        /// Adds a conditional style to the builder with space separator and closing semicolon.
+        /// Adds a conditional style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="style">The style to add</param>
-        /// <param name="when">The condition</param>
-        /// <returns>The <see cref="StyleBuilder"/></returns>
+        /// <param name="style">The style to add.</param>
+        /// <param name="when">The condition.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string? style, bool when) => when ? AddStyle(style) : this;
 
         /// <summary>
-        /// Adds a conditional style to the builder with space separator and closing semicolon.
+        /// Adds a conditional style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="style">The style to add</param>
-        /// <param name="when">The condition as function</param>
-        /// <returns>The <see cref="StyleBuilder"/></returns>
+        /// <param name="style">The style to add.</param>
+        /// <param name="when">The condition as function.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string? style, Func<bool>? when) => AddStyle(style, when is not null && when());
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next style or value added to the builder.
         /// </summary>
-        /// <param name="style"></param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="style">The raw style to add.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         private StyleBuilder AddRaw(string? style)
         {
             _stringBuffer += style;
@@ -71,80 +91,81 @@ namespace MudBlazor.Utilities
         }
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value">Style to add</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string prop, string? value) => AddRaw($"{prop}:{value};");
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value">Style to conditionally add.</param>
-        /// <param name="when">Condition in which the style is added.</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property to conditionally add.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string prop, string? value, bool when) => when ? AddStyle(prop, value) : this;
 
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value">Style to conditionally add.</param>
-        /// <param name="when">Condition in which the style is added.</param>
-        /// <returns></returns>
-        public StyleBuilder AddStyle(string prop, Func<string> value, bool when = true) => when ? AddStyle(prop, value()) : this;
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property to conditionally add.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string prop, Func<string?> value, bool when = true) => when ? AddStyle(prop, value()) : this;
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value">Style to conditionally add.</param>
-        /// <param name="when">Condition in which the style is added.</param>
-        /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, string value, Func<bool>? when) => AddStyle(prop, value, when is not null && when());
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property to conditionally add.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string prop, string? value, Func<bool>? when) => AddStyle(prop, value, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="value">Style to conditionally add.</param>
-        /// <param name="when">Condition in which the style is added.</param>
-        /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, Func<string> value, Func<bool>? when = null) => AddStyle(prop, value(), when is not null && when());
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="value">The value of the property to conditionally add.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string prop, Func<string?> value, Func<bool>? when = null) => AddStyle(prop, value(), when is not null && when());
 
         /// <summary>
-        /// Adds a conditional nested StyleBuilder to the builder with separator and closing semicolon.
+        /// Adds a conditional nested StyleBuilder to the builder with a separator and closing semicolon.
         /// </summary>
-        /// <param name="builder">Style Builder to conditionally add.</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="builder">The StyleBuilder to conditionally add.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(StyleBuilder builder) => AddRaw(builder.Build());
 
         /// <summary>
-        /// Adds a conditional nested StyleBuilder to the builder with separator and closing semicolon.
+        /// Adds a conditional nested StyleBuilder to the builder with a separator and closing semicolon.
         /// </summary>
-        /// <param name="builder">Style Builder to conditionally add.</param>
-        /// <param name="when">Condition in which the style is added.</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="builder">The StyleBuilder to conditionally add.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(StyleBuilder builder, bool when) => when ? AddRaw(builder.Build()) : this;
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// </summary>
-        /// <param name="builder">Style Builder to conditionally add.</param>
-        /// <param name="when">Condition in which the styles are added.</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="builder">The StyleBuilder to conditionally add.</param>
+        /// <param name="when">The condition in which the styles are added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(StyleBuilder builder, Func<bool>? when) => AddStyle(builder, when is not null && when());
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
         /// A ValueBuilder action defines a complex set of values for the property.
         /// </summary>
-        /// <param name="prop"></param>
-        /// <param name="builder"></param>
-        /// <param name="when"></param>
+        /// <param name="prop">The CSS property.</param>
+        /// <param name="builder">The ValueBuilder action that defines the values for the property.</param>
+        /// <param name="when">The condition in which the style is added.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string prop, Action<ValueBuilder> builder, bool when = true)
         {
             var values = new ValueBuilder();
@@ -153,11 +174,11 @@ namespace MudBlazor.Utilities
         }
 
         /// <summary>
-        /// Adds a conditional in-line style when it exists in a dictionary to the builder with separator.
-        /// Null safe operation.
+        /// Adds a conditional in-line style when it exists in a dictionary to the builder with a separator.
+        /// This is a null-safe operation.
         /// </summary>
-        /// <param name="additionalAttributes">Additional Attribute splat parameters</param>
-        /// <returns>StyleBuilder</returns>
+        /// <param name="additionalAttributes">Additional attribute splat parameters.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyleFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
             return additionalAttributes is null
@@ -167,11 +188,10 @@ namespace MudBlazor.Utilities
                     : this;
         }
 
-
         /// <summary>
-        /// Finalize the completed Style as a string.
+        /// Finalizes the completed style as a string.
         /// </summary>
-        /// <returns>string</returns>
+        /// <returns>The string representation of the style.</returns>
         public string Build()
         {
             // String buffer finalization code

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Utilities
 #nullable enable
     public struct StyleBuilder
     {
-        private string _stringBuffer;
+        private string? _stringBuffer;
 
         /// <summary>
         /// Creates a StyleBuilder used to define conditional in-line style used in a component. Call Build() to return the completed style as a string.
@@ -41,7 +41,7 @@ namespace MudBlazor.Utilities
         /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
         /// </summary>
         /// <param name="style"></param>
-        public StyleBuilder AddStyle(string style) => !string.IsNullOrWhiteSpace(style) ? AddRaw($"{style};") : this;
+        public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw($"{style};") : this;
 
         /// <summary>
         /// Adds a conditional style to the builder with space separator and closing semicolon.
@@ -49,7 +49,7 @@ namespace MudBlazor.Utilities
         /// <param name="style">The style to add</param>
         /// <param name="when">The condition</param>
         /// <returns>The <see cref="StyleBuilder"/></returns>
-        public StyleBuilder AddStyle(string style, bool when) => when ? AddStyle(style) : this;
+        public StyleBuilder AddStyle(string? style, bool when) => when ? AddStyle(style) : this;
 
         /// <summary>
         /// Adds a conditional style to the builder with space separator and closing semicolon.
@@ -57,14 +57,14 @@ namespace MudBlazor.Utilities
         /// <param name="style">The style to add</param>
         /// <param name="when">The condition as function</param>
         /// <returns>The <see cref="StyleBuilder"/></returns>
-        public StyleBuilder AddStyle(string style, Func<bool>? when) => AddStyle(style, when is not null && when());
+        public StyleBuilder AddStyle(string? style, Func<bool>? when) => AddStyle(style, when is not null && when());
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next style or value added to the builder.
         /// </summary>
         /// <param name="style"></param>
         /// <returns>StyleBuilder</returns>
-        private StyleBuilder AddRaw(string style)
+        private StyleBuilder AddRaw(string? style)
         {
             _stringBuffer += style;
             return this;
@@ -76,7 +76,7 @@ namespace MudBlazor.Utilities
         /// <param name="prop"></param>
         /// <param name="value">Style to add</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, string value) => AddRaw($"{prop}:{value};");
+        public StyleBuilder AddStyle(string prop, string? value) => AddRaw($"{prop}:{value};");
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with space separator and closing semicolon.
@@ -85,7 +85,7 @@ namespace MudBlazor.Utilities
         /// <param name="value">Style to conditionally add.</param>
         /// <param name="when">Condition in which the style is added.</param>
         /// <returns>StyleBuilder</returns>
-        public StyleBuilder AddStyle(string prop, string value, bool when) => when ? AddStyle(prop, value) : this;
+        public StyleBuilder AddStyle(string prop, string? value, bool when) => when ? AddStyle(prop, value) : this;
 
 
         /// <summary>
@@ -160,21 +160,11 @@ namespace MudBlazor.Utilities
         /// <returns>StyleBuilder</returns>
         public StyleBuilder AddStyleFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
-            if (additionalAttributes is null)
-            {
-                return this;
-            }
-
-            if (additionalAttributes.TryGetValue("style", out var result))
-            {
-                var resultString = result.ToString();
-                if (resultString is not null)
-                {
-                    return AddRaw(resultString);
-                }
-            }
-
-            return this;
+            return additionalAttributes is null
+                ? this
+                : additionalAttributes.TryGetValue("style", out var result)
+                    ? AddRaw(result.ToString())
+                    : this;
         }
 
 
@@ -185,7 +175,7 @@ namespace MudBlazor.Utilities
         public string Build()
         {
             // String buffer finalization code
-            return _stringBuffer != null ? _stringBuffer.Trim() : string.Empty;
+            return _stringBuffer is not null ? _stringBuffer.Trim() : string.Empty;
         }
 
         // ToString should only and always call Build to finalize the rendered string.


### PR DESCRIPTION
## Description
The problem with this is that if you have overloads:
```C#
StyleBuilder AddStyle(string style)
StyleBuilder AddStyle(string style, bool when = true)
```
And someone of them has an optional value `bool when = true` this two start to conflict with each other and code analyzers will tell you to fix it.
To fix it, there is two ways:
1) Remove the one with least parameters and combine it with the optional one
2) Remove optional parameter value

I went for second option.

More info: https://stackoverflow.com/questions/16546831/overloaded-methods-give-method-with-optional-parameter-is-hidden-by-overload-w

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
