### PR TITLE
Better Illegal Razor Parameter Runtime Detection for v7

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarBottomExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarBottomExample.razor
@@ -4,7 +4,7 @@
 
 <MudLayout>
     <MudMainContent Class="pt-0">
-        <MudList T="string" Clickable="true">
+        <MudList T="string">
             <MudListItem Text="App Bookmark Item 1" Icon="@Icons.Material.Filled.Bookmark" />
             <MudListItem Text="App Bookmark Item 2" Icon="@Icons.Material.Filled.Bookmark" IconColor="Color.Primary" />
             <MudListItem Text="App Bookmark Item 3" Icon="@Icons.Material.Filled.Bookmark" IconColor="Color.Secondary" />

--- a/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerInsertExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerInsertExample.razor
@@ -2,15 +2,15 @@
 
 <MudPaper Width="300px" Square="true">
     <MudList T="string">
-        <MudListItem Avatar="@Icons.Material.Filled.TrendingUp">
+        <MudListItem Icon="@Icons.Material.Filled.TrendingUp">
             Trending
         </MudListItem>
         <MudDivider DividerType="DividerType.Inset" />
-        <MudListItem Avatar="@Icons.Material.Filled.StarRate">
+        <MudListItem Icon="@Icons.Material.Filled.StarRate">
             Most Stars
         </MudListItem>
         <MudDivider DividerType="DividerType.Inset" />
-        <MudListItem Avatar="@Icons.Material.Filled.History">
+        <MudListItem Icon="@Icons.Material.Filled.History">
             History
         </MudListItem>
     </MudList>

--- a/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerListExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Divider/Examples/DividerListExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px" Square="true">
-    <MudList T="string" Clickable="true">
+    <MudList T="string">
         <MudListItem>Inbox</MudListItem>
         <MudDivider />
         <MudListItem>Sent</MudListItem>

--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListNestedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListNestedExample.razor
@@ -2,7 +2,7 @@
 
 
 <MudPaper Width="300px">
-    <MudList T="string" Clickable>
+    <MudList T="string">
         <MudListSubheader>
             Nested List Items
         </MudListSubheader>

--- a/src/MudBlazor.Docs/Pages/Components/List/Examples/ListSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/Examples/ListSimpleExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px">
-    <MudList T="string" Clickable>
+    <MudList T="string">
         <MudListItem Text="Inbox" Icon="@Icons.Material.Filled.Inbox" />
         <MudListItem Text="Sent" Icon="@Icons.Material.Filled.Send" />
         <MudDivider />

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px" Elevation="0">
-    <MudTreeView Hover ReadOnly="@ReadOnly" TriState="@TriState" @bind-SelectedValues="SelectedValues" SelectionMode="@SelectionMode.MultiSelection"
+    <MudTreeView Hover ReadOnly="@ReadOnly" TriState="@TriState" @bind-SelectedValues="SelectedValues" SelectionMode="SelectionMode.MultiSelection"
                  CheckBoxColor="Color.Info">
         <MudTreeViewItem Value="@("config")" Expanded Icon="@Icons.Custom.Uncategorized.Folder" IconExpanded="@Icons.Custom.Uncategorized.FolderOpen">
             <MudTreeViewItem Value='"launch.json"' Icon="@Icons.Custom.FileFormats.FileCode" />
@@ -14,7 +14,7 @@
 </MudPaper>
 
 <MudStack Row Justify="Justify.Center" Style="width: 100%" Wrap="Wrap.Wrap">
-    <MudChipSet T="string" @bind-SelectedValues="SelectedValues" MultiSelection Color="Color.Info" Variant="Variant.Text">
+    <MudChipSet T="string" @bind-SelectedValues="SelectedValues" SelectionMode="SelectionMode.MultiSelection" Color="Color.Info" Variant="Variant.Text">
         <MudChip Text="config"/>
         <MudChip Text="launch.json"/>
         <MudChip Text="tasks.json"/>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/RightClickDrawerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Usage/Examples/RightClickDrawerExample.razor
@@ -10,7 +10,7 @@
                 <MudButton Color="Color.Primary" Variant="Variant.Outlined">New Record</MudButton>
             </MudCardContent>
         </MudCard>
-        <MudList T="string" Clickable="true">
+        <MudList T="string">
             <MudListSubheader>List</MudListSubheader>
             <MudListItem Text="Item 1"></MudListItem>
         </MudList>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
@@ -40,7 +40,7 @@
         <MudItem xs="5">
             <MudText Typo="Typo.h5" GutterBottom="true">Cart</MudText>
             <MudPaper Class="d-flex flex-column" Style="height:100%;" Outlined="true">
-                <MudList T="string" Clickable="true">
+                <MudList T="string">
                     <MudListItem Icon="@Icons.Material.Filled.ContentCut">
                         <div class="d-flex">
                             <MudText>Scissor - Big</MudText>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
@@ -2,11 +2,7 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <div>
-    <MudSelect T="string" Variant="Variant.Text"
-               @bind-Value="fruit"
-               Direction="Direction.Bottom" Dense="true"
-               SelectedValuesChanged="@(() => FruitChanged(null))">
-
+    <MudSelect T="string" Variant="Variant.Text" @bind-Value="fruit" Dense SelectedValuesChanged="@(() => FruitChanged(null))">
         <MudSelectItem Value="@("Apple")">Apple</MudSelectItem>
         <MudSelectItem Value="@("Orange")">Orange</MudSelectItem>
     </MudSelect>

