### PR TITLE
MudDrawer: Fix initialization behaviour, use ParameterState, remove PreserveOpenState

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerAnchorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerAnchorExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Height="200px" Class="mud-theme-primary" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@openStart" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openStart" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">My App</MudText>
             </MudDrawerHeader>
@@ -12,7 +12,7 @@
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Forum">Community</MudNavLink>
             </MudNavMenu>
         </MudDrawer>
-        <MudDrawer @bind-Open="@openEnd" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openEnd" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">Settings</MudText>
             </MudDrawerHeader>
@@ -31,19 +31,19 @@
 
 @code
 {
+    private bool _openStart = false;
+    private bool _openEnd = false;
+
     [CascadingParameter]
     public bool Rtl { get; set; }
 
-    bool openStart = false;
-    bool openEnd = false;
-
-    void ToggleStartDrawer()
+    private void ToggleStartDrawer()
     {
-        openStart = !openStart;
+        _openStart = !_openStart;
     }
 
-    void ToggleEndDrawer()
+    private void ToggleEndDrawer()
     {
-        openEnd = !openEnd;
+        _openEnd = !_openEnd;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerBreakpointExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerBreakpointExample.razor
@@ -8,7 +8,7 @@
         <MudSpacer />
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" />
     </MudAppBar>
-    <MudDrawer @bind-Open="@open" Breakpoint="@breakpoint" Elevation="1" Variant="@DrawerVariant.Responsive" PreserveOpenState="@preserveOpenState">
+    <MudDrawer @bind-Open="@_open" Breakpoint="@_breakpoint" Elevation="1" Variant="@DrawerVariant.Responsive">
         <MudDrawerHeader>
             <MudText Typo="Typo.h6">My App</MudText>
         </MudDrawerHeader>
@@ -20,25 +20,22 @@
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
-            <MudSelect Label="Select breakpoint" @bind-Value="breakpoint">
+            <MudSelect Label="Select breakpoint" @bind-Value="_breakpoint">
                 <MudSelectItem Value="@Breakpoint.Sm">Breakpoint.Sm</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Md">Breakpoint.Md</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Lg">Breakpoint.Lg</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Xl">Breakpoint.Xl</MudSelectItem>
             </MudSelect>
-            <MudSwitch @bind-Value="preserveOpenState" Label="Preserve open state" Color="Color.Primary" Style="width:100%;" />
         </MudContainer>
     </MudMainContent>
 </MudLayout>
 
-
 @code{
-    bool open = false;
-    bool preserveOpenState = false;
-    Breakpoint breakpoint = Breakpoint.Lg;
+    private bool _open = false;
+    private Breakpoint _breakpoint = Breakpoint.Lg;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerClippingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerClippingExample.razor
@@ -3,12 +3,12 @@
 @page "/iframe/docs/examples/drawer/clipped"
 
 <MudLayout>
-    <MudAppBar Elevation="1" Dense="@dense">
+    <MudAppBar Elevation="1" Dense="@_dense">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
         <MudSpacer />
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" />
     </MudAppBar>
-    <MudDrawer @bind-Open="@open" ClipMode="clipMode" Elevation="1" Variant="@DrawerVariant.Responsive">
+    <MudDrawer @bind-Open="@_open" ClipMode="_clipMode" Elevation="1" Variant="@DrawerVariant.Responsive">
         <MudDrawerHeader>
             <MudText Typo="Typo.h6">My App</MudText>
         </MudDrawerHeader>
@@ -20,24 +20,23 @@
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
-            <MudSelect Label="Select clip mode" @bind-Value="clipMode">
+            <MudSelect Label="Select clip mode" @bind-Value="_clipMode">
                 <MudSelectItem Value="@DrawerClipMode.Never">Not clipped (DrawerClipMode.Never)</MudSelectItem>
                 <MudSelectItem Value="@DrawerClipMode.Docked">Drawer is docked (DrawerClipMode.Docked)</MudSelectItem>
                 <MudSelectItem Value="@DrawerClipMode.Always">Always (DrawerClipMode.Always)</MudSelectItem>
             </MudSelect>
-            <MudSwitch @bind-Value="dense" Label="Dense appbar" Color="Color.Primary" Style="width:100%;" />
+            <MudSwitch @bind-Value="_dense" Label="Dense appbar" Color="Color.Primary" Style="width:100%;" />
         </MudContainer>
     </MudMainContent>
 </MudLayout>
 
-
 @code{
-    bool open = false;
-    bool dense = false;
-    DrawerClipMode clipMode = DrawerClipMode.Never;
+    private bool _open = false;
+    private bool _dense = false;
+    private DrawerClipMode _clipMode = DrawerClipMode.Never;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerLeftRightExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerLeftRightExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Height="200px" Class="mud-theme-primary" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@openLeft" Anchor="Anchor.Left" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openLeft" Anchor="Anchor.Left" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">My App</MudText>
             </MudDrawerHeader>
@@ -12,7 +12,7 @@
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Forum">Community</MudNavLink>
             </MudNavMenu>
         </MudDrawer>
-        <MudDrawer @bind-Open="@openRight" Fixed="false" Anchor="Anchor.Right" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openRight" Fixed="false" Anchor="Anchor.Right" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">Settings</MudText>
             </MudDrawerHeader>
@@ -39,19 +39,19 @@
 
 @code
 {
+    private bool _openLeft = false;
+    private bool _openRight = false;
+
     [CascadingParameter]
     public bool Rtl { get; set; }
 
-    bool openLeft = false;
-    bool openRight = false;
-
-    void ToggleLeftDrawer()
+    private void ToggleLeftDrawer()
     {
-        openLeft = !openLeft;
+        _openLeft = !_openLeft;
     }
 
-    void ToggleRightDrawer()
+    private void ToggleRightDrawer()
     {
-        openRight = !openRight;
+        _openRight = !_openRight;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerMiniCustomExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerMiniCustomExample.razor
@@ -3,12 +3,12 @@
 @page "/iframe/docs/examples/drawer/mini"
 
 <MudLayout>
-    <MudAppBar Elevation="1" Dense="@dense">
+    <MudAppBar Elevation="1" Dense="@_dense">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
         <MudSpacer />
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" />
     </MudAppBar>
-    <MudDrawer @bind-Open="@open" ClipMode="clipMode" Breakpoint="@breakpoint" PreserveOpenState="@preserveOpenState" Elevation="1" Variant="@DrawerVariant.Mini">
+    <MudDrawer @bind-Open="@_open" ClipMode="_clipMode" Breakpoint="@_breakpoint" Elevation="1" Variant="@DrawerVariant.Mini">
         <MudNavMenu>
             <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
             <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.LibraryBooks">Library</MudNavLink>
@@ -17,33 +17,30 @@
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
-            <MudSelect Label="Select clip mode" @bind-Value="clipMode">
+            <MudSelect Label="Select clip mode" @bind-Value="_clipMode">
                 <MudSelectItem Value="@DrawerClipMode.Never">Not clipped (DrawerClipMode.Never)</MudSelectItem>
                 <MudSelectItem Value="@DrawerClipMode.Docked">Drawer is docked (DrawerClipMode.Docked)</MudSelectItem>
                 <MudSelectItem Value="@DrawerClipMode.Always">Always (DrawerClipMode.Always)</MudSelectItem>
             </MudSelect>
-            <MudSelect Label="Select breakpoint" @bind-Value="breakpoint">
+            <MudSelect Label="Select breakpoint" @bind-Value="_breakpoint">
                 <MudSelectItem Value="@Breakpoint.Sm">Breakpoint.Sm</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Md">Breakpoint.Md</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Lg">Breakpoint.Lg</MudSelectItem>
                 <MudSelectItem Value="@Breakpoint.Xl">Breakpoint.Xl</MudSelectItem>
             </MudSelect>
-            <MudSwitch @bind-Value="preserveOpenState" Label="Preserve open state" Color="Color.Primary" Style="width:100%;" />
-            <MudSwitch @bind-Value="dense" Label="Dense appbar" Color="Color.Primary" Style="width:100%;" />
+            <MudSwitch @bind-Value="_dense" Label="Dense appbar" Color="Color.Primary" Style="width:100%;" />
         </MudContainer>
     </MudMainContent>
 </MudLayout>
 
-
 @code{
-    bool open = false;
-    bool dense = false;
-    bool preserveOpenState = false;
-    Breakpoint breakpoint = Breakpoint.Lg;
-    DrawerClipMode clipMode = DrawerClipMode.Never;
+    private bool _open = false;
+    private bool _dense = false;
+    private Breakpoint _breakpoint = Breakpoint.Lg;
+    private DrawerClipMode _clipMode = DrawerClipMode.Never;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerMiniExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerMiniExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Height="200px" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@open" Fixed="false" Elevation="1" Variant="@DrawerVariant.Mini" OpenMiniOnHover="true">
+        <MudDrawer @bind-Open="@_open" Fixed="false" Elevation="1" Variant="@DrawerVariant.Mini" OpenMiniOnHover="true">
             <MudNavMenu>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.LibraryBooks">Library</MudNavLink>
@@ -17,10 +17,10 @@
 
 @code
 { 
-    bool open = false;
+    private bool _open = false;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     } 
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerOverlayExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerOverlayExample.razor
@@ -2,7 +2,7 @@
 
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => ToggleDrawer())">Toggle drawer</MudButton>
 
-<MudDrawer @bind-Open="@open" Overlay="false" Elevation="1" Variant="@DrawerVariant.Temporary">
+<MudDrawer @bind-Open="@_open" Overlay="false" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
         <MudText Typo="Typo.h6">My App</MudText>
     </MudDrawerHeader>
@@ -14,10 +14,10 @@
 </MudDrawer>
 
 @code{ 
-    bool open;
-    
-    void ToggleDrawer()
+    private bool _open;
+
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerPersistentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerPersistentExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Height="200px" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
+        <MudDrawer @bind-Open="@_open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">My App</MudText>
             </MudDrawerHeader>
@@ -20,10 +20,10 @@
 
 @code
 {
-    bool open = false;
+    private bool _open = false;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerResponsiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerResponsiveExample.razor
@@ -2,14 +2,13 @@
 @namespace MudBlazor.Docs.Examples
 @page "/iframe/docs/examples/drawer/persistent"
 
-
 <MudLayout>
     <MudAppBar Elevation="1">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
         <MudSpacer />
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" />
     </MudAppBar>
-    <MudDrawer @bind-Open="@open" Elevation="1">
+    <MudDrawer @bind-Open="@_open" Elevation="1">
         <MudDrawerHeader>
             <MudText Typo="Typo.h6">My App</MudText>
         </MudDrawerHeader>
@@ -26,12 +25,11 @@
     </MudMainContent>
 </MudLayout>
 
-
 @code{
-    bool open = false;
+    private bool _open = false;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeContainerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeContainerExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Height="200px" Class="mud-theme-primary" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@openStart" Width="150px" Fixed="false" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openStart" Width="150px" Fixed="false" Anchor="Anchor.Start" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">My App</MudText>
             </MudDrawerHeader>
@@ -12,7 +12,7 @@
                 <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Forum">Community</MudNavLink>
             </MudNavMenu>
         </MudDrawer>
-        <MudDrawer @bind-Open="@openEnd" Width="300px" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
+        <MudDrawer @bind-Open="@_openEnd" Width="300px" Fixed="false" Anchor="Anchor.End" Elevation="0" Variant="@DrawerVariant.Persistent">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">Settings</MudText>
             </MudDrawerHeader>
@@ -30,20 +30,20 @@
 </MudPaper>
 
 @code
-{ 
+{
+    private bool _openStart = false;
+    private bool _openEnd = false;
+
     [CascadingParameter]
     public bool Rtl { get; set; }
 
-    bool openStart = false;
-    bool openEnd = false;
-
-    void ToggleStartDrawer()
+    private void ToggleStartDrawer()
     {
-        openStart = !openStart;
+        _openStart = !_openStart;
     }
 
-    void ToggleEndDrawer()
+    private void ToggleEndDrawer()
     {
-        openEnd = !openEnd;
+        _openEnd = !_openEnd;
     } 
 }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeTemporaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerSizeTemporaryExample.razor
@@ -5,7 +5,7 @@
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Top))">Top</MudButton>
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Bottom))">Bottom</MudButton>
 
-<MudDrawer @bind-Open="@open" Width="@width" Height="@height" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
+<MudDrawer @bind-Open="@_open" Width="@_width" Height="@_height" Anchor="@_anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
         <MudText Typo="Typo.h6">My App</MudText>
     </MudDrawerHeader>
@@ -17,32 +17,32 @@
 </MudDrawer>
 
 @code{ 
-    bool open;
-    Anchor anchor;
-    string width, height;
+    private bool _open;
+    private Anchor _anchor;
+    private string _width, _height;
 
-    void OpenDrawer(Anchor anchor)
+    private void OpenDrawer(Anchor anchor)
     {
-        open = true;
-        this.anchor = anchor;
+        _open = true;
+        _anchor = anchor;
 
         switch (anchor)
         {
             case Anchor.Start:
-                width = "300px";
-                height = "100%";
+                _width = "300px";
+                _height = "100%";
                 break;
             case Anchor.End:
-                width = "400px";
-                height = "100%";
+                _width = "400px";
+                _height = "100%";
                 break;
             case Anchor.Bottom:
-                width = "100%";
-                height = "200px";
+                _width = "100%";
+                _height = "200px";
                 break;
             case Anchor.Top:
-                width = "100%";
-                height = "350px";
+                _width = "100%";
+                _height = "350px";
                 break;
         }
     }

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
@@ -5,7 +5,7 @@
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Top))">Top</MudButton>
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Bottom))">Bottom</MudButton>
 
-<MudDrawer @bind-Open="@open" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
+<MudDrawer @bind-Open="@_open" Anchor="@_anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
     <MudDrawerHeader>
         <MudText Typo="Typo.h6">My App</MudText>
     </MudDrawerHeader>
@@ -17,12 +17,12 @@
 </MudDrawer>
 
 @code{ 
-    bool open;
-    Anchor anchor;
-    
-    void OpenDrawer(Anchor anchor)
+    private bool _open;
+    private Anchor _anchor;
+
+    private void OpenDrawer(Anchor anchor)
     {
-        open = true;
-        this.anchor = anchor;
+        _open = true;
+        _anchor = anchor;
     }
 }

--- a/src/MudBlazor.Docs/Shared/Utilities/IframeLayout.razor
+++ b/src/MudBlazor.Docs/Shared/Utilities/IframeLayout.razor
@@ -2,6 +2,6 @@
 @inherits LayoutComponentBase
 
 <MudThemeProvider />
+<MudPopoverProvider />
 
 @Body
-

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -4,7 +4,7 @@
     <MudAppBar Elevation="1">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>
-    <MudDrawer @ref="@Drawer" @bind-Open="@open" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode" PreserveOpenState="@PreserveOpenState">
+    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
@@ -12,14 +12,10 @@
     </MudMainContent>
 </MudLayout>
 
-
 @code{ 
-    bool open = false;
+    private bool _open;
 
     public MudDrawer Drawer { get; set; }
-
-    [Parameter]
-    public bool PreserveOpenState { get; set; }
 
     [Parameter]
     public Breakpoint Breakpoint { get; set; } = Breakpoint.Md;
@@ -27,8 +23,8 @@
     [Parameter]
     public DrawerClipMode ClipMode { get; set; }
 
-    void ToggleDrawer()
+    public void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable CS1998 // async without await
-
+﻿using System.ComponentModel;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -12,30 +11,54 @@ using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
+#nullable enable
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class DrawerTest : BunitTest
     {
-        private BrowserViewportService _browserViewportService;
-
-        public override void Setup()
+        private BrowserViewportService GetBrowserViewportService(BrowserWindowSize browserWindowSize)
         {
-            base.Setup();
             var jsRuntimeMock = new Mock<IJSRuntime>();
-            _browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
-            // Initial browser size is Md
+            var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
+            // Sets the initial browser size aka simulating the windows size when the website was opened for the first time
             jsRuntimeMock
                 .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
-                .ReturnsAsync(new BrowserWindowSize { Height = 640, Width = 960 })
+                .ReturnsAsync(browserWindowSize)
                 .Verifiable();
 
-            Context.Services.AddScoped<IBrowserViewportService>(_ => _browserViewportService);
+            return browserViewportService;
+        }
+
+        private BrowserViewportService AddBrowserViewportService(BrowserWindowSize browserWindowSize)
+        {
+            var service = GetBrowserViewportService(browserWindowSize);
+
+            Context.Services.AddScoped<IBrowserViewportService>(_ => service);
+
+            return service;
+        }
+
+        private BrowserViewportService AddBrowserViewportService(int height = 640, int width = 960) => AddBrowserViewportService(new BrowserWindowSize { Height = height, Width = width });
+
+        private BrowserWindowSize BreakpointBrowserAssociatedSize(Breakpoint breakpoint)
+        {
+            return breakpoint switch
+            {
+                Breakpoint.Xs => new BrowserWindowSize { Height = 0, Width = 0 },
+                Breakpoint.Sm => new BrowserWindowSize { Height = 400, Width = 600 },
+                Breakpoint.Md => new BrowserWindowSize { Height = 640, Width = 960 },
+                Breakpoint.Lg => new BrowserWindowSize { Height = 720, Width = 1280 },
+                Breakpoint.Xl => new BrowserWindowSize { Height = 1080, Width = 1920 },
+                Breakpoint.Xxl => new BrowserWindowSize { Height = 1440, Width = 2560 },
+                _ => throw new InvalidEnumArgumentException("Only acceptable breakpoints are: Xs, Sm, Md, Lg, Xl and Xxl")
+            };
         }
 
         [Test]
-        public async Task TemporaryClosed_Open_CheckOpened_Close_CheckClosed()
+        public void TemporaryClosed_Open_CheckOpened_Close_CheckClosed()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary));
 
             comp.Find("button").Click();
@@ -48,8 +71,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TemporaryClosedWithoutOverlay_Open_CheckOverlay()
+        public void TemporaryClosedWithoutOverlay_Open_CheckOverlay()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.Overlay), false));
@@ -63,8 +87,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TemporaryClosedClipped_Open_CheckState()
+        public void TemporaryClosedClipped_Open_CheckState()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
@@ -78,8 +103,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task PersistentClosed_Open_CheckOpened_Close_CheckClosed()
+        public void PersistentClosed_Open_CheckOpened_Close_CheckClosed()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Persistent));
 
             comp.Find("button").Click();
