### PR TITLE
Rename the `Margin.None` enum value to `Margin.Default`.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteMarginDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteMarginDenseExample.razor
@@ -16,18 +16,18 @@
 </MudGrid>
 
 @code {
-    Margin _margin = Margin.None;
+    Margin _margin = Margin.Default;
     bool _dense = false;
 
     private void ChangeMargin()
     {
-        if (_margin == Margin.None)
+        if (_margin == Margin.Default)
         {
             _margin = Margin.Dense;
         }
         else
         {
-            _margin = Margin.None;
+            _margin = Margin.Default;
         }
     }
 

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Bordered.Should().Be(false);
             comp.Instance.Color.Should().Be(Color.Default);
             comp.Instance.Dense.Should().Be(false);
-            comp.Instance.Margin.Should().Be(Margin.None);
+            comp.Instance.Margin.Should().Be(Margin.Default);
             comp.Instance.Rounded.Should().Be(false);
 
             comp.FindAll("mud-navmenu-bordered").Count.Should().Be(0);

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -207,11 +207,11 @@ namespace MudBlazor
         /// Gets or sets the amount of vertical spacing for this input.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Margin.None"/>.
+        /// Defaults to <see cref="Margin.Default"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         /// Typography for the input text.

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
                 .AddClass("mud-input-underline", when: () => Underline && Variant != Variant.Outlined)
                 .AddClass("mud-shrink", when: () => !string.IsNullOrWhiteSpace(ChildContent?.ToString()) || Adornment == Adornment.Start)
                 .AddClass("mud-disabled", Disabled)
@@ -26,7 +26,7 @@ namespace MudBlazor
                 .AddClass("mud-input-slot-nopadding", when: () => InnerPadding == false)
                 .AddClass($"mud-input-root-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
                 .Build();
 
         protected string AdornmentClassname =>
@@ -53,7 +53,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Field.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         /// If true, the label will be displayed in an error state.

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -10,13 +10,12 @@ namespace MudBlazor
                 .AddClass($"mud-input-{baseInput.Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-{baseInput.Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(baseInput.Label))
                 .AddClass($"mud-input-adorned-{baseInput.Adornment.ToDescriptionString()}", baseInput.Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
+                .AddClass($"mud-input-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.Default)
                 .AddClass("mud-input-underline", when: () => baseInput.Underline && baseInput.Variant != Variant.Outlined)
                 .AddClass("mud-shrink", when: shrinkWhen)
                 .AddClass("mud-disabled", baseInput.Disabled)
                 .AddClass("mud-input-error", baseInput.HasErrors)
                 .AddClass("mud-ltr", baseInput.GetInputType() == InputType.Email || baseInput.GetInputType() == InputType.Telephone)
-                .AddClass($"mud-typography-{baseInput.Typo.ToDescriptionString()}")
                 .AddClass(baseInput.Class)
                 .Build();
 
@@ -25,7 +24,7 @@ namespace MudBlazor
                 .AddClass("mud-input-root")
                 .AddClass($"mud-input-root-{baseInput.Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-root-adorned-{baseInput.Adornment.ToDescriptionString()}", baseInput.Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.Default)
                 .AddClass(baseInput.Class)
                 .Build();
 

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
          .AddClass("mud-input-label")
          .AddClass("mud-input-label-animated")
          .AddClass($"mud-input-label-{Variant.ToDescriptionString()}")
-         .AddClass($"mud-input-label-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+         .AddClass($"mud-input-label-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
          .AddClass($"mud-disabled", Disabled)
          .AddClass("mud-input-error", Error)
          .AddClass(Class)
@@ -40,7 +40,7 @@ namespace MudBlazor
         /// <summary>
         ///  Will adjust vertical spacing. 
         /// </summary>
-        [Parameter] public Margin Margin { get; set; } = Margin.None;
+        [Parameter] public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         ///  Will set the for attribute for WCAG accessiblility

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -9,7 +9,7 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-input-control")
                 .AddClass("mud-input-required", when: () => Required)
-                .AddClass($"mud-input-control-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-control-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
                 .AddClass("mud-input-control-full-width", FullWidth)
                 .AddClass("mud-input-error", Error)
                 .AddClass(Class)
@@ -43,7 +43,7 @@ namespace MudBlazor
         ///  Will adjust vertical spacing. 
         /// </summary>
         [Parameter]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         /// If true, will apply mud-input-required class to the output div

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
                 .AddClass("mud-input-underline", when: () => Underline && Variant != Variant.Outlined)
                 .AddClass("mud-shrink",
                     when: () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start ||
@@ -43,7 +43,7 @@ namespace MudBlazor
                 .AddClass("mud-input-root")
                 .AddClass($"mud-input-root-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-root-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.Default)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -45,7 +45,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.NavMenu.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         /// If true, compact vertical padding will be applied to all navmenu items.

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -301,7 +301,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = Margin.Default;
 
         /// <summary>
         /// A mask for structured input of the date (requires Editable to be true).

--- a/src/MudBlazor/Enums/Margin.cs
+++ b/src/MudBlazor/Enums/Margin.cs
@@ -4,8 +4,8 @@ namespace MudBlazor
 {
     public enum Margin
     {
-        [Description("none")]
-        None,
+        [Description("default")]
+        Default,
         [Description("dense")]
         Dense,
         [Description("normal")]


### PR DESCRIPTION
`Margin.None` value can be misleading, as the name suggests that no margin will be applied to the element, which is not the case. This PR renames the enum value to `Margin.Default` to more accurately describe its intended use.

Note to add to the v7.0.0 Migration Guide #8447:
- Replace `Margin.None` with `Margin.Default`

## Description
Closes #8650.

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
