### PR TITLE
MudCheckBox/MudChip/MudChipSet/MudCollapse: Added XML Documentation for Public Members

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/colorpicker"
 
 <DocsPage>
-    <DocsPageHeader Title="Color Picker" SubTitle="A short description of the component." />
+    <DocsPageHeader Title="Color Picker" SubTitle="A sophisticated and customizable pop-up for choosing a color." />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -28,7 +28,7 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
-        /// Gets or sets a value indicating whether the appbar will be placed at the bottom of the screen instead of the top.
+        /// Gets or sets whether the appbar will be placed at the bottom of the screen instead of the top.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AppBar.Behavior)]
@@ -45,7 +45,7 @@ namespace MudBlazor
         public int Elevation { set; get; } = 4;
 
         /// <summary>
-        /// Gets or sets a value indicating whether compact padding will be used.
+        /// Gets or sets whether compact padding will be used.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -55,7 +55,7 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether left and right padding is added to the appbar.
+        /// Gets or sets whether left and right padding is added to the appbar.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -75,7 +75,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the appbar remains in the same place when the page is scrolled.
+        /// Gets or sets whether the appbar remains in the same place when the page is scrolled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -85,7 +85,7 @@ namespace MudBlazor
         public bool Fixed { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the appbar content is allowed to wrap.
+        /// Gets or sets whether the appbar content is allowed to wrap.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -8,6 +8,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+    /// <summary>
+    /// Represents a form input for boolean values or selecting multiple items in a list.
+    /// </summary>
+    /// <typeparam name="T">The type of item managed by this checkbox.</typeparam>
     public partial class MudCheckBox<T> : MudBooleanInput<T>
     {
         private IKeyInterceptor? _keyInterceptor;
@@ -16,118 +20,151 @@ namespace MudBlazor
         [Inject]
         private IKeyInterceptorFactory KeyInterceptorFactory { get; set; } = null!;
 
-        protected string Classname =>
-            new CssBuilder("mud-input-control-boolean-input")
-                .AddClass(Class)
-                .Build();
+        protected string Classname => new CssBuilder("mud-input-control-boolean-input")
+            .AddClass(Class)
+            .Build();
 
-        protected string LabelClassname =>
-            new CssBuilder("mud-checkbox")
-                .AddClass($"mud-disabled", GetDisabledState())
-                .AddClass($"mud-readonly", GetReadOnlyState())
-                .AddClass("flex-row-reverse", LabelPosition == LabelPosition.Start)
-                .Build();
+        protected string LabelClassname => new CssBuilder("mud-checkbox")
+            .AddClass($"mud-disabled", GetDisabledState())
+            .AddClass($"mud-readonly", GetReadOnlyState())
+            .AddClass("flex-row-reverse", LabelPosition == LabelPosition.Start)
+            .Build();
 
-        protected string CheckBoxClassname =>
-            new CssBuilder("mud-button-root mud-icon-button")
-                .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor == null || (UncheckedColor != null && BoolValue == true))
-                .AddClass($"mud-{UncheckedColor?.ToDescriptionString()}-text hover:mud-{UncheckedColor?.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
-                .AddClass($"mud-checkbox-dense", Dense)
-                .AddClass($"mud-ripple mud-ripple-checkbox", Ripple && !GetReadOnlyState() && !GetDisabledState())
-                .AddClass($"mud-disabled", GetDisabledState())
-                .AddClass($"mud-readonly", GetReadOnlyState())
-                .AddClass($"mud-checkbox-true", BoolValue == true)
-                .AddClass($"mud-checkbox-false", BoolValue == false)
-                .AddClass($"mud-checkbox-null", BoolValue is null)
-                .Build();
+        protected string CheckBoxClassname => new CssBuilder("mud-button-root mud-icon-button")
+            .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor == null || (UncheckedColor != null && BoolValue == true))
+            .AddClass($"mud-{UncheckedColor?.ToDescriptionString()}-text hover:mud-{UncheckedColor?.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
+            .AddClass($"mud-checkbox-dense", Dense)
+            .AddClass($"mud-ripple mud-ripple-checkbox", Ripple && !GetReadOnlyState() && !GetDisabledState())
+            .AddClass($"mud-disabled", GetDisabledState())
+            .AddClass($"mud-readonly", GetReadOnlyState())
+            .AddClass($"mud-checkbox-true", BoolValue == true)
+            .AddClass($"mud-checkbox-false", BoolValue == false)
+            .AddClass($"mud-checkbox-null", BoolValue is null)
+            .Build();
 
         /// <summary>
-        /// The color of the component. It supports the theme colors.
+        /// Gets or sets the color of the checkbox.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The base color of the component in its none active/unchecked state. It supports the theme colors.
+        /// Gets or sets the color of the checkbox when its <c>Value</c> is <c>false</c> or <c>null</c>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Theme colors are supported.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public Color? UncheckedColor { get; set; } = null;
 
         /// <summary>
-        /// The text/label will be displayed next to the checkbox if set.
+        /// Gets or sets the text to display next to the checkbox.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string? Label { get; set; }
 
         /// <summary>
-        /// The position of the text/label.
+        /// Gets or sets the position of the <see cref="Label" /> text.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="LabelPosition.End"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public LabelPosition LabelPosition { get; set; } = LabelPosition.End;
 
         /// <summary>
-        /// If true, the checkbox can be controlled with the keyboard.
+        /// Gets or sets whether the checkbox can be controlled with the keyboard.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.  The <c>Space</c> key cycles through true and false values (or true/false/null states if <see cref="TriState"/> is <c>true</c>). <c>Delete</c> will clear the checkbox. <c>Enter</c> (or <c>NumPadEnter</c>) will set the checkbox.  <c>Backspace</c> will set an indeterminate value.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool KeyboardEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to show a ripple effect when the user clicks the button. Default is true.
+        /// Gets or sets whether a ripple effect is shown whhen the checkbox is clicked.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool Ripple { get; set; } = true;
 
         /// <summary>
-        /// If true, compact padding will be applied.
+        /// Gets or sets whether compact padding will be used.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool Dense { get; set; }
 
         /// <summary>
-        /// The Size of the component.
+        /// Gets or sets the size of the checkbox.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Child content of component.
+        /// Gets or sets any child content for the component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Custom checked icon, leave null for default.
+        /// Gets or sets the icon to display for a checked state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.CheckBox"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public string CheckedIcon { get; set; } = Icons.Material.Filled.CheckBox;
 
         /// <summary>
-        /// Custom unchecked icon, leave null for default.
+        /// Gets or sets the icon to display for an unchecked state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.CheckBoxOutlineBlank"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public string UncheckedIcon { get; set; } = Icons.Material.Filled.CheckBoxOutlineBlank;
 
         /// <summary>
-        /// Custom indeterminate icon, leave null for default.
+        /// Gets or sets the icon to display for an indeterminate state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.IndeterminateCheckBox"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public string IndeterminateIcon { get; set; } = Icons.Material.Filled.IndeterminateCheckBox;
 
         /// <summary>
-        /// Define if the checkbox can cycle again through indeterminate status.
+        /// Gets or sets whether the checkbox can cycle to an indeterminate state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the checkbox can support an indeterminate state such as a <c>null</c> value, in addition to <c>true</c> and <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool TriState { get; set; }

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -8,6 +8,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// Represents a compact element used to enter information, select a choice, filter content, or trigger an action.
+/// </summary>
+/// <typeparam name="T">The type of item managed by this component.</typeparam>
 public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 {
     public MudChip()
@@ -34,24 +39,29 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 
     internal readonly ParameterState<bool> IsSelectedState;
 
+    /// <summary>
+    /// Gets or sets the service used to navigate the browser to another URL.
+    /// </summary>
     [Inject]
     public NavigationManager? UriHelper { get; set; }
 
+    /// <summary>
+    /// Gets or sets the service used to perform browser actions such as navigation.
+    /// </summary>
     [Inject]
     public IJsApiService? JsApiService { get; set; }
 
-    protected string Classname =>
-        new CssBuilder("mud-chip")
-            .AddClass($"mud-chip-{GetVariant().ToDescriptionString()}")
-            .AddClass($"mud-chip-size-{GetSize().ToDescriptionString()}")
-            .AddClass($"mud-chip-color-{GetColor().ToDescriptionString()}")
-            .AddClass("mud-clickable", IsClickable)
-            .AddClass("mud-ripple", IsClickable && GetRipple())
-            .AddClass("mud-chip-label", GetLabel())
-            .AddClass("mud-disabled", GetDisabled())
-            .AddClass("mud-chip-selected", IsSelectedState.Value)
-            .AddClass(Class)
-            .Build();
+    protected string Classname => new CssBuilder("mud-chip")
+        .AddClass($"mud-chip-{GetVariant().ToDescriptionString()}")
+        .AddClass($"mud-chip-size-{GetSize().ToDescriptionString()}")
+        .AddClass($"mud-chip-color-{GetColor().ToDescriptionString()}")
+        .AddClass("mud-clickable", IsClickable)
+        .AddClass("mud-ripple", IsClickable && GetRipple())
+        .AddClass("mud-chip-label", GetLabel())
+        .AddClass("mud-disabled", GetDisabled())
+        .AddClass("mud-chip-selected", IsSelectedState.Value)
+        .AddClass(Class)
+        .Build();
 
     private bool IsClickable => !ChipSet?.ReadOnly ?? (OnClick.HasDelegate || !string.IsNullOrEmpty(Href));
 
@@ -98,8 +108,11 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     private MudChipSet<T>? ChipSet { get; set; }
 
     /// <summary>
-    /// The chip color when not selected.
+    /// Gets or sets the color of this chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  When <see cref="SelectedColor"/> is set, this color is used when the chip is unselected.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color? Color { get; set; }
@@ -107,151 +120,203 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// The chip color to use when selected, only works together with ChipSet, Color.Inherit for default value.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  When set, this color is used for a selected chip, otherwise <see cref="Color"/> is used.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color? SelectedColor { get; set; }
 
     /// <summary>
-    /// The chip size.
+    /// Gets or sets the size of the chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Size? Size { get; set; }
 
     /// <summary>
-    /// The chip variant.
+    /// Gets or sets the display variation to use.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Variant? Variant { get; set; }
 
+    /// <summary>
+    /// Gets or sets any avatar content to display inside the chip.
+    /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public RenderFragment? AvatarContent { get; set; }
 
     /// <summary>
-    /// Removes circle edges and applies theme default.
+    /// Gets or sets whether the theme border radius is used for the chip edges.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  When <c>true</c>, the <see cref="LayoutProperties.DefaultBorderRadius"/> is used for chip edges.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public bool? Label { get; set; }
 
     /// <summary>
-    /// If true, the chip will be visibly disabled and interaction is disabled as well.
-    /// Note, if the ChipSet is disabled this setting is overruled.
+    /// Gets or sets whether the user cannot interact with this chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>true</c>, the chip is visibly disabled and interaction is not allowed.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Sets the Icon to use.
+    /// Gets or sets the icon to display within the chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Use the <see cref="IconColor"/> to control the color of this icon.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public string? Icon { get; set; }
 
     /// <summary>
-    /// Custom checked icon.
+    /// Gets or sets the icon to display when <see cref="IsSelected"/> is <c>true</c>.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public string? CheckedIcon { get; set; }
 
     /// <summary>
-    /// The color of the icon.
+    /// Gets or sets the color of the <see cref="Icon"/>.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color? IconColor { get; set; }
 
     /// <summary>
-    /// Overrides the default close icon, only shown if OnClose is set.
+    /// Gets or sets the close icon to display when <see cref="OnClose"/> is set.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public string? CloseIcon { get; set; }
 
     /// <summary>
-    /// If true, a ripple effect is applied to clickable chips.
+    /// Gets or sets whether a ripple effect is show when the chip is clicked.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public bool? Ripple { get; set; }
 
     /// <summary>
-    /// Child content of component.
+    /// Gets or sets any custom content within this chip.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// If set to a URL, clicking the button will open the referenced document. Use Target to specify where
+    /// Gets or sets the URL to navigate to when the chip is clicked.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Use <see cref="Target"/> to control where the URL is opened.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.ClickAction)]
     public string? Href { get; set; }
 
     /// <summary>
-    /// The target attribute specifies where to open the link, if Href is specified. Possible values: _blank | _self | _parent | _top | <i>framename</i>
+    /// Gets or sets the target to open URLs if <see cref="Href"/> is set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  This value is typically <c>_blank</c>, <c>_self</c>, <c>_parent</c>, <c>_top</c>, or the name of an <c>iframe</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.ClickAction)]
     public string? Target { get; set; }
 
     /// <summary>
-    /// A string you want to associate with the chip. If the ChildContent is not set this will be shown as chip text.
+    /// Gets or sets the text label for the chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  This will be shown so long as <see cref="ChildContent"/> is not set.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public string? Text { get; set; }
 
     /// <summary>
-    /// A value that should be managed in the SelectedValues collection.
-    /// Note: do not change the value during the chip's lifetime
+    /// Gets or sets the value applied when the chip is selected.
     /// </summary>
+    /// <remarks>
+    /// When part of a <see cref="MudChipSet{T}"/>, the <see cref="MudChipSet{T}.SelectedValue"/> is set to this value when the chip is selected.  Once set, the value should not change.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public T? Value { get; set; }
 
     /// <summary>
-    /// This concerns only chips with Href set to a hyperlink. If ForceLoad is true, the browser will follow the link outside of Blazor routing.
+    /// Gets or sets whether a full page refresh is performed when navigating to the URL in <see cref="Href"/>.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>true</c>, client-side routing is bypassed and a full page reload occurs.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.ClickAction)]
     public bool ForceLoad { get; set; }
 
     /// <summary>
-    /// If true, this chip is selected by default if used in a ChipSet.
+    /// Gets or sets whether this chip is selected by default when part of a <see cref="MudChipSet{T}"/>.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public bool? Default { get; set; }
 
     /// <summary>
-    /// Chip click event, if set the chip focus, hover and click effects are applied.
+    /// Occurs when this chip is clicked.
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     /// <summary>
-    /// Chip delete event, if set the delete icon will be visible.
+    /// Occurs when this chip has been closed.
     /// </summary>
+    /// <remarks>
+    /// When set, the close icon can be controlled via the <see cref="CloseIcon"/> property.
+    /// </remarks>
     [Parameter]
     public EventCallback<MudChip<T>> OnClose { get; set; }
 
     internal bool ShowCheckMark => IsSelectedState.Value && ChipSet?.CheckMark == true;
 
     /// <summary>
-    /// True if the chip is selected. Bind this to manipulate the chip's selection state.
+    /// Gets or sets whether this chip is selected.
     /// </summary>
+    /// <remarks>
+    /// When <c>true</c>, the chip is displayed in a selected state.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public bool IsSelected { get; set; }
 
     /// <summary>
-    /// Raised when IsSelected changes
+    /// Occurs when the <see cref="IsSelected"/> property has changed.
     /// </summary>
     [Parameter]
     public EventCallback<bool> IsSelectedChanged { get; set; }
@@ -263,6 +328,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         return Value;
     }
 
+    /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
@@ -311,6 +377,9 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Releases unused resources.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         try

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -118,7 +118,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Color? Color { get; set; }
 
     /// <summary>
-    /// The chip color to use when selected, only works together with ChipSet, Color.Inherit for default value.
+    /// Gets or sets the color of the chip when it is selected.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  When set, this color is used for a selected chip, otherwise <see cref="Color"/> is used.

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -10,6 +10,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// Represents a set of multiple <see cref="MudChip{T}"/> components.
+/// </summary>
+/// <typeparam name="T">The type of item managed by this component.</typeparam>
 public partial class MudChipSet<T> : MudComponentBase, IDisposable
 {
     public MudChipSet()
@@ -41,161 +46,204 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     private bool MultiSelection => SelectionMode == SelectionMode.MultiSelection;
     private bool Mandatory => SelectionMode == SelectionMode.SingleSelection;
 
-    protected string Classname =>
-        new CssBuilder("mud-chipset")
-            .AddClass(Class)
-            .Build();
+    protected string Classname => new CssBuilder("mud-chipset")
+        .AddClass(Class)
+        .Build();
 
     /// <summary>
-    /// Child content of component.
+    /// Gets or sets the content within this chipset.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Allows selecting more than one chip.
+    /// Gets or sets how many selections are allowed.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="SelectionMode.SingleSelection"/>.  Other values include <see cref="SelectionMode.MultiSelection"/> and <see cref="SelectionMode.ToggleSelection"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public SelectionMode SelectionMode { get; set; } = SelectionMode.SingleSelection;
 
     /// <summary>
-    /// Will make all chips closable.
+    /// Gets or sets whether all chips in this set are closeable.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public bool AllClosable { get; set; } = false;
 
     /// <summary>
-    /// The default chip variant if they don't set their own.
-    /// Chips may override this.
+    /// Gets or sets the default variant for all chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Variant.Filled"/>.  Can be overridden by setting <see cref="MudChip{T}.Variant"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Variant Variant { get; set; } = Variant.Filled;
 
     /// <summary>
-    /// The default chip color if they don't set their own.
-    /// Chips may override this.
+    /// Gets or sets the default color for all chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.  Can be overridden by setting <see cref="MudChip{T}.Color"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color Color { get; set; } = Color.Default;
 
     /// <summary>
-    /// The default selected chip color. Color.Inherit for default value.
-    /// Chips may override this.
+    /// Gets or sets the default color for all selected chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Inherit"/>.  Can be overridden by setting <see cref="MudChip{T}.SelectedColor"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color SelectedColor { get; set; } = Color.Inherit;
 
     /// <summary>
-    /// The default icon color for all chips.
-    /// Chips may override this.
+    /// Gets or sets the default icon color for all chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Inherit"/>.  Can be overridden by setting <see cref="MudChip{T}.IconColor"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Color IconColor { get; set; } = Color.Inherit;
 
     /// <summary>
-    /// The default chip size.
-    /// Chips may override this.
+    /// Gets or sets the default size for all chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Size.Medium"/>.  Can be overridden by setting <see cref="MudChip{T}.Size"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public Size Size { get; set; } = Size.Medium;
 
     /// <summary>
-    ///  Will show a check-mark for the selected components.
+    /// Gets or sets whether checkmarks are shown for selected chips.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Appearance)]
     public bool CheckMark { get; set; }
 
     /// <summary>
-    /// The default checked icon for all chips.
-    /// Chips may override this.
+    /// Gets or sets the default icon shown for selected chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.Check"/>.  Can be overridden by setting <see cref="MudChip{T}.CheckedIcon"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public string CheckedIcon { get; set; } = Icons.Material.Filled.Check;
 
     /// <summary>
-    /// Rhe default close icon for all chips, only shown if OnClose is set.
-    /// Chips may override this.
+    /// Gets or sets the default close icon shown for closeable chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.Cancel"/>.  Can be overridden by setting <see cref="MudChip{T}.CloseIcon"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public string CloseIcon { get; set; } = Icons.Material.Filled.Cancel;
 
     /// <summary>
-    /// Ripple default setting for all chips. If true, a ripple effect is applied to clickable chips on click.
-    /// Chips may override this.
+    /// Gets or sets whether a ripple effect is shown for chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.  Can be overridden by setting <see cref="MudChip{T}.Ripple"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public bool Ripple { get; set; } = true;
 
     /// <summary>
-    /// Removes circle edges and applies theme default. This setting is for all chips,
-    /// unless they override it.
+    /// Gets or sets whether the theme border radius is used be default for chips in this set.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="LayoutProperties.DefaultBorderRadius"/> is used for chip edges.  Can be overridden by setting <see cref="MudChip{T}.Label"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public bool Label { get; set; }
 
     /// <summary>
-    /// If true, all chips will be disabled.
-    /// Although chips have their own setting they can NOT override this.
+    /// Gets or sets whether the user cannot interact with this chip.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>true</c>, the all chips are visibly disabled and interaction is not allowed.  Overrides any value set for <see cref="MudChip{T}.Disabled"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
     public bool Disabled { get; set; }
 
     /// <summary>
-    ///  Will make all chips read only.
+    /// Gets or sets whether chips in this set are clickable.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>true</c>, chips cannot be clicked even if <see cref="MudChip{T}.OnClick"/> is set.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public bool ReadOnly { get; set; } = false;
 
     /// <summary>
-    /// The Comparer to use for comparing selected values internally.
+    /// Gets or sets the comparer used to determine when a selection has changed.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="EqualityComparer{T}.Default"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public IEqualityComparer<T?> Comparer { get; set; } = EqualityComparer<T?>.Default;
 
     /// <summary>
-    /// The currently selected value.
+    /// Gets or sets the currently selected value.
     /// </summary>
+    /// <remarks>
+    /// This property is used when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection" /> or <see cref="SelectionMode.ToggleSelection"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public T? SelectedValue { get; set; }
 
     /// <summary>
-    /// Called whenever SelectedValue changes
+    /// Occurs when <see cref="SelectedValue"/> has changed.
     /// </summary>
+    /// <remarks>
+    /// This property is used when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection" /> or <see cref="SelectionMode.ToggleSelection"/>.
+    /// </remarks>
     [Parameter]
     public EventCallback<T?> SelectedValueChanged { get; set; }
 
     /// <summary>
-    /// The currently selected values if MultiSelection="true".
+    /// Gets or sets the currently selected chips in this set. 
     /// </summary>
+    /// <remarks>
+    /// This event occurs when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection" />.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public IReadOnlyCollection<T>? SelectedValues { get; set; }
 
     /// <summary>
-    /// Called whenever SelectedValues changes
+    /// Occurs when <see cref="SelectedValues"/> has changed.
     /// </summary>
+    /// <remarks>
+    /// This event occurs when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection" />.
+    /// </remarks>
     [Parameter]
     public EventCallback<IReadOnlyCollection<T>?> SelectedValuesChanged { get; set; }
 
     /// <summary>
-    /// Called when a Chip was deleted (by click on the close icon)
+    /// Occurs when any chip has been closed.
     /// </summary>
     [Parameter]
     public EventCallback<MudChip<T>> OnClose { get; set; }
@@ -351,6 +399,9 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
 
     private bool _disposed;
 
+    /// <summary>
+    /// Releases unused resources.
+    /// </summary>
     public void Dispose()
     {
         _disposed = true;

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -9,6 +9,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+    /// <summary>
+    /// Represents a container for content which can be collapsed and expanded.
+    /// </summary>
     public partial class MudCollapse : MudComponentBase
     {
         internal enum CollapseState
@@ -23,44 +26,54 @@ namespace MudBlazor
         private ElementReference _wrapper;
         internal CollapseState _state = CollapseState.Exited;
 
-        protected string Stylename =>
-            new StyleBuilder()
-                .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
-                .AddStyle("height", "auto", _state == CollapseState.Entered)
-                .AddStyle("height", _height.ToPx(), _state is CollapseState.Entering or CollapseState.Exiting)
-                .AddStyle("animation-duration", $"{CalculatedAnimationDuration.ToString("#.##", CultureInfo.InvariantCulture)}s", _state == CollapseState.Entering)
-                .AddStyle(Style)
-                .Build();
+        protected string Stylename => new StyleBuilder()
+            .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
+            .AddStyle("height", "auto", _state == CollapseState.Entered)
+            .AddStyle("height", _height.ToPx(), _state is CollapseState.Entering or CollapseState.Exiting)
+            .AddStyle("animation-duration", $"{CalculatedAnimationDuration.ToString("#.##", CultureInfo.InvariantCulture)}s", _state == CollapseState.Entering)
+            .AddStyle(Style)
+            .Build();
 
-        protected string Classname =>
-            new CssBuilder("mud-collapse-container")
-                .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
-                .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
-                .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
-                .AddClass(Class)
-                .Build();
+        protected string Classname => new CssBuilder("mud-collapse-container")
+            .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
+            .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
+            .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
+            .AddClass(Class)
+            .Build();
 
         /// <summary>
-        /// If true, expands the panel, otherwise collapse it. Setting this prop enables control over the panel.
+        /// Gets or sets whether content within this panel is visible.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         public bool Expanded { get; set; }
 
         /// <summary>
-        /// Explicitly sets the height for the Collapse element to override the css default.
+        /// Gets or sets the maximum allowed height of this panel, in pixels.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         public int? MaxHeight { get; set; }
 
         /// <summary>
-        /// Child content of component.
+        /// Gets or sets any content within this panel.
         /// </summary>
         [Parameter]
         public RenderFragment? ChildContent { get; set; }
 
+        /// <summary>
+        /// Occurs when the collapse or expand animation has finished.
+        /// </summary>
         [Parameter]
         public EventCallback OnAnimationEnd { get; set; }
 
+        /// <summary>
+        /// Occurs when the <see cref="Expanded"/> property has changed.
+        /// </summary>
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
 
@@ -141,6 +154,9 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
+        /// <summary>
+        /// Completes an ongoing animation.
+        /// </summary>
         public Task AnimationEndAsync()
         {
             if (_state == CollapseState.Entering)

--- a/src/MudBlazor/Enums/SelectionMode.cs
+++ b/src/MudBlazor/Enums/SelectionMode.cs
@@ -4,17 +4,28 @@
 
 using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Indicates the types of selections allowed.
+/// </summary>
+public enum SelectionMode
 {
-    public enum SelectionMode
-    {
-        [Description("single-selection")]
-        SingleSelection,
+    /// <summary>
+    /// One selection is allowed at a time.
+    /// </summary>
+    [Description("single-selection")]
+    SingleSelection,
 
-        [Description("multi-selection")]
-        MultiSelection,
+    /// <summary>
+    /// More than one selection is allowed.
+    /// </summary>
+    [Description("multi-selection")]
+    MultiSelection,
 
-        [Description("toggle-selection")]
-        ToggleSelection
-    }
+    /// <summary>
+    /// One selection is toggled.
+    /// </summary>
+    [Description("toggle-selection")]
+    ToggleSelection
 }

--- a/src/MudBlazor/Enums/Variant.cs
+++ b/src/MudBlazor/Enums/Variant.cs
@@ -2,12 +2,26 @@
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// Indicates the display variation applied to a component.
+    /// </summary>
     public enum Variant
     {
+        /// <summary>
+        /// The component has drop shadow, background or border.
+        /// </summary>
         [Description("text")]
         Text,
+
+        /// <summary>
+        /// The component interior is filled with a solid color.
+        /// </summary>
         [Description("filled")]
         Filled,
+
+        /// <summary>
+        /// The component has an outline around the edge.
+        /// </summary>
         [Description("outlined")]
         Outlined
     }

--- a/src/MudBlazor/Enums/Variant.cs
+++ b/src/MudBlazor/Enums/Variant.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
     public enum Variant
     {
         /// <summary>
-        /// The component has drop shadow, background or border.
+        /// The component has no drop shadow, background or border.
         /// </summary>
         [Description("text")]
         Text,


### PR DESCRIPTION
## Description

This update adds XML documentation for public members, for the following components and classes:

* MudCheckBox
* MudChip
* MudChipSet
* MudCollapse
* SelectionMode enum
* Variant enum

This update also fixes a default text issue in the `ColorPickerPage.razor` example page.

This update also fixes a minor documentation issue in `MudAppBar`, changing "a value indicating whether" to just "whether".

## How Has This Been Tested?

This was tested by observing the XML documentation for examples:

### MudCheckBox

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/c35bc648-1671-4abe-b832-ca333099913e)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/8085e0f5-da6c-4ec3-b9fa-7bfd001e8140)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/d6889007-39be-4931-ab66-7c5eb6267781)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/35652968-226a-4b88-85ea-a256b59faad7)

### MudChip 

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/ea397886-c99c-442e-8861-c5f1e1adfc09)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/8f12085c-6005-4f1d-b239-f59449bd8b2b)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/e282e80a-6287-48cb-b2f5-c9bebcaebf48)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/7efaca3f-cdc3-44ce-8018-7693b155f7d5)

### MudChipSet

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/a3956ad4-a46c-46a6-8799-a8e11d6b91b6)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/467ac68c-84a4-4f94-8a23-ffe68f18d3d8)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/b89e3cfc-4350-4d86-89b7-c45a64adeec9)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/c77f142c-54b3-41a0-8a94-d59f73d8fd80)

### MudCollapse

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/d4131980-3ec2-4e36-a135-7bfb75d45a59)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/a05efe79-1041-4e60-bb7e-e51eda995b66)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
