### PR TITLE
Build: Ignore version format check for assembly attribute

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -308,6 +308,9 @@ dotnet_diagnostic.IDE0056.severity = none
 dotnet_diagnostic.IDE0057.severity = none
 # BL0007 Component Parameters must be auto props
 dotnet_diagnostic.BL0007.severity = suggestion
+# CS7035 The specified version string does not conform to the recommended format - major.minor.build.revision 
+# Needed to pack preview versions of the nuget
+dotnet_diagnostic.CS7035.severity = none
 
 [*]
 end_of_line = lf


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Compile will check the assembly info version attribute and if does not conform to `major.minor.revsion.build` it will warn which in our case fails the build.
https://github.com/MudBlazor/MudBlazor/actions/runs/8912229261/job/24475232585#step:4:11

This causes problems when packing previews for example `v7.0.0-preview.1`

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Will need to check on next release of preview that it works.


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
