### PR TITLE
TimePicker: Prepare for touch support & ColorPicker: Prevent touch pan in static mode

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -394,19 +394,19 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public void DragMouse_SelectHour_CheckMinutesAppear()
+        public void DragPointer_SelectHour_CheckMinutesAppear()
         {
             var comp = OpenPicker();
             var picker = comp.Instance;
             var underlyingPicker = comp.FindComponent<MudTimePicker>().Instance;
 
             // click on the minutes input
-            comp.Find("div.mud-time-picker-hour").MouseDown();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseOver();
+            comp.Find("div.mud-time-picker-hour").PointerDown();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(16);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseOver();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].PointerOver();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(18);
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(0);
             // Are minutes displayed
@@ -414,7 +414,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DragMouse_SelectMinutes()
+        public void DragPointer_SelectMinutes()
         {
             // Use bare component
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Minutes));
@@ -424,13 +424,13 @@ namespace MudBlazor.UnitTests.Components
             // Any hours displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
             // click and drag
-            comp.Find("div.mud-time-picker-minute").MouseDown();
-            comp.FindAll("div.mud-minute")[3].MouseOver();
+            comp.Find("div.mud-time-picker-minute").PointerDown();
+            comp.FindAll("div.mud-minute")[3].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(3);
-            comp.FindAll("div.mud-minute")[31].MouseOver();
+            comp.FindAll("div.mud-minute")[31].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(31);
-            comp.FindAll("div.mud-minute")[5].MouseOver();
-            comp.FindAll("div.mud-minute")[5].MouseUp();
+            comp.FindAll("div.mud-minute")[5].PointerOver();
+            comp.FindAll("div.mud-minute")[5].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(5);
         }
 
@@ -484,10 +484,10 @@ namespace MudBlazor.UnitTests.Components
             for (var i = 0; i < 12; i++)
             {
                 var expected = i == 11 ? 0 : i + 1;
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-hour")[i].PointerOver();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
-                comp.FindAll("div.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-hour")[i].PointerUp();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-hour")[i].Click();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
@@ -510,10 +510,10 @@ namespace MudBlazor.UnitTests.Components
             for (var i = 0; i < 12; i++)
             {
                 var expected = i == 11 ? 12 : i + 13;
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-hour")[i].PointerOver();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
-                comp.FindAll("div.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-hour")[i].PointerUp();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-hour")[i].Click();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
@@ -533,10 +533,10 @@ namespace MudBlazor.UnitTests.Components
             for (var i = 0; i < 12; i++)
             {
                 var expected = i + 13 == 24 ? 0 : i + 13;
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].PointerOver();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].PointerUp();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].Click();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
@@ -545,10 +545,10 @@ namespace MudBlazor.UnitTests.Components
             for (var i = 0; i < 12; i++)
             {
                 var expected = i + 1;
-                comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseOver();
+                comp.Find("div.mud-time-picker-hour").PointerDown();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].PointerOver();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseUp();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].PointerUp();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].Click();
                 comp.WaitForAssertion(() => underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(expected));
@@ -556,10 +556,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// drag and mouseup on minutes for test coverage
+        /// drag and pointerup on minutes for test coverage
         /// </summary>
         [Test]
-        public void DragAndMouseUp_AllMinutes()
+        public void DragAndPointerUp_AllMinutes()
         {
             var comp = OpenPicker(Parameter("TimeEditMode", TimeEditMode.OnlyMinutes));
             var picker = comp.Instance;
@@ -568,16 +568,16 @@ namespace MudBlazor.UnitTests.Components
             // Any minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
 
-            // click and drag (hold mouse down)
-            comp.Find("div.mud-time-picker-minute").MouseDown();
+            // click and drag (hold pointer down)
+            comp.Find("div.mud-time-picker-minute").PointerDown();
             for (var i = 0; i < 60; i++)
             {
-                comp.FindAll("div.mud-minute")[i].MouseOver();
+                comp.FindAll("div.mud-minute")[i].PointerOver();
                 underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
 
                 if (i == 59)
                 {
-                    comp.FindAll("div.mud-minute")[i].MouseUp();
+                    comp.FindAll("div.mud-minute")[i].PointerUp();
                     underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(i);
                 }
             }
@@ -607,7 +607,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// drag and mouseup in every view
+        /// drag and pointerup in every view
         /// </summary>
         [Test]
         public void SelectTime_UsingDrag_DefaultMode_CheckCloseWhenFinished()
@@ -620,22 +620,22 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-time-picker-hour").Count.Should().Be(1);
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
 
-            // drag to 13 and mouse up
-            comp.Find("div.mud-time-picker-hour").MouseDown();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseOver();
+            // drag to 13 and pointer up
+            comp.Find("div.mud-time-picker-hour").PointerDown();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[0].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(13);
 
             // check if the view changed to minutes
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
             comp.FindAll("div.mud-time-picker-minute").Count.Should().Be(1);
 
-            // drag to 37 minutes and mouse up
-            comp.Find("div.mud-time-picker-minute").MouseDown();
-            comp.FindAll("div.mud-minute")[37].MouseOver();
+            // drag to 37 minutes and pointer up
+            comp.Find("div.mud-time-picker-minute").PointerDown();
+            comp.FindAll("div.mud-minute")[37].PointerOver();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
-            comp.FindAll("div.mud-minute")[37].MouseUp();
+            comp.FindAll("div.mud-minute")[37].PointerUp();
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(37);
 
             // check if closed
@@ -952,11 +952,11 @@ namespace MudBlazor.UnitTests.Components
             });
 
             // Select 16 hours
