### PR TITLE
MudInputControl: Fix nested `<div>` inside `<p>`

### DIFF
--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -15,7 +15,7 @@
     @if (Error || !string.IsNullOrEmpty(HelperText) || !string.IsNullOrEmpty(CounterText))
     {
         <div class="@HelperContainer">
-            <p class="@HelperClass">
+            <span class="@HelperClass">
                 <div class="d-flex">
                     @if (Error)
                     {
@@ -36,7 +36,7 @@
                         </div>            
                     }
                 </div>
-            </p>
+            </span>
         </div>
     }
     @ChildContent


### PR DESCRIPTION
## Description
We cannot nest `<div>` inside `<p>`.

The problem appears in SSR non-interactive mode. When the server send new page, DOM will refuse to nest `<div>` inside `<p>` #8855 .

`<span>` is an inline element, It will allow `<div>` nesting.
I have compared the two styles visually and computed values after changing them.

## How Has This Been Tested?
visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
