### PR TITLE
Standardise the use of `Checked`, `CheckedChanged` and `Checkable`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
@@ -24,7 +24,7 @@
             <MudTh colspan="2">Basic</MudTh>
             <MudTh colspan="3">Extended</MudTh>
         </MudTHeadRow>
-        <MudTHeadRow IsCheckable="true">
+        <MudTHeadRow Checkable="true">
             <MudTh>Nr</MudTh> 
             <MudTh>Sign</MudTh>
             <MudTh>Name</MudTh>
@@ -47,7 +47,7 @@
             <MudTd>Position</MudTd>
             <MudTd>Molar mass</MudTd>
         </MudTFootRow>
-        <MudTFootRow IsCheckable="true">
+        <MudTFootRow Checkable="true">
             <MudTd colspan="5">Selected: @selectedItems.Count</MudTd>
         </MudTFootRow>
     </FooterContent>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -194,7 +194,7 @@
                     If you need to customize the behavior, as well as rendering multiple header or footer rows, you can set the <CodeInline>CustomHeader</CodeInline> and <CodeInline>CustomFooter</CodeInline> attributes to true.<br />
                     Then setting a list of <CodeInline>&lt;MudTHeadRow></CodeInline> or <CodeInline>&lt;MudTFootRow></CodeInline> with their respective cells will render exactly what's required inside the table header and footer.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                        Note: Unless you specify the attribute <CodeInline>IsCheckable</CodeInline> for a specific row, MudTable won't render a checkbox in case of a multi-selection table.
+                        Note: Unless you specify the attribute <CodeInline>@nameof(MudTr.Checkable)</CodeInline> for a specific row, MudTable won't render a checkbox in case of a multi-selection table.
                         Attributes <CodeInline>IgnoreCheckbox</CodeInline> and <CodeInline>IgnoreEditable</CodeInline> won't render an empty cell either, requiring you to do it manually (for example for a colspan on the entire row).
                     </MudAlert>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomCheckboxExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomCheckboxExample.razor
@@ -7,7 +7,7 @@
 		  <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.TreeItems">
 			  <Content>
 				  <MudTreeViewItemToggleButton @bind-Expanded="@context.Expanded" Visible="@context.HasChild" />
-				  <MudCheckBox T="bool?" Value="@(context.HasPartialChildSelection() ? null : context.IsChecked)" ValueChanged="@((e) => CheckedChanged(context))"></MudCheckBox>
+				  <MudCheckBox T="bool?" Value="@(context.HasPartialChildSelection() ? null : context.Checked)" ValueChanged="@((e) => CheckedChanged(context))"></MudCheckBox>
 				  <MudText>@context.Text</MudText>
 			  </Content>
 		  </MudTreeViewItem>
@@ -27,7 +27,7 @@
 
         public bool Expanded { get; set; } = false;
 
-        public bool IsChecked { get; set; } = false;
+        public bool Checked { get; set; } = false;
 
         public bool HasChild => TreeItems != null && TreeItems.Count > 0;
 
@@ -46,7 +46,7 @@
 
         public bool HasPartialChildSelection()
         {
-            int iChildrenCheckedCount = (from c in TreeItems where c.IsChecked select c).Count();
+            int iChildrenCheckedCount = (from c in TreeItems where c.Checked select c).Count();
             return HasChild && iChildrenCheckedCount > 0 && iChildrenCheckedCount < TreeItems.Count();
         }
 
