### PR TITLE
Docs: App bar tweaks to align with v6 & Accessibility

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -21,7 +21,7 @@
         // Just show copyright and version
         <MudContainer MaxWidth="MaxWidth.Large">
             <MudToolBar Gutters="false" Dense="true">
-                <MudText Typo="Typo.body1">Copyright © 2020-@DateTime.Now.Year MudBlazor.</MudText>
+                <MudText Typo="Typo.body1">Copyright © 2020-@DateTime.Now.Year MudBlazor</MudText>
                 <MudSpacer/>
                 <MudText Typo="Typo.body1">Powered by .NET @Environment.Version.ToString()</MudText>
             </MudToolBar>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -69,7 +69,7 @@
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
                          AutoFocus="false" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
-                         ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
+                         ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentAriaLabel="Search adornment">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,5 +1,7 @@
 ﻿<div class="d-flex align-center flex-grow-1 d-md-none">
-    <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" />
+    <MudTooltip Delay="1000" Text="Drawer">
+        <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" />
+    </MudTooltip>
     <MudSpacer />
     <NavLink ActiveClass="d-flex align-center" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo" />
@@ -19,7 +21,7 @@
     <MudButton Href="/docs/overview" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.Docs)">Docs</MudButton>
     <MudButton Href="/mud/introduction" Color="Color.Inherit" Variant="Variant.Text" Class="@GetActiveClass(DocsBasePage.DiscoverMore)">Learn More</MudButton>
     <MudMenu Color="Color.Inherit" Variant="Variant.Text" Class="mx-1 px-3" PopoverClass="docs-layout-menu-shadow" ListClass="d-flex px-4 pb-2 docs-appbar-special-menu" LockScroll="true" Label="Products" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
-        <MudList T="string" Clickable="true">
+        <MudList T="string">
             <MudListSubheader>
                 Products
             </MudListSubheader>
@@ -64,7 +66,7 @@
     <MudSpacer />
     @if (DisplaySearchBar)
     {
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar ml-4"
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
                          AutoFocus="false" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search">
@@ -72,7 +74,7 @@
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
         </MudAutocomplete>
-        <MudDivider FlexItem="true" Vertical="true" DividerType="DividerType.Middle" Class="my-4" />
+        <MudDivider FlexItem="true" Vertical="true" DividerType="DividerType.Middle" Class="mx-4 my-4" />
     }
     else
     {
@@ -81,6 +83,9 @@
         </MudTooltip>
     }
     <AppbarButtons />
+    <MudTooltip Delay="1000" Text="GitHub">
+        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" />
+    </MudTooltip>
 </div>
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -33,6 +33,3 @@
 <MudTooltip Delay="1000" Text="@(DarkLightModeButtonText)">
     <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightModeAsync" />
 </MudTooltip>
-<MudTooltip Delay="1000" Text="GitHub">
-    <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" />
-</MudTooltip>

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -6,7 +6,7 @@
     <MudAppBar Class="docs-appbar" Elevation="0">
         <Appbar DrawerToggleCallback="ToggleDrawer" />
     </MudAppBar>
-    <MudDrawer Open="@_drawerOpen" OpenChanged="OnDrawerOpenChanged" ClipMode="DrawerClipMode.Docked" Elevation="0" Breakpoint="Breakpoint.Md">
+    <MudDrawer Open="@_drawerOpen" OpenChanged="OnDrawerOpenChanged" ClipMode="DrawerClipMode.Docked" Elevation="0" Breakpoint="Breakpoint.Md" aria-label="Navigation Drawer">
         <div class="d-block d-md-none">
             <MudToolBar Dense="true" Gutters="false" Class="docs-gray-bg">
                 <MudIconButton Icon="@Icons.Material.Rounded.Close" Color="Color.Inherit" OnClick="ToggleDrawer" />

--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -32,9 +32,7 @@
             }
         </div>
         <MudNavMenu Color="Color.Primary" Rounded="true" Dense="true" Margin="Margin.Dense" Class="pa-2 overflow-auto mb-3">
-
             <NavMenu @ref="@_navMenuRef" />
-
         </MudNavMenu>
     </MudDrawer>
     @Body

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -5,7 +5,7 @@
     <MudAppBar Class="landing-appbar" Elevation="0">
         <Appbar DrawerToggleCallback="ToggleDrawer" DisplaySearchBar="false" />
     </MudAppBar>
-    <MudDrawer @bind-Open="@_drawerOpen" Elevation="25" Variant="@DrawerVariant.Temporary">
+    <MudDrawer @bind-Open="@_drawerOpen" Elevation="25" Variant="@DrawerVariant.Temporary" aria-label="Navigation Drawer">
         <MudToolBar Dense="true" Gutters="false" Class="px-1 docs-gray-bg">
             <MudIconButton Icon="@Icons.Material.Rounded.Close" Color="Color.Inherit" OnClick="@ToggleDrawer" />
             <MudSpacer/>

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -5,7 +5,7 @@
 <div class="@GetPanelClass()" @attributes="UserAttributes">
     @if (_sections.Count > 1)
     {
-        <MudNavMenu Class="pl-4">
+        <MudNavMenu Class="pl-4" aria-label="Table of Contents">
             <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
                 @Headline
             </MudText>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Small tweaks to maintain visual consistency and improve accessibility.

Also fixes `Unhandled exception rendering component: Illegal parameter 'Clickable' in component of type 'MudList1'. This was removed in v7.0.0, see Migration Guide for more info `

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Horizontal margins around divider were tweaked to restore it back to original style along with the icon being Edge.End.**

v6.19.1:

![153](https://github.com/MudBlazor/MudBlazor/assets/7112040/9a10a997-062b-4684-88f1-6d27b343aa24)


This PR:

![69](https://github.com/MudBlazor/MudBlazor/assets/7112040/ce7db7db-7efe-4abf-98bc-fb3c14f43f78)

Search bar is still not right because of #8878

v7.0.0-preview1:

![97](https://github.com/MudBlazor/MudBlazor/assets/7112040/5634b64b-6450-4ce3-8060-3c6ee4f9f1c1)

**GitHub icon was removed from drawer because it was ruining alignment from too many icons**

v6.19.1:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/a0856196-2b87-4c44-99eb-0f8d1906e834)


This PR:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/588fbd01-3d1e-4d04-b750-6aacb2af8268)

v7.0.0-preview1:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/70d1ea93-ba4f-4821-9c10-54673d548397)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
