### PR TITLE
Docs: Don't auto-focus search bar to allow keyboard navigation

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -65,7 +65,7 @@
     @if (DisplaySearchBar)
     {
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
-                         AutoFocus="true" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
+                         AutoFocus="false" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
             <ItemTemplate Context="result">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Improves accessibility by disabling auto-focus from the docs search bar. It still remains in the search dialog, but the bar would steal focus and stop you from controlling the page via keyboard.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Doesn't auto-focus which also resolves oversight of menu appearing from #8758.
Before

https://github.com/MudBlazor/MudBlazor/assets/7112040/1f1245c2-6572-449b-a37e-797dce15c75f

After

https://github.com/MudBlazor/MudBlazor/assets/7112040/2dcd8033-bf74-44d3-aa58-a82adeb7f050


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