@@ -92,8 +118,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task PersistentClosedClipped_Open_CheckState()
+        public void PersistentClosedClipped_Open_CheckState()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(
                 Parameter(nameof(DrawerTest1.Variant),
                     DrawerVariant.Persistent), Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
@@ -107,8 +134,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MiniClosed_Open_CheckOpened_Close_CheckClosed()
+        public void MiniClosed_Open_CheckOpened_Close_CheckClosed()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini));
 
             comp.Find("button").Click();
@@ -121,8 +149,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MiniClosedClipped_Open_CheckState()
+        public void MiniClosedClipped_Open_CheckState()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
@@ -136,8 +165,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ResponsiveClosed_Open_CheckOpened_Close_CheckClosed()
+        public void ResponsiveClosed_Open_CheckOpened_Close_CheckClosed()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
             comp.Find("button").Click();
@@ -152,12 +182,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         [TestCase(Breakpoint.Xs)]
         [TestCase(Breakpoint.Sm)]
-        public async Task ResponsiveSmallClosed_Open_CheckOpenedAndOverlay(Breakpoint point)
+        public void ResponsiveSmallClosed_Open_CheckOpenedAndOverlay(Breakpoint point)
         {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(point));
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
-            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = _browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize(), point, subscription.JavaScriptListenerId));
 
             comp.Find("button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -173,12 +201,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
-        public async Task ResponsiveClosed_LargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
+        public void ResponsiveClosed_StartLargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xl));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
-            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = _browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 1080, Width = 1920 }, Breakpoint.Xl, subscription.JavaScriptListenerId));
 
             comp.Find("button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -194,12 +220,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
-        public async Task ResponsiveClosed_SmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
+        public void ResponsiveClosed_StartSmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
-            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = _browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
             comp.Find("button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -213,10 +237,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
         {
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true));
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.RenderComponent<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = _browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             //open drawer
             comp.Find("button").Click();
@@ -225,13 +249,13 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             //resize to small, drawer should close
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to large, drawer should open automatically
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -242,7 +266,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
             //resize to small, then open drawer
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             comp.Find("button").Click();
 
@@ -250,7 +274,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
 
             //resize to large, drawer should stays open
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
@@ -263,10 +287,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
         {
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true));
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.RenderComponent<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = _browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             //open drawer
             comp.Find("button").Click();
