### PR TITLE
TreeViewItem: Throw exception when ItemTemplate is misconfigured

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest8.razor
@@ -13,7 +13,7 @@
 </MudTreeView>
 
 @code {
-    #nullable enable
+#nullable enable
     public MudTreeView<TreeItemData>? Tree { get; set; }
 
     public HashSet<TreeItemData> TreeItems { get; set; } = new HashSet<TreeItemData>();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest8.razor
@@ -1,0 +1,65 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="TreeItemData" Items="@TreeItems" Hover="true" Width="100%" ServerData="LoadServerData" @ref="Tree">
+    <ItemTemplate Context="item">
+        <MudTreeViewItem T="TreeItemData" Items="@item.TreeItems" CanExpand=@item.CanExpand>
+            <BodyContent>
+                <MudIcon Icon="@item.Icon" Size="Size.Small"></MudIcon>
+                <MudText>@item.Title</MudText>
+                <MudText Typo="Typo.caption">@item.Number</MudText>
+            </BodyContent>
+        </MudTreeViewItem>
+    </ItemTemplate>
+</MudTreeView>
+
+@code {
+    #nullable enable
+    public MudTreeView<TreeItemData>? Tree { get; set; }
+
+    public HashSet<TreeItemData> TreeItems { get; set; } = new HashSet<TreeItemData>();
+
+    public class TreeItemData
+    {
+        public string Title { get; set; }
+
+        public string Icon { get; set; }
+
+        public int? Number { get; set; }
+
+        public bool CanExpand { get; set; }
+
+        public HashSet<TreeItemData>? TreeItems { get; set; }
+
+        public TreeItemData(string title, string icon, int? number = null, bool canExpand = true)
+        {
+            Title = title;
+            Icon = icon;
+            Number = number;
+            CanExpand = canExpand;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        TreeItems.Add(new TreeItemData("All Mail", Icons.Material.Filled.Email));
+        TreeItems.Add(new TreeItemData("Trash", Icons.Material.Filled.Delete));
+        TreeItems.Add(new TreeItemData("Categories", Icons.Material.Filled.Label)
+            {
+                TreeItems = new HashSet<TreeItemData>()
+            {
+                new TreeItemData("Social", Icons.Material.Filled.Group, 90),
+                new TreeItemData("Updates", Icons.Material.Filled.Info, 2294),
+                new TreeItemData("Forums", Icons.Material.Filled.QuestionAnswer, 3566),
+                new TreeItemData("Promotions", Icons.Material.Filled.LocalOffer, 733)
+            }
+            });
+        TreeItems.Add(new TreeItemData("History", Icons.Material.Filled.Label, null, false));
+    }
+
+    public async Task<IReadOnlyCollection<TreeItemData>?> LoadServerData(TreeItemData parentNode)
+    {
+        if (parentNode == null) throw new Exception("Parent node is null!");
+        await Task.Delay(500);
+        return parentNode.TreeItems;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -931,8 +931,8 @@ namespace MudBlazor.UnitTests.Components
             });
 
 #nullable enable 
-            MudTreeView<T>? nullInstanceTree =null;
-            MudTreeViewItem<T>? nullInstanceItem =null;
+            MudTreeView<T>? nullInstanceTree = null;
+            MudTreeViewItem<T>? nullInstanceItem = null;
 #nullable disable
 
             exception.Message.Should().Be($"'{nameof(MudTreeView<T>)}.{nameof(nullInstanceTree.ServerData)}' requires '{nameof(nullInstanceTree.ItemTemplate)}.{nameof(MudTreeViewItem<T>)}.{nameof(nullInstanceItem.Value)}' to be supplied.");

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
@@ -929,7 +930,12 @@ namespace MudBlazor.UnitTests.Components
                 comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
             });
 
-            exception.Message.Should().Be("'MudTreeView.ServerData' requires 'ItemTemplate.MudTreeViewItem.Value' to be supplied.");
+#nullable enable 
+            MudTreeView<T>? nullInstanceTree =null;
+            MudTreeViewItem<T>? nullInstanceItem =null;
+#nullable disable
+
+            exception.Message.Should().Be($"'{nameof(MudTreeView<T>)}.{nameof(nullInstanceTree.ServerData)}' requires '{nameof(nullInstanceTree.ItemTemplate)}.{nameof(MudTreeViewItem<T>)}.{nameof(nullInstanceItem.Value)}' to be supplied.");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -919,5 +919,17 @@ namespace MudBlazor.UnitTests.Components
             isExpanded("images").Should().Be(false);
             isExpanded("logo.png").Should().Be(false);
         }
+        [Test]
+        public void TreeViewItem_SetParameters_ValueIsSetNull_WhenTextUnset_RootServerdataIsSet_Throw()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var comp = Context.RenderComponent<TreeViewTest8>();
+                comp.SetParametersAndRender();
+                comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
+            });
+
+            exception.Message.Should().Be("'MudTreeView.ServerData' requires 'ItemTemplate.MudTreeViewItem.Value' to be supplied.");
+        }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -331,7 +331,14 @@ namespace MudBlazor
             foreach (var item in _childItems)
                 await item.CollapseAllAsync();
         }
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
 
+            if (Text == null && (Value == null && MudTreeRoot?.ServerData != null))
+                throw new InvalidOperationException(
+                    $"'{nameof(MudTreeView<T>)}.{nameof(MudTreeRoot.ServerData)}' requires '{nameof(MudTreeRoot.ItemTemplate)}.{nameof(MudTreeViewItem<T>)}.{nameof(Value)}' to be supplied.");
+        }
         private async Task OnCheckboxChangedAsync()
         {
             if (MudTreeRoot == null)


### PR DESCRIPTION
## Description
I'm creating this PR in reference to my previously deleted PR [https://github.com/MudBlazor/MudBlazor/pull/8168](https://github.com/MudBlazor/MudBlazor/pull/8168).

@henon fix is now ready to merge for v7. Thanks.

> This TreeView-bug only occurs when TreeView.ServeData is used with a custom ItemTemplate.
<br>The parent node reference passed to the MudTreeView.ServerData delegate function is ALWAYS null when the parameter > 'Value' is NOT set in the customized MudTreeViewItems-Template. To fix this issue an exception is thrown when the parameter <br> <br> MudTreeView.ServerData is set with MudTreeViewItem.Value & > MudTreeViewItem.Text unset.
<br> MudTreeView.Text needs to be null to make sure the TreeViewItem is not only supplied with a display text - in which case the parentNode would be null anyways.<br> <br> See Ticket https://github.com/MudBlazor/MudBlazor/issues/7156 for bug reproduction - still present in latest release v6.0.15.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit test is included in the comit covering the same scenario from Ticket [#7156](https://github.com/MudBlazor/MudBlazor/issues/7156).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
