### PR TITLE
Popover: Prevent the Popover from going outside the browser window in some situations

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -277,9 +277,9 @@ window.mudpopoverHelper = {
                 offsetY += window.scrollY
             }
 
-            // make sure the popover doesn't go outside the window
-            var leftPos = Math.max(Math.min(left + offsetX, window.innerWidth - selfRect.width), 0);
-            var topPos = Math.max(Math.min(top + offsetY, window.innerHeight - selfRect.height), 0);
+            // make sure the popover doesn't go outside the viewport
+            var leftPos = Math.max(Math.min(left + offsetX, window.scrollX + window.innerWidth - selfRect.width), window.scrollX);
+            var topPos = Math.max(Math.min(top + offsetY, window.scrollY + window.innerHeight - selfRect.height), window.scrollY);
 
             popoverContentNode.style['left'] = leftPos + 'px';
             popoverContentNode.style['top'] = topPos + 'px';

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -277,8 +277,12 @@ window.mudpopoverHelper = {
                 offsetY += window.scrollY
             }
 
-            popoverContentNode.style['left'] = (left + offsetX) + 'px';
-            popoverContentNode.style['top'] = (top + offsetY) + 'px';
+            // make sure the popover doesn't go outside the window
+            var leftPos = Math.max(Math.min(left + offsetX, window.innerWidth - selfRect.width), 0);
+            var topPos = Math.max(Math.min(top + offsetY, window.innerHeight - selfRect.height), 0);
+
+            popoverContentNode.style['left'] = leftPos + 'px';
+            popoverContentNode.style['top'] = topPos + 'px';
 
             if (window.getComputedStyle(popoverNode).getPropertyValue('z-index') != 'auto') {
                 popoverContentNode.style['z-index'] = window.getComputedStyle(popoverNode).getPropertyValue('z-index');


### PR DESCRIPTION
## Description
`popover-content` is positioned based on the parent element of the `MudPopover` component, and when this parent element is outside the browser window, the popup also goes outside the window and is partially visible or not visible at all, this seems to be a common occurrence in `MudDataGrid`'s simple filter popover when the grid has a scroll.

This behavior can be viewed here: https://try.mudblazor.com/snippet/cOGeEScJpoYZVWLx
This commit attempts to fix the issue by preventing the popover from going outside the window.
It potentially fixes these issues: Fixes #8180, fixes #8173, fixes #7032, fixes #7707

This video shows how it currently is: https://github.com/MudBlazor/MudBlazor/assets/5804803/803e4884-a5b0-4452-ae4c-afe2552c3ed8
This one shows how it will behave after the change: https://github.com/MudBlazor/MudBlazor/assets/5804803/5f30914b-9bd0-4680-a603-246639298a47


## How Has This Been Tested?
This change has been tested visually, I made a component out of the TryMudBlazor snippet and tested manually.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