@@ -56,25 +56,25 @@
         public bool? GetChecked()
         {
             if (TreeItems.Count == 0)
-                return IsChecked;
+                return Checked;
             if (HasPartialChildSelection())
                 return null;
-            return IsChecked = TreeItems.All(x => x.IsChecked);
+            return Checked = TreeItems.All(x => x.Checked);
         }
     }
 
     protected void CheckedChanged(TreeItemData item)
     {
-        item.IsChecked = !item.IsChecked;
-        // checked status on any child items should mirrror this parent item
+        item.Checked = !item.Checked;
+        // checked status on any child items should mirror this parent item
         if (item.HasChild) {
             foreach (TreeItemData child in item.TreeItems) {
-                child.IsChecked = item.IsChecked;
+                child.Checked = item.Checked;
             }
         }
         // if there's a parent and all children are checked/unchecked, parent should match
         if (item.Parent != null) {
-            item.Parent.IsChecked = item.Parent.TreeItems.All(i => i.IsChecked);
+            item.Parent.Checked = item.Parent.TreeItems.All(i => i.Checked);
         }
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
@@ -3,7 +3,7 @@
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" CustomHeader="true">
     <HeaderContent>
-        <MudTHeadRow IsCheckable="true">
+        <MudTHeadRow Checkable="true">
             <MudTh>#</MudTh>
         </MudTHeadRow>
     </HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
@@ -9,7 +9,7 @@
         <MudTd>@context</MudTd>
     </RowTemplate>
     <FooterContent>
-        <MudTFootRow IsCheckable="true">
+        <MudTFootRow Checkable="true">
             <MudTd>F</MudTd>
         </MudTFootRow>
     </FooterContent>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -647,16 +647,16 @@ namespace MudBlazor.UnitTests.Components
             var mudTable = comp.Instance.MudTable;
 
             // All row checkbox states must be false.
-            mudTable.Context.Rows.Count(r => r.Value.IsChecked).Should().Be(0);
+            mudTable.Context.Rows.Count(r => r.Value.Checked).Should().Be(0);
 
             // All grouprow checkbox states must be false.
-            mudTable.Context.GroupRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(14);
+            mudTable.Context.GroupRows.Count(r => r.Checked.HasValue && !r.Checked.Value).Should().Be(14);
 
             // The headerrow checkbox state must be false.
-            mudTable.Context.HeaderRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(1);
+            mudTable.Context.HeaderRows.Count(r => r.Checked.HasValue && !r.Checked.Value).Should().Be(1);
 
             // The footerrow checkbox state must be false.
-            mudTable.Context.FooterRows.Count(r => r.IsChecked.HasValue && !r.IsChecked.Value).Should().Be(0);
+            mudTable.Context.FooterRows.Count(r => r.Checked.HasValue && !r.Checked.Value).Should().Be(0);
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -327,6 +327,9 @@ namespace MudBlazor
                         case "InitiallyExpanded":
                         case "RightAlignSmall":
                         case "IsExpandable":
+                        case "IsChecked":
+                        case "IsCheckable":
+                        case "IsCheckedChanged":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor
@@ -10,7 +10,7 @@
 else
 {
     <span class="@ClassName" style="@Style" @onmouseover="HandleMouseOver" @onclick="HandleClick" @onmouseout="HandleMouseOut ">
-        <input class="mud-rating-input" type="radio" tabindex="-1" value="@ItemValue" name="@Rating?.Name" disabled="@Disabled" checked="@(IsChecked)" @attributes="UserAttributes" />
+        <input class="mud-rating-input" type="radio" tabindex="-1" value="@ItemValue" name="@Rating?.Name" disabled="@Disabled" checked="@(Checked)" @attributes="UserAttributes" />
         <MudIcon Icon="@ItemIcon" Size="@Size"></MudIcon>
     </span>
 }

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -78,7 +78,7 @@ namespace MudBlazor
 
         internal bool IsActive { get; set; }
 
-        private bool IsChecked => ItemValue == Rating?.SelectedValue;
+        private bool Checked => ItemValue == Rating?.SelectedValue;
 
         protected override void OnParametersSet()
         {

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor
@@ -14,9 +14,9 @@
             {
                 <div class="ml-4 mr-5"></div>
             }
-            @if (IsCheckable)
+            @if (Checkable)
             {
-                <MudCheckBox @bind-Value="IsChecked" Class="mud-table-cell-checkbox"/>
+                <MudCheckBox @bind-Value="Checked" Class="mud-table-cell-checkbox"/>
             }
         </MudTd>
     }
@@ -26,5 +26,3 @@
 		<MudTh />
 	}
 </tr>
-
-

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         /// <summary>
         /// Add a multi-select checkbox that will select/unselect every item in the table
         /// </summary>
-        [Parameter] public bool IsCheckable { get; set; }
+        [Parameter] public bool Checkable { get; set; }
 
         /// <summary>
         /// Specify behavior in case the table is multi-select mode. If set to <c>true</c>, it won't render an additional empty column.
@@ -37,7 +37,7 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
         private bool? _checked = false;
-        public bool? IsChecked
+        public bool? Checked
         {
             get => _checked;
             set
@@ -45,7 +45,7 @@ namespace MudBlazor
                 if (value != _checked)
                 {
                     _checked = value;
-                    if (IsCheckable)
+                    if (Checkable)
                         Context.Table.OnHeaderCheckboxClicked(_checked.HasValue && _checked.Value);
                 }
             }
@@ -67,11 +67,11 @@ namespace MudBlazor
             if (_checked != checkedState)
             {
                 if (notify)
-                    IsChecked = checkedState;
+                    Checked = checkedState;
                 else
                 {
                     _checked = checkedState;
-                    if (IsCheckable)
+                    if (Checkable)
                         InvokeAsync(StateHasChanged);
                 }
             }

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor
@@ -3,12 +3,10 @@
 @inherits MudComponentBase
 
 <tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