--- a/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests
+{
+    [TestFixture]
+    public class ComponentBaseTests
+    {
+        [Test]
+        public void MatchTypes()
+        {
+            new MudAvatar().MatchTypes(typeof(MudAvatar), typeof(MudButton)).Should().Be(true);
+            new MudAvatar().MatchTypes(typeof(MudButton)).Should().Be(false);
+            new MudList<string>().MatchTypes(typeof(MudList<>), typeof(MudListItem<>)).Should().Be(true);
+            new MudList<int>().MatchTypes(typeof(MudList<>), typeof(MudListItem<>)).Should().Be(true);
+        }
+    }
+}

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -334,7 +334,7 @@ namespace MudBlazor
         [ExcludeFromCodeCoverage]
         private void NotifyIllegalParameter(string parameter)
         {
-            throw new ArgumentException($"Illegal parameter '{parameter}'. This was removed in v7.0.0, see Migration Guide for more info https://github.com/MudBlazor/MudBlazor/issues/8447");
+            throw new ArgumentException($"Illegal parameter '{parameter}' in component of type '{GetType().Name}'. This was removed in v7.0.0, see Migration Guide for more info https://github.com/MudBlazor/MudBlazor/issues/8447");
         }
     }
 }

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
@@ -127,7 +129,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudRadio<>))
+                else if (MatchTypes( typeof(MudRadio<>)))
                 {
                     switch (parameter)
                     {
@@ -145,7 +147,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudCheckBox<>) || GetType() == typeof(MudSwitch<>))
+                else if (MatchTypes(typeof(MudCheckBox<>),typeof(MudSwitch<>)))
                 {
                     switch (parameter)
                     {
@@ -154,7 +156,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (this is MudPopover || GetType() == typeof(MudAutocomplete<>) || GetType() == typeof(MudSelect<>))
+                else if (MatchTypes(typeof(MudPopover), typeof(MudAutocomplete<>), typeof(MudSelect<>)))
                 {
                     switch (parameter)
                     {
@@ -165,7 +167,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudToggleGroup<>))
+                else if (MatchTypes(typeof(MudToggleGroup<>)))
                 {
                     switch (parameter)
                     {
@@ -184,7 +186,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudSlider<>))
+                else if (MatchTypes(typeof(MudSlider<>)))
                 {
                     switch (parameter)
                     {
@@ -193,7 +195,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudRadioGroup<>))
+                else if (MatchTypes(typeof(MudRadioGroup<>)))
                 {
                     switch (parameter)
                     {
@@ -212,7 +214,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudChip<>))
+                else if (MatchTypes(typeof(MudChip<>)))
                 {
                     switch (parameter)
                     {
@@ -222,7 +224,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudChipSet<>))
+                else if (MatchTypes(typeof(MudChipSet<>)))
                 {
                     switch (parameter)
                     {
@@ -237,7 +239,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudList<>))
+                else if (MatchTypes(typeof(MudList<>), typeof(MudListItem<>)))
                 {
                     switch (parameter)
                     {
@@ -250,7 +252,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (GetType() == typeof(MudTreeView<>) || GetType() == typeof(MudTreeViewItem<>))
+                else if (MatchTypes(typeof(MudTreeView<>), typeof(MudTreeViewItem<>)))
                 {
                     switch (parameter)
                     {
@@ -321,6 +323,12 @@ namespace MudBlazor
                     }
                 }
             }
+        }
+
+        internal bool MatchTypes(params Type[] types)
+        {
+            var self = GetType().IsGenericType ? GetType().GetGenericTypeDefinition() : GetType();
+            return types.Any(type => self == type);
         }
 
         [ExcludeFromCodeCoverage]

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -129,7 +129,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (MatchTypes( typeof(MudRadio<>)))
+                else if (MatchTypes(typeof(MudRadio<>)))
                 {
                     switch (parameter)
                     {
@@ -147,7 +147,7 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (MatchTypes(typeof(MudCheckBox<>),typeof(MudSwitch<>)))
+                else if (MatchTypes(typeof(MudCheckBox<>), typeof(MudSwitch<>)))
                 {
                     switch (parameter)
                     {

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -2,7 +2,7 @@
 @using MudBlazor.Interfaces
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" Class="@Classname" Style="@Style"
+<div @attributes="UserAttributes" class="@Classname" style="@Style"
         @onmouseenter="@MouseEnterAsync"
         @onmouseleave="@MouseLeaveAsync"
         @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
@@ -39,7 +39,7 @@
     @* The portal has to include  the cascading values inside, because it's not able to teletransport the cascade *@
     <MudPopover Open="@_isOpen" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@_popoverStyle" @ontouchend:preventDefault>
         <CascadingValue Value="@this">
-            <MudList T="object" Class="@ListClass" Clickable="true" Dense="@Dense"
+            <MudList T="object" Class="@ListClass" Dense="@Dense"
                 @onmouseenter="@MouseEnterAsync"
                 @onmouseleave="@MouseLeaveAsync">
                 @ChildContent


### PR DESCRIPTION
## Description
Follow-up to Illegal Razor Parameter Runtime Detection for v7 #8771

I noticed that the detection didn't work for generic types. After fixing that the detector finds at least 26 more illegal usages in our docs and tests. Naturally this PR fails until I fix the old params.

I think we probably should not remove this detector, ever. It is just too useful. We can use it to detect illegal usage of obsolete API in our docs and tests when we enter the next stable development phase. Of course then we'd change it to opt-in instead of opt-out.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