@@ -275,27 +299,57 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             //resize to small, drawer should close
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to extra small, drawer should close
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to large, drawer should open automatically
-            await comp.InvokeAsync(async () => await _browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Resize screen from small to big. Once the screen is large enough, the drawer should open automatically.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task Responsive_ResizeFromSmall_ToLarge_CheckStates()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
+
+            //drawer should be closed
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            //resize to small, drawer should stay closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            //resize above breakpoint - drawer should open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
         }
 
         [Test]
-        public async Task DrawerContainer_RemoveDrawer_CheckStates()
+        public void DrawerContainer_RemoveDrawer_CheckStates()
         {
+            _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerContainerTest1>();
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(1);

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interfaces;
 using MudBlazor.Services;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -13,27 +14,47 @@ namespace MudBlazor
     {
         private double _height;
         private int _disposeCount;
-        private DrawerClipMode _clipMode;
+        private readonly ParameterState<bool> _rtlState;
+        private readonly ParameterState<bool> _openState;
+        private readonly ParameterState<Breakpoint> _breakpointState;
+        private readonly ParameterState<DrawerClipMode> _clipModeState;
         private ElementReference _contentRef;
-        private bool? _isOpenWhenLarge = null;
         private bool _closeOnMouseLeave = false;
-        private bool _open, _rtl, _isRendered, _initial = true, _keepInitialState, _fixed = true;
-        private Breakpoint _breakpoint = Breakpoint.Md, _screenBreakpoint = Breakpoint.None;
+        private bool _isRendered;
+        private bool _fixed = true;
+        private bool _initial = true;
+        private bool _keepInitialState;
+        private Breakpoint _lastUpdatedBreakpoint = Breakpoint.None;
 
-        private bool OverlayVisible => _open && Overlay &&
-                                       (Variant == DrawerVariant.Temporary ||
-                                        (_screenBreakpoint < Breakpoint && Variant == DrawerVariant.Mini) ||
-                                        (_screenBreakpoint < Breakpoint && Variant == DrawerVariant.Responsive));
+        public MudDrawer()
+        {
+            using var registerScope = CreateRegisterScope();
+            _clipModeState = registerScope.RegisterParameter<DrawerClipMode>(nameof(ClipMode))
+                .WithParameter(() => ClipMode)
+                .WithChangeHandler(OnClipModeParameterChange);
+            _breakpointState = registerScope.RegisterParameter<Breakpoint>(nameof(Breakpoint))
+                .WithParameter(() => Breakpoint)
+                .WithChangeHandler(OnBreakpointParameterChangedAsync);
+            _openState = registerScope.RegisterParameter<bool>(nameof(Open))
+                .WithParameter(() => Open)
+                .WithEventCallback(() => OpenChanged)
+                .WithChangeHandler(OnOpenParameterChangedAsync);
+            _rtlState = registerScope.RegisterParameter<bool>(nameof(RightToLeft))
+                .WithParameter(() => RightToLeft)
+                .WithChangeHandler(OnRightToLeftParameterChanged);
+        }
+
+        private bool OverlayVisible => _openState.Value && Overlay && (Variant == DrawerVariant.Temporary || (IsBelowCurrentBreakpoint() && IsResponsiveOrMini()));
 
         protected string Classname =>
             new CssBuilder("mud-drawer")
                 .AddClass($"mud-drawer-fixed", Fixed)
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
-                .AddClass($"mud-drawer--open", Open)
-                .AddClass($"mud-drawer--closed", !Open)
+                .AddClass($"mud-drawer--open", _openState.Value)
+                .AddClass($"mud-drawer--closed", !_openState.Value)
                 .AddClass($"mud-drawer--initial", _initial)
-                .AddClass($"mud-drawer-{Breakpoint.ToDescriptionString()}")
-                .AddClass($"mud-drawer-clipped-{_clipMode.ToDescriptionString()}")
+                .AddClass($"mud-drawer-{_breakpointState.Value.ToDescriptionString()}")
+                .AddClass($"mud-drawer-clipped-{_clipModeState.Value.ToDescriptionString()}")
                 .AddClass($"mud-theme-{Color.ToDescriptionString()}", Color != Color.Default)
                 .AddClass($"mud-elevation-{Elevation}")
                 .AddClass($"mud-drawer-{Variant.ToDescriptionString()}")
@@ -43,19 +64,18 @@ namespace MudBlazor
         protected string OverlayClass =>
             new CssBuilder("mud-drawer-overlay mud-overlay-drawer")
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
-                .AddClass($"mud-drawer-overlay--open", Open)
+                .AddClass($"mud-drawer-overlay--open", _openState.Value)
                 .AddClass($"mud-drawer-overlay-{Variant.ToDescriptionString()}")
-                .AddClass($"mud-drawer-overlay-{Breakpoint.ToDescriptionString()}")
+                .AddClass($"mud-drawer-overlay-{_breakpointState.Value.ToDescriptionString()}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .Build();
 
         protected string Stylename =>
             new StyleBuilder()
-                //.AddStyle("width", Width, !string.IsNullOrWhiteSpace(Width) && !Fixed)
                 .AddStyle("--mud-drawer-width", Width, !string.IsNullOrWhiteSpace(Width) && (!Fixed || Variant == DrawerVariant.Temporary))
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
                 .AddStyle("--mud-drawer-content-height", string.IsNullOrWhiteSpace(Height) ? _height.ToPx() : Height, Anchor == Anchor.Bottom || Anchor == Anchor.Top)
-                .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && (Anchor == Anchor.Bottom || Anchor == Anchor.Top))
+                .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && Anchor is Anchor.Bottom or Anchor.Top)
                 .AddStyle(Style)
                 .Build();
 
@@ -66,20 +86,7 @@ namespace MudBlazor
         private MudDrawerContainer? DrawerContainer { get; set; }
 
         [CascadingParameter(Name = "RightToLeft")]
-        private bool RightToLeft
-        {
-            get => _rtl;
-            set
-            {
-                if (_rtl == value)
-                {
-                    return;
-                }
-
-                _rtl = value;
-                (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
-            }
-        }
+        private bool RightToLeft { get; set; }
 
         /// <summary>
         /// If true, drawer position will be fixed. (CSS position: fixed;)
@@ -138,13 +145,6 @@ namespace MudBlazor
         public bool Overlay { get; set; } = true;
 
         /// <summary>
-        /// Preserve open state for responsive drawer when window resized above <see cref="Breakpoint" />.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Drawer.Behavior)]
-        public bool PreserveOpenState { get; set; } = false;
-
-        /// <summary>
         /// Open drawer automatically on mouse enter when <see cref="Variant" /> parameter is set to <see cref="DrawerVariant.Mini" />.
         /// </summary>
         [Parameter]
@@ -156,56 +156,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
-        public Breakpoint Breakpoint
-        {
-            get => _breakpoint;
-            set
-            {
-                if (value == _breakpoint)
-                    return;
-
-                _breakpoint = value;
-                if (_isRendered)
-                {
-                    _ = UpdateBreakpointStateAsync(_screenBreakpoint);
-                }
-
-                (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
-            }
-        }
+        public Breakpoint Breakpoint { get; set; } = Breakpoint.Md;
 
         /// <summary>
         /// Sets the opened state on the drawer. Can be used with two-way binding to close itself on navigation.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
-        public bool Open
-        {
-            get => _open;
-            set
-            {
-                if (_open == value)
-                {
-                    return;
-                }
-                _open = value;
-                if (_isRendered && _initial && !_keepInitialState)
-                {
-                    _initial = false;
-                }
-                if (_keepInitialState)
-                {
-                    _keepInitialState = false;
-                }
-                if (_isRendered && value && (Anchor == Anchor.Top || Anchor == Anchor.Bottom))
-                {
-                    _ = UpdateHeight();
-                }
-
-                (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
-                OpenChanged.InvokeAsync(_open);
-            }
-        }
+        public bool Open { get; set; }
 
         [Parameter]
         public EventCallback<bool> OpenChanged { get; set; }
@@ -236,23 +194,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
-        public DrawerClipMode ClipMode
-        {
-            get => _clipMode;
-            set
-            {
-                if (_clipMode == value)
-                {
-                    return;
-                }
-                _clipMode = value;
-                if (Fixed)
-                {
-                    (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
-                }
-                StateHasChanged();
-            }
-        }
+        public DrawerClipMode ClipMode { get; set; }
 
         protected override void OnInitialized()
         {
@@ -267,11 +209,11 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                await UpdateHeight();
+                await UpdateHeightAsync();
                 await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
 
                 _isRendered = true;
-                if (string.IsNullOrWhiteSpace(Height) && (Anchor == Anchor.Bottom || Anchor == Anchor.Top))
+                if (string.IsNullOrWhiteSpace(Height) && Anchor is Anchor.Bottom or Anchor.Top)
                 {
                     StateHasChanged();
                 }
@@ -302,84 +244,133 @@ namespace MudBlazor
             }
         }
 
-        private Task CloseDrawerAsync() => Open ? OpenChanged.InvokeAsync(false) : Task.CompletedTask;
-
-        async Task INavigationEventReceiver.OnNavigation()
+        private async Task OnOpenParameterChangedAsync(ParameterChangedEventArgs<bool> arg)
         {
-            if (Variant == DrawerVariant.Temporary ||
-                (Variant == DrawerVariant.Responsive && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
+            if (_isRendered && _initial && !_keepInitialState)
             {
-                await OpenChanged.InvokeAsync(false);
+                _initial = false;
             }
+            if (_keepInitialState)
+            {
+                _keepInitialState = false;
+            }
+            if (_isRendered && arg.Value && Anchor is Anchor.Top or Anchor.Bottom)
+            {
+                await UpdateHeightAsync();
+            }
+
+            DrawerContainerUpdate();
         }
 
-        private async Task UpdateHeight()
+        private async Task OnBreakpointParameterChangedAsync(ParameterChangedEventArgs<Breakpoint> arg)
+        {
+            if (_isRendered)
+            {
+                await UpdateBreakpointStateAsync(_lastUpdatedBreakpoint);
+            }
+
+            DrawerContainerUpdate();
+        }
+
+        private void OnClipModeParameterChange()
+        {
+            if (Fixed)
+            {
+                DrawerContainerUpdate();
+            }
+
+            StateHasChanged();
+        }
+
+        private void OnRightToLeftParameterChanged() => DrawerContainerUpdate();
+
+        private void DrawerContainerUpdate() => (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
+
+        private Task CloseDrawerAsync()
+        {
+            if (_openState.Value)
+            {
+                return _openState.SetValueAsync(false);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task UpdateHeightAsync()
         {
             _height = (await _contentRef.MudGetBoundingClientRectAsync())?.Height ?? 0;
         }
 
         private async Task UpdateBreakpointStateAsync(Breakpoint breakpoint)
         {
-            var isStateChanged = false;
             if (breakpoint == Breakpoint.None)
             {
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
             }
 
-            if (breakpoint < Breakpoint && _screenBreakpoint >= Breakpoint && (Variant == DrawerVariant.Responsive || Variant == DrawerVariant.Mini))
+            var isStateChanged = false;
+            if (ShouldCloseDrawer(breakpoint))
             {
-                _isOpenWhenLarge = Open;
-
-                await OpenChanged.InvokeAsync(false);
+                await _openState.SetValueAsync(false);
                 isStateChanged = true;
             }
-            else if (breakpoint >= Breakpoint && _screenBreakpoint < Breakpoint && (Variant == DrawerVariant.Responsive || Variant == DrawerVariant.Mini))
+            else if (ShouldOpenDrawer(breakpoint))
             {
-                if (Open && PreserveOpenState)
-                {
-                    (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
-                    isStateChanged = true;
-                }
-                else if (_isOpenWhenLarge != null)
-                {
-                    await OpenChanged.InvokeAsync(_isOpenWhenLarge.Value);
-                    _isOpenWhenLarge = null;
-                    isStateChanged = true;
-                }
+                await _openState.SetValueAsync(true);
+                isStateChanged = true;
             }
 
-            _screenBreakpoint = breakpoint;
+            _lastUpdatedBreakpoint = breakpoint;
             if (isStateChanged)
             {
-                StateHasChanged();
+                await InvokeAsync(StateHasChanged);
             }
         }
+
+        private bool IsBelowCurrentBreakpoint() => IsBelowBreakpoint(_lastUpdatedBreakpoint);
+
+        private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < _breakpointState.Value;
+
+        private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
+
+        private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint() && IsResponsiveOrMini();
+
+        private bool ShouldOpenDrawer(Breakpoint breakpoint) => !IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint() && IsResponsiveOrMini();
 
         internal string GetPosition()
         {
             return Anchor switch
             {
-                Anchor.Start => RightToLeft ? "right" : "left",
-                Anchor.End => RightToLeft ? "left" : "right",
+                Anchor.Start => _rtlState.Value ? "right" : "left",
+                Anchor.End => _rtlState.Value ? "left" : "right",
                 _ => Anchor.ToDescriptionString()
             };
         }
 
         private async Task OnMouseEnterAsync()
         {
-            if (Variant == DrawerVariant.Mini && !Open && OpenMiniOnHover)
+            if (Variant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
             {
                 _closeOnMouseLeave = true;
-                await OpenChanged.InvokeAsync(true);
+                await _openState.SetValueAsync(true);
             }
         }
 
         private async Task OnMouseLeaveAsync()
         {
-            if (Variant == DrawerVariant.Mini && Open && _closeOnMouseLeave)
+            if (Variant == DrawerVariant.Mini && _openState.Value && _closeOnMouseLeave)
             {
                 _closeOnMouseLeave = false;
-                await OpenChanged.InvokeAsync(false);
+                await _openState.SetValueAsync(false);
+            }
+        }
+
+        async Task INavigationEventReceiver.OnNavigation()
+        {
+            if (Variant == DrawerVariant.Temporary ||
+                (Variant == DrawerVariant.Responsive && await BrowserViewportService.GetCurrentBreakpointAsync() < _breakpointState.Value))
+            {
+                await _openState.SetValueAsync(false);
             }
         }
 
@@ -395,11 +386,12 @@ namespace MudBlazor
         {
             if (browserViewportEventArgs.IsImmediate)
             {
-                _screenBreakpoint = browserViewportEventArgs.Breakpoint;
-                if (_screenBreakpoint < Breakpoint && _open)
+                var isBelowBreakpoint = IsBelowBreakpoint(browserViewportEventArgs.Breakpoint);
+                _lastUpdatedBreakpoint = browserViewportEventArgs.Breakpoint;
+                if (isBelowBreakpoint && _openState.Value)
                 {
                     _keepInitialState = true;
-                    await OpenChanged.InvokeAsync(false);
+                    await _openState.SetValueAsync(false);
                 }
 
                 return;

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -56,10 +57,10 @@ namespace MudBlazor
                 return string.Empty;
             }
 
-            var className = $"mud-drawer-{(drawer.Open ? "open" : "close")}-{drawer.Variant.ToDescriptionString()}";
+            var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{drawer.Variant.ToDescriptionString()}";
             if (drawer.Variant is DrawerVariant.Responsive or DrawerVariant.Mini)
             {
-                className += $"-{drawer.Breakpoint.ToDescriptionString()}";
+                className += $"-{drawer.GetState<Breakpoint>(nameof(MudDrawer.Breakpoint)).ToDescriptionString()}";
             }
             className += $"-{drawer.GetPosition()}";
 


### PR DESCRIPTION
## Description
Replaces PR: https://github.com/MudBlazor/MudBlazor/pull/5012
Fixes: https://github.com/MudBlazor/MudBlazor/issues/4585
Fixes: https://github.com/MudBlazor/MudBlazor/issues/7273
Fixes: https://github.com/MudBlazor/MudBlazor/issues/4535

If you open the docs in small initial size, and start to resize it (large direction), the Drawer will not open. This should fix it.
Added our ParameterState framework.
I removed `PreserveOpenState`, it doesn't seems useful anymore, it looks like https://github.com/MudBlazor/MudBlazor/pull/684#issuecomment-769632930 it was just some property to overcome some implementation problems.
Now when the `_isOpenWhenLarge` is gone (it was the main culprit why this whole thing wouldn't work adequately) the `PreserveOpenState` is the default behavior now because it stays open when you increase the browser size:
https://github.com/MudBlazor/MudBlazor/blob/fa7d7e880ff6fc00f388b9aa694747c88408fa42/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs#L317-L321

As I understand the `_isOpenWhenLarge` existed to restore the state when you lower window from a large window size and then resize it back then it goes to the "original" state before the resize. For example, if you had a large window and drawer closed (manually), then make the window small and back large again the drawer doesn't open, the `PreserveOpenState` was there to disable this this restore logic, but it doesn't help with initial behavior. This in fact all conflicts with the initial behavior when you start with a small window, the `_isOpenWhenLarge` is triggering when you resize to small window, but you already started small so it's just doesn't do anything. I removed all this logic, as it hard for me to find the justification for this default behavior, and there were no test coverage for it, all responsive tests were done against `PreserveOpenState=true`.
The logic is simple, if it doesn't meet the breakpoints condition the drawer closes, and it does it opens, no "smart" features like restore state from large window etc.

I tried to chunk the code to small methods so that the main logic would look like this:
```C#
if (ShouldCloseDrawer(breakpoint))
{
	await _openState.SetValueAsync(false);
}
else if (ShouldOpenDrawer(breakpoint))
{
	await _openState.SetValueAsync(true);
}
```

Also it seems like the missing popover provider was the reason why examples wouldn't work locally in Edge as I complained in discord.

## How Has This Been Tested?
new bUnit tests Visual

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
