### PR TITLE
Allow registration of DefaultConverters for non-standard types

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Converters/ConvertersPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Converters/ConvertersPage.razor
@@ -59,7 +59,18 @@
                 <SpecialConverterExample/>
             </SectionContent>
         </DocsPageSection>
-
+        <DocsPageSection>
+            <SectionHeader Title="Default Custom Binding Converters">
+                <Description>
+                    If you need to setup global converter for a certain class or struct you can do it as well through static delegate:
+                    Just set a <CodeInline>Converter<Tag>T</Tag>.GlobalGetFunc</CodeInline> and
+                    <CodeInline>Converter<Tag>T</Tag>.GlobalSetFunc</CodeInline>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="false" Code="@nameof(PointConverterExample)" ShowCode="false">
+                <PointConverterExample />
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>
 

--- a/src/MudBlazor.Docs/Pages/Features/Converters/Examples/PointConverterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Converters/Examples/PointConverterExample.razor
@@ -1,0 +1,34 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System.Drawing
+@using System.Globalization;
+@using System.Text.Json
+@using Color = MudBlazor.Color
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudTextField Label="Point"
+                      Variant="Variant.Outlined"
+                      @bind-Value="_point"
+                      Immediate="true" />
+    </MudItem>
+    
+    <MudItem xs="12" sm="6" md="4">
+        <MudTextField Label="Mirrored point" 
+                      Variant="Variant.Outlined"  
+                      @bind-Value="_point" 
+                      Immediate="true"/>
+    </MudItem>
+
+</MudGrid>
+
+@code {
+    Point _point;
+
+    protected override void OnInitialized()
+    {
+        // should be in your Startup:
+        DefaultConverter<Point>.GlobalGetFunc = x => $"[{x.X}, {x.Y}]";
+        DefaultConverter<Point>.GlobalSetFunc = x => { var tmp = JsonSerializer.Deserialize<int[]>(x); return new Point(tmp[0], tmp[1]); };
+
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.UnitTests.Utilities
     {
         
         [Test]
-        public void FallbackConverterTests()
+        public void GlobalConverterTests()
         {
             var c10 = new DefaultConverter<Point>();
             DefaultConverter<Point>.GlobalGetFunc = x => $"[{x.X},{x.Y}]";

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Utilities
     [TestFixture]
     public class BindingConverterTests
     {
-        
+
         [Test]
         public void GlobalConverterTests()
         {

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -26,6 +26,15 @@ namespace MudBlazor.UnitTests.Utilities
             c10.Set(new Point(1, 2)).Should().Be("[1,2]");
             c10.Get("[1,2]").Should().Be(new Point(1, 2));
         }
+        [Test]
+        public void GlobalConverterTestsErrorHandling()
+        {
+            var c10 = new DefaultConverter<Point>();
+            DefaultConverter<Point>.GlobalSetFunc = x => { var tmp = JsonSerializer.Deserialize<int[]>(x); return new Point(tmp[0], tmp[1]); };
+
+            c10.Get("[1,2").Should().Be(Point.Empty);
+            c10.GetErrorMessage.Should().Be("Not a valid Point");
+        }
 
         [Test]
         public void DefaultIntegerConverterTest()

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Drawing;
 using System.Globalization;
+using System.Text.Json;
+using ColorCode.Compilation.Languages;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -12,6 +15,18 @@ namespace MudBlazor.UnitTests.Utilities
     [TestFixture]
     public class BindingConverterTests
     {
+        
+        [Test]
+        public void FallbackConverterTests()
+        {
+            var c10 = new DefaultConverter<Point>();
+            DefaultConverter<Point>.GlobalGetFunc = x => $"[{x.X},{x.Y}]";
+            DefaultConverter<Point>.GlobalSetFunc = x => { var tmp = JsonSerializer.Deserialize<int[]>(x); return new Point(tmp[0], tmp[1]); };
+
+            c10.Set(new Point(1, 2)).Should().Be("[1,2]");
+            c10.Get("[1,2]").Should().Be(new Point(1, 2));
+        }
+
         [Test]
         public void DefaultIntegerConverterTest()
         {

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -1,14 +1,25 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 
 namespace MudBlazor
 {
-
+    
+    
     /// <summary>
     /// A universal T to string binding converter
     /// </summary>
     public class DefaultConverter<T> : Converter<T>
     {
+        /// <summary>
+        /// A static global delegate used if no converter is found. 
+        /// </summary>
+        public static Func<T, string> GlobalGetFunc;
+        /// <summary>
+        /// A static global delegate used if no converter is found.
+        /// </summary>
+        public static Func<string, T> GlobalSetFunc;
 
         public DefaultConverter()
         {
@@ -166,6 +177,17 @@ namespace MudBlazor
                         UpdateGetError("Not a valid time span");
                     }
                 }
+                else if (GlobalSetFunc!=null)
+                {
+                    try
+                    {
+                        return GlobalSetFunc(value);
+                    }
+                    catch (Exception)
+                    {
+                        UpdateGetError($"Not a valid {typeof(T).Name}");
+                    }
+                }
                 else
                 {
                     UpdateGetError($"Conversion to type {typeof(T)} not implemented");
@@ -178,6 +200,8 @@ namespace MudBlazor
 
             return default(T);
         }
+       
+        
 
         protected virtual string ConvertToString(T arg)
         {
@@ -296,7 +320,9 @@ namespace MudBlazor
                 {
                     var value = (TimeSpan?)(object)arg;
                     return value.Value.ToString(Format ?? DefaultTimeSpanFormat, Culture);
-                }
+                } 
+                else if(GlobalGetFunc !=null)
+                    return GlobalGetFunc(arg);
                 return arg.ToString();
             }
             catch (FormatException e)

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -5,8 +5,6 @@ using System.Reflection;
 
 namespace MudBlazor
 {
-    
-    
     /// <summary>
     /// A universal T to string binding converter
     /// </summary>
@@ -177,7 +175,7 @@ namespace MudBlazor
                         UpdateGetError("Not a valid time span");
                     }
                 }
-                else if (GlobalSetFunc!=null)
+                else if (GlobalSetFunc != null)
                 {
                     try
                     {
@@ -200,8 +198,6 @@ namespace MudBlazor
 
             return default(T);
         }
-       
-        
 
         protected virtual string ConvertToString(T arg)
         {
@@ -321,8 +317,10 @@ namespace MudBlazor
                     var value = (TimeSpan?)(object)arg;
                     return value.Value.ToString(Format ?? DefaultTimeSpanFormat, Culture);
                 } 
-                else if(GlobalGetFunc !=null)
+                else if (GlobalGetFunc != null)
+                {
                     return GlobalGetFunc(arg);
+                }
                 return arg.ToString();
             }
             catch (FormatException e)

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -316,7 +316,7 @@ namespace MudBlazor
                 {
                     var value = (TimeSpan?)(object)arg;
                     return value.Value.ToString(Format ?? DefaultTimeSpanFormat, Culture);
-                } 
+                }
                 else if (GlobalGetFunc != null)
                 {
                     return GlobalGetFunc(arg);


### PR DESCRIPTION
This is a tiny change that allows a developer to set up a global default converter that is used in bindings.
With this change, one can setup global default converter for structs such as Point, Vector, etc, especially from 3rd party libraries.

## Description
Code was added, not changed. It is backward compatible. 

## How Has This Been Tested?
--> A UT was added to test this small change. BindingConverterTests->GlobalConverterTests()
--> docs project contains a component that tested new functionality: PointConverterExample 

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
