### PR TITLE
MudRating: make HandleKeyDown async Task

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
@@ -20,34 +21,34 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudRating>();
             // select elements needed for the test
-            var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
-            var inputs = comp.FindAll("input[type=\"radio\"].mud-rating-input").ToArray();
+            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IRefreshableElementCollection<IElement> Inputs() => comp.FindAll("input[type=\"radio\"].mud-rating-input");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
-            ratingItemsSpans.Length.Should().Be(5);
-            inputs.Length.Should().Be(5);
+            RatingItemsSpans().Count.Should().Be(5);
+            Inputs().Count.Should().Be(5);
 
             // click first rating item
-            ratingItemsSpans[0].Click();
+            RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(1);
 
             // click 2nd rating item
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 3rd rating item
-            ratingItemsSpans[2].Click();
+            RatingItemsSpans()[2].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(3);
 
             // click 4th rating item
-            ratingItemsSpans[3].Click();
+            RatingItemsSpans()[3].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(4);
 
             // click 5th rating item
-            ratingItemsSpans[4].Click();
+            RatingItemsSpans()[4].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(5);
 
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
         }
 
@@ -59,33 +60,33 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudRating>();
             // select elements needed for the test
-            var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
+            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
-            ratingItemsSpans.Length.Should().Be(5);
+            RatingItemsSpans().Count.Should().Be(5);
 
             // click 2nd rating item
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 2nd rating item
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
 
             // click 2nd rating item
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click first rating item
-            ratingItemsSpans[0].Click();
+            RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(1);
 
             // click first rating item
-            ratingItemsSpans[0].Click();
+            RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
 
             // click first rating item
-            ratingItemsSpans[0].Click();
+            RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(1);
         }
 
@@ -113,29 +114,29 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.SelectedValue, 2));
             // print the generated html
             // select elements needed for the test
-            var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
+            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
-            ratingItemsSpans.Length.Should().Be(5);
+            RatingItemsSpans().Count.Should().Be(5);
 
             // click first rating item
-            ratingItemsSpans[0].Click();
+            RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 2nd rating item
-            ratingItemsSpans[1].Click();
+            RatingItemsSpans()[1].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 3rd rating item
-            ratingItemsSpans[2].Click();
+            RatingItemsSpans()[2].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 4th rating item
-            ratingItemsSpans[3].Click();
+            RatingItemsSpans()[3].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
 
             // click 5th rating item
-            ratingItemsSpans[4].Click();
+            RatingItemsSpans()[4].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
         }
 
@@ -149,10 +150,10 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.MaxValue, 12));
             // print the generated html
             // select elements needed for the test
-            var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
+            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
-            ratingItemsSpans.Length.Should().Be(12);
+            RatingItemsSpans().Count.Should().Be(12);
 
             await comp.Instance.HandleItemHoveredAsync(6);
             comp.Instance.HoveredValue.Should().Be(6);

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -8,11 +8,12 @@ using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
 {
+#nullable enable
     [TestFixture]
     public class RatingTests : BunitTest
     {
         /// <summary>
-        /// click should change selected value
+        /// Click should change selected value
         /// </summary>
         [Test]
         public void RatingTest1()
@@ -51,7 +52,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// click already selected item should change selected value to 0
+        /// Click already selected item should change selected value to 0
         /// </summary>
         [Test]
         public void RatingTest2()
@@ -89,12 +90,13 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        ///  initialized selected value by parameter should equal component selected value
+        /// Initialized selected value by parameter should equal component selected value
         /// </summary>
         [Test]
         public void RatingTest3()
         {
-            var comp = Context.RenderComponent<MudRating>(("SelectedValue", 3));
+            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+                .Add(p => p.SelectedValue, 3));
             // print the generated html
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(3);
@@ -106,7 +108,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTest4()
         {
-            var comp = Context.RenderComponent<MudRating>(("Disabled", true), ("SelectedValue", 2));
+            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+                .Add(p => p.Disabled, true)
+                .Add(p => p.SelectedValue, 2));
             // print the generated html
             // select elements needed for the test
             var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
@@ -141,7 +145,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RatingTest5()
         {
-            var comp = Context.RenderComponent<MudRating>(("MaxValue", 12));
+            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+                .Add(p => p.MaxValue, 12));
             // print the generated html
             // select elements needed for the test
             var ratingItemsSpans = comp.FindAll("span.mud-rating-item").ToArray();
@@ -158,14 +163,16 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyRating_ShouldNotRenderInputs()
         {
-            var comp = Context.RenderComponent<MudRating>(("ReadOnly", true));
+            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+                .Add(p => p.ReadOnly, true));
             comp.FindAll("input").Should().BeEmpty();
         }
 
         [Test]
         public async Task RatingTest_KeyboardNavigation()
         {
-            var comp = Context.RenderComponent<MudRating>(("MaxValue", 12));
+            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+                .Add(p => p.MaxValue, 12));
             var item = comp.FindComponent<MudRatingItem>();
             // print the generated html
 
@@ -179,29 +186,29 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => item.Instance.SelectIcon());
             comp.SetParam(x => x.SelectedValue, 0);
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(1));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(0));
             //ArrowLeft should not decrease when the value is 0
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(0));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(12));
             //Shift+ArrowKey should not go beyond the max value
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(12));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(0));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(0));
 
             comp.SetParam(x => x.Disabled, true);
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.GetState(x => x.SelectedValue).Should().Be(0));
 
             await comp.InvokeAsync(() => item.Instance.HandleMouseOutAsync(new MouseEventArgs()));

--- a/src/MudBlazor/Components/Rating/MudRating.razor
+++ b/src/MudBlazor/Components/Rating/MudRating.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<span tabindex="@(Disabled?-1:0)" @onkeydown="HandleKeyDown" @attributes="UserAttributes" class="@ClassName" style="@Style" >
+<span tabindex="@(Disabled?-1:0)" @onkeydown="HandleKeyDownAsync" @attributes="UserAttributes" class="@ClassName" style="@Style" >
     <CascadingValue Value="this" >
         @for (int i = 1; i <= MaxValue; i++)
         {

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -160,7 +160,7 @@ namespace MudBlazor
             }
         }
 
-        protected internal async void HandleKeyDown(KeyboardEventArgs keyboardEventArgs)
+        protected internal async Task HandleKeyDownAsync(KeyboardEventArgs keyboardEventArgs)
         {
             if (Disabled || ReadOnly)
             {


### PR DESCRIPTION
## Description
Follow up for https://github.com/MudBlazor/MudBlazor/pull/8877

I missed it since I thought the `HandleKeyDown` is done via key interceptor therefore it cannot be a `Task` for now, but it's coming from `onkeydown`.

## How Has This Been Tested?
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
