### PR TITLE
MudDataGrid: Apply Footer/Header Style Funcs

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVisualStylingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVisualStylingTest.razor
@@ -2,7 +2,7 @@
 
 <MudDataGrid Items="@_items">
     <Columns>
-        <PropertyColumn Property="x => x.Name" CellStyleFunc="@_cellStyleFunc" HeaderStyleFunc="@_headerStyleFunc" />
+        <PropertyColumn Property="x => x.Name" CellStyleFunc="@_cellStyleFunc" HeaderStyleFunc="@_headerStyleFunc" HeaderClassFunc="@_headerClassFunc" />
     </Columns>
 </MudDataGrid>
 
@@ -45,6 +45,19 @@
         }
 
         return style;
+    };
+    
+    // add classes to the header according to the presence of elements.
+    private Func<IEnumerable<Item>, string> _headerClassFunc => x =>
+    {
+        var classes = "";
+        
+        foreach (var item in x)
+        {
+            classes += "class-" + item.Name + " ";
+        }
+
+        return classes.ToLower().Trim();
     };
 
     public class Item

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVisualStylingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVisualStylingTest.razor
@@ -2,7 +2,7 @@
 
 <MudDataGrid Items="@_items">
     <Columns>
-        <PropertyColumn Property="x => x.Name" CellStyleFunc="@_cellStyleFunc" />
+        <PropertyColumn Property="x => x.Name" CellStyleFunc="@_cellStyleFunc" HeaderStyleFunc="@_headerStyleFunc" />
     </Columns>
 </MudDataGrid>
 
@@ -24,6 +24,27 @@
             return "font-weight:bold";
 
         return "";
+    };
+    
+    // style the header according to the presence of elements.
+    private Func<IEnumerable<Item>, string> _headerStyleFunc => x =>
+    {
+        var style = "";
+        
+        foreach (var item in x)
+        {
+            switch (item.Name)
+            {
+                case "A":
+                    style += "background-color:#E5BDE5;";
+                    break;
+                case "B":
+                    style += "font-weight:bold;";
+                    break;
+            }
+        }
+
+        return style;
     };
 
     public class Item

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -761,6 +761,10 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
             dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("font-weight:bold");
+
+            dataGrid.FindAll("th")[0].GetAttribute("class").Should().Contain("class-a");
+            dataGrid.FindAll("th")[0].GetAttribute("class").Should().Contain("class-b");
+            dataGrid.FindAll("th")[0].GetAttribute("class").Should().Contain("class-c");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -758,6 +758,9 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("td")[1].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
             dataGrid.FindAll("td")[2].GetAttribute("style").Should().Contain("font-weight:bold");
+            
+            dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
+            dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("font-weight:bold");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -758,7 +758,7 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll("td")[1].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
             dataGrid.FindAll("td")[2].GetAttribute("style").Should().Contain("font-weight:bold");
-            
+
             dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
             dataGrid.FindAll("th")[0].GetAttribute("style").Should().Contain("font-weight:bold");
         }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -52,9 +52,9 @@ namespace MudBlazor
         #region HeaderCell Properties
 
         [Parameter] public string HeaderClass { get; set; }
-        [Parameter] public Func<T, string> HeaderClassFunc { get; set; }
+        [Parameter] public Func<IEnumerable<T>, string> HeaderClassFunc { get; set; }
         [Parameter] public string HeaderStyle { get; set; }
-        [Parameter] public Func<T, string> HeaderStyleFunc { get; set; }
+        [Parameter] public Func<IEnumerable<T>, string> HeaderStyleFunc { get; set; }
 
         /// <summary>
         /// Determines whether this columns data can be sorted. This overrides the SortMode parameter on the DataGrid.
@@ -163,9 +163,9 @@ namespace MudBlazor
         #region FooterCell Properties
 
         [Parameter] public string FooterClass { get; set; }
-        [Parameter] public Func<T, string> FooterClassFunc { get; set; }
+        [Parameter] public Func<IEnumerable<T>, string> FooterClassFunc { get; set; }
         [Parameter] public string FooterStyle { get; set; }
-        [Parameter] public Func<T, string> FooterStyleFunc { get; set; }
+        [Parameter] public Func<IEnumerable<T>, string> FooterStyleFunc { get; set; }
         [Parameter] public bool EnableFooterSelection { get; set; }
         [Parameter] public AggregateDefinition<T> AggregateDefinition { get; set; }
 

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
@@ -18,12 +19,14 @@ namespace MudBlazor
 
         private string _classname =>
             new CssBuilder("footer-cell")
+                .AddClass(Column?.FooterClassFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.FooterClass)
                 .AddClass(Column?.footerClassname)
                 .AddClass(Class)
             .Build();
         private string _style =>
             new StyleBuilder()
+                .AddStyle(Column?.FooterStyleFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddStyle(Column?.FooterStyle)
                 .AddStyle(Style)
                 .AddStyle("font-weight", "600")

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -37,12 +37,14 @@ namespace MudBlazor
 
         private string _classname =>
             new CssBuilder(Column?.HeaderClass)
+                .AddClass(Column?.HeaderClassFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.headerClassname)
                 .AddClass(Class)
             .Build();
 
         private string _style =>
             new StyleBuilder()
+                .AddStyle(Column?.HeaderStyleFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
                 .AddStyle(Column?.HeaderStyle)
                 .AddStyle("width", Width?.ToPx(), when: Width.HasValue)
                 .AddStyle(Style)


### PR DESCRIPTION
Add implementations to apply FooterStyleFunc, FooterClassFunc, HeaderStyleFunc and HeaderClassFunc

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added code that actually applies the functions to the Css/Stylebuilders.
Changed func signature to accept IEnumerable<T> as Func<T, string> makes no sense as the Header/Footer cant be styled based on just one cell as the CellStyleFuncs allow.

fixes #8852 

## How Has This Been Tested?
none - sorry :(
I can add them if required

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
