### PR TITLE
MudColor: Make H, S, L readonly

### DIFF
--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -84,19 +84,19 @@ namespace MudBlazor.Utilities
         /// Gets the hue component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double H { get; private set; }
+        public double H { get; private init; }
 
         /// <summary>
         /// Gets the luminance component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double L { get; private set; }
+        public double L { get; private init; }
 
         /// <summary>
         /// Gets the saturation component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double S { get; private set; }
+        public double S { get; private init; }
 
         /// <summary>
         /// Deserialization constructor for <see cref="MudColor"/>.
@@ -215,7 +215,10 @@ namespace MudBlazor.Utilities
             _valuesAsByte[2] = b;
             _valuesAsByte[3] = a;
 
-            CalculateHsl();
+            var (h, s, l) = CalculateHsl();
+            H = h;
+            S = s;
+            L = l;
         }
 
         /// <summary>
@@ -279,7 +282,7 @@ namespace MudBlazor.Utilities
                     throw new ArgumentException("Invalid color format.");
                 }
 
-                _valuesAsByte = new byte[]
+                _valuesAsByte = new[]
                 {
                     byte.Parse(parts[0], CultureInfo.InvariantCulture),
                     byte.Parse(parts[1], CultureInfo.InvariantCulture),
@@ -295,11 +298,12 @@ namespace MudBlazor.Utilities
                     throw new ArgumentException("Invalid color format.");
                 }
 
-                _valuesAsByte = new byte[]
+                _valuesAsByte = new[]
                 {
                     byte.Parse(parts[0], CultureInfo.InvariantCulture),
                     byte.Parse(parts[1], CultureInfo.InvariantCulture),
-                    byte.Parse(parts[2], CultureInfo.InvariantCulture), 255
+                    byte.Parse(parts[2], CultureInfo.InvariantCulture),
+                    byte.MaxValue
                 };
             }
             else
@@ -327,7 +331,7 @@ namespace MudBlazor.Utilities
                         throw new ArgumentException(@"Not a valid color.", nameof(value));
                 }
 
-                _valuesAsByte = new byte[]
+                _valuesAsByte = new[]
                 {
                     GetByteFromValuePart(value,0),
                     GetByteFromValuePart(value,2),
@@ -336,7 +340,10 @@ namespace MudBlazor.Utilities
                 };
             }
 
-            CalculateHsl();
+            var (h, s, l) = CalculateHsl();
+            H = h;
+            S = s;
+            L = l;
         }
 
         /// <summary>
@@ -531,7 +538,7 @@ namespace MudBlazor.Utilities
         /// <returns>The string representation of the color.</returns>
         public static explicit operator string(MudColor? color) => color == null ? string.Empty : color.Value;
 
-        private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new char[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
+        private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 
         private static string[] SplitInputIntoParts(string value)
         {
@@ -547,7 +554,7 @@ namespace MudBlazor.Utilities
             return parts;
         }
 
-        private void CalculateHsl()
+        private (double h, double s, double j) CalculateHsl()
         {
             var h = 0D;
             var s = 0D;
@@ -599,9 +606,7 @@ namespace MudBlazor.Utilities
                 s = (max - min) / (2D - (max + min)); //(max-min > 0)?
             }
 
-            H = Math.Round(h.EnsureRange(360), 0);
-            S = Math.Round(s.EnsureRange(1), 2);
-            L = Math.Round(l.EnsureRange(1), 2);
+            return (Math.Round(h.EnsureRange(360), 0), Math.Round(s.EnsureRange(1), 2), Math.Round(l.EnsureRange(1), 2));
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -84,19 +84,19 @@ namespace MudBlazor.Utilities
         /// Gets the hue component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double H { get; private init; }
+        public double H { get; }
 
         /// <summary>
         /// Gets the luminance component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double L { get; private init; }
+        public double L { get; }
 
         /// <summary>
         /// Gets the saturation component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double S { get; private init; }
+        public double S { get; }
 
         /// <summary>
         /// Deserialization constructor for <see cref="MudColor"/>.
@@ -554,7 +554,7 @@ namespace MudBlazor.Utilities
             return parts;
         }
 
-        private (double h, double s, double j) CalculateHsl()
+        private (double h, double s, double l) CalculateHsl()
         {
             var h = 0D;
             var s = 0D;


### PR DESCRIPTION
## Description
Just small improvement that makes MudColor truly safe immutable,
Before you could accidentally change HSL values because of `private set`, now they are protected against unexpected modifications.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