-            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click(new MouseEventArgs()));
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click(new PointerEventArgs()));
             picker.TimeIntermediate.Value.Hours.Should().Be(16);
 
             // Select 30 minutes
-            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new MouseEventArgs()));
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-minute")[30].Click(new PointerEventArgs()));
             picker.TimeIntermediate.Value.Minutes.Should().Be(30);
 
             count.Should().Be(1);
@@ -985,7 +985,7 @@ namespace MudBlazor.UnitTests.Components
             // click on the hour input
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[nextHourIndex].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[nextHourIndex].PointerUp();
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[nextHourIndex].Click();
             comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be(nextHour.ToString());
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(nextHour);
@@ -997,7 +997,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             // are hours displayed
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[finalHourIndex].MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[finalHourIndex].PointerUp();
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[finalHourIndex].Click();
             // ensure displayed hour text is has updated
             comp.FindAll("div.mud-timepicker-hourminute button.mud-timepicker-button span.mud-button-label")[0].TextContent.Should().Be(finalHour.ToString());

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
     {
         public IRenderedComponent<SimpleTimePickerTest> OpenPicker(ComponentParameter parameter)
         {
-            return OpenPicker(new ComponentParameter[] { parameter });
+            return OpenPicker([parameter]);
         }
 
         public IRenderedComponent<SimpleTimePickerTest> OpenPicker(ComponentParameter[] parameters = null)
@@ -49,7 +49,6 @@ namespace MudBlazor.UnitTests.Components
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Time Picker");
         }
-
 
         [Test]
         public void TimePicker_Should_Clear()
@@ -157,7 +156,7 @@ namespace MudBlazor.UnitTests.Components
             underlyingPicker.TimeIntermediate.Value.Minutes.Should().Be(21);
 
             // open picker
-            await comp.InvokeAsync(() => picker.Open());
+            await comp.InvokeAsync(picker.Open);
 
             // click 10 hours
             comp.FindAll("div.mud-picker-stick-inner.mud-hour")[9].Click();
@@ -269,7 +268,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MinuteSelectionStep_0_SelectTime_UsingClicks_CheckTime()
         {
-            var comp = Context.RenderComponent<MudTimePicker>(new ComponentParameter[] { Parameter(nameof(MudTimePicker.MinuteSelectionStep), 0), Parameter("TimeEditMode", TimeEditMode.OnlyMinutes), Parameter("PickerVariant", PickerVariant.Static), Parameter("OpenTo", OpenTo.Minutes) });
+            var comp = Context.RenderComponent<MudTimePicker>([Parameter(nameof(MudTimePicker.MinuteSelectionStep), 0), Parameter("TimeEditMode", TimeEditMode.OnlyMinutes), Parameter("PickerVariant", PickerVariant.Static), Parameter("OpenTo", OpenTo.Minutes)]);
             var picker = comp.Instance;
 
             // Any minutes displayed
@@ -307,7 +306,6 @@ namespace MudBlazor.UnitTests.Components
             // Are hours displayed
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
-
 
         [Test]
         public void OpenToMinutes_CheckHoursHidden()
@@ -379,7 +377,6 @@ namespace MudBlazor.UnitTests.Components
 
             // should be 14 hours
             underlyingPicker.TimeIntermediate.Value.Hours.Should().Be(14);
-
         }
 
         [Test]
@@ -391,7 +388,6 @@ namespace MudBlazor.UnitTests.Components
             // Are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
-
 
         [Test]
         public void DragPointer_SelectHour_CheckMinutesAppear()
@@ -592,7 +588,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Click_AllMinutes_Static()
         {
-            var comp = Context.RenderComponent<MudTimePicker>(new ComponentParameter[] { Parameter("TimeEditMode", TimeEditMode.OnlyMinutes), Parameter("PickerVariant", PickerVariant.Static), Parameter("OpenTo", OpenTo.Minutes) });
+            var comp = Context.RenderComponent<MudTimePicker>([Parameter("TimeEditMode", TimeEditMode.OnlyMinutes), Parameter("PickerVariant", PickerVariant.Static), Parameter("OpenTo", OpenTo.Minutes)]);
             var picker = comp.Instance;
 
             // Any minutes displayed
@@ -729,7 +725,7 @@ namespace MudBlazor.UnitTests.Components
             var timePicker = comp.FindComponent<MudTimePicker>();
 
             // Open the timepicker
-            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
+            await comp.InvokeAsync(timePicker.Instance.OpenAsync);
             var picker = timePicker.Instance;
 
             // Select 16 hours
@@ -747,7 +743,7 @@ namespace MudBlazor.UnitTests.Components
             // and there are actions which are defined
             picker.Time.Should().Be(new TimeSpan(00, 45, 00));
 
-            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
+            await comp.InvokeAsync(timePicker.Instance.OpenAsync);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
             await comp.InvokeAsync(() => timePicker.Instance.ClearAsync());
@@ -757,7 +753,7 @@ namespace MudBlazor.UnitTests.Components
             timePicker.Instance.AutoClose = true;
 
             // Open the timepicker
-            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
+            await comp.InvokeAsync(timePicker.Instance.OpenAsync);
             picker = timePicker.Instance;
 
             // Select 16 hours
@@ -774,7 +770,7 @@ namespace MudBlazor.UnitTests.Components
             // Check that the time should be equal to the selection this time!
             picker.Time.Should().Be(new TimeSpan(16, 30, 00));
 
-            await comp.InvokeAsync(() => timePicker.Instance.OpenAsync());
+            await comp.InvokeAsync(timePicker.Instance.OpenAsync);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
             await comp.InvokeAsync(() => timePicker.Instance.ClearAsync());
@@ -790,7 +786,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.FindComponent<MudTimePicker>().Instance;
             comp.WaitForAssertion(() => picker.Time.Should().Be(null));
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.OpenAsync());
+            await comp.InvokeAsync(picker.OpenAsync);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 16 hours
@@ -811,7 +807,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => picker.ReadOnly = true);
 
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.OpenAsync());
+            await comp.InvokeAsync(picker.OpenAsync);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             // Select 17 hours
@@ -930,8 +926,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => timePicker.TimeFormat = "hhmm");
 
             timePicker.ReadOnly = true;
