### PR TITLE
Illegal Razor Parameter Runtime Detection for v7

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselBindingTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudCarousel @ref="_carousel" ItemsSource="@_source" ArrowsPosition="Position.End" Style="height:200px;" ShowBullets="true" ShowArrows="@_arrows" ShowDelimiters="@_delimiters" AutoCycle="@_autocycle">
+<MudCarousel @ref="_carousel" ItemsSource="@_source" ArrowsPosition="Position.End" Style="height:200px;" ShowArrows="@_arrows" ShowBullets="@_delimiters" AutoCycle="@_autocycle">
     <ItemTemplate>
         <div class="d-flex flex-column flex-column justify-center" style="height:100%">
             <MudIcon Class="mx-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudCarousel @bind-SelectedIndex="SelectedIndex" Style="height:200px;" ShowArrows="true" ArrowsPosition="Position.Top" BulletsPosition="Position.Start" ShowDelimiters="true" AutoCycle="false" AutoCycleTime="TimeSpan.FromMilliseconds(500)" TData="object">
+<MudCarousel @bind-SelectedIndex="SelectedIndex" Style="height:200px;" ShowArrows ArrowsPosition="Position.Top" BulletsPosition="Position.Start" ShowBullets AutoCycle="false" AutoCycleTime="TimeSpan.FromMilliseconds(500)" TData="object">
     <MudCarouselItem Class="fake-class-item1" Transition="Transition.Slide">
         <div class="d-flex" style="background-color:#594AE2; height:100%">
             <MudIcon Class="mx-auto my-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestVariants.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestVariants.razor
@@ -5,26 +5,26 @@
 
 <MudMenu Label="Button Standart" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" PopoverClass="menu-popover-class">
     <MudMenuItem Class="test-class">1</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
 </MudMenu>
 
 <MudMenu Label="Button Right Click" ActivationEvent="MouseEvent.RightClick" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" PopoverClass="menu-popover-class">
     <MudMenuItem Class="test-class">1</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
 </MudMenu>
 
 <MudMenu Label="Icon Button Standart" Icon="@Icons.Custom.Brands.MudBlazor" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" PopoverClass="menu-popover-class">
     <MudMenuItem Class="test-class">1</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
 </MudMenu>
 
 <MudMenu Label="Icon Button Right Click" ActivationEvent="MouseEvent.RightClick" Icon="@Icons.Custom.Brands.MudBlazor" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" PopoverClass="menu-popover-class">
     <MudMenuItem Class="test-class">1</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-    <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
 </MudMenu>
 
 <MudMenu FullWidth="true" PopoverClass="menu-popover-class">
@@ -33,8 +33,8 @@
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem Class="test-class">1</MudMenuItem>
-        <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-        <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+        <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+        <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
     </ChildContent>
 </MudMenu>
 
