### PR TITLE
Docs: Standard Language for XML Documentation for Previously Documented Classes

### DIFF
--- a/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
         where TChildComponent : MudComponentBase
     {
         /// <summary>
-        /// The items.
+        /// The alternate source of items if <c>Items</c> is not set.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Data)]

--- a/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
@@ -28,7 +28,7 @@ namespace MudBlazor
         public RenderFragment<TData>? ItemTemplate { get; set; }
 
         /// <summary>
-        /// Gets the currently selected item.
+        /// The currently selected item.
         /// </summary>
         /// <remarks>
         /// This property will return either an item from the <c>Items</c> property, or an item from <see cref="ItemsSource"/> if <c>Items</c> is <c>null</c>.

--- a/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
@@ -14,14 +14,14 @@ namespace MudBlazor
         where TChildComponent : MudComponentBase
     {
         /// <summary>
-        /// Gets or sets the items.
+        /// The items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Data)]
         public IEnumerable<TData>? ItemsSource { get; set; }
 
         /// <summary>
-        /// Gets or sets the template used to display each item.
+        /// The template used to display each item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Appearance)]

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
         private bool ParentDisabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the HTML tag rendered for this component.
+        /// The HTML tag rendered for this component.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>button</c>.
@@ -35,7 +35,7 @@ namespace MudBlazor
         public string HtmlTag { get; set; } = "button";
 
         /// <summary>
-        /// Gets or sets the type of button.
+        /// The type of button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>Button</c>. Other values are <c>Submit</c> to submit a form, and <c>Reset</c> to clear a form.
@@ -45,7 +45,7 @@ namespace MudBlazor
         public ButtonType ButtonType { get; set; }
 
         /// <summary>
-        /// Gets or sets the URL to navigate to when the button is clicked.
+        /// The URL to navigate to when the button is clicked.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>. When clicked, the browser will navigate to this URL.  Use the <see cref="Target"/> property to target a specific tab.
@@ -55,7 +55,7 @@ namespace MudBlazor
         public string? Href { get; set; }
 
         /// <summary>
-        /// Gets or sets the browser tab/window opened when a click occurs and <see cref="Href"/> is set.
+        /// The browser tab/window opened when a click occurs and <see cref="Href"/> is set.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>. This property allows navigation to open a new tab/window or to reuse a specific tab.  Possible values are <c>_blank</c>, <c>_self</c>, <c>_parent</c>, <c>_top</c>, <c>noopener</c>, or the name of an <c>iframe</c> element.
@@ -65,7 +65,7 @@ namespace MudBlazor
         public string? Target { get; set; }
 
         /// <summary>
-        /// Gets or sets the relationship between the current document and the linked document when <see cref="Href"/> is set.
+        /// The relationship between the current document and the linked document when <see cref="Href"/> is set.
         /// </summary>
         /// <remarks>
         /// This property is typically used by web crawlers to get more information about a link.  Common values can be found here: <see href="https://www.w3schools.com/tags/att_a_rel.asp" />
@@ -75,7 +75,7 @@ namespace MudBlazor
         public string? Rel { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the user can interact with this button.
+        /// Whether the user can interact with this button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -85,7 +85,7 @@ namespace MudBlazor
         public bool Disabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the title of this button.
+        /// The title of this button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  This property is typically used to improve accessibility.
@@ -95,7 +95,7 @@ namespace MudBlazor
         public string? Title { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a click event is bubbled up to the parent component.
+        /// Whether a click event is bubbled up to the parent component.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -105,7 +105,7 @@ namespace MudBlazor
         public bool ClickPropagation { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a shadow is displayed.
+        /// Whether a shadow is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -115,7 +115,7 @@ namespace MudBlazor
         public bool DropShadow { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether a ripple effect is shown when the user clicks the button.
+        /// Whether a ripple effect is shown when the user clicks the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
     public abstract class MudBaseButton : MudComponentBase
     {
         /// <summary>
-        /// Gets or sets any custom activation behavior.
+        /// The custom activation behavior.
         /// </summary>
         /// <remarks>
         /// Default to <c>null</c>.  This property is used to implement a custom behavior beyond a basic button click.  The activation will occur during the <see cref="OnClick"/> event.

--- a/src/MudBlazor/Base/MudBaseColumn.cs
+++ b/src/MudBlazor/Base/MudBaseColumn.cs
@@ -35,13 +35,13 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets the way to render this column.
+        /// The way to render this column.
         /// </summary>
         [CascadingParameter(Name = "Mode")]
         public Rendermode Mode { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the column is displayed.
+        /// Whether the column is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -50,7 +50,7 @@ namespace MudBlazor
         public bool Visible { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the text to display for the column header.
+        /// The text to display for the column header.
         /// </summary>
         [Parameter]
         public string HeaderText { get; set; }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -181,7 +181,7 @@ namespace MudBlazor
         /// The size of the icon.
         /// </summary>
         /// <remarks>
-        /// Default to <see cref="Size.Medium"/>.
+        /// Defaults to <see cref="Size.Medium"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
     {
         private bool _isDirty;
         /// <summary>
-        /// Gets whether validation has been performed during a validation cycle.
+        /// Whether validation has been performed during a validation cycle.
         /// </summary>
         /// <remarks>
         /// This field is set to <c>true</c> to prevent validation from occurring more than once during a validation cycle.  Each change in the <see cref="Value"/> will reset this field to <c>false</c>.
@@ -148,7 +148,7 @@ namespace MudBlazor
         public Adornment Adornment { get; set; } = Adornment.None;
 
         /// <summary>
-        /// Gets whether validation only occurs when the user changes the <see cref="Value"/>.
+        /// Whether validation only occurs when the user changes the <see cref="Value"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>. When <c>true</c>, validation only occurs if the user has changed the input value at least once.
@@ -231,7 +231,7 @@ namespace MudBlazor
         public string? Placeholder { get; set; }
 
         /// <summary>
-        /// Gets or sets an optional character count and stop count.
+        /// The optional character count and stop count.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  When <c>0</c>, the current character count is displayed.  When <c>1</c> or greater, the character count and this count are displayed.
@@ -702,7 +702,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets the type of input received by this component.
+        /// The type of input received by this component.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="InputType.Text"/>.

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets whether the component can receive input.
+        /// Whether the component can receive input.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -55,7 +55,7 @@ namespace MudBlazor
         private bool ParentDisabled { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the input can be changed by the user.
+        /// Whether the input can be changed by the user.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the user can copy text in the control, but cannot change the <see cref="Value" />.
@@ -68,7 +68,7 @@ namespace MudBlazor
         private bool ParentReadOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this input fills the full width of its container.
+        /// Whether this input fills the full width of its container.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -78,7 +78,7 @@ namespace MudBlazor
         public bool FullWidth { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the <see cref="Value"/> is changed as soon as input is received.
+        /// Whether the <see cref="Value"/> is changed as soon as input is received.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="Value"/> property will be updated any time user input occurs.  Otherwise, <see cref="Value"/> is updated when the user presses <c>Enter</c> or the input loses focus.
@@ -88,7 +88,7 @@ namespace MudBlazor
         public bool Immediate { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the input has an underline.
+        /// Whether the input has an underline.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -98,7 +98,7 @@ namespace MudBlazor
         public bool Underline { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the text displayed below the text field.
+        /// The text displayed below the text field.
         /// </summary>
         /// <remarks>
         /// This property is typically used to help the user understand what kind of input is allowed.  The <see cref="HelperTextOnFocus"/> property controls when this text is visible.
@@ -108,7 +108,7 @@ namespace MudBlazor
         public string? HelperText { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the <see cref="HelperText"/> is only shown when this input has focus.
+        /// Whether the <see cref="HelperText"/> is only shown when this input has focus.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -118,7 +118,7 @@ namespace MudBlazor
         public bool HelperTextOnFocus { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon displayed for the adornment.
+        /// The icon displayed for the adornment.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  This icon will be displayed when <see cref="Adornment"/> is <c>Start</c> or <c>End</c>, and no value for <see cref="AdornmentText"/> is set.
@@ -128,7 +128,7 @@ namespace MudBlazor
         public string? AdornmentIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets the text displayed for the adornment.
+        /// The text displayed for the adornment.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  This text will be displayed when <see cref="Adornment"/> is <c>Start</c> or <c>End</c>.  The <see cref="AdornmentIcon"/> property will be ignored if this property is set.
@@ -138,7 +138,7 @@ namespace MudBlazor
         public string? AdornmentText { get; set; }
 
         /// <summary>
-        /// Gets or sets the location of the adornment icon or text.
+        /// The location of the adornment icon or text.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Adornment.None"/>.  Then set to <c>Start</c> or <c>End</c>, the <see cref="AdornmentText"/> will be displayed, or <see cref="AdornmentIcon"/> if no adornment text is specified.  
@@ -158,7 +158,7 @@ namespace MudBlazor
         public bool OnlyValidateIfDirty { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of <see cref="AdornmentText"/> or <see cref="AdornmentIcon"/>.
+        /// The color of <see cref="AdornmentText"/> or <see cref="AdornmentIcon"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -168,7 +168,7 @@ namespace MudBlazor
         public Color AdornmentColor { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the ARIA label of the adornment.
+        /// The ARIA label of the adornment.
         /// </summary>
         /// <remarks>
         /// Defaults to an empty string.  This property controls the value set for the <c>aria-label</c> attribute.
@@ -178,7 +178,7 @@ namespace MudBlazor
         public string AdornmentAriaLabel { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the size of the icon.
+        /// The size of the icon.
         /// </summary>
         /// <remarks>
         /// Default to <see cref="Size.Medium"/>.
@@ -194,7 +194,7 @@ namespace MudBlazor
         public EventCallback<MouseEventArgs> OnAdornmentClick { get; set; }
 
         /// <summary>
-        /// Gets or sets the appearance variation to use.
+        /// The appearance variation to use.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Text"/>.  Other options are <c>Outlined</c> and <c>Filled</c>.
@@ -204,7 +204,7 @@ namespace MudBlazor
         public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        /// Gets or sets the amount of vertical spacing for this input.
+        /// The amount of vertical spacing for this input.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Margin.None"/>.
@@ -221,7 +221,7 @@ namespace MudBlazor
         public Typo Typo { get; set; } = Typo.input;
 
         /// <summary>
-        /// Gets or sets the text displayed in the input if no <see cref="Value"/> is specified.
+        /// The text displayed in the input if no <see cref="Value"/> is specified.
         /// </summary>
         /// <remarks>
         /// This property is typically used to give the user a hint as to what kind of input is expected.
@@ -241,7 +241,7 @@ namespace MudBlazor
         public int? Counter { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number of characters allowed.
+        /// The maximum number of characters allowed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>524288</c>.  This value is typically set to a maximum length such as the size of a database column the value will be persisted to.
@@ -251,7 +251,7 @@ namespace MudBlazor
         public int MaxLength { get; set; } = 524288;
 
         /// <summary>
-        /// Gets or sets the label for this input.
+        /// The label for this input.
         /// </summary>
         /// <remarks>
         /// If no <see cref="Value"/> is specified, the label will be displayed in the input.  Otherwise, it will be scaled down to the top of the input.
@@ -261,7 +261,7 @@ namespace MudBlazor
         public string? Label { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this input automatically receives focus.
+        /// Whether this input automatically receives focus.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the input will receive focus automatically.
@@ -278,14 +278,14 @@ namespace MudBlazor
         public int Lines { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets the text displayed in the input.
+        /// The text displayed in the input.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
         public string? Text { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the text cannot be updated via a bound value.
+        /// Whether the text cannot be updated via a bound value.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  Applies only to Blazor Server (BSS) applications.  When <c>false</c>, the input's text can be updated programmatically while the input has focus.
@@ -295,7 +295,7 @@ namespace MudBlazor
         public bool TextUpdateSuppression { get; set; } = true; // Solves issue #1012: Textfield swallowing chars when typing rapidly
 
         /// <summary>
-        /// Gets or sets the type of input expected.
+        /// The type of input expected.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="InputMode.text"/>.
@@ -305,7 +305,7 @@ namespace MudBlazor
         public virtual InputMode InputMode { get; set; } = InputMode.text;
 
         /// <summary>
-        /// Gets or sets the regular expression used to validate the <see cref="Value"/> property.
+        /// The regular expression used to validate the <see cref="Value"/> property.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  This property is used to validate the input against a regular expression.  Not supported if <see cref="Lines"/> is <c>2</c> or greater.  Must be a valid JavaScript regular expression.
@@ -315,7 +315,7 @@ namespace MudBlazor
         public virtual string? Pattern { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the label is allowed to appear inside the input if no <see cref="Value"/> is specified.
+        /// Whether the label is allowed to appear inside the input if no <see cref="Value"/> is specified.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the label will not move into the input when the input is empty.
@@ -349,7 +349,7 @@ namespace MudBlazor
         public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the default key-down action occurs.
+        /// Whether the default key-down action occurs.
         /// </summary>
         /// <remarks>
         /// When <c>true</c>, the browser will not perform its default behavior when a key-down occurs.  This is typically used when a key-down needs to override a browser's default behavior.
@@ -365,7 +365,7 @@ namespace MudBlazor
         public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the default key-up action occurs.
+        /// Whether the default key-up action occurs.
         /// </summary>
         /// <remarks>
         /// When <c>true</c>, the browser will not perform its default behavior when a key-up occurs.  This is typically used when a key-up needs to override the browser's default behavior.
@@ -381,7 +381,7 @@ namespace MudBlazor
         public EventCallback<T> ValueChanged { get; set; }
 
         /// <summary>
-        /// Gets or sets the value for this input.
+        /// The value for this input.
         /// </summary>
         /// <remarks>
         /// This property represents the strongly typed value for the input.  It is typically the result of parsing raw input via the <see cref="Text"/> property.
@@ -395,7 +395,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets the format applied to values.
+        /// The format applied to values.
         /// </summary>
         /// <remarks>
         /// This property is passed into the <c>ToString()</c> method of the <see cref="Value"/> property, such as formatting <c>int</c>, <c>float</c>, <c>DateTime</c> and <c>TimeSpan</c> values.

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -15,14 +15,14 @@ namespace MudBlazor
         private int _selectedIndexField = -1;
 
         /// <summary>
-        /// Gets or sets the content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Data)]
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Gets or sets the index of the currently selected item.
+        /// The index of the currently selected item.
         /// </summary>
         /// <remarks>When this property changes, the <see cref="SelectedIndexChanged"/> event occurs.</remarks>
         [Parameter]

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -51,18 +51,18 @@ namespace MudBlazor
         public EventCallback<int> SelectedIndexChanged { get; set; }
 
         /// <summary>
-        /// Gets the previously selected item.
+        /// The previously selected item.
         /// </summary>
         public TChildComponent? LastContainer { get; private set; } = null;
 
         /// <summary>
-        /// Gets the list of items.
+        /// The list of items.
         /// </summary>
         /// <remarks>This property is ignored when <c>ItemsSource</c> is not null.</remarks>
         public List<TChildComponent> Items { get; } = new List<TChildComponent>();
 
         /// <summary>
-        /// Gets the currently selected item.
+        /// The currently selected item.
         /// </summary>
         /// <remarks>This property returns the item in the <see cref="Items"/> property at the <see cref="SelectedIndex"/>.</remarks>
         public TChildComponent? SelectedContainer

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -24,7 +24,9 @@ namespace MudBlazor
         /// <summary>
         /// The index of the currently selected item.
         /// </summary>
-        /// <remarks>When this property changes, the <see cref="SelectedIndexChanged"/> event occurs.</remarks>
+        /// <remarks>
+        /// When this property changes, the <see cref="SelectedIndexChanged"/> event occurs.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.General.Behavior)]
         public int SelectedIndex
@@ -58,13 +60,17 @@ namespace MudBlazor
         /// <summary>
         /// The list of items.
         /// </summary>
-        /// <remarks>This property is ignored when <c>ItemsSource</c> is not null.</remarks>
+        /// <remarks>
+        /// This property is ignored when <c>ItemsSource</c> is not null.
+        /// </remarks>
         public List<TChildComponent> Items { get; } = new List<TChildComponent>();
 
         /// <summary>
         /// The currently selected item.
         /// </summary>
-        /// <remarks>This property returns the item in the <see cref="Items"/> property at the <see cref="SelectedIndex"/>.</remarks>
+        /// <remarks>
+        /// This property returns the item in the <see cref="Items"/> property at the <see cref="SelectedIndex"/>.
+        /// </remarks>
         public TChildComponent? SelectedContainer
         {
             get => SelectedIndex >= 0 && Items.Count > SelectedIndex ? Items[SelectedIndex] : null;
@@ -146,7 +152,9 @@ namespace MudBlazor
         /// <summary>
         /// When overridden, adds an item to the list.
         /// </summary>
-        /// <param name="item">The item to add.</param>
+        /// <param name="item">
+        /// The item to add.
+        /// </param>
         public virtual void AddItem(TChildComponent item) { }
     }
 }

--- a/src/MudBlazor/Base/MudBaseSelectItem.cs
+++ b/src/MudBlazor/Base/MudBaseSelectItem.cs
@@ -14,28 +14,28 @@ namespace MudBlazor
         private NavigationManager UriHelper { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets whether the user can interact with this item.
+        /// Whether the user can interact with this item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Behavior)]
         public bool Disabled { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to show a ripple effect when the user clicks the button. Default is true.
+        /// Whether to show a ripple effect when the user clicks the button. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Appearance)]
         public bool Ripple { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the URL to navigate to when this item is clicked.
+        /// The URL to navigate to when this item is clicked.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.ClickAction)]
         public string? Href { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a full page load occurs during navigation.
+        /// Whether a full page load occurs during navigation.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>. When <c>true</c>, client-side routing is bypassed and the browser is forced to load the new page from the server.
@@ -45,7 +45,7 @@ namespace MudBlazor
         public bool ForceLoad { get; set; }
 
         /// <summary>
-        /// Gets or sets the content within this item.
+        /// The content within this item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.General.Behavior)]

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
         public MudBooleanInput() : base(new BoolConverter<T?>()) { }
 
         /// <summary>
-        /// Gets or sets whether the user can interact with this input.
+        /// Whether the user can interact with this input.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -33,7 +33,7 @@ namespace MudBlazor
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
         /// <summary>
-        /// Gets or sets whether the use can change the input.
+        /// Whether the use can change the input.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the user can copy the input but cannot change it.
@@ -48,7 +48,7 @@ namespace MudBlazor
         protected bool GetReadOnlyState() => ReadOnly || ParentReadOnly;
 
         /// <summary>
-        /// Gets or sets the currently selected value.
+        /// The currently selected value.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
@@ -63,7 +63,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets whether the parent component also handles the click event.
+        /// Whether the parent component also handles the click event.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, the click will not bubble up to parent components.

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         protected ILogger Logger => _logger ??= LoggerFactory.CreateLogger(GetType());
 
         /// <summary>
-        /// Gets or sets CSS classes applied to this component.
+        /// The CSS classes applied to this component.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.  Use the <see cref="Style"/> property to apply custom CSS styles.
@@ -36,7 +36,7 @@ namespace MudBlazor
         public string? Class { get; set; }
 
         /// <summary>
-        /// Gets or sets any CSS styles applied to this component.
+        /// The CSS styles applied to this component.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="Class"/> property to apply CSS classes.
@@ -46,7 +46,7 @@ namespace MudBlazor
         public string? Style { get; set; }
 
         /// <summary>
-        /// Gets or sets an arbitrary object to link to this component.
+        /// The arbitrary object to link to this component.
         /// </summary>
         /// <remarks>
         /// This property is typically used to associate additional information with this component, such as a model containing data for this component.
@@ -56,7 +56,7 @@ namespace MudBlazor
         public object? Tag { get; set; }
 
         /// <summary>
-        /// Gets or sets any additional HTML attributes to apply to this component.
+        /// The additional HTML attributes to apply to this component.
         /// </summary>
         /// <remarks>
         /// This property is typically used to provide additional HTML attributes during rendering such as ARIA accessibility tags or a custom ID.

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -66,7 +66,7 @@ namespace MudBlazor
         public Dictionary<string, object?> UserAttributes { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
-        /// Gets or sets whether <see cref="JSRuntime" /> is available.
+        /// Whether <see cref="JSRuntime" /> is available.
         /// </summary>
         protected bool IsJSRuntimeAvailable { get; set; }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
         internal bool SubscribeToParentForm { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether an input is required.
+        /// Whether an input is required.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, an error with the text in <see cref="RequiredError"/> will be shown during validation if no input was given.
@@ -54,7 +54,7 @@ namespace MudBlazor
         public bool Required { get; set; }
 
         /// <summary>
-        /// Gets or sets the text displayed during validation if no input was given.
+        /// The text displayed during validation if no input was given.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>"Required"</c>.  This text is only shown when <see cref="Required"/> is <c>true</c>.
@@ -64,14 +64,14 @@ namespace MudBlazor
         public string RequiredError { get; set; } = "Required";
 
         /// <summary>
-        /// Gets or sets the text displayed if the <see cref="Error"/> property is <c>true</c>.
+        /// The text displayed if the <see cref="Error"/> property is <c>true</c>.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
         public string? ErrorText { get; set; }
 
         /// <summary>
-        /// Gets or sets whether an error is displayed.
+        /// Whether an error is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the text in <see cref="ErrorText"/> is displayed.
@@ -81,7 +81,7 @@ namespace MudBlazor
         public bool Error { get; set; }
 
         /// <summary>
-        /// Gets or sets the ID of the error description element, for use by <c>aria-describedby</c> when <see cref="Error"/> is <c>true</c>.
+        /// The ID of the error description element, for use by <c>aria-describedby</c> when <see cref="Error"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  When set and the <see cref="Error"/> property is <c>true</c>, an <c>aria-describedby</c> attribute is rendered to improve accessibility for users.
@@ -91,7 +91,7 @@ namespace MudBlazor
         public string? ErrorId { get; set; }
 
         /// <summary>
-        /// Gets or sets the type converter for this input.
+        /// The type converter for this input.
         /// </summary>
         /// <remarks>
         /// This property provides a way to customize conversions between <typeparamref name="T"/> objects and <typeparamref name="U"/> values.  If no converter is specified, a default will be chosen based on the kind of input.
@@ -117,7 +117,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets the culture used to format and interpret values such as dates and currency.
+        /// The culture used to format and interpret values such as dates and currency.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="CultureInfo.InvariantCulture"/>.
@@ -221,7 +221,7 @@ namespace MudBlazor
         public List<string> ValidationErrors { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets the function used to detect problems with the input.
+        /// The function used to detect problems with the input.
         /// </summary>
         /// <remarks>
         /// When using a <see cref="MudForm"/>, this property can be any of several kinds of functions:
@@ -641,7 +641,7 @@ namespace MudBlazor
         #region --> Blazor EditForm validation support
 
         /// <summary>
-        /// Gets or sets the context used to perform validation.
+        /// The context used to perform validation.
         /// </summary>
         /// <remarks>
         /// When using an <see cref="EditForm"/>, gets a context used to perform validation.
@@ -661,7 +661,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets the model field containing validation attributes.
+        /// The model field containing validation attributes.
         /// </summary>
         /// <remarks>
         /// When using an <see cref="EditForm"/>, this property is used to find data annotation validation attributes such as <see cref="MaxLengthAttribute"/> used to perform validation.
@@ -671,7 +671,7 @@ namespace MudBlazor
         public Expression<Func<T>>? For { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the <see cref="For"/> property is <c>null</c>.
+        /// Whether the <see cref="For"/> property is <c>null</c>.
         /// </summary>
         [MemberNotNullWhen(false, nameof(For))]
         public bool IsForNull => For is null;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -156,7 +156,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets whether a problem has occurred during conversion.
+        /// Whether a problem has occurred during conversion.
         /// </summary>
         /// <remarks>
         /// When <c>true</c>, the <see cref="Converter"/> was unable to convert values, usually due to invalid input.
@@ -165,7 +165,7 @@ namespace MudBlazor
         public bool ConversionError => _converter.GetError;
 
         /// <summary>
-        /// Gets an error describing why type conversion failed.
+        /// The error describing why type conversion failed.
         /// </summary>
         /// <remarks>
         /// When set, returns the reason that the <see cref="Converter"/> was unable to convert values, usually due to invalid input.
@@ -173,7 +173,7 @@ namespace MudBlazor
         public string? ConversionErrorMessage => _converter.GetErrorMessage;
 
         /// <summary>
-        /// Gets whether an error, conversion error, or validation error is active.
+        /// Whether an error, conversion error, or validation error is active.
         /// </summary>
         /// <remarks>
         /// When <c>true</c>, the <see cref="Error"/> property is <c>true</c>, or <see cref="ConversionError"/> is <c>true</c>, or one or more <see cref="ValidationErrors"/> exists.
@@ -181,7 +181,7 @@ namespace MudBlazor
         public bool HasErrors => Error || ConversionError || ValidationErrors.Count > 0;
 
         /// <summary>
-        /// Gets the current error or conversion error.
+        /// The current error or conversion error.
         /// </summary>
         /// <returns>
         /// This property returns the value in <see cref="ErrorText"/> or <see cref="ConversionErrorMessage"/>.
@@ -203,7 +203,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets whether the user has interacted with this input, or focus has been released.
+        /// Whether the user has interacted with this input, or focus has been released.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the user has performed input, or focus has moved away from this input.  This property is typically used to show the <see cref="RequiredError"/> text only after the user has interacted with this input.
@@ -213,7 +213,7 @@ namespace MudBlazor
         #region MudForm Validation
 
         /// <summary>
-        /// Gets or sets a list of problems with the current input value.
+        /// The list of problems with the current input value.
         /// </summary>
         /// <remarks>
         /// When using a <see cref="MudForm"/>, this property is updated when validation has been performed.  Use the <see cref="Validation"/> property to control what validations are performed.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -67,7 +67,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the CSS classes applied to the popover.
+        /// The CSS classes applied to the popover.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
@@ -77,7 +77,7 @@ namespace MudBlazor
         public string PopoverClass { get; set; }
 
         /// <summary>
-        /// Gets or sets the CSS classes applied to the internal list.
+        /// The CSS classes applied to the internal list.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
@@ -87,7 +87,7 @@ namespace MudBlazor
         public string ListClass { get; set; }
 
         /// <summary>
-        /// Gets or sets the CSS classes applied to internal list items.
+        /// The CSS classes applied to internal list items.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
@@ -107,7 +107,7 @@ namespace MudBlazor
         public Origin AnchorOrigin { get; set; } = Origin.BottomCenter;
 
         /// <summary>
-        /// Gets or sets the transform origin point for the popover.
+        /// The transform origin point for the popover.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Origin.TopCenter"/>.
@@ -117,7 +117,7 @@ namespace MudBlazor
         public Origin TransformOrigin { get; set; } = Origin.TopCenter;
 
         /// <summary>
-        /// Gets or sets whether compact padding will be used.
+        /// Whether compact padding will be used.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -127,7 +127,7 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Gets or sets the "open" Autocomplete icon.
+        /// The "open" Autocomplete icon.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.ArrowDropDown"/>.
@@ -137,7 +137,7 @@ namespace MudBlazor
         public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
-        /// Gets or sets the "close" Autocomplete icon.
+        /// The "close" Autocomplete icon.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.ArrowDropDown"/>.
@@ -147,7 +147,7 @@ namespace MudBlazor
         public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
-        /// Gets or sets the maximum height, in pixels, of the Autocomplete when it is open.
+        /// The maximum height, in pixels, of the Autocomplete when it is open.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>300</c>.
@@ -157,7 +157,7 @@ namespace MudBlazor
         public int MaxHeight { get; set; } = 300;
 
         /// <summary>
-        /// Gets or sets the function used to get the display text for each item.
+        /// The function used to get the display text for each item.
         /// </summary>
         /// <remarks>
         /// Defaults to the <c>ToString()</c> method of items.
@@ -181,7 +181,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets whether to show the progress indicator during searches.
+        /// Whether to show the progress indicator during searches.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  The progress indicator uses the color specified in the <see cref="ProgressIndicatorColor"/> property.
@@ -191,7 +191,7 @@ namespace MudBlazor
         public bool ShowProgressIndicator { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the color of the progress indicator.
+        /// The color of the progress indicator.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  This property is used when <see cref="ShowProgressIndicator"/> is <c>true</c>.
@@ -211,7 +211,7 @@ namespace MudBlazor
         public Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFunc { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number of items to display.
+        /// The maximum number of items to display.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>10</c>.  A value of <c>null</c> will display all items.
@@ -221,7 +221,7 @@ namespace MudBlazor
         public int? MaxItems { get; set; } = 10;
 
         /// <summary>
-        /// Gets or sets the minimum number of characters typed to initiate a search.
+        /// The minimum number of characters typed to initiate a search.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.
@@ -231,7 +231,7 @@ namespace MudBlazor
         public int MinCharacters { get; set; } = 0;
 
         /// <summary>
-        /// Gets or sets whether to reset the selected value if the user deletes the text.
+        /// Whether to reset the selected value if the user deletes the text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -241,7 +241,7 @@ namespace MudBlazor
         public bool ResetValueOnEmptyText { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the text will be selected (highlighted) when the component receives focus.
+        /// Whether the text will be selected (highlighted) when the component receives focus.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -251,7 +251,7 @@ namespace MudBlazor
         public bool SelectOnActivation { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether other items can be selected without resetting the Value.
+        /// Whether other items can be selected without resetting the Value.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, selecting an option will trigger a <see cref="SearchFunc"/> with the current Text.  Otherwise, an empty string is passed which can make it easier to view and select other options without resetting the Value. When <c>false</c>, <c>T</c> must either be a <c>record</c> or override the <c>GetHashCode</c> and <c>Equals</c> methods.
@@ -261,7 +261,7 @@ namespace MudBlazor
         public bool Strict { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the debounce interval, in milliseconds.
+        /// The debounce interval, in milliseconds.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>100</c>.  A higher value can help reduce the number of calls to <see cref="SearchFunc"/>, which can improve responsiveness.
@@ -271,7 +271,7 @@ namespace MudBlazor
         public int DebounceInterval { get; set; } = 100;
 
         /// <summary>
-        /// Gets or sets the custom template used to display unselected items.
+        /// The custom template used to display unselected items.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="ItemSelectedTemplate"/> property to control the display of selected items.
@@ -281,7 +281,7 @@ namespace MudBlazor
         public RenderFragment<T> ItemTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used to display selected items.
+        /// The custom template used to display selected items.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="ItemTemplate"/> property to control the display of unselected items.
@@ -291,7 +291,7 @@ namespace MudBlazor
         public RenderFragment<T> ItemSelectedTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used to display disabled items.
+        /// The custom template used to display disabled items.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -301,7 +301,7 @@ namespace MudBlazor
         public RenderFragment<T> ItemDisabledTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used when the number of items returned by <see cref="SearchFunc"/> is more than the value of the <see cref="MaxItems"/> property.
+        /// The custom template used when the number of items returned by <see cref="SearchFunc"/> is more than the value of the <see cref="MaxItems"/> property.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -311,7 +311,7 @@ namespace MudBlazor
         public RenderFragment MoreItemsTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used when no items are returned by <see cref="SearchFunc"/>.
+        /// The custom template used when no items are returned by <see cref="SearchFunc"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -321,7 +321,7 @@ namespace MudBlazor
         public RenderFragment NoItemsTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template shown above the list of items, if <see cref="SearchFunc"/> returns items to display.  Otherwise, the fragment is hidden.
+        /// The custom template shown above the list of items, if <see cref="SearchFunc"/> returns items to display.  Otherwise, the fragment is hidden.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="AfterItemsTemplate"/> property to control content displayed below items.
@@ -331,7 +331,7 @@ namespace MudBlazor
         public RenderFragment BeforeItemsTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template shown below the list of items, if <see cref="SearchFunc"/> returns items to display.  Otherwise, the fragment is hidden.
+        /// The custom template shown below the list of items, if <see cref="SearchFunc"/> returns items to display.  Otherwise, the fragment is hidden.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="BeforeItemsTemplate"/> property to control content displayed above items.
@@ -341,7 +341,7 @@ namespace MudBlazor
         public RenderFragment AfterItemsTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used for the progress indicator when <see cref="ShowProgressIndicator"/> is <c>true</c>.
+        /// The custom template used for the progress indicator when <see cref="ShowProgressIndicator"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="ProgressIndicatorInPopoverTemplate"/> property to control content displayed for the progress indicator inside the popover.
@@ -351,7 +351,7 @@ namespace MudBlazor
         public RenderFragment ProgressIndicatorTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used for the progress indicator inside the popover when <see cref="ShowProgressIndicator"/> is <c>true</c>.
+        /// The custom template used for the progress indicator inside the popover when <see cref="ShowProgressIndicator"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="ProgressIndicatorTemplate"/> property to control content displayed for the progress indicator.
@@ -361,7 +361,7 @@ namespace MudBlazor
         public RenderFragment ProgressIndicatorInPopoverTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the <c>Text</c> property is overridden when an item is selected.
+        /// Whether the <c>Text</c> property is overridden when an item is selected.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, selecting a value will update the Text property.  When <c>false</c>, incomplete values for Text are allowed.
@@ -371,7 +371,7 @@ namespace MudBlazor
         public bool CoerceText { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether the <c>Value</c> property is set even if no match is found by <see cref="SearchFunc"/>.
+        /// Whether the <c>Value</c> property is set even if no match is found by <see cref="SearchFunc"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the user input will be applied to the Value property which allows it to be validated and show an error message.
@@ -381,7 +381,7 @@ namespace MudBlazor
         public bool CoerceValue { get; set; }
 
         /// <summary>
-        /// Gets or sets the function used to determine if an item should be disabled.
+        /// The function used to determine if an item should be disabled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -397,7 +397,7 @@ namespace MudBlazor
         public EventCallback<bool> IsOpenChanged { get; set; }
 
         /// <summary>
-        /// Gets or sets whether pressing the <c>Tab</c> key updates the Value to the currently selected item.
+        /// Whether pressing the <c>Tab</c> key updates the Value to the currently selected item.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -407,7 +407,7 @@ namespace MudBlazor
         public bool SelectValueOnTab { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a Clear icon button is displayed.
+        /// Whether a Clear icon button is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, an icon is displayed which, when clicked, clears the Text and Value.  Use the <c>ClearIcon</c> property to control the Clear button icon.
@@ -435,7 +435,7 @@ namespace MudBlazor
         public EventCallback<int> ReturnedItemsCountChanged { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the search result drop-down is currently displayed.
+        /// Whether the search result drop-down is currently displayed.
         /// </summary>
         /// <remarks>
         /// When this property changes, the <see cref="IsOpenChanged"/> event will occur.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -97,7 +97,7 @@ namespace MudBlazor
         public string ListItemClass { get; set; }
 
         /// <summary>
-        /// Gets or sets where the popover will open from.
+        /// The location where the popover will open from.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Origin.BottomCenter" />.
@@ -201,7 +201,7 @@ namespace MudBlazor
         public Color ProgressIndicatorColor { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets a function used to search for items.
+        /// The function used to search for items.
         /// </summary>
         /// <remarks>
         /// This function searches for items containing the specified <c>string</c> value, and returns items which match up to the <see cref="MaxItems"/> property.  You can use the provided <see cref="CancellationToken"/> which is marked as canceled when the user changes the search text or selects a value from the list.

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the size of the drop shadow.
+        /// The size of the drop shadow.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
@@ -40,7 +40,7 @@ namespace MudBlazor
         public int Elevation { set; get; } = 0;
 
         /// <summary>
-        /// Gets or sets whether rounded corners are disabled.
+        /// Whether rounded corners are disabled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -50,7 +50,7 @@ namespace MudBlazor
         public bool Square { get; set; }
 
         /// <summary>
-        /// Gets or sets whether corners are rounded.
+        /// Whether corners are rounded.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
@@ -60,7 +60,7 @@ namespace MudBlazor
         public bool Rounded { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the avatar.
+        /// The color of the avatar.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -70,7 +70,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of the avatar.
+        /// The size of the avatar.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
@@ -80,7 +80,7 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets the display variant to use.
+        /// The display variant to use.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Filled" />. The variant changes the appearance of the avatar, such as <c>Text</c>, <c>Outlined</c>, or <c>Filled</c>.
@@ -90,7 +90,7 @@ namespace MudBlazor
         public Variant Variant { get; set; } = Variant.Filled;
 
         /// <summary>
-        /// Gets or sets the content within the avatar.
+        /// The content within the avatar.
         /// </summary>
         /// <remarks>
         /// This property allows for custom content to displayed inside of the avatar, but it is not required.

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -132,7 +132,7 @@ namespace MudBlazor
         public string? MaxAvatarClass { get; set; }
 
         /// <summary>
-        /// Gets or sets a template used to render avatars when the number of avatars exceeds <see cref="Max"/>.
+        /// The template used to render avatars when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the amount of space between avatars, between <c>0</c> and <c>16</c>.
+        /// The amount of space between avatars, between <c>0</c> and <c>16</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>3</c>.
@@ -35,7 +35,7 @@ namespace MudBlazor
         public int Spacing { get; set; } = 3;
 
         /// <summary>
-        /// Gets or sets whether an outline is displayed for the group.
+        /// Whether an outline is displayed for the group.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  This property is useful to differentiate avatars which are the same color or use images.
@@ -45,14 +45,14 @@ namespace MudBlazor
         public bool Outlined { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the color of the outline when <see cref="Outlined"/> is <c>true</c>.
+        /// The color of the outline when <see cref="Outlined"/> is <c>true</c>.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
         public Color OutlineColor { get; set; } = Color.Surface;
 
         /// <summary>
-        /// Gets or sets the size of the drop shadow when the number of avatars exceeds <see cref="Max"/>.
+        /// The size of the drop shadow when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.
@@ -62,7 +62,7 @@ namespace MudBlazor
         public int MaxElevation { set; get; } = 0;
 
         /// <summary>
-        /// Gets or sets whether rounded corners are disabled when the number of avatars exceeds <see cref="Max"/>.
+        /// Whether rounded corners are disabled when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> CSS style is set to <c>0</c>.
@@ -72,7 +72,7 @@ namespace MudBlazor
         public bool MaxSquare { get; set; }
 
         /// <summary>
-        /// Gets or sets whether corners are rounded when the number of avatars exceeds <see cref="Max"/>.
+        /// Whether corners are rounded when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
@@ -82,7 +82,7 @@ namespace MudBlazor
         public bool MaxRounded { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the avatar when the number of avatars exceeds <see cref="Max"/>.
+        /// The color of the avatar when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -92,7 +92,7 @@ namespace MudBlazor
         public Color MaxColor { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of the avatar when the number of avatars exceeds <see cref="Max"/>.
+        /// The size of the avatar when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
@@ -102,7 +102,7 @@ namespace MudBlazor
         public Size MaxSize { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets the display variant to use when the number of avatars exceeds <see cref="Max"/>.
+        /// The display variant to use when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Filled" />. The variant changes the appearance of the avatar, such as <c>Text</c>, <c>Outlined</c>, or <c>Filled</c>.
@@ -112,7 +112,7 @@ namespace MudBlazor
         public Variant MaxVariant { get; set; } = Variant.Filled;
 
         /// <summary>
-        /// Gets or sets the maximum allowed avatars to display.
+        /// The maximum allowed avatars to display.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.  When <c>0</c>, no maximum is enforced.  Otherwise, a "+#" avatar is shown for the number of avatars exceeding this number.
@@ -122,7 +122,7 @@ namespace MudBlazor
         public int Max { get; set; }
 
         /// <summary>
-        /// Gets or sets the CSS class applied when the number of avatars exceeds <see cref="Max"/>.
+        /// The CSS class applied when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -139,7 +139,7 @@ namespace MudBlazor
         public RenderFragment<int>? MaxAvatarsTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Behavior)]

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the location of the badge.
+        /// The location of the badge.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Origin.TopRight" />.
@@ -42,7 +42,7 @@ namespace MudBlazor
         public Origin Origin { get; set; } = Origin.TopRight;
 
         /// <summary>
-        /// Gets or sets the size of the drop shadow.
+        /// The size of the drop shadow.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
@@ -52,7 +52,7 @@ namespace MudBlazor
         public int Elevation { set; get; } = 0;
 
         /// <summary>
-        /// Gets or sets whether the badge can be seen.
+        /// Whether the badge can be seen.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -62,7 +62,7 @@ namespace MudBlazor
         public bool Visible { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the color of the badge.
+        /// The color of the badge.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -72,7 +72,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets whether a dot is displayed instead of any content.
+        /// Whether a dot is displayed instead of any content.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -82,7 +82,7 @@ namespace MudBlazor
         public bool Dot { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to display <see cref="ChildContent"/> over the main badge content.
+        /// Whether to display <see cref="ChildContent"/> over the main badge content.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -92,7 +92,7 @@ namespace MudBlazor
         public bool Overlap { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a border is displayed around the badge.
+        /// Whether a border is displayed around the badge.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -102,14 +102,14 @@ namespace MudBlazor
         public bool Bordered { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon to display in the badge.
+        /// The icon to display in the badge.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Badge.Behavior)]
         public string? Icon { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number allowed in the <see cref="Content"/> property.
+        /// The maximum number allowed in the <see cref="Content"/> property.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>99</c>.
@@ -119,7 +119,7 @@ namespace MudBlazor
         public int Max { get; set; } = 99;
 
         /// <summary>
-        /// Gets or sets the <c>string</c> or <c>int</c> value to display inside the badge.
+        /// The <c>string</c> or <c>int</c> value to display inside the badge.
         /// </summary>
         /// <remarks>
         /// Supported types are <c>string</c> and <c>int</c>.

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -129,7 +129,7 @@ namespace MudBlazor
         public object? Content { get; set; }
 
         /// <summary>
-        /// Gets or sets any CSS classes applied to the badge.
+        /// The CSS classes applied to the badge.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
@@ -139,7 +139,7 @@ namespace MudBlazor
         public string? BadgeClass { get; set; }
 
         /// <summary>
-        /// Gets or sets any child content for the component.
+        /// The content within this badge.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Badge.Behavior)]

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
@@ -11,17 +11,17 @@ namespace MudBlazor
     public class BreadcrumbItem
     {
         /// <summary>
-        /// Gets or sets the text to display.
+        /// The text to display.
         /// </summary>
         public string Text { get; }
 
         /// <summary>
-        /// Gets or sets the URL to navigate to when clicked.
+        /// The URL to navigate to when clicked.
         /// </summary>
         public string? Href { get; }
 
         /// <summary>
-        /// Gets or sets whether this item cannot be clicked.
+        /// Whether this item cannot be clicked.
         /// </summary>
         public bool Disabled { get; }
 

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         public bool Disabled { get; }
 
         /// <summary>
-        /// Gets or sets any custom icon for this item.
+        /// The custom icon for this item.
         /// </summary>
         public string? Icon { get; }
 

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -15,13 +15,13 @@ namespace MudBlazor;
 public partial class BreadcrumbLink
 {
     /// <summary>
-    /// Gets or sets the item to display.
+    /// The item to display.
     /// </summary>
     [Parameter]
     public BreadcrumbItem? Item { get; set; }
 
     /// <summary>
-    /// Gets or sets the parent breadcrumb component.
+    /// The parent breadcrumb component.
     /// </summary>
     [CascadingParameter]
     public MudBreadcrumbs? Parent { get; set; }

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbSeparator.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbSeparator.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor;
 public partial class BreadcrumbSeparator
 {
     /// <summary>
-    /// Gets or sets the parent breadcrumb component.
+    /// The parent breadcrumb component.
     /// </summary>
     [CascadingParameter]
     public MudBreadcrumbs? Parent { get; set; }

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -16,14 +16,14 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the list of items to display.
+        /// The list of items to display.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Breadcrumbs.Behavior)]
         public IReadOnlyList<BreadcrumbItem>? Items { get; set; }
 
         /// <summary>
-        /// Gets or sets the separator shown between items.
+        /// The separator shown between items.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>/</c>.  Will not be shown if <see cref="SeparatorTemplate"/> is set.
@@ -33,21 +33,21 @@ namespace MudBlazor
         public string Separator { get; set; } = "/";
 
         /// <summary>
-        /// Gets or sets the content shown between items.
+        /// The content shown between items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Breadcrumbs.Appearance)]
         public RenderFragment? SeparatorTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the custom template used to display items.
+        /// The custom template used to display items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Breadcrumbs.Behavior)]
         public RenderFragment<BreadcrumbItem>? ItemTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number of items to dislpay.
+        /// The maximum number of items to dislpay.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  If <see cref="Collapsed"/> is <c>true</c> and the number of items exceeds this value, the breadcrumbs will automatically collapse.
@@ -57,7 +57,7 @@ namespace MudBlazor
         public byte? MaxItems { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon to display when items are collapsed.
+        /// The icon to display when items are collapsed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>Icons.Material.Filled.SettingsEthernet</c>.  Displays when <see cref="Collapsed"/> and the number of items exceeds <see cref="MaxItems"/>.
@@ -67,7 +67,7 @@ namespace MudBlazor
         public string ExpanderIcon { get; set; } = Icons.Material.Filled.SettingsEthernet;
 
         /// <summary>
-        /// Gets or sets whether items are allowed to be collapsed when the number of items exceeds <see cref="MaxItems"/>.
+        /// Whether items are allowed to be collapsed when the number of items exceeds <see cref="MaxItems"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
     public partial class MudBreakpointProvider : IBrowserViewportObserver, IAsyncDisposable
     {
         /// <summary>
-        /// Gets or sets the current breakpoint.
+        /// The current breakpoint.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Breakpoint.Always"/>.
@@ -32,7 +32,7 @@ namespace MudBlazor
         protected IBrowserViewportService BrowserViewportService { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.BreakpointProvider.Behavior)]

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the icon displayed before the text.
+        /// The icon displayed before the text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use <see cref="EndIcon"/> to display an icon after the text.
@@ -41,7 +41,7 @@ namespace MudBlazor
         public string? StartIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon displayed after the text.
+        /// The icon displayed after the text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use <see cref="StartIcon"/> to display an icon before the text.
@@ -51,7 +51,7 @@ namespace MudBlazor
         public string? EndIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of icons.
+        /// The color of icons.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Inherit"/>.  
@@ -61,7 +61,7 @@ namespace MudBlazor
         public Color IconColor { get; set; } = Color.Inherit;
 
         /// <summary>
-        /// Gets or sets the size of icons.
+        /// The size of icons.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  When <c>null</c>, the value of <see cref="Size"/> is used.
@@ -81,7 +81,7 @@ namespace MudBlazor
         public string? IconClass { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the button.
+        /// The color of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -91,7 +91,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of the button.
+        /// The size of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.   Use the <see cref="IconSize"/> property to set the size of icons.
@@ -101,7 +101,7 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets the display variation to use.
+        /// The display variation to use.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Text"/>.
@@ -111,7 +111,7 @@ namespace MudBlazor
         public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        /// Gets or sets whether the button takes up 100% of the container width.
+        /// Whether the button takes up 100% of the container width.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -71,7 +71,7 @@ namespace MudBlazor
         public Size? IconSize { get; set; }
 
         /// <summary>
-        /// Gets or sets any CSS classes applied to icons.
+        /// The CSS classes applied to icons.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
@@ -121,7 +121,7 @@ namespace MudBlazor
         public bool FullWidth { get; set; }
 
         /// <summary>
-        /// Gets or sets any content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -81,7 +81,7 @@ namespace MudBlazor
         public Size IconSize { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets any text displayed in the button.
+        /// The text displayed in the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the color of the button.
+        /// The color of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -31,7 +31,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of the button.
+        /// The size of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Large"/>.
@@ -41,7 +41,7 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Large;
 
         /// <summary>
-        /// Gets or sets the icon shown before any text.
+        /// The icon shown before any text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="EndIcon"/> property to show an icon after text.
@@ -51,7 +51,7 @@ namespace MudBlazor
         public string? StartIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon shown after any text.
+        /// The icon shown after any text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Use the <see cref="StartIcon"/> property to show an icon before text.
@@ -61,7 +61,7 @@ namespace MudBlazor
         public string? EndIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of any icons.
+        /// The color of any icons.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Inherit"/>.  Controls the color of <see cref="StartIcon"/> and <see cref="EndIcon"/> icons.
@@ -71,7 +71,7 @@ namespace MudBlazor
         public Color IconColor { get; set; } = Color.Inherit;
 
         /// <summary>
-        /// Gets or sets the size of the icon.
+        /// The size of the icon.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
         protected bool AsButton => Variant != Variant.Text;
 
         /// <summary>
-        /// Gets or sets the icon to display.
+        /// The icon to display.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -37,7 +37,7 @@ namespace MudBlazor
         public string? Icon { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of the button.
+        /// The color of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -47,7 +47,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of the button.
+        /// The size of the button.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
@@ -67,7 +67,7 @@ namespace MudBlazor
         public Edge Edge { get; set; }
 
         /// <summary>
-        /// Gets or sets the variation to use.
+        /// The variation to use.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Text"/>.  Other values include <see cref="Variant.Filled"/> and <see cref="Variant.Outlined"/>.

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -57,10 +57,10 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets any negative margin applied.
+        /// The amount of negative margin applied.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Edge.False"/>.
+        /// Defaults to <see cref="Edge.False"/>.  Other values are <see cref="Edge.Start"/> and <see cref="Edge.End"/>
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
@@ -77,7 +77,7 @@ namespace MudBlazor
         public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        /// Gets or sets any custom content within this button.
+        /// The custom content within this button.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Only displays if <see cref="Icon"/> is not set.

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -83,7 +83,7 @@ namespace MudBlazor
         public Edge Edge { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to show a ripple effect when the user clicks the button. Default is true.
+        /// Whether to show a ripple effect when the user clicks the button. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
         public bool OverrideStyles { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets any custom content within this group.
+        /// The custom content within this group.
         /// </summary>
         /// <remarks>
         /// This property allows for custom content to displayed inside of the group, but it is not required.

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets whether text is displayed Right-to-Left (RTL).
+        /// Whether text is displayed Right-to-Left (RTL).
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, text will display property for RTL languages such as Arabic, Hebrew, and Persian.
@@ -32,7 +32,7 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this group's style overrides the style of individual buttons.
+        /// Whether this group's style overrides the style of individual buttons.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, the button styles are defined by this group.
@@ -52,7 +52,7 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Gets or sets whether buttons are displayed vertically.
+        /// Whether buttons are displayed vertically.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, buttons will be displayed vertically, otherwise horizontally.
@@ -62,7 +62,7 @@ namespace MudBlazor
         public bool Vertical { get; set; }
 
         /// <summary>
-        /// Gets or sets whether a shadow is displayed.
+        /// Whether a shadow is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -72,7 +72,7 @@ namespace MudBlazor
         public bool DropShadow { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the color of all buttons in this group.
+        /// The color of all buttons in this group.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default" />.  Theme colors are supported.
@@ -82,7 +82,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the size of all buttons in the group.
+        /// The size of all buttons in the group.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
@@ -92,7 +92,7 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets the display variant of all buttons in the group.
+        /// The display variant of all buttons in the group.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Variant.Text"/>.  Other supported values are <see cref="Variant.Outlined"/> and <see cref="Variant.Filled"/>.

--- a/src/MudBlazor/Components/Card/MudCard.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCard.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
         public bool Outlined { get; set; }
 
         /// <summary>
-        /// Gets or sets any content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]

--- a/src/MudBlazor/Components/Card/MudCard.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCard.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the size of the drop shadow.
+        /// The size of the drop shadow.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>1</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
@@ -24,7 +24,7 @@ namespace MudBlazor
         public int Elevation { set; get; } = 1;
 
         /// <summary>
-        /// Gets or sets whether rounded corners are disabled.
+        /// Whether rounded corners are disabled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -34,7 +34,7 @@ namespace MudBlazor
         public bool Square { get; set; }
 
         /// <summary>
-        /// Gets or sets whether an outline is displayed.
+        /// Whether an outline is displayed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  This property is useful to differentiate cards which are the same color or use images.

--- a/src/MudBlazor/Components/Card/MudCardActions.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardActions.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets any content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]

--- a/src/MudBlazor/Components/Card/MudCardContent.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardContent.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets any content within this component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]

--- a/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
         public RenderFragment? CardHeaderAvatar { get; set; }
 
         /// <summary>
-        /// Gets or sets the main content of the header.
+        /// The main content of the header.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]

--- a/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
@@ -14,28 +14,28 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets any avatar to display.
+        /// The avatar to display within this header.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]
         public RenderFragment? CardHeaderAvatar { get; set; }
 
         /// <summary>
-        /// The main content of the header.
+        /// The main content of this header.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]
         public RenderFragment? CardHeaderContent { get; set; }
 
         /// <summary>
-        /// Gets or sets any actions displayed in this header.
+        /// The actions displayed within this header.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]
         public RenderFragment? CardHeaderActions { get; set; }
 
         /// <summary>
-        /// Gets or sets any additional content to display.
+        /// The custom content within this header.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]

--- a/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the title of the media.
+        /// The title of the media.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  This property can improve accessibility by describing the media in the <see cref="Image"/> property.
@@ -28,14 +28,14 @@ namespace MudBlazor
         public string? Title { get; set; }
 
         /// <summary>
-        /// Gets or sets the URL of the image to display.
+        /// The URL of the image to display.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Card.Behavior)]
         public string? Image { get; set; }
 
         /// <summary>
-        /// Gets or sets the height, in pixels, of the <see cref="Image"/>.
+        /// The height, in pixels, of the <see cref="Image"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>300</c>.

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -34,7 +34,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets whether text is displayed Right-to-Left (RTL).
+        /// Whether text is displayed Right-to-Left (RTL).
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, text will display property for RTL languages such as Arabic, Hebrew, and Persian.
@@ -43,7 +43,7 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Gets or sets whether "Next" and "Previous" arrows are displayed.
+        /// Whether "Next" and "Previous" arrows are displayed.
         /// </summary>
         /// <reamrks>
         /// Defaults to <c>true</c>.  
@@ -63,7 +63,7 @@ namespace MudBlazor
         public Position ArrowsPosition { get; set; } = Position.Center;
 
         /// <summary>
-        /// Gets or sets whether a bullet is displayed for each <see cref="MudCarouselItem"/>.
+        /// Whether a bullet is displayed for each <see cref="MudCarouselItem"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -73,7 +73,7 @@ namespace MudBlazor
         public bool ShowBullets { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the location of the bullets when <see cref="ShowBullets"/> is <c>true</c>.
+        /// The location of the bullets when <see cref="ShowBullets"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Position.Bottom"/>.  
@@ -83,7 +83,7 @@ namespace MudBlazor
         public Position BulletsPosition { get; set; } = Position.Bottom;
 
         /// <summary>
-        /// Gets or sets the color of bullets when <see cref="ShowBullets"/> is <c>true</c>.
+        /// The color of bullets when <see cref="ShowBullets"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  When <c>null</c> the <see cref="MudCarouselItem.Color"/> property is used.
@@ -93,7 +93,7 @@ namespace MudBlazor
         public Color? BulletsColor { get; set; }
 
         /// <summary>
-        /// Gets or sets whether items are automatically cycled.
+        /// Whether items are automatically cycled.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="MudCarouselItem"/> items will be rotated after the delay specified in <see cref="AutoCycleTime" />.
@@ -119,7 +119,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets the delay before displaying the next <see cref="MudCarouselItem"/> when <see cref="AutoCycle"/> is <c>true</c>.
+        /// The delay before displaying the next <see cref="MudCarouselItem"/> when <see cref="AutoCycle"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="TimeSpan.Zero"/>.
@@ -165,7 +165,7 @@ namespace MudBlazor
         public string? BulletsClass { get; set; }
 
         /// <summary>
-        /// Gets or sets the "Previous" button icon when <see cref="ShowBullets" /> is <c>true</c> and no <see cref="PreviousButtonTemplate"/> is set.
+        /// The "Previous" button icon when <see cref="ShowBullets" /> is <c>true</c> and no <see cref="PreviousButtonTemplate"/> is set.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.NavigateBefore" />.
@@ -175,21 +175,21 @@ namespace MudBlazor
         public string PreviousIcon { get; set; } = Icons.Material.Filled.NavigateBefore;
 
         /// <summary>
-        /// Gets or sets the icon displayed for the current <see cref="MudCarouselItem"/> when no <see cref="BulletTemplate"/> is set.
+        /// The icon displayed for the current <see cref="MudCarouselItem"/> when no <see cref="BulletTemplate"/> is set.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]
         public string CheckedIcon { get; set; } = Icons.Material.Filled.RadioButtonChecked;
 
         /// <summary>
-        /// Gets or sets the icon displayed for unselected <see cref="MudCarouselItem"/>s when no <see cref="BulletTemplate"/> is set.
+        /// The icon displayed for unselected <see cref="MudCarouselItem"/>s when no <see cref="BulletTemplate"/> is set.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]
         public string UncheckedIcon { get; set; } = Icons.Material.Filled.RadioButtonUnchecked;
 
         /// <summary>
-        /// Gets or sets the "Next" button icon when <see cref="ShowBullets" /> is <c>true</c> and no <see cref="NextButtonTemplate"/> is set.
+        /// The "Next" button icon when <see cref="ShowBullets" /> is <c>true</c> and no <see cref="NextButtonTemplate"/> is set.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.NavigateNext" />.
@@ -223,7 +223,7 @@ namespace MudBlazor
         public RenderFragment<bool>? BulletTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets whether swipe gestures are allowed for touch devices.
+        /// Whether swipe gestures are allowed for touch devices.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, swipe gestures on touch devices can be used to change the current <see cref="MudCarouselItem"/>.

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -53,7 +53,7 @@ namespace MudBlazor
         public bool ShowArrows { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets where the arrows are displayed, if <see cref="ShowArrows"/> is <c>true</c>.
+        /// The position where the arrows are displayed, if <see cref="ShowArrows"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Position.Center"/>.
@@ -145,7 +145,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets any custom CSS classes for the "Next" and "Previous" icons when <see cref="ShowArrows"/> is <c>true</c>.
+        /// The custom CSS classes for the "Next" and "Previous" icons when <see cref="ShowArrows"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Separate each CSS class with spaces.
@@ -155,7 +155,7 @@ namespace MudBlazor
         public string? NavigationButtonsClass { get; set; }
 
         /// <summary>
-        /// Gets or sets any custom CSS classes for bullets when <see cref="ShowBullets"/> is <c>true</c>.
+        /// The custom CSS classes for bullets when <see cref="ShowBullets"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Separate each CSS class with spaces.
@@ -199,21 +199,21 @@ namespace MudBlazor
         public string NextIcon { get; set; } = Icons.Material.Filled.NavigateNext;
 
         /// <summary>
-        /// Gets or sets any custom template for the "Next" button.
+        /// The custom template for the "Next" button.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]
         public RenderFragment? NextButtonTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets any custom template for the "Previous" button.
+        /// The custom template for the "Previous" button.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]
         public RenderFragment? PreviousButtonTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets any custom template for bullets.
+        /// The custom template for bullets.
         /// </summary>
         /// <remarks>
         /// When set, the template will be used and the <see cref="CheckedIcon"/> and <see cref="UncheckedIcon"/> properties will be ignored.

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets any content displayed within this component.
+        /// The content displayed within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Behavior)]
@@ -72,14 +72,14 @@ namespace MudBlazor
         public Transition Transition { get; set; } = Transition.Slide;
 
         /// <summary>
-        /// Gets or sets any custom CSS transition used to blend into this carousel item.
+        /// The custom CSS transition used to blend into this carousel item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]
         public string? CustomTransitionEnter { get; set; }
 
         /// <summary>
-        /// Gets or sets any custom CSS transition used to blend away from this carousel item.
+        /// The custom CSS transition used to blend away from this carousel item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Carousel.Appearance)]

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
         protected internal MudBaseItemsControl<MudCarouselItem>? Parent { get; set; }
 
         /// <summary>
-        /// Gets or sets whether text is displayed Right-to-Left (RTL).
+        /// Whether text is displayed Right-to-Left (RTL).
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, text will display property for RTL languages such as Arabic, Hebrew, and Persian.
@@ -52,7 +52,7 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Gets or sets the color of this item. 
+        /// The color of this item. 
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -62,7 +62,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the effect used to blend from this item to a different <see cref="MudCarouselItem"/>.
+        /// The effect used to blend from this item to a different <see cref="MudCarouselItem"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Transition.Slide"/>.
@@ -86,7 +86,7 @@ namespace MudBlazor
         public string? CustomTransitionExit { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this item is currently visible.
+        /// Whether this item is currently visible.
         /// </summary>
         public bool IsVisible => Parent is not null && (Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this));
 

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.Charts
         private const double VerticalEndSpace = 25.0;
 
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.Charts
     partial class Donut : MudChartBase
     {
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -22,7 +22,7 @@ namespace MudBlazor.Charts
         private const double VerticalEndSpace = 25.0;
 
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.Charts
     partial class Pie : MudChartBase
     {
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.Charts
     partial class StackedBar : MudChartBase
     {
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -59,7 +59,7 @@ namespace MudBlazor
         public bool ShowLegend { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a list of colors applied to series values.
+        /// The list of colors applied to series values.
         /// </summary>
         /// <remarks>
         /// Defaults to an array of <c>20</c> colors.

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     public class ChartOptions
     {
         /// <summary>
-        /// Gets or sets the spacing between vertical tick marks.
+        /// The spacing between vertical tick marks.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>20</c>.
@@ -19,7 +19,7 @@ namespace MudBlazor
         public int YAxisTicks { get; set; } = 20;
 
         /// <summary>
-        /// Gets or sets the maximum allowed number of vertical tick marks.
+        /// The maximum allowed number of vertical tick marks.
         /// </summary>
         /// <remarks>
         /// If the number of ticks calculated exceeds this value, the tick marks will automatically be thinned out.
@@ -27,7 +27,7 @@ namespace MudBlazor
         public int MaxNumYAxisTicks { get; set; } = 20;
 
         /// <summary>
-        /// Gets or sets the format applied to numbers on the vertical axis.
+        /// The format applied to numbers on the vertical axis.
         /// </summary>
         /// <remarks>
         /// Values in this property are standard .NET format strings, such as those passed into the <c>ToString()</c> method.  For a list of common formats, see: <see href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/formatting-types" />
@@ -35,7 +35,7 @@ namespace MudBlazor
         public string YAxisFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets whether vertical axis lines are shown.
+        /// Whether vertical axis lines are shown.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -43,7 +43,7 @@ namespace MudBlazor
         public bool YAxisLines { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether horizontal axis lines are shown.
+        /// Whether horizontal axis lines are shown.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -51,7 +51,7 @@ namespace MudBlazor
         public bool XAxisLines { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the legend is shown.
+        /// Whether the legend is shown.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -73,7 +73,7 @@ namespace MudBlazor
         };
 
         /// <summary>
-        /// Gets or sets the technique used to smooth lines.
+        /// The technique used to smooth lines.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="InterpolationOption.Straight"/>.  Only takes effect when the <see cref="MudChart"/> type is <see cref="ChartType.Line"/>.
@@ -81,7 +81,7 @@ namespace MudBlazor
         public InterpolationOption InterpolationOption { get; set; } = InterpolationOption.Straight;
 
         /// <summary>
-        /// Gets or sets the width of lines, in pixels.
+        /// The width of lines, in pixels.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>3</c> for three pixels.  Only takes effect when the <see cref="MudChart"/> type is <see cref="ChartType.Line"/>.

--- a/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
@@ -12,12 +12,12 @@ namespace MudBlazor
     public class ChartSeries
     {
         /// <summary>
-        /// Gets or sets the legend label for this series.
+        /// The legend label for this series.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the values to display.
+        /// The values to display.
         /// </summary>
         /// <remarks>
         /// The number of values in this array is typically equal to the number of values in the <see cref="MudChart"/> <c>XAxisLabels</c> property.
@@ -25,12 +25,12 @@ namespace MudBlazor
         public double[] Data { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this series is displayed in the chart.
+        /// Whether this series is displayed in the chart.
         /// </summary>
         public bool IsVisible { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the position of this series within a list.
+        /// The position of this series within a list.
         /// </summary>
         public int Index { get; set; }
     }

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -57,14 +57,14 @@ namespace MudBlazor
         public List<ChartSeries> ChartSeries { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets display options applied to the chart.
+        /// The display options applied to the chart.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chart.Appearance)]
         public ChartOptions ChartOptions { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets any custom graphics within this chart.
+        /// The custom graphics within this chart.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chart.Appearance)]

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -20,7 +20,7 @@ namespace MudBlazor
     public abstract class MudChartBase : MudComponentBase
     {
         /// <summary>
-        /// Gets or sets the data to be displayed.
+        /// The data to be displayed.
         /// </summary>
         /// <remarks>
         /// Applies to <c>Pie</c> and <c>Donut</c> charts.  The number of values in this array should be the same as the number of labels in the <see cref="InputLabels"/> property.
@@ -30,7 +30,7 @@ namespace MudBlazor
         public double[] InputData { get; set; } = Array.Empty<double>();
 
         /// <summary>
-        /// Gets or sets the labels describing data values.
+        /// The labels describing data values.
         /// </summary>
         /// <remarks>
         /// Applies to <c>Pie</c> and <c>Donut</c> charts.  The number of labels in this array is typically the same as the number of values in the <see cref="InputData"/> property.
@@ -40,7 +40,7 @@ namespace MudBlazor
         public string[] InputLabels { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// Gets or sets the labels applied to the horizontal axis.
+        /// The labels applied to the horizontal axis.
         /// </summary>
         /// <remarks>
         /// Applies to <c>Line</c>, <c>Bar</c>, and <c>StackedBar</c> charts.  The number of values in this array is typically equal to the number of values in the <see cref="ChartSeries.Data"/> property.
@@ -50,7 +50,7 @@ namespace MudBlazor
         public string[] XAxisLabels { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// Gets or sets the series of values to display.
+        /// The series of values to display.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chart.Behavior)]
@@ -76,7 +76,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets whether text is displayed Right-to-Left (RTL).
+        /// Whether text is displayed Right-to-Left (RTL).
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, text will display property for RTL languages such as Arabic, Hebrew, and Persian.
@@ -85,14 +85,14 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Gets or sets the type of chart to display.
+        /// The type of chart to display.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Chart.Behavior)]
         public ChartType ChartType { get; set; }
 
         /// <summary>
-        /// Gets or sets the width of the chart, as a CSS style.
+        /// The width of the chart, as a CSS style.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>80%</c>.  Values can be a percentage or pixel width such as <c>200px</c>.
@@ -102,7 +102,7 @@ namespace MudBlazor
         public string Width { get; set; } = "80%";
 
         /// <summary>
-        /// Gets or sets the height of the chart, as a CSS style.
+        /// The height of the chart, as a CSS style.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>80%</c>.  Values can be a percentage or pixel width such as <c>200px</c>.
@@ -112,7 +112,7 @@ namespace MudBlazor
         public string Height { get; set; } = "80%";
 
         /// <summary>
-        /// Gets or sets the location of series labels.
+        /// The location of series labels.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Position.Bottom"/>.
@@ -134,7 +134,7 @@ namespace MudBlazor
         private int _selectedIndex;
 
         /// <summary>
-        /// Gets or sets the currently selected data point.
+        /// The currently selected data point.
         /// </summary>
         /// <remarks>
         /// When this property changes, the <see cref="SelectedIndexChanged"/> event occurs.
@@ -180,7 +180,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets or sets whether lines can be hidden when <see cref="ChartType"/> is <see cref="ChartType.Line"/>.
+        /// Whether lines can be hidden when <see cref="ChartType"/> is <see cref="ChartType.Line"/>.
         /// </summary>
         /// <remarks>
         /// When <c>true</c>, checkboxes are displayed which can toggle visibility of each line.

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
@@ -10,13 +10,13 @@ namespace MudBlazor.Charts
     public partial class Legend : MudChartBase
     {
         /// <summary>
-        /// Gets or sets the chart, if any, containing this component.
+        /// The chart, if any, containing this component.
         /// </summary>
         [CascadingParameter]
         public MudChart MudChartParent { get; set; }
 
         /// <summary>
-        /// Gets or sets the data labels for this legend.
+        /// The data labels for this legend.
         /// </summary>
         [Parameter]
         public List<SvgLegend> Data { get; set; } = new List<SvgLegend>();

--- a/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
@@ -9,27 +9,27 @@ namespace MudBlazor.Charts.SVG.Models
     public class SvgCircle
     {
         /// <summary>
-        /// Gets or sets the position of this path within a list.
+        /// The position of this path within a list.
         /// </summary>
         public int Index { get; set; }
 
         /// <summary>
-        /// Gets or sets the horizontal position of the center of the circle.
+        /// The horizontal position of the center of the circle.
         /// </summary>
         public double CX { get; set; }
 
         /// <summary>
-        /// Gets or sets the vertical position of the center of the circle.
+        /// The vertical position of the center of the circle.
         /// </summary>
         public double CY { get; set; }
 
         /// <summary>
-        /// Gets or sets the distance from the center of the circle to the edge.
+        /// The distance from the center of the circle to the edge.
         /// </summary>
         public double Radius { get; set; }
 
         /// <summary>
-        /// Gets or sets the pattern of dashes and gaps used to paint the outline of the circle.
+        /// The pattern of dashes and gaps used to paint the outline of the circle.
         /// </summary>
         public string StrokeDashArray { get; set; }
 

--- a/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
@@ -34,7 +34,7 @@ namespace MudBlazor.Charts.SVG.Models
         public string StrokeDashArray { get; set; }
 
         /// <summary>
-        /// Gets or sets an offset applied to the <see cref="StrokeDashArray"/>.
+        /// The offset applied to the <see cref="StrokeDashArray"/>.
         /// </summary>
         public double StrokeDashOffset { get; set; }
     }

--- a/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
@@ -11,22 +11,22 @@ namespace MudBlazor.Charts.SVG.Models
     public class SvgLegend
     {
         /// <summary>
-        /// Gets or sets the position of this path within a list.
+        /// The position of this path within a list.
         /// </summary>
         public int Index { get; set; }
 
         /// <summary>
-        /// Gets or sets the series labels to display.
+        /// The series labels to display.
         /// </summary>
         public string Labels { get; set; }
 
         /// <summary>
-        /// Gets or sets the data values to display.
+        /// The data values to display.
         /// </summary>
         public string Data { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the legend is displayed.
+        /// Whether the legend is displayed.
         /// </summary>
         public bool IsVisible { get; set; } = true;
 

--- a/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
@@ -8,12 +8,12 @@ namespace MudBlazor.Charts.SVG.Models
     public class SvgPath
     {
         /// <summary>
-        /// Gets or sets the position of this path within a list.
+        /// The position of this path within a list.
         /// </summary>
         public int Index { get; set; }
 
         /// <summary>
-        /// Gets or sets the SVG path to draw.
+        /// The SVG path to draw.
         /// </summary>
         public string Data { get; set; }
     }

--- a/src/MudBlazor/Components/Chart/Svg/SvgText.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgText.cs
@@ -9,17 +9,17 @@ namespace MudBlazor.Charts.SVG.Models
     public class SvgText
     {
         /// <summary>
-        /// Gets or sets the horizontal position of the text.
+        /// The horizontal position of the text.
         /// </summary>
         public double X { get; set; }
 
         /// <summary>
-        /// Gets or sets the vertical position of the text.
+        /// The vertical position of the text.
         /// </summary>
         public double Y { get; set; }
 
         /// <summary>
-        /// Gets or sets the text to display.
+        /// The text to display.
         /// </summary>
         public string Value { get; set; }
     }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets the color of the checkbox.
+        /// The color of the checkbox.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
@@ -53,7 +53,7 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Gets or sets the color of the checkbox when its <c>Value</c> is <c>false</c> or <c>null</c>.
+        /// The color of the checkbox when its <c>Value</c> is <c>false</c> or <c>null</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.  Theme colors are supported.
@@ -63,7 +63,7 @@ namespace MudBlazor
         public Color? UncheckedColor { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the text to display next to the checkbox.
+        /// The text to display next to the checkbox.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -73,7 +73,7 @@ namespace MudBlazor
         public string? Label { get; set; }
 
         /// <summary>
-        /// Gets or sets the position of the <see cref="Label" /> text.
+        /// The position of the <see cref="Label" /> text.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="LabelPosition.End"/>.
@@ -83,7 +83,7 @@ namespace MudBlazor
         public LabelPosition LabelPosition { get; set; } = LabelPosition.End;
 
         /// <summary>
-        /// Gets or sets whether the checkbox can be controlled with the keyboard.
+        /// Whether the checkbox can be controlled with the keyboard.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.  The <c>Space</c> key cycles through true and false values (or true/false/null states if <see cref="TriState"/> is <c>true</c>). <c>Delete</c> will clear the checkbox. <c>Enter</c> (or <c>NumPadEnter</c>) will set the checkbox.  <c>Backspace</c> will set an indeterminate value.
@@ -93,7 +93,7 @@ namespace MudBlazor
         public bool KeyboardEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether a ripple effect is shown whhen the checkbox is clicked.
+        /// Whether a ripple effect is shown whhen the checkbox is clicked.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.
@@ -103,7 +103,7 @@ namespace MudBlazor
         public bool Ripple { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether compact padding will be used.
+        /// Whether compact padding will be used.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -113,7 +113,7 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Gets or sets the size of the checkbox.
+        /// The size of the checkbox.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
@@ -130,7 +130,7 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Gets or sets the icon to display for a checked state.
+        /// The icon to display for a checked state.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.CheckBox"/>.
@@ -140,7 +140,7 @@ namespace MudBlazor
         public string CheckedIcon { get; set; } = Icons.Material.Filled.CheckBox;
 
         /// <summary>
-        /// Gets or sets the icon to display for an unchecked state.
+        /// The icon to display for an unchecked state.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.CheckBoxOutlineBlank"/>.
@@ -150,7 +150,7 @@ namespace MudBlazor
         public string UncheckedIcon { get; set; } = Icons.Material.Filled.CheckBoxOutlineBlank;
 
         /// <summary>
-        /// Gets or sets the icon to display for an indeterminate state.
+        /// The icon to display for an indeterminate state.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.IndeterminateCheckBox"/>.
@@ -160,7 +160,7 @@ namespace MudBlazor
         public string IndeterminateIcon { get; set; } = Icons.Material.Filled.IndeterminateCheckBox;
 
         /// <summary>
-        /// Gets or sets whether the checkbox can cycle to an indeterminate state.
+        /// Whether the checkbox can cycle to an indeterminate state.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the checkbox can support an indeterminate state such as a <c>null</c> value, in addition to <c>true</c> and <c>false</c>.

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -123,7 +123,7 @@ namespace MudBlazor
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Gets or sets any child content for the component.
+        /// The content within this checkbox.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -40,13 +40,13 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     internal readonly ParameterState<bool> IsSelectedState;
 
     /// <summary>
-    /// Gets or sets the service used to navigate the browser to another URL.
+    /// The service used to navigate the browser to another URL.
     /// </summary>
     [Inject]
     public NavigationManager? UriHelper { get; set; }
 
     /// <summary>
-    /// Gets or sets the service used to perform browser actions such as navigation.
+    /// The service used to perform browser actions such as navigation.
     /// </summary>
     [Inject]
     public IJsApiService? JsApiService { get; set; }
@@ -108,7 +108,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     private MudChipSet<T>? ChipSet { get; set; }
 
     /// <summary>
-    /// Gets or sets the color of this chip.
+    /// The color of this chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  When <see cref="SelectedColor"/> is set, this color is used when the chip is unselected.
@@ -118,7 +118,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Color? Color { get; set; }
 
     /// <summary>
-    /// Gets or sets the color of the chip when it is selected.
+    /// The color of the chip when it is selected.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  When set, this color is used for a selected chip, otherwise <see cref="Color"/> is used.
@@ -128,7 +128,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Color? SelectedColor { get; set; }
 
     /// <summary>
-    /// Gets or sets the size of the chip.
+    /// The size of the chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -138,7 +138,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Size? Size { get; set; }
 
     /// <summary>
-    /// Gets or sets the display variation to use.
+    /// The display variation to use.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -155,7 +155,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public RenderFragment? AvatarContent { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the theme border radius is used for the chip edges.
+    /// Whether the theme border radius is used for the chip edges.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  When <c>true</c>, the <see cref="LayoutProperties.DefaultBorderRadius"/> is used for chip edges.
@@ -165,7 +165,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public bool? Label { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the user cannot interact with this chip.
+    /// Whether the user cannot interact with this chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.  When <c>true</c>, the chip is visibly disabled and interaction is not allowed.
@@ -175,7 +175,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to display within the chip.
+    /// The icon to display within the chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  Use the <see cref="IconColor"/> to control the color of this icon.
@@ -185,7 +185,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? Icon { get; set; }
 
     /// <summary>
-    /// Gets or sets the icon to display when <see cref="IsSelected"/> is <c>true</c>.
+    /// The icon to display when <see cref="IsSelected"/> is <c>true</c>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -195,7 +195,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? CheckedIcon { get; set; }
 
     /// <summary>
-    /// Gets or sets the color of the <see cref="Icon"/>.
+    /// The color of the <see cref="Icon"/>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -205,14 +205,14 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Color? IconColor { get; set; }
 
     /// <summary>
-    /// Gets or sets the close icon to display when <see cref="OnClose"/> is set.
+    /// The close icon to display when <see cref="OnClose"/> is set.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
     public string? CloseIcon { get; set; }
 
     /// <summary>
-    /// Gets or sets whether a ripple effect is show when the chip is clicked.
+    /// Whether a ripple effect is show when the chip is clicked.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -229,7 +229,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the URL to navigate to when the chip is clicked.
+    /// The URL to navigate to when the chip is clicked.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  Use <see cref="Target"/> to control where the URL is opened.
@@ -239,7 +239,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? Href { get; set; }
 
     /// <summary>
-    /// Gets or sets the target to open URLs if <see cref="Href"/> is set.
+    /// The target to open URLs if <see cref="Href"/> is set.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  This value is typically <c>_blank</c>, <c>_self</c>, <c>_parent</c>, <c>_top</c>, or the name of an <c>iframe</c>.
@@ -249,7 +249,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? Target { get; set; }
 
     /// <summary>
-    /// Gets or sets the text label for the chip.
+    /// The text label for the chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  This will be shown so long as <see cref="ChildContent"/> is not set.
@@ -259,7 +259,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? Text { get; set; }
 
     /// <summary>
-    /// Gets or sets the value applied when the chip is selected.
+    /// The value applied when the chip is selected.
     /// </summary>
     /// <remarks>
     /// When part of a <see cref="MudChipSet{T}"/>, the <see cref="MudChipSet{T}.SelectedValue"/> is set to this value when the chip is selected.  Once set, the value should not change.
@@ -269,7 +269,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public T? Value { get; set; }
 
     /// <summary>
-    /// Gets or sets whether a full page refresh is performed when navigating to the URL in <see cref="Href"/>.
+    /// Whether a full page refresh is performed when navigating to the URL in <see cref="Href"/>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.  When <c>true</c>, client-side routing is bypassed and a full page reload occurs.
@@ -279,7 +279,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public bool ForceLoad { get; set; }
 
     /// <summary>
-    /// Gets or sets whether this chip is selected by default when part of a <see cref="MudChipSet{T}"/>.
+    /// Whether this chip is selected by default when part of a <see cref="MudChipSet{T}"/>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -306,7 +306,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     internal bool ShowCheckMark => IsSelectedState.Value && ChipSet?.CheckMark == true;
 
     /// <summary>
-    /// Gets or sets whether this chip is selected.
+    /// Whether this chip is selected.
     /// </summary>
     /// <remarks>
     /// When <c>true</c>, the chip is displayed in a selected state.

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -148,7 +148,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public Variant? Variant { get; set; }
 
     /// <summary>
-    /// Gets or sets any avatar content to display inside the chip.
+    /// The avatar content to display inside the chip.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Appearance)]
@@ -222,7 +222,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public bool? Ripple { get; set; }
 
     /// <summary>
-    /// Gets or sets any custom content within this chip.
+    /// The content within this chip.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -51,7 +51,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
         .Build();
 
     /// <summary>
-    /// Gets or sets the content within this chipset.
+    /// The content within this chipset.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Behavior)]
@@ -68,7 +68,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public SelectionMode SelectionMode { get; set; } = SelectionMode.SingleSelection;
 
     /// <summary>
-    /// Gets or sets whether all chips in this set are closeable.
+    /// Whether all chips in this set are closeable.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.
@@ -78,7 +78,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public bool AllClosable { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the default variant for all chips in this set.
+    /// The default variant for all chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Variant.Filled"/>.  Can be overridden by setting <see cref="MudChip{T}.Variant"/>.
@@ -88,7 +88,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public Variant Variant { get; set; } = Variant.Filled;
 
     /// <summary>
-    /// Gets or sets the default color for all chips in this set.
+    /// The default color for all chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Color.Default"/>.  Can be overridden by setting <see cref="MudChip{T}.Color"/>.
@@ -98,7 +98,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public Color Color { get; set; } = Color.Default;
 
     /// <summary>
-    /// Gets or sets the default color for all selected chips in this set.
+    /// The default color for all selected chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Color.Inherit"/>.  Can be overridden by setting <see cref="MudChip{T}.SelectedColor"/>.
@@ -108,7 +108,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public Color SelectedColor { get; set; } = Color.Inherit;
 
     /// <summary>
-    /// Gets or sets the default icon color for all chips in this set.
+    /// The default icon color for all chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Color.Inherit"/>.  Can be overridden by setting <see cref="MudChip{T}.IconColor"/>.
@@ -118,7 +118,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public Color IconColor { get; set; } = Color.Inherit;
 
     /// <summary>
-    /// Gets or sets the default size for all chips in this set.
+    /// The default size for all chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Size.Medium"/>.  Can be overridden by setting <see cref="MudChip{T}.Size"/>.
@@ -128,14 +128,14 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public Size Size { get; set; } = Size.Medium;
 
     /// <summary>
-    /// Gets or sets whether checkmarks are shown for selected chips.
+    /// Whether checkmarks are shown for selected chips.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.ChipSet.Appearance)]
     public bool CheckMark { get; set; }
 
     /// <summary>
-    /// Gets or sets the default icon shown for selected chips in this set.
+    /// The default icon shown for selected chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Icons.Material.Filled.Check"/>.  Can be overridden by setting <see cref="MudChip{T}.CheckedIcon"/>.
@@ -145,7 +145,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public string CheckedIcon { get; set; } = Icons.Material.Filled.Check;
 
     /// <summary>
-    /// Gets or sets the default close icon shown for closeable chips in this set.
+    /// The default close icon shown for closeable chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Icons.Material.Filled.Cancel"/>.  Can be overridden by setting <see cref="MudChip{T}.CloseIcon"/>.
@@ -155,7 +155,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public string CloseIcon { get; set; } = Icons.Material.Filled.Cancel;
 
     /// <summary>
-    /// Gets or sets whether a ripple effect is shown for chips in this set.
+    /// Whether a ripple effect is shown for chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.  Can be overridden by setting <see cref="MudChip{T}.Ripple"/>.
@@ -165,7 +165,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public bool Ripple { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether the theme border radius is used be default for chips in this set.
+    /// Whether the theme border radius is used be default for chips in this set.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="LayoutProperties.DefaultBorderRadius"/> is used for chip edges.  Can be overridden by setting <see cref="MudChip{T}.Label"/>.
@@ -175,7 +175,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public bool Label { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the user cannot interact with this chip.
+    /// Whether the user cannot interact with this chip.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.  When <c>true</c>, the all chips are visibly disabled and interaction is not allowed.  Overrides any value set for <see cref="MudChip{T}.Disabled"/>.
@@ -185,7 +185,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets whether chips in this set are clickable.
+    /// Whether chips in this set are clickable.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.  When <c>true</c>, chips cannot be clicked even if <see cref="MudChip{T}.OnClick"/> is set.
@@ -195,7 +195,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public bool ReadOnly { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the comparer used to determine when a selection has changed.
+    /// The comparer used to determine when a selection has changed.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="EqualityComparer{T}.Default"/>.
@@ -205,7 +205,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public IEqualityComparer<T?> Comparer { get; set; } = EqualityComparer<T?>.Default;
 
     /// <summary>
-    /// Gets or sets the currently selected value.
+    /// The currently selected value.
     /// </summary>
     /// <remarks>
     /// This property is used when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection" /> or <see cref="SelectionMode.ToggleSelection"/>.
@@ -224,7 +224,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public EventCallback<T?> SelectedValueChanged { get; set; }
 
     /// <summary>
-    /// Gets or sets the currently selected chips in this set. 
+    /// The currently selected chips in this set. 
     /// </summary>
     /// <remarks>
     /// This event occurs when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection" />.

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -58,7 +58,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// Gets or sets how many selections are allowed.
+    /// The mode controlling how many selections are allowed.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="SelectionMode.SingleSelection"/>.  Other values include <see cref="SelectionMode.MultiSelection"/> and <see cref="SelectionMode.ToggleSelection"/>.

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -60,7 +60,7 @@ namespace MudBlazor
         public int? MaxHeight { get; set; }
 
         /// <summary>
-        /// Gets or sets any content within this panel.
+        /// The content within this panel.
         /// </summary>
         [Parameter]
         public RenderFragment? ChildContent { get; set; }

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
-        /// Gets or sets whether content within this panel is visible.
+        /// Whether content within this panel is visible.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
@@ -51,7 +51,7 @@ namespace MudBlazor
         public bool Expanded { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum allowed height of this panel, in pixels.
+        /// The maximum allowed height of this panel, in pixels.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.

--- a/src/MudBlazor/Enums/Edge.cs
+++ b/src/MudBlazor/Enums/Edge.cs
@@ -2,12 +2,26 @@
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// Indicates the location of any negative margin.
+    /// </summary>
     public enum Edge
     {
+        /// <summary>
+        /// No negative margin is applied.
+        /// </summary>
         [Description("false")]
         False,
+
+        /// <summary>
+        /// A negative margin is applied at the start.
+        /// </summary>
         [Description("start")]
         Start,
+
+        /// <summary>
+        /// A negative margin is applied at the end.
+        /// </summary>
         [Description("end")]
         End
     }


### PR DESCRIPTION
## Description

This update revisits the XML documentation for previously documented classes, to use simpler language:

* Using "The" instead of "Gets or sets the"
* Using "Whether" instead of "Gets or sets whether"
* Some other adjustments like "The location where" instead of "Gets or sets where"

This update also adds documentation for the `Edge` enumeration.

## How Has This Been Tested?

This was tested by observing the examples for previously documented classes.

![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/4591d6c9-5eab-4239-ad7f-f35363d519af)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/4d68b4a4-c851-4318-b54a-c41684d27e53)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/a810262d-b5fb-4b8e-a5dd-575cc4601d02)
![image](https://github.com/MudBlazor/MudBlazor/assets/18043079/76ee4c06-f91d-4e36-abec-615c22cc5377)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