-            await comp.InvokeAsync(() => timePicker.SubmitAsync());
-
+            await comp.InvokeAsync(timePicker.SubmitAsync);
         }
 
         [Test]
@@ -942,7 +937,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.FindComponent<MudTimePicker>().Instance;
             comp.WaitForAssertion(() => picker.Time.Should().Be(null));
             // Open the timepicker
-            await comp.InvokeAsync(() => picker.OpenAsync());
+            await comp.InvokeAsync(picker.OpenAsync);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover").Count.Should().Be(1));
 
             var count = 0;
@@ -965,7 +960,6 @@ namespace MudBlazor.UnitTests.Components
 
             // Check that the time have been changed
             comp.WaitForAssertion(() => picker.Time.Should().Be(new TimeSpan(16, 30, 00)));
-
         }
 
         // See #7483 for details

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -50,7 +50,7 @@
                                 for(int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(async () => await OnPointerClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
+                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(async () => await OnClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
                                 }
                             }
                             else
@@ -73,8 +73,8 @@
                                 {
                                     var _i = i;
                                     <div class="mud-picker-stick" style="@($"transform: rotateZ({_i * 30}deg);")">
-                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(async () => await OnPointerClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
-                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(async () => await OnPointerClickHourAsync((_i + 12) % 24))" @onpointerover="(async () => await OnPointerOverHourAsync((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(async () => await OnClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(async () => await OnClickHourAsync((_i + 12) % 24))" @onpointerover="(async () => await OnPointerOverHourAsync((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
                                     </div>
                                 }
                             }
@@ -90,7 +90,7 @@
                             @for (int i = 0; i < 60; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(async () => await OnPointerClickMinuteAsync(_i))" @onpointerover="(async () => await OnPointerOverMinuteAsync(_i))" @onclick:stopPropagation="true"></div>
+                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(async () => await OnClickMinuteAsync(_i))" @onpointerover="(async () => await OnPointerOverMinuteAsync(_i))" @onclick:stopPropagation="true"></div>
                             }
                         </div>
                     </div>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -32,7 +32,7 @@
         <MudPickerContent>
             <div class="mud-picker-time-container">
                 <div class="mud-picker-time-clock">
-                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onmousedown="OnMouseDown" @onmouseup="OnMouseUpAsync">
+                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @onpointerdown="OnPointerDown" @onpointerup="OnPointerUpAsync">
                         <div class="@GetClockPinColor()"></div>
                         <div class="@GetClockPointerColor()" style="height: @GetPointerHeight(); transform: @GetPointerRotation()">
                             <div class="@GetClockPointerThumbColor()"></div>
@@ -50,7 +50,7 @@
                                 for(int i = 1; i <= 12; ++i)
                                 {
                                     var _i = i;
-                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(async () => await OnMouseClickHourAsync(_i))" @onmouseover="(async () => await OnMouseOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
+                                    <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="(async () => await OnPointerClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
                                 }
                             }
                             else
@@ -73,8 +73,8 @@
                                 {
                                     var _i = i;
                                     <div class="mud-picker-stick" style="@($"transform: rotateZ({_i * 30}deg);")">
-                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(async () => await OnMouseClickHourAsync(_i))" @onmouseover="(async () => await OnMouseOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
-                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(async () => await OnMouseClickHourAsync((_i + 12) % 24))" @onmouseover="(async () => await OnMouseOverHourAsync((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-inner mud-hour" @onclick="(async () => await OnPointerClickHourAsync(_i))" @onpointerover="(async () => await OnPointerOverHourAsync(_i))" @onclick:stopPropagation="true"></div>
+                                        <div class="mud-picker-stick-outer mud-hour" @onclick="(async () => await OnPointerClickHourAsync((_i + 12) % 24))" @onpointerover="(async () => await OnPointerOverHourAsync((_i + 12) % 24))" @onclick:stopPropagation="true"></div>
                                     </div>
                                 }
                             }
@@ -90,7 +90,7 @@
                             @for (int i = 0; i < 60; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(async () => await OnMouseClickMinuteAsync(_i))" @onmouseover="(async () => await OnMouseOverMinuteAsync(_i))" @onclick:stopPropagation="true"></div>
+                                <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="(async () => await OnPointerClickMinuteAsync(_i))" @onpointerover="(async () => await OnPointerOverMinuteAsync(_i))" @onclick:stopPropagation="true"></div>
                             }
                         </div>
                     </div>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -11,14 +15,14 @@ namespace MudBlazor
 {
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
-        private const string format24Hours = "HH:mm";
-        private const string format12Hours = "hh:mm tt";
+        private const string Format24Hours = "HH:mm";
+        private const string Format12Hours = "hh:mm tt";
 
         public MudTimePicker() : base(new DefaultConverter<TimeSpan?>())
         {
             Converter.GetFunc = OnGet;
             Converter.SetFunc = OnSet;
-            ((DefaultConverter<TimeSpan?>)Converter).Format = format24Hours;
+            ((DefaultConverter<TimeSpan?>)Converter).Format = Format24Hours;
             AdornmentIcon = Icons.Material.Filled.AccessTime;
             AdornmentAriaLabel = "Open Time Picker";
         }
@@ -26,7 +30,9 @@ namespace MudBlazor
         private string OnSet(TimeSpan? timespan)
         {
             if (timespan == null)
+            {
                 return string.Empty;
+            }
 
             var time = DateTime.Today.Add(timespan.Value);
 
@@ -36,7 +42,9 @@ namespace MudBlazor
         private TimeSpan? OnGet(string value)
         {
             if (string.IsNullOrEmpty(value))
+            {
                 return null;
+            }
 
             if (DateTime.TryParseExact(value, ((DefaultConverter<TimeSpan?>)Converter).Format, Culture, DateTimeStyles.None, out var time))
             {
@@ -46,16 +54,14 @@ namespace MudBlazor
             var m = AmPmRegularExpression().Match(value);
             if (m.Success)
             {
-                if (DateTime.TryParseExact(value, format12Hours, CultureInfo.InvariantCulture, DateTimeStyles.None,
-                        out time))
+                if (DateTime.TryParseExact(value, Format12Hours, CultureInfo.InvariantCulture, DateTimeStyles.None, out time))
                 {
                     return time.TimeOfDay;
                 }
             }
             else
             {
-                if (DateTime.TryParseExact(value, format24Hours, CultureInfo.InvariantCulture, DateTimeStyles.None,
-                        out time))
+                if (DateTime.TryParseExact(value, Format24Hours, CultureInfo.InvariantCulture, DateTimeStyles.None, out time))
                 {
                     return time.TimeOfDay;
                 }
@@ -67,7 +73,7 @@ namespace MudBlazor
 
         private void HandleParsingError()
         {
-            const string ParsingErrorMessage = "Not a valid time span";
+            const string ParsingErrorMessage = "Not a valid time span.";
             Converter.GetError = true;
             Converter.GetErrorMessage = ParsingErrorMessage;
             Converter.OnError?.Invoke(ParsingErrorMessage);
@@ -87,21 +93,24 @@ namespace MudBlazor
         public OpenTo OpenTo { get; set; } = OpenTo.Hours;
 
         /// <summary>
-        /// Choose the edition mode. By default, you can edit hours and minutes.
+        /// Selects the edit mode. By default, you can edit hours and minutes.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public TimeEditMode TimeEditMode { get; set; } = TimeEditMode.Normal;
 
         /// <summary>
-        /// Sets the amount of time in milliseconds to wait before closing the picker. This helps the user see that the time was selected before the popover disappears.
+        /// Sets the amount of time in milliseconds to wait before closing the picker.
         /// </summary>
+        /// <remarks>
+        /// This helps the user see that the time was selected before the popover disappears.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int ClosingDelay { get; set; } = 200;
 
         /// <summary>
-        /// If AutoClose is set to true and PickerActions are defined, the hour and the minutes can be defined without any action.
+        /// If true and PickerActions are defined, the hour and the minutes can be defined without any action.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -115,7 +124,7 @@ namespace MudBlazor
         public int MinuteSelectionStep { get; set; } = 1;
 
         /// <summary>
-        /// If true, sets 12 hour selection clock.
+        /// If true, enables 12 hour selection clock.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
@@ -125,13 +134,15 @@ namespace MudBlazor
             set
             {
                 if (value == _amPm)
+                {
                     return;
+                }
 
                 _amPm = value;
 
                 if (Converter is DefaultConverter<TimeSpan?> defaultConverter && string.IsNullOrWhiteSpace(_timeFormat))
                 {
-                    defaultConverter.Format = AmPm ? format12Hours : format24Hours;
+                    defaultConverter.Format = AmPm ? Format12Hours : Format24Hours;
                 }
 
                 Touched = true;
@@ -140,7 +151,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// String Format for selected time view
+        /// String format for selected time view.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
@@ -150,11 +161,15 @@ namespace MudBlazor
             set
             {
                 if (_timeFormat == value)
+                {
                     return;
+                }
 
                 _timeFormat = value;
                 if (Converter is DefaultConverter<TimeSpan?> defaultConverter)
+                {
                     defaultConverter.Format = _timeFormat;
+                }
 
                 Touched = true;
                 SetTextAsync(Converter.Set(_value), false).AndForget();
@@ -162,7 +177,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The currently selected time (two-way bindable). If null, then nothing was selected.
+        /// The currently selected time (two-way bindable). If <c>null</c>, nothing was selected.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
@@ -180,7 +195,10 @@ namespace MudBlazor
                 TimeIntermediate = time;
                 _value = time;
                 if (updateValue)
+                {
                     await SetTextAsync(Converter.Set(_value), false);
+                }
+
                 UpdateTimeSetFromTime();
                 await TimeChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
@@ -196,11 +214,12 @@ namespace MudBlazor
         protected override Task StringValueChangedAsync(string value)
         {
             Touched = true;
+
             // Update the time property (without updating back the Value property)
             return SetTimeAsync(Converter.Get(value), false);
         }
 
-        //The last line cannot be tested
+        // The last line cannot be tested.
         [ExcludeFromCodeCoverage]
         protected override async Task OnPickerOpenedAsync()
         {
@@ -240,7 +259,10 @@ namespace MudBlazor
         private string GetHourString()
         {
             if (TimeIntermediate == null)
+            {
                 return "--";
+            }
+
             var h = AmPm ? TimeIntermediate.Value.ToAmPmHour() : TimeIntermediate.Value.Hours;
             return $"{Math.Min(23, Math.Max(0, h)):D2}";
         }
@@ -248,7 +270,10 @@ namespace MudBlazor
         private string GetMinuteString()
         {
             if (TimeIntermediate == null)
+            {
                 return "--";
+            }
+
             return $"{Math.Min(59, Math.Max(0, TimeIntermediate.Value.Minutes)):D2}";
         }
 
@@ -276,15 +301,18 @@ namespace MudBlazor
 
         private async Task OnAmClickedAsync()
         {
-            _timeSet.Hour %= 12;  // "12:-- am" is "00:--" in 24h
+            _timeSet.Hour %= 12;  // "12:-- am" is "00:--" in 24h.
             await UpdateTimeAsync();
             await FocusAsync();
         }
 
         private async Task OnPmClickedAsync()
         {
-            if (_timeSet.Hour <= 12) // "12:-- pm" is "12:--" in 24h
+            if (_timeSet.Hour <= 12) // "12:-- pm" is "12:--" in 24h.
+            {
                 _timeSet.Hour += 12;
+            }
+
             _timeSet.Hour %= 24;
             await UpdateTimeAsync();
             await FocusAsync();
@@ -292,46 +320,46 @@ namespace MudBlazor
 
         protected string ToolbarClass =>
             new CssBuilder("mud-picker-timepicker-toolbar")
-                .AddClass($"mud-picker-timepicker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
+                .AddClass("mud-picker-timepicker-toolbar-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
                 .AddClass(Class)
                 .Build();
 
         protected string HoursButtonClass =>
             new CssBuilder("mud-timepicker-button")
-                .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Minutes)
+                .AddClass("mud-timepicker-toolbar-text", _currentView == OpenTo.Minutes)
                 .Build();
 
         protected string MinuteButtonClass =>
             new CssBuilder("mud-timepicker-button")
-                .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Hours)
+                .AddClass("mud-timepicker-toolbar-text", _currentView == OpenTo.Hours)
                 .Build();
 
         protected string AmButtonClass =>
             new CssBuilder("mud-timepicker-button")
-                .AddClass($"mud-timepicker-toolbar-text", !IsAm) // gray it out
+                .AddClass("mud-timepicker-toolbar-text", !IsAm) // gray it out.
                 .Build();
 
         protected string PmButtonClass =>
             new CssBuilder("mud-timepicker-button")
-                .AddClass($"mud-timepicker-toolbar-text", !IsPm) // gray it out
+                .AddClass("mud-timepicker-toolbar-text", !IsPm) // gray it out.
                 .Build();
 
         private string HourDialClass =>
             new CssBuilder("mud-time-picker-hour")
-                .AddClass($"mud-time-picker-dial")
-                .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Hours)
-                .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Hours)
+                .AddClass("mud-time-picker-dial")
+                .AddClass("mud-time-picker-dial-out", _currentView != OpenTo.Hours)
+                .AddClass("mud-time-picker-dial-hidden", _currentView != OpenTo.Hours)
                 .Build();
 
         private string MinuteDialClass =>
             new CssBuilder("mud-time-picker-minute")
-                .AddClass($"mud-time-picker-dial")
-                .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Minutes)
-                .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
+                .AddClass("mud-time-picker-dial")
+                .AddClass("mud-time-picker-dial-out", _currentView != OpenTo.Minutes)
+                .AddClass("mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
                 .Build();
 
-        private bool IsAm => _timeSet.Hour is >= 00 and < 12; // am is 00:00 to 11:59
-        private bool IsPm => _timeSet.Hour is >= 12 and < 24; // pm is 12:00 to 23:59
+        private bool IsAm => _timeSet.Hour is >= 00 and < 12; // AM is 00:00 to 11:59.
+        private bool IsPm => _timeSet.Hour is >= 12 and < 24; // PM is 12:00 to 23:59.
 
         private string GetClockPinColor()
         {
@@ -341,18 +369,26 @@ namespace MudBlazor
         private string GetClockPointerColor()
         {
             if (PointerDown)
+            {
                 return $"mud-picker-time-clock-pointer mud-{Color.ToDescriptionString()}";
+            }
             else
+            {
                 return $"mud-picker-time-clock-pointer mud-picker-time-clock-pointer-animation mud-{Color.ToDescriptionString()}";
+            }
         }
 
         private string GetClockPointerThumbColor()
         {
             var deg = GetDeg();
             if (deg % 30 == 0)
+            {
                 return $"mud-picker-time-clock-pointer-thumb mud-onclock-text mud-onclock-primary mud-{Color.ToDescriptionString()}";
+            }
             else
+            {
                 return $"mud-picker-time-clock-pointer-thumb mud-onclock-minute mud-{Color.ToDescriptionString()}-text";
+            }
         }
 
         private string GetNumberColor(int value)
@@ -360,33 +396,47 @@ namespace MudBlazor
             if (_currentView == OpenTo.Hours)
             {
                 var h = _timeSet.Hour;
+
                 if (AmPm)
                 {
                     h = _timeSet.Hour % 12;
                     if (_timeSet.Hour % 12 == 0)
+                    {
                         h = 12;
+                    }
                 }
+
                 if (h == value)
+                {
                     return $"mud-clock-number mud-theme-{Color.ToDescriptionString()}";
+                }
             }
             else if (_currentView == OpenTo.Minutes && _timeSet.Minute == value)
             {
                 return $"mud-clock-number mud-theme-{Color.ToDescriptionString()}";
             }
-            return $"mud-clock-number";
+
+            return "mud-clock-number";
         }
 
         private double GetDeg()
         {
             double deg = 0;
+
             if (_currentView == OpenTo.Hours)
-                deg = (_timeSet.Hour * 30) % 360;
+            {
+                deg = _timeSet.Hour * 30 % 360;
+            }
+
             if (_currentView == OpenTo.Minutes)
-                deg = (_timeSet.Minute * 6) % 360;
+            {
+                deg = _timeSet.Minute * 6 % 360;
+            }
+
             return deg;
         }
 
-        private string GetTransform(double angle, double radius, double offsetX, double offsetY)
+        private static string GetTransform(double angle, double radius, double offsetX, double offsetY)
         {
             angle = angle / 180 * Math.PI;
             var x = ((Math.Sin(angle) * radius) + offsetX).ToString("F3", CultureInfo.InvariantCulture);
@@ -397,25 +447,41 @@ namespace MudBlazor
         private string GetPointerRotation()
         {
             double deg = 0;
+
             if (_currentView == OpenTo.Hours)
-                deg = (_timeSet.Hour * 30) % 360;
+            {
+                deg = _timeSet.Hour * 30 % 360;
+            }
+
             if (_currentView == OpenTo.Minutes)
-                deg = (_timeSet.Minute * 6) % 360;
+            {
+                deg = _timeSet.Minute * 6 % 360;
+            }
+
             return $"rotateZ({deg}deg);";
         }
 
         private string GetPointerHeight()
         {
             var height = 40;
+
             if (_currentView == OpenTo.Minutes)
+            {
                 height = 40;
+            }
+
             if (_currentView == OpenTo.Hours)
             {
                 if (!AmPm && _timeSet.Hour > 0 && _timeSet.Hour < 13)
+                {
                     height = 26;
+                }
                 else
+                {
                     height = 40;
+                }
             }
+
             return $"{height}%;";
         }
 
@@ -434,7 +500,6 @@ namespace MudBlazor
             _initialMinute = _timeSet.Minute;
         }
 
-
         private void UpdateTimeSetFromTime()
         {
             if (TimeIntermediate == null)
@@ -443,6 +508,7 @@ namespace MudBlazor
                 _timeSet.Minute = 0;
                 return;
             }
+
             _timeSet.Hour = TimeIntermediate.Value.Hours;
             _timeSet.Minute = TimeIntermediate.Value.Minutes;
         }
@@ -450,7 +516,7 @@ namespace MudBlazor
         public bool PointerDown { get; set; }
 
         /// <summary>
-        /// Sets Pointer Down bool to true if pointer is inside the clock mask.
+        /// Sets <see cref="PointerDown"/> to true if the pointer is inside the clock mask.
         /// </summary>
         private void OnPointerDown(PointerEventArgs e)
         {
@@ -458,11 +524,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Sets Pointer Down bool to false if pointer is inside the clock mask.
+        /// Sets <see cref="PointerDown"/> to false if the pointer is inside the clock mask.
         /// </summary>
         private async Task OnPointerUpAsync(PointerEventArgs e)
         {
-            if (PointerDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
+            if ((PointerDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute) || (_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours))
             {
                 PointerDown = false;
                 await SubmitAndCloseAsync();
@@ -476,26 +542,31 @@ namespace MudBlazor
             }
         }
 
-        private int HourAmPm(int value)
+        private int HourAmPm(int hour)
         {
             if (AmPm)
             {
-                if (IsAm && value == 12)
+                if (IsAm && hour == 12)
+                {
                     return 0;
-                else if (IsPm && value < 12)
-                    return value + 12;
+                }
+                else if (IsPm && hour < 12)
+                {
+                    return hour + 12;
+                }
             }
-            return value;
+
+            return hour;
         }
 
         /// <summary>
-        /// If PointerDown is true enables "dragging" effect on the clock pin/stick.
+        /// If <see cref="PointerDown"/> is true enables "dragging" effect on the clock pin/stick.
         /// </summary>
-        private async Task OnPointerOverHourAsync(int value)
+        private async Task OnPointerOverHourAsync(int hour)
         {
             if (PointerDown)
             {
-                _timeSet.Hour = HourAmPm(value);
+                _timeSet.Hour = HourAmPm(hour);
                 await UpdateTimeAsync();
             }
         }
@@ -503,12 +574,11 @@ namespace MudBlazor
         /// <summary>
         /// On click for the hour "sticks", sets the hour.
         /// </summary>
-        private async Task OnPointerClickHourAsync(int value)
+        private async Task OnPointerClickHourAsync(int hour)
         {
-            _timeSet.Hour = HourAmPm(value);
+            _timeSet.Hour = HourAmPm(hour);
 
-            if (_currentView == OpenTo.Hours
-                || _timeSet.Hour != _lastSelectedHour)
+            if (_currentView == OpenTo.Hours || _timeSet.Hour != _lastSelectedHour)
             {
                 await UpdateTimeAsync();
             }
@@ -526,12 +596,12 @@ namespace MudBlazor
         /// <summary>
         /// On pointer over for the minutes "sticks", sets the minute.
         /// </summary>
-        private async Task OnPointerOverMinuteAsync(int value)
+        private async Task OnPointerOverMinuteAsync(int minute)
         {
             if (PointerDown)
             {
-                value = RoundToStepInterval(value);
-                _timeSet.Minute = value;
+                minute = RoundToStepInterval(minute);
+                _timeSet.Minute = minute;
                 await UpdateTimeAsync();
             }
         }
@@ -539,25 +609,26 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private async Task OnPointerClickMinuteAsync(int value)
+        private async Task OnPointerClickMinuteAsync(int minute)
         {
-            value = RoundToStepInterval(value);
-            _timeSet.Minute = value;
+            minute = RoundToStepInterval(minute);
+            _timeSet.Minute = minute;
             await UpdateTimeAsync();
             await SubmitAndCloseAsync();
         }
 
         private int RoundToStepInterval(int value)
         {
-            if (MinuteSelectionStep > 1) // Ignore if step is less than or equal to 1
+            if (MinuteSelectionStep > 1) // Ignore if step is less than or equal to 1.
             {
                 var interval = MinuteSelectionStep % 60;
                 value = (value + (interval / 2)) / interval * interval;
-                if (value == 60) // For when it rounds up to 60
+                if (value == 60) // For when it rounds up to 60.
                 {
                     value = 0;
                 }
             }
+
             return value;
         }
 
@@ -578,8 +649,12 @@ namespace MudBlazor
         protected internal override async Task OnHandleKeyDownAsync(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
+            {
                 return;
+            }
+
             await base.OnHandleKeyDownAsync(obj);
+
             switch (obj.Key)
             {
                 case "ArrowRight":
@@ -595,6 +670,7 @@ namespace MudBlazor
                             {
                                 await ChangeHourAsync(1);
                             }
+
                             await ChangeMinuteAsync(5);
                         }
                         else
@@ -603,9 +679,11 @@ namespace MudBlazor
                             {
                                 await ChangeHourAsync(1);
                             }
+
                             await ChangeMinuteAsync(1);
                         }
                     }
+
                     break;
                 case "ArrowLeft":
                     if (IsOpen)
@@ -620,6 +698,7 @@ namespace MudBlazor
                             {
                                 await ChangeHourAsync(-1);
                             }
+
                             await ChangeMinuteAsync(-5);
                         }
                         else
@@ -628,12 +707,14 @@ namespace MudBlazor
                             {
                                 await ChangeHourAsync(-1);
                             }
+
                             await ChangeMinuteAsync(-1);
                         }
                     }
+
                     break;
                 case "ArrowUp":
-                    if (IsOpen == false && Editable == false)
+                    if (!IsOpen && !Editable)
                     {
                         IsOpen = true;
                     }
@@ -649,9 +730,10 @@ namespace MudBlazor
                     {
                         await ChangeHourAsync(1);
                     }
+
                     break;
                 case "ArrowDown":
-                    if (IsOpen == false && Editable == false)
+                    if (!IsOpen && !Editable)
                     {
                         IsOpen = true;
                     }
@@ -663,6 +745,7 @@ namespace MudBlazor
                     {
                         await ChangeHourAsync(-1);
                     }
+
                     break;
                 case "Escape":
                     await ReturnTimeBackUpAsync();
@@ -679,6 +762,7 @@ namespace MudBlazor
                         await CloseAsync();
                         _inputReference?.SetText(Text);
                     }
+
                     break;
                 case " ":
                     if (!Editable)
@@ -694,24 +778,25 @@ namespace MudBlazor
                             _inputReference?.SetText(Text);
                         }
                     }
+
                     break;
             }
 
             StateHasChanged();
         }
 
-        protected Task ChangeMinuteAsync(int val)
+        protected Task ChangeMinuteAsync(int minute)
         {
             _currentView = OpenTo.Minutes;
-            _timeSet.Minute = (_timeSet.Minute + val + 60) % 60;
+            _timeSet.Minute = (_timeSet.Minute + minute + 60) % 60;
 
             return UpdateTimeAsync();
         }
 
-        protected Task ChangeHourAsync(int val)
+        protected Task ChangeHourAsync(int hour)
         {
             _currentView = OpenTo.Hours;
-            _timeSet.Hour = (_timeSet.Hour + val + 24) % 24;
+            _timeSet.Hour = (_timeSet.Hour + hour + 24) % 24;
 
             return UpdateTimeAsync();
         }
@@ -731,12 +816,11 @@ namespace MudBlazor
             }
         }
 
-        private class SetTime
+        private record SetTime
         {
             public int Hour { get; set; }
 
             public int Minute { get; set; }
-
         }
 
         [GeneratedRegex("AM|PM", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -340,7 +340,7 @@ namespace MudBlazor
 
         private string GetClockPointerColor()
         {
-            if (MouseDown)
+            if (PointerDown)
                 return $"mud-picker-time-clock-pointer mud-{Color.ToDescriptionString()}";
             else
                 return $"mud-picker-time-clock-pointer mud-picker-time-clock-pointer-animation mud-{Color.ToDescriptionString()}";
@@ -447,28 +447,28 @@ namespace MudBlazor
             _timeSet.Minute = TimeIntermediate.Value.Minutes;
         }
 
-        public bool MouseDown { get; set; }
+        public bool PointerDown { get; set; }
 
         /// <summary>
-        /// Sets Mouse Down bool to true if mouse is inside the clock mask.
+        /// Sets Pointer Down bool to true if pointer is inside the clock mask.
         /// </summary>
-        private void OnMouseDown(MouseEventArgs e)
+        private void OnPointerDown(PointerEventArgs e)
         {
-            MouseDown = true;
+            PointerDown = true;
         }
 
         /// <summary>
-        /// Sets Mouse Down bool to false if mouse is inside the clock mask.
+        /// Sets Pointer Down bool to false if pointer is inside the clock mask.
         /// </summary>
-        private async Task OnMouseUpAsync(MouseEventArgs e)
+        private async Task OnPointerUpAsync(PointerEventArgs e)
         {
-            if (MouseDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
+            if (PointerDown && _currentView == OpenTo.Minutes && _timeSet.Minute != _initialMinute || _currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.OnlyHours)
             {
-                MouseDown = false;
+                PointerDown = false;
                 await SubmitAndCloseAsync();
             }
 
-            MouseDown = false;
+            PointerDown = false;
 
             if (_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour && TimeEditMode == TimeEditMode.Normal)
             {
@@ -489,11 +489,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// If MouseDown is true enables "dragging" effect on the clock pin/stick.
+        /// If PointerDown is true enables "dragging" effect on the clock pin/stick.
         /// </summary>
-        private async Task OnMouseOverHourAsync(int value)
+        private async Task OnPointerOverHourAsync(int value)
         {
-            if (MouseDown)
+            if (PointerDown)
             {
                 _timeSet.Hour = HourAmPm(value);
                 await UpdateTimeAsync();
@@ -503,7 +503,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the hour "sticks", sets the hour.
         /// </summary>
-        private async Task OnMouseClickHourAsync(int value)
+        private async Task OnPointerClickHourAsync(int value)
         {
             _timeSet.Hour = HourAmPm(value);
 
@@ -524,11 +524,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// On mouse over for the minutes "sticks", sets the minute.
+        /// On pointer over for the minutes "sticks", sets the minute.
         /// </summary>
-        private async Task OnMouseOverMinuteAsync(int value)
+        private async Task OnPointerOverMinuteAsync(int value)
         {
-            if (MouseDown)
+            if (PointerDown)
             {
                 value = RoundToStepInterval(value);
                 _timeSet.Minute = value;
@@ -539,7 +539,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private async Task OnMouseClickMinuteAsync(int value)
+        private async Task OnPointerClickMinuteAsync(int value)
         {
             value = RoundToStepInterval(value);
             _timeSet.Minute = value;

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -73,7 +73,7 @@ namespace MudBlazor
 
         private void HandleParsingError()
         {
-            const string ParsingErrorMessage = "Not a valid time span.";
+            const string ParsingErrorMessage = "Not a valid time span";
             Converter.GetError = true;
             Converter.GetErrorMessage = ParsingErrorMessage;
             Converter.OnError?.Invoke(ParsingErrorMessage);

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -574,7 +574,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the hour "sticks", sets the hour.
         /// </summary>
-        private async Task OnPointerClickHourAsync(int hour)
+        private async Task OnClickHourAsync(int hour)
         {
             _timeSet.Hour = HourAmPm(hour);
 
@@ -609,7 +609,7 @@ namespace MudBlazor
         /// <summary>
         /// On click for the minute "sticks", sets the minute.
         /// </summary>
-        private async Task OnPointerClickMinuteAsync(int minute)
+        private async Task OnClickMinuteAsync(int minute)
         {
             minute = RoundToStepInterval(minute);
             _timeSet.Minute = minute;

--- a/src/MudBlazor/Styles/components/_pickercolor.scss
+++ b/src/MudBlazor/Styles/components/_pickercolor.scss
@@ -27,11 +27,11 @@
   height: 250px;
   position: relative;
   overflow: hidden;
+  touch-action: pinch-zoom;
 
   .mud-picker-color-overlay {
     width: 100%;
     height: 100%;
-
     /*Don't let the browser selection menu pop up from double clicking the svg*/
     user-select: none;
 
@@ -48,7 +48,6 @@
     position: absolute;
     top: -13px;
     left: -13px;
-
     /*Let the overlay handle the clicks*/
     pointer-events: none;
   }

--- a/src/MudBlazor/Styles/components/_pickertime.scss
+++ b/src/MudBlazor/Styles/components/_pickertime.scss
@@ -103,6 +103,7 @@
     position: relative;
     border-radius: 50%;
     pointer-events: none;
+    touch-action: pinch-zoom;
     background-color: rgba(0,0,0,.07);
 
     .mud-picker-time-clock-mask {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Follows up on #8394 and prepares for touch support in the time picker.

- Color Picker and Time Picker will no longer pan if used in static mode which was an oversight from #8394
- All mouse events were changed to pointer to include touch
- Refactoring was done to make the codebase more consistent and easier to work on
  - I will have to make fundamental changes anyway so this will make it much easier to review
- No actual functionality should have changed and that will be saved for another PR

If wanted I can do the touch work directly in this PR but it will start to get messy and may or may not get done before v7 preview.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
