### PR TITLE
MudProgressLinear: fix XMLDoc of Value parameter

### DIFF
--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -98,7 +98,7 @@ namespace MudBlazor
         public double Max { get; set; } = 100.0;
 
         /// <summary>
-        /// The maximum allowed value of the linear progress. Should not be equal to min.
+        /// The current value of the linear progress. Should be between min and max.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]


### PR DESCRIPTION


## Description
The `Value` parameter used the same XMLDoc summary/description as the `Max` parameter.
Changed that to describe what value should be set for this parameter: the current one to display, which should be between min & max.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