-
 	@if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditbuttonAtStart(IgnoreEditable))
 	{
 		<MudTh />
 	}
-
 	@if (Expandable || ((Context?.Table.MultiSelection ?? false) && !IgnoreCheckbox))
 	{
 		<MudTh>
@@ -16,9 +14,9 @@
 			{
 				<div class="ml-4 mr-5"></div>
 			}
-			@if (IsCheckable)
+			@if (Checkable)
 			{
-				<MudCheckBox @bind-Value="IsChecked" Class="mud-table-cell-checkbox" />
+				<MudCheckBox @bind-Value="Checked" Class="mud-table-cell-checkbox" />
 			}
 		</MudTh>
 	}

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         /// <summary>
         /// Add a multi-select checkbox that will select/unselect every item in the table
         /// </summary>
-        [Parameter] public bool IsCheckable { get; set; }
+        [Parameter] public bool Checkable { get; set; }
 
         /// <summary>
         /// Specify behavior in case the table is multi-select mode. If set to <c>true</c>, it won't render an additional empty column.
@@ -37,7 +37,7 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
         private bool? _checked = false;
-        public bool? IsChecked
+        public bool? Checked
         {
             get => _checked;
             set
@@ -45,7 +45,7 @@ namespace MudBlazor
                 if (value != _checked)
                 {
                     _checked = value;
-                    if (IsCheckable)
+                    if (Checkable)
                         Context.Table.OnHeaderCheckboxClicked(_checked.HasValue && _checked.Value);
                 }
             }
