### PR TITLE
NavLink and NavGroup: `IconOnly` Mode

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuIconOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuIconOnlyExample.razor
@@ -1,0 +1,41 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px" Class="d-inline-flex py-3" Elevation="0">
+    <MudNavMenu>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" OnClick="ToggleSimpleCollapsed"></MudIconButton>
+        <MudDivider Class="my-2"/>
+        <MudNavLink Href="/dashboard" Icon="@Icons.Material.Filled.Dashboard" IconOnly="isSimpleCollapsed">Dashboard</MudNavLink>
+        <MudNavLink Href="/servers" Icon="@Icons.Material.Filled.Storage" IconOnly="isSimpleCollapsed">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Icon="@Icons.Material.Filled.Receipt" Disabled="true" IconOnly="isSimpleCollapsed">Billing</MudNavLink>
+    </MudNavMenu>
+    <MudText Typo="Typo.body1" Class="pa-2">NavLink Only NavMenu</MudText>
+</MudPaper>
+<MudPaper Width="300px" Class="d-inline-flex py-3" Elevation="0">
+    <MudNavMenu>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" OnClick="ToggleComplexCollapsed"></MudIconButton>
+        <MudDivider Class="my-2"/>
+        <MudNavLink Href="/dashboard" Icon="@Icons.Material.Filled.Dashboard" IconOnly="isComplexCollapsed">Dashboard</MudNavLink>
+        <MudNavLink Href="/servers" Icon="@Icons.Material.Filled.Storage" IconOnly="isComplexCollapsed">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Icon="@Icons.Material.Filled.Receipt" Disabled="true" IconOnly="isComplexCollapsed">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Icon="@Icons.Material.Filled.Settings" Expanded="true" IconOnly="isComplexCollapsed">
+            <MudNavLink Href="/users" Icon="@Icons.Material.Filled.People" IconColor="Color.Success" IconOnly="isComplexCollapsed">Users</MudNavLink>
+            <MudNavLink Href="/security" Icon="@Icons.Material.Filled.Security" IconColor="Color.Info" IconOnly="isComplexCollapsed">Security</MudNavLink>
+        </MudNavGroup>
+    </MudNavMenu>
+    <MudText Typo="Typo.body1" Class="pa-2">Even supports complex NavGroup setups</MudText>
+</MudPaper>
+
+@code {
+    private bool isSimpleCollapsed = false;
+    private bool isComplexCollapsed = false;
+
+    private void ToggleSimpleCollapsed()
+    {
+        isSimpleCollapsed = !isSimpleCollapsed;
+    }
+
+    private void ToggleComplexCollapsed()
+    {
+        isComplexCollapsed = !isComplexCollapsed;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -41,6 +41,15 @@
                 <NavMenuIconExample/>
             </SectionContent>
         </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Icon Only">
+                <Description>You can set the property <CodeInline>IconOnly</CodeInline> to true to not render the child components of <CodeInline>MudNavGroup</CodeInline> or <CodeInline>MudNavLink</CodeInline>. This is handy for a collapsed mode for your NavMenu</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(NavMenuIconOnlyExample)" ShowCode="false">
+                <NavMenuIconOnlyExample/>
+            </SectionContent>
+        </DocsPageSection>
         
         <DocsPageSection>
             <SectionHeader Title="Bordered">

--- a/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
@@ -42,5 +42,18 @@ namespace MudBlazor.UnitTests.Components
 
             comp.FindAll("nav").Should().Contain(navNode => navNode.GetAttribute("aria-label") == expectedTitle);
         }
+
+        /// <summary>
+        /// Verify that when IconOnly is set on the MudNavGroup component, the div with the class ".mud-nav-link-text" is not rendered
+        /// Also verify that when IconOnly is not set on the MudNavGroup component, that the div with the class ".mud-nav-link-text" is rendered
+        /// </summary>
+        [Test]
+        public async Task NavGroup_IconOnly_NoText()
+        {
+            var comp = Context.RenderComponent<MudNavGroup>(Parameter(nameof(MudNavLink.IconOnly), true));
+            comp.FindAll(".mud-nav-link-text").Should().BeEmpty();
+            comp = Context.RenderComponent<MudNavGroup>();
+            comp.FindAll(".mud-nav-link-text").Should().NotBeEmpty();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -68,5 +68,18 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("a").Click();
             comp.Instance.IsNavigated.Should().BeFalse();
         }
+
+        /// <summary>
+        /// Verify that when IconOnly is set on the MudNavLink component, the div with the class ".mud-nav-link-text" is not rendered
+        /// Also verify that when IconOnly is not set on the MudNavLink component, that the div with the class ".mud-nav-link-text" is rendered
+        /// </summary>
+        [Test]
+        public async Task NavLink_IconOnly_NoText()
+        {
+            var comp = Context.RenderComponent<MudNavLink>(Parameter(nameof(MudNavLink.IconOnly), true));
+            comp.FindAll(".mud-nav-link-text").Should().BeEmpty();
+            comp = Context.RenderComponent<MudNavLink>();
+            comp.FindAll(".mud-nav-link-text").Should().NotBeEmpty();
+        }
     }
 }

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
@@ -19,9 +19,12 @@
         {
             <MudIcon Icon="@Icon" Color="@IconColor" Class="@IconClassname" />
         }