@@ -44,7 +44,7 @@
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem Class="test-class">1</MudMenuItem>
-        <MudMenuItem Link="https://www.test.com">2</MudMenuItem>
-        <MudMenuItem Link="https://www.test.com" Target="_blank">3</MudMenuItem>
+        <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+        <MudMenuItem Href="https://www.test.com" Target="_blank">3</MudMenuItem>
     </ChildContent>
 </MudMenu>

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -83,5 +83,231 @@ namespace MudBlazor
 
         /// <inheritdoc />
         void IMudStateHasChanged.StateHasChanged() => StateHasChanged();
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            foreach (var parameter in UserAttributes.Keys)
+            {
+                if (this is MudBadge)
+                {
+                    switch (parameter)
+                    {
+                        case "Bottom":
+                        case "Left":
+                        case "Start":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudProgressCircular || this is MudProgressLinear)
+                {
+                    switch (parameter)
+                    {
+                        case "Minimum":
+                        case "Maximum":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudRadio<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Option":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudFab)
+                {
+                    switch (parameter)
+                    {
+                        case "Icon":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudCheckBox<>) || GetType() == typeof(MudSwitch<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Checked":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudPopover || GetType() == typeof(MudAutocomplete<>) || GetType() == typeof(MudSelect<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Direction":
+                        case "OffsetX":
+                        case "OffsetY":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudToggleGroup<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Outline":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudAvatar)
+                {
+                    switch (parameter)
+                    {
+                        case "Image":
+                        case "Alt":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudSlider<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Text":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudRadioGroup<>))
+                {
+                    switch (parameter)
+                    {
+                        case "SelectedOption":
+                        case "SelectedOptionChanged":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudSwipeArea)
+                {
+                    switch (parameter)
+                    {
+                        case "OnSwipe":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudChip<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Avatar":
+                        case "AvatarClass":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudChipSet<>))
+                {
+                    switch (parameter)
+                    {
+                        case "Filter":
+                        case "MultiSelection":
+                        case "Mandatory":
+                        case "SelectedChip":
+                        case "SelectedChipChanged":
+                        case "SelectedChips":
+                        case "SelectedChipsChanged":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudList<>))
+                {
+                    switch (parameter)
+                    {
+                        case "SelectedItem":
+                        case "SelectedItemChanged":
+                        case "Clickable":
+                        case "Avatar":
+                        case "AvatarClass":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (GetType() == typeof(MudTreeView<>) || GetType() == typeof(MudTreeViewItem<>))
+                {
+                    switch (parameter)
+                    {
+                        case "CanActivate":
+                        case "CanHover":
+                        case "CanSelect":
+                        case "ActivatedValue":
+                        case "ActivatedValueChanged":
+                        case "Multiselection":
+                        case "Activated":
+                        case "ExpandedIcon":
+                        case "SelectedItem":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else if (this is MudMenu || this is MudMenuItem)
+                {
+                    switch (parameter)
+                    {
+                        case "Link":
+                        case "Target":
+                        case "HtmlTag":
+                        case "ButtonType":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+                else
+                {
+                    switch (parameter)
+                    {
+                        case "Command":
+                        case "CommandParameter":
+                        case "IsEnabled":
+                        case "ClassAction":
+                        case "InputIcon":
+                        case "InputVariant":
+                        case "AllowKeyboardInput":
+                        case "ClassActions":
+                        case "DisableRipple":
+                        case "DisableGutters":
+                        case "DisablePadding":
+                        case "DisableElevation":
+                        case "DisableUnderLine":
+                        case "DisableRowsPerPage":
+                        case "Link":
+                        case "Delayed":
+                        case "AlertTextPosition":
+                        case "ShowDelimiters":
+                        case "DelimitersColor":
+                        case "DrawerWidth":
+                        case "DrawerHeightTop":
+                        case "DrawerHeightBottom":
+                        case "AppbarMinHeight":
+                        case "ClassBackground":
+                        case "Cancelled":
+                        case "ClassContent":
+                        case "IsExpanded":
+                        case "IsExpandedChanged":
+                        case "IsInitiallyExpanded":
+                        case "InitiallyExpanded":
+                        case "RightAlignSmall":
+                        case "IsExpandable":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
+            }
+        }
+
+        private void NotifyIllegalParameter(string parameter)
+        {
+            throw new ArgumentException($"Illegal parameter '{parameter}'. This was removed in v7.0.0, see Migration Guide for more Info https://github.com/MudBlazor/MudBlazor/issues/8447");
+        }
     }
 }

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
@@ -87,7 +88,10 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            DetectIllegalRazorParametersV7();
+            if (MudGlobal.EnableIllegalRazorParameterDetection)
+            {
+                DetectIllegalRazorParametersV7();
+            }
         }
 
         /// <summary>
@@ -97,7 +101,8 @@ namespace MudBlazor
         /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
         /// Sometime when the v7 version has stabilized.
         /// </summary>
-        private void DetectIllegalRazorParametersV7()
+        [ExcludeFromCodeCoverage]
+        protected void DetectIllegalRazorParametersV7()
         {
             foreach (var parameter in UserAttributes.Keys)
             {
@@ -317,6 +322,7 @@ namespace MudBlazor
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private void NotifyIllegalParameter(string parameter)
         {
             throw new ArgumentException($"Illegal parameter '{parameter}'. This was removed in v7.0.0, see Migration Guide for more info https://github.com/MudBlazor/MudBlazor/issues/8447");

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -87,6 +87,18 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            DetectIllegalRazorParametersV7();
+        }
+
+        /// <summary>
+        /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
+        /// to help our users find old parameters they missed by throwing a runtime exception.
+        ///
+        /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
+        /// Sometime when the v7 version has stabilized.
+        /// </summary>
+        private void DetectIllegalRazorParametersV7()
+        {
             foreach (var parameter in UserAttributes.Keys)
             {
                 if (this is MudBadge)
@@ -307,7 +319,7 @@ namespace MudBlazor
 
         private void NotifyIllegalParameter(string parameter)
         {
-            throw new ArgumentException($"Illegal parameter '{parameter}'. This was removed in v7.0.0, see Migration Guide for more Info https://github.com/MudBlazor/MudBlazor/issues/8447");
+            throw new ArgumentException($"Illegal parameter '{parameter}'. This was removed in v7.0.0, see Migration Guide for more info https://github.com/MudBlazor/MudBlazor/issues/8447");
         }
     }
 }

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -32,6 +32,18 @@ public static class MudGlobal
     public static Action<Exception> UnhandledExceptionHandler { get; set; } = OnDefaultExceptionHandler;
 
     /// <summary>
+    /// Gets or sets whether old parameters that were renamed in v7.0.0 should cause a runtime exception.
+    /// </summary>
+    /// <remarks>
+    /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
+    /// to help our users find old parameters they missed by throwing a runtime exception.
+    ///
+    /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
+    /// Sometime when the v7 version has stabilized.
+    /// </remarks>
+    public static bool EnableIllegalRazorParameterDetection = true;
+
+    /// <summary>
     /// Note: the user can overwrite this default handler with their own implementation. The default implementation
     /// makes sure that the unhandled exceptions don't go unnoticed
     /// </summary>


### PR DESCRIPTION
I implemented an illegal parameter detection for Razor
![image](https://github.com/MudBlazor/MudBlazor/assets/44090/f88c2ab5-dda9-4b9f-83c0-5390e7df5ea1)
it finds parameters we forgot to remove
or migrate rather
this could also be useful for our users
it just throws an ArgumentException. Not sure what you think about this