@@ -67,11 +67,11 @@ namespace MudBlazor
             if (_checked != checkedState)
             {
                 if (notify)
-                    IsChecked = checkedState;
+                    Checked = checkedState;
                 else
                 {
                     _checked = checkedState;
-                    if (IsCheckable)
+                    if (Checkable)
                         InvokeAsync(StateHasChanged);
                 }
             }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -47,7 +47,7 @@
                         }
                         else
                         {
-                            <MudTHeadRow IsCheckable="MultiSelection" Expandable="@(GroupBy?.Expandable ?? false)">
+                            <MudTHeadRow Checkable="MultiSelection" Expandable="@(GroupBy?.Expandable ?? false)">
                                 @if (HeaderContent != null)
                                 {
                                     @HeaderContent
@@ -86,7 +86,7 @@
                     {
                         @foreach (var group in GroupItemsPage)
                         {
-                            <MudTableGroupRow GroupDefinition="GroupBy" Items="group" IsCheckable="MultiSelection" 
+                            <MudTableGroupRow GroupDefinition="GroupBy" Items="group" Checkable="MultiSelection" 
                                               HeaderClass="@GroupHeaderClass" HeaderStyle="@GroupHeaderStyle" 
                                               FooterClass="@GroupFooterClass" FooterStyle="@GroupFooterStyle"
                                               HeaderTemplate="@GroupHeaderTemplate" FooterTemplate="@GroupFooterTemplate" T="T"  />
@@ -100,9 +100,9 @@
                                 <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
-                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable"
-                                      IsChecked="@(IsCheckedRow(item))"
-                                      IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" IsEditable="IsEditable"
+                                      Checked="@(IsCheckedRow(item))"
+                                      CheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                                    @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                                    {
@@ -170,7 +170,7 @@
                         }
                         else
                         {
-                            <MudTFootRow IsCheckable="MultiSelection" Expandable="@(GroupBy?.Expandable ?? false)">
+                            <MudTFootRow Checkable="MultiSelection" Expandable="@(GroupBy?.Expandable ?? false)">
                                 @if (@FooterContent != null)
                                 {
                                     @FooterContent
@@ -215,8 +215,8 @@
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
              } 
-             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="IsEditable" Expandable="expandable"
-                        IsChecked="Context.Selection.Contains(item)" IsCheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" IsEditable="IsEditable" Expandable="expandable"
+                        Checked="Context.Selection.Contains(item)" CheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
                     @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
                     {

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -22,9 +22,9 @@
                         <div style="@ActionsStylename"></div>
                     }
                 }
-                @if (IsCheckable)
+                @if (Checkable)
                 {
-                    <MudCheckBox T="bool?" @bind-Value="IsChecked" Class="mud-table-cell-checkbox"/>
+                    <MudCheckBox T="bool?" @bind-Value="Checked" Class="mud-table-cell-checkbox"/>
                 }
             </div>
         </MudTd>
@@ -50,7 +50,7 @@ else
     {
         @foreach (var group in _innerGroupItems)
         {
-            <MudTableGroupRow GroupDefinition="GroupDefinition.InnerGroup" Items="@group" IsCheckable="@IsCheckable"
+            <MudTableGroupRow GroupDefinition="GroupDefinition.InnerGroup" Items="@group" Checkable="@Checkable"
                               HeaderClass="@HeaderClass" HeaderStyle="@HeaderStyle"
                               FooterClass="@FooterClass" FooterStyle="@FooterStyle"
                               HeaderTemplate="@HeaderTemplate" FooterTemplate="@FooterTemplate" T="T" @attributes="@UserAttributes" />

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -58,7 +58,7 @@ namespace MudBlazor
         /// <summary>
         /// Add a multi-select checkbox that will select/unselect every item in the table
         /// </summary>
-        [Parameter] public bool IsCheckable { get; set; }
+        [Parameter] public bool Checkable { get; set; }
 
         [Parameter] public string HeaderClass { get; set; }
         [Parameter] public string FooterClass { get; set; }
@@ -82,7 +82,7 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
 
         private bool? _checked = false;
-        public bool? IsChecked
+        public bool? Checked
         {
             get => _checked;
             set
@@ -90,7 +90,7 @@ namespace MudBlazor
                 if (value != _checked)
                 {
                     _checked = value;
-                    if (IsCheckable)
+                    if (Checkable)
                         Table.OnGroupHeaderCheckboxClicked(_checked.HasValue && _checked.Value, Items.ToList());
                 }
             }
@@ -127,11 +127,11 @@ namespace MudBlazor
             if (_checked != checkedState)
             {
                 if (notify)
-                    IsChecked = checkedState;
+                    Checked = checkedState;
                 else
                 {
                     _checked = checkedState;
-                    if (IsCheckable)
+                    if (Checkable)
                         InvokeAsync(StateHasChanged);
                 }
             }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -34,13 +34,13 @@
             }
         </MudTd>
     }
-    @if (Expandable || IsCheckable)
+    @if (Expandable || Checkable)
     {
         <MudElement HtmlTag="@("Td")" Class="mud-table-cell">
             <div class="d-flex" style="@ActionsStylename">
-                @if (IsCheckable)
+                @if (Checkable)
                 {
-                    <MudCheckBox @bind-Value="IsChecked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
+                    <MudCheckBox @bind-Value="Checked" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
                 }
             </div>
         </MudElement>

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
 
         [Parameter] public object Item { get; set; }
 
-        [Parameter] public bool IsCheckable { get; set; }
+        [Parameter] public bool Checkable { get; set; }
 
         [Parameter] public bool IsEditable { get; set; }
 
@@ -39,11 +39,11 @@ namespace MudBlazor
 
 
         [Parameter]
-        public EventCallback<bool> IsCheckedChanged { get; set; }
+        public EventCallback<bool> CheckedChanged { get; set; }
 
         private bool _checked;
         [Parameter]
-        public bool IsChecked
+        public bool Checked
         {
             get => _checked;
             set
@@ -51,7 +51,7 @@ namespace MudBlazor
                 if (value != _checked)
                 {
                     _checked = value;
-                    IsCheckedChanged.InvokeAsync(value);
+                    CheckedChanged.InvokeAsync(value);
                 }
             }
         }
@@ -64,7 +64,7 @@ namespace MudBlazor
             table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
             if (table.MultiSelection && table.SelectOnRowClick && !table.IsEditable)
-                IsChecked = !IsChecked;
+                Checked = !Checked;
             await table.FireRowClickEventAsync(args, this, Item);
         }
 
@@ -164,11 +164,11 @@ namespace MudBlazor
             if (_checked != checkedState)
             {
                 if (notify)
-                    IsChecked = checkedState;
+                    Checked = checkedState;
                 else
                 {
                     _checked = checkedState;
-                    if (IsCheckable)
+                    if (Checkable)
                         InvokeAsync(StateHasChanged);
                 }
             }


### PR DESCRIPTION
MudBlazor currently uses the `Checked` and `IsChecked` properties. This PR aims to standardise the use of `Checked`, `CheckedChanged` and `Checkable`.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudRatingItem**: replace `IsChecked` with `Checked`
**MudTableGroupRow**: replace `IsCheckable` with `Checkable`
**MudTableGroupRow**: replace `IsChecked` with `Checked`
**MudTFootRow**: replace `IsCheckable` with `Checkable`
**MudTFootRow**: replace `IsChecked` with `Checked`
**MudTHeadRow**: replace `IsCheckable` with `Checkable`
**MudTHeadRow**: replace `IsChecked` with `Checked`
**MudTr**: replace `IsCheckable` with `Checkable`
**MudTr**: replace `IsCheckedChanged` with `CheckedChanged`
**MudTr**: replace `IsChecked` with `Checked`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