-        <div Class="mud-nav-link-text">
-            @Title
-        </div>
+        @if (!IconOnly)
+        {
+            <div Class="mud-nav-link-text">
+                @Title
+            </div>
+        }
         @if (!HideExpandIcon)
         {
             <MudIcon Icon="@ExpandIcon" Class="@ExpandIconClassname" />

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -138,7 +138,7 @@ namespace MudBlazor
 
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
-        
+
         /// <summary>
         /// Controls the render of the Title element, true to hide the Title
         /// </summary>

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -138,6 +138,13 @@ namespace MudBlazor
 
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
+        
+        /// <summary>
+        /// Controls the render of the Title element, true to hide the Title
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public bool IconOnly { get; set; }
 
         private Task ExpandedToggleAsync()
         {

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor
@@ -16,9 +16,12 @@
                 {
                     <MudIcon Icon="@Icon" Color="@IconColor" Class="@IconClassname"/>
                 }
-                <div class="mud-nav-link-text">
-                    @ChildContent
-                </div>
+                @if (!IconOnly)
+                {
+                    <div class="mud-nav-link-text">
+                        @ChildContent
+                    </div>
+                }
             </NavLink>
         }
         else
@@ -30,9 +33,12 @@
                 {
                     <MudIcon Icon="@Icon" Color="@IconColor" Class="@IconClassname" />
                 }
-                <div class="mud-nav-link-text">
-                    @ChildContent
-                </div>
+                @if (!IconOnly)
+                {
+                    <div class="mud-nav-link-text">
+                        @ChildContent
+                    </div>
+                }
             </div>
         }
     }

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -58,6 +58,13 @@ namespace MudBlazor
         [Category(CategoryTypes.NavMenu.Appearance)]
         public Color IconColor { get; set; } = Color.Default;
 
+        /// <summary>
+        /// Controls the render of the child elements, true to hide child elements
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Appearance)]
+        public bool IconOnly { get; set; } = false;
+
         [Parameter]
         [Category(CategoryTypes.NavMenu.Behavior)]
         public NavLinkMatch Match { get; set; } = NavLinkMatch.Prefix;


### PR DESCRIPTION
This PR adds a `boolean` property to the MudNavLink and MudNavGroup components that controls the conditional rendering of the child elements of MudNavLink and the Title of MudNavGroup. 

## Description
The PR adds an `if` around the `<div>` tags that wrap `@ChildContent` for MudNavLink and `@Title` for MudNavGroup controlled by the new boolean parameter for the components named `IconOnly`. 

This is to enable functionality of collapsed sidebars, common in vertical navigation pane paradigms, to save horizontal space but still allow navigation through the icons on the sidebar.

## How Has This Been Tested?
- [x] New Component Specific Unit Tests
- [x] Visually through Docs

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Examples
![Screenshot 2024-04-24 231740](https://github.com/MudBlazor/MudBlazor/assets/6509976/e25af9ef-163f-45fe-94ca-350afb75a6a8)

https://github.com/MudBlazor/MudBlazor/assets/6509976/f36cfc67-b397-4ea0-948d-d8288bdfdcf3


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
