### PR TITLE
MudDataGrid: Add support for MudPagination

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -519,6 +519,20 @@ namespace MudBlazor.UnitTests.Components
             // navigate back to the first page programmatically
             await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(Page.First));
             dataGrid.Instance.CurrentPage.Should().Be(0);
+
+            // Test MudPagination int base NavigateTo
+            int pagecount = (int)Math.Ceiling((double)(dataGrid.Instance.Items.Count() / dataGrid.Instance.RowsPerPage));
+            // navigate to the last page programmatically
+            await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(pagecount - 1));
+            dataGrid.Instance.CurrentPage.Should().Be(4);
+
+            // navigate to the previous page programmatically
+            await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(dataGrid.Instance.CurrentPage - 1));
+            dataGrid.Instance.CurrentPage.Should().Be(3);
+
+            // navigate back to the first page programmatically
+            await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(0));
+            dataGrid.Instance.CurrentPage.Should().Be(0);
         }
 
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1191,6 +1191,17 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Navigates to a specific page when the data grid has an attached MudPagination component.
+        /// </summary>
+        /// <param name="pageIndex">Index of the page to navigate to.</param>
+        public void NavigateTo(int pageIndex)
+        {
+            CurrentPage = Math.Min(Math.Max(0, pageIndex), numPages - 1);
+
+            GroupItems();
+        }
+
+        /// <summary>
         /// Sets the rows displayed per page when the data grid has an attached data pager.
         /// </summary>
         /// <param name="size">The page size.</param>


### PR DESCRIPTION
## Description
MudDataGrid only had a Page (last, next, first,...) based NavigateTo method. Added a int based NavigateTo method so the MudPagination component can be used with the MudDataGrid component. Inspired by the MudTableBase.cs version. Resolves #8819 

## How Has This Been Tested?
Visually tested with docs project, and added unit tests.

Used this code:
```
<MudDataGrid @ref="@_table" Items="@Elements.Take(40)">
    <Columns>
        <PropertyColumn Property="x => x.Number" Title="Nr" />
        <PropertyColumn Property="x => x.Sign" />
        <PropertyColumn Property="x => x.Name" />
        <PropertyColumn Property="x => x.Position" />
        <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
    </Columns>
  <PagerContent>
    <MudPagination SelectedChanged="PageChanged" Count="@((_table.GetFilteredItemsCount() + _table.RowsPerPage - 1) / _table.RowsPerPage)" Class="pa-4" />
  </PagerContent>
</MudDataGrid>

@code { 
  private MudDataGrid<Element> _table;

    private IEnumerable<Element> Elements = new List<Element>();

    protected override async Task OnInitializedAsync()
    {
        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
    }

  private void PageChanged(int i)
  {
    _table.NavigateTo(i - 1);
  }
}
```

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![MudDataGridMudPagination](https://github.com/MudBlazor/MudBlazor/assets/22691956/e030014c-6ffd-49e5-b543-c08934c2bce7)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
