### PR TITLE
Standardise the use of `Selected` and `SelectedChanged`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
@@ -63,7 +63,7 @@
         <DocsPageSection>
             <SectionHeader Title="Binding chips in a selection">
                 <Description>
-                    You can bind a Chip's <CodeInline>IsSelected</CodeInline> parameter to manipulate the selection.
+                    You can bind a Chip's <CodeInline>@nameof(MudChip<T>.Selected)</CodeInline> parameter to manipulate the selection.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(ChipSetChipBindingExample)" Block="true">

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetChipBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetChipBindingExample.razor
@@ -4,7 +4,7 @@
     @for (int i = 0; i < _included.Length; i++) 
     {
         var index = i;
-        <MudChip Value="@_ingredients[index]" @bind-IsSelected="_included[index]" Color="Color.Primary" Variant="@Variant.Text" />
+        <MudChip Value="@_ingredients[index]" @bind-Selected="_included[index]" Color="Color.Primary" Variant="@Variant.Text" />
     }
 </MudChipSet>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetChipBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetChipBindingTest.razor
@@ -4,7 +4,7 @@
     @for (int i = 0; i < _included.Length; i++) 
     {
         var index = i;
-        <MudChip Value="@_ingredients[index]" @bind-IsSelected="_included[index]" Color="Color.Primary" Variant="@Variant.Text" />
+        <MudChip Value="@_ingredients[index]" @bind-Selected="_included[index]" Color="Color.Primary" Variant="@Variant.Text" />
     }
 </MudChipSet>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
@@ -2,7 +2,7 @@
 
 <MudTreeView SelectionMode="SelectionMode.MultiSelection" Items="TreeItems" Style="width: 500px;">
     <ItemTemplate>
-        <MudTreeViewItem @bind-Selected="@context.IsSelected" @bind-Expanded="@context.Expanded" Icon="@context.Icon"
+        <MudTreeViewItem @bind-Selected="@context.Selected" @bind-Expanded="@context.Expanded" Icon="@context.Icon"
                          Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" Items="@context.TreeItems" />
     </ItemTemplate>
 </MudTreeView>
@@ -17,7 +17,7 @@
 
         public int? Number { get; set; } = null;
 
-        public bool IsSelected { get; set; }
+        public bool Selected { get; set; }
 
         public bool Expanded { get; set; }
 

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -373,7 +373,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.CloseIcon, Icons.Material.Filled.Plagiarism)
                 .Add(x => x.Ripple, false)
                 .Add(x => x.IconColor, Color.Error)
-                .Add(x => x.IsSelected, true)
+                .Add(x => x.Selected, true)
             ).Instance;
             await comp.InvokeAsync(() => chip.UpdateSelectionStateAsync(true));
             chip.ShowCheckMark.Should().Be(false); // because not in a chipset

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.Utilities.Clone;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -698,6 +699,64 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("td")[8].Html().Trim().Should().Be("snakex64");
 
             //if no crash occurs, we know the datagrid is properly filtering out the GetOnly property when calling set
+        }
+
+        [Test(Description = "Checks if clone strategy is working, if we used default one it would fail as STJ doesn't support abstract classes without additional configuration.")]
+        public async Task DataGridDialogEditCloneStrategyTest1()
+        {
+            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
+
+            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
+            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
+            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
+            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("John");
+            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("David");
+            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("2");
+            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
+
+            //open edit dialog
+            dataGrid.FindAll("tbody tr")[1].Click();
+            //No close button
+            comp.FindAll("button[aria-label=\"close\"]").Should().BeEmpty();
+            //edit data
+            comp.FindAll("div input")[0].Change("Galadriel");
+            comp.FindAll("div input")[1].Change("Steve");
+            comp.FindAll("div input")[2].Change("3");
+
+            comp.Find(".mud-dialog-actions .mud-button-filled-primary").Click();
+
+            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
+            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
+            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
+            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("Galadriel");
+            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("Steve");
+            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("3");
+            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
+        }
+
+        [Test]
+        public async Task DataGridDialogEditCloneStrategyTest2()
+        {
+            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>(parameters => parameters
+                .Add(p => p.CloneStrategy, SystemTextJsonDeepCloneStrategy<DataGridFormEditCloneStrategyTest.Movement>.Instance));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
+
+            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
+            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
+            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
+            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
+            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("John");
+            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("David");
+            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("2");
+            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
+
+            //open edit dialog
+            var openDialog = () => dataGrid.FindAll("tbody tr")[1].Click();
+
+            openDialog.Should().Throw<NotSupportedException>("STJ doesn't support abstract classes without polymorphic type discriminators.");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.TestComponents;
-using MudBlazor.Utilities.Clone;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -699,64 +698,6 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("td")[8].Html().Trim().Should().Be("snakex64");
 
             //if no crash occurs, we know the datagrid is properly filtering out the GetOnly property when calling set
-        }
-
-        [Test(Description = "Checks if clone strategy is working, if we used default one it would fail as STJ doesn't support abstract classes without additional configuration.")]
-        public async Task DataGridDialogEditCloneStrategyTest1()
-        {
-            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
-
-            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
-            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
-            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
-            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
-            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("John");
-            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("David");
-            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("2");
-            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
-
-            //open edit dialog
-            dataGrid.FindAll("tbody tr")[1].Click();
-            //No close button
-            comp.FindAll("button[aria-label=\"close\"]").Should().BeEmpty();
-            //edit data
-            comp.FindAll("div input")[0].Change("Galadriel");
-            comp.FindAll("div input")[1].Change("Steve");
-            comp.FindAll("div input")[2].Change("3");
-
-            comp.Find(".mud-dialog-actions .mud-button-filled-primary").Click();
-
-            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
-            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
-            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
-            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
-            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("Galadriel");
-            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("Steve");
-            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("3");
-            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
-        }
-
-        [Test]
-        public async Task DataGridDialogEditCloneStrategyTest2()
-        {
-            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>(parameters => parameters
-                .Add(p => p.CloneStrategy, SystemTextJsonDeepCloneStrategy<DataGridFormEditCloneStrategyTest.Movement>.Instance));
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
-
-            dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
-            dataGrid.FindAll("td")[1].Html().Trim().Should().Be("Robert");
-            dataGrid.FindAll("td")[2].Html().Trim().Should().Be("1");
-            dataGrid.FindAll("td")[3].Html().Trim().Should().Be("first");
-            dataGrid.FindAll("td")[4].Html().Trim().Should().Be("John");
-            dataGrid.FindAll("td")[5].Html().Trim().Should().Be("David");
-            dataGrid.FindAll("td")[6].Html().Trim().Should().Be("2");
-            dataGrid.FindAll("td")[7].Html().Trim().Should().Be("second");
-
-            //open edit dialog
-            var openDialog = () => dataGrid.FindAll("tbody tr")[1].Click();
-
-            openDialog.Should().Throw<NotSupportedException>("STJ doesn't support abstract classes without polymorphic type discriminators.");
         }
 
         /// <summary>
@@ -2929,9 +2870,9 @@ namespace MudBlazor.UnitTests.Components
             var column = dataGrid.Instance.RenderedColumns.First();
             var cell = new Cell<DataGridCellContextTest.Model>(dataGrid.Instance, column, item);
 
-            cell._cellContext.IsSelected.Should().Be(false);
+            cell._cellContext.Selected.Should().Be(false);
             await cell._cellContext.Actions.SetSelectedItemAsync(true);
-            cell._cellContext.IsSelected.Should().Be(true);
+            cell._cellContext.Selected.Should().Be(true);
 
             await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().Contain(item);

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -518,7 +518,7 @@ namespace MudBlazor.UnitTests.Components
             items.Should().HaveCount(7);
             foreach (var item in items)
             {
-                item.Instance.IsSelected.Should().BeTrue();
+                item.Instance.Selected.Should().BeTrue();
                 item.FindComponent<MudListItem<string>>().Instance.Icon.Should().Be("<path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z\"/>");
             }
 

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -363,6 +363,8 @@ namespace MudBlazor
                         case "IsCheckedChanged":
                         case "IsVisible":
                         case "IsVisibleChanged":
+                        case "IsSelected":
+                        case "IsSelectedChanged":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -18,26 +18,26 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public MudChip()
     {
         using var registerScope = CreateRegisterScope();
-        IsSelectedState = registerScope.RegisterParameter<bool>(nameof(IsSelected))
-            .WithParameter(() => IsSelected)
-            .WithEventCallback(() => IsSelectedChanged)
-            .WithChangeHandler(OnIsSelectedChangedAsync);
+        SelectedState = registerScope.RegisterParameter<bool>(nameof(Selected))
+            .WithParameter(() => Selected)
+            .WithEventCallback(() => SelectedChanged)
+            .WithChangeHandler(OnSelectedChangedAsync);
     }
 
-    private Task OnIsSelectedChangedAsync(ParameterChangedEventArgs<bool> args)
+    private Task OnSelectedChangedAsync(ParameterChangedEventArgs<bool> args)
     {
         if (ChipSet == null)
             return Task.CompletedTask;
-        return ChipSet.OnChipIsSelectedChangedAsync(this, args.Value);
+        return ChipSet.OnChipSelectedChangedAsync(this, args.Value);
     }
 
-    internal async Task UpdateSelectionStateAsync(bool isSelected)
+    internal async Task UpdateSelectionStateAsync(bool selected)
     {
-        await IsSelectedState.SetValueAsync(isSelected);
+        await SelectedState.SetValueAsync(selected);
         StateHasChanged();
     }
 
-    internal readonly ParameterState<bool> IsSelectedState;
+    internal readonly ParameterState<bool> SelectedState;
 
     /// <summary>
     /// The service used to navigate the browser to another URL.
@@ -59,7 +59,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         .AddClass("mud-ripple", IsClickable && GetRipple())
         .AddClass("mud-chip-label", GetLabel())
         .AddClass("mud-disabled", GetDisabled())
-        .AddClass("mud-chip-selected", IsSelectedState.Value)
+        .AddClass("mud-chip-selected", SelectedState.Value)
         .AddClass(Class)
         .Build();
 
@@ -71,8 +71,8 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         var variant = Variant ?? chipSetVariant;
         return variant switch
         {
-            MudBlazor.Variant.Text => IsSelectedState.Value ? MudBlazor.Variant.Filled : MudBlazor.Variant.Text,
-            MudBlazor.Variant.Filled => IsSelectedState.Value ? MudBlazor.Variant.Text : MudBlazor.Variant.Filled,
+            MudBlazor.Variant.Text => SelectedState.Value ? MudBlazor.Variant.Filled : MudBlazor.Variant.Text,
+            MudBlazor.Variant.Filled => SelectedState.Value ? MudBlazor.Variant.Text : MudBlazor.Variant.Filled,
             MudBlazor.Variant.Outlined => MudBlazor.Variant.Outlined,
             _ => MudBlazor.Variant.Outlined
         };
@@ -81,7 +81,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     private Color GetColor()
     {
         var selectedColor = GetSelectedColor();
-        if (IsSelectedState.Value && selectedColor != MudBlazor.Color.Inherit)
+        if (SelectedState.Value && selectedColor != MudBlazor.Color.Inherit)
         {
             return selectedColor;
         }
@@ -185,7 +185,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     public string? Icon { get; set; }
 
     /// <summary>
-    /// The icon to display when <see cref="IsSelected"/> is <c>true</c>.
+    /// The icon to display when <see cref="Selected"/> is <c>true</c>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.
@@ -303,7 +303,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     [Parameter]
     public EventCallback<MudChip<T>> OnClose { get; set; }
 
-    internal bool ShowCheckMark => IsSelectedState.Value && ChipSet?.CheckMark == true;
+    internal bool ShowCheckMark => SelectedState.Value && ChipSet?.CheckMark == true;
 
     /// <summary>
     /// Whether this chip is selected.
@@ -313,13 +313,13 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chip.Behavior)]
-    public bool IsSelected { get; set; }
+    public bool Selected { get; set; }
 
     /// <summary>
-    /// Occurs when the <see cref="IsSelected"/> property has changed.
+    /// Occurs when the <see cref="Selected"/> property has changed.
     /// </summary>
     [Parameter]
-    public EventCallback<bool> IsSelectedChanged { get; set; }
+    public EventCallback<bool> SelectedChanged { get; set; }
 
     internal T? GetValue()
     {
@@ -345,8 +345,8 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         }
         if (ChipSet != null)
         {
-            await IsSelectedState.SetValueAsync(!IsSelectedState.Value);
-            await ChipSet.OnChipIsSelectedChangedAsync(this, IsSelectedState.Value);
+            await SelectedState.SetValueAsync(!SelectedState.Value);
+            await ChipSet.OnChipSelectedChangedAsync(this, SelectedState.Value);
         }
         if (Href != null)
         {

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -278,8 +278,8 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
             foreach (var chip in _chips.ToArray())
             {
                 var value = chip.GetValue();
-                var isSelected = Comparer.Equals(value, newValue);
-                await chip.UpdateSelectionStateAsync(isSelected);
+                var selected = Comparer.Equals(value, newValue);
+                await chip.UpdateSelectionStateAsync(selected);
             }
         }
         await _selectedValue.SetValueAsync(newValue);
@@ -304,12 +304,12 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
         foreach (var chip in _chips.ToArray())
         {
             var value = chip.GetValue();
-            bool isSelected;
+            bool selected;
             if (MultiSelection)
-                isSelected = value is not null && _selection.Contains(value);
+                selected = value is not null && _selection.Contains(value);
             else
-                isSelected = Comparer.Equals(_selectedValue, value);
-            await chip.UpdateSelectionStateAsync(isSelected);
+                selected = Comparer.Equals(_selectedValue, value);
+            await chip.UpdateSelectionStateAsync(selected);
         }
     }
 
@@ -359,7 +359,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
         StateHasChanged();
     }
 
-    internal async Task OnChipIsSelectedChangedAsync(MudChip<T> chip, bool isSelected)
+    internal async Task OnChipSelectedChangedAsync(MudChip<T> chip, bool selected)
     {
         var value = chip.GetValue();
         if (!MultiSelection)
@@ -372,7 +372,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
             else
             {
                 // Toggle Selection
-                await UpdateSelectedValueAsync(isSelected ? value : default);
+                await UpdateSelectedValueAsync(selected ? value : default);
             }
             return;
         }
@@ -380,7 +380,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
         if (value is null)
             return;
         var newSelection = new HashSet<T>(_selection, Comparer);
-        if (isSelected)
+        if (selected)
         {
             newSelection.Add(value);
         }

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
 
         public CellActions Actions { get; }
 
-        public bool IsSelected
+        public bool Selected
         {
             get
             {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private SortDirection _initialDirection;
-        private bool _isSelected;
+        private bool _selected;
 
         [Parameter]
         public SortDirection SortDirection
@@ -239,13 +239,13 @@ namespace MudBlazor
 
         private void OnSelectedAllItemsChanged(bool value)
         {
-            _isSelected = value;
+            _selected = value;
             StateHasChanged();
         }
 
         private void OnSelectedItemsChanged(HashSet<T> items)
         {
-            _isSelected = items.Count == DataGrid.GetFilteredItemsCount();
+            _selected = items.Count == DataGrid.GetFilteredItemsCount();
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -10,7 +10,7 @@
         }
     </HeaderTemplate>
     <CellTemplate>
-        <MudCheckBox T="bool" Size="@Size" Value="@context.IsSelected" ValueChanged="@context.Actions.SetSelectedItemAsync" />
+        <MudCheckBox T="bool" Size="@Size" Value="@context.Selected" ValueChanged="@context.Actions.SetSelectedItemAsync" />
     </CellTemplate>
 </TemplateColumn>
 

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -319,8 +319,8 @@ namespace MudBlazor
         {
             foreach (var item in _items.ToArray())
             {
-                var isSelected = value is not null && Comparer.Equals(value, item.GetValue());
-                item.SetSelected(isSelected);
+                var selected = value is not null && Comparer.Equals(value, item.GetValue());
+                item.SetSelected(selected);
             }
             foreach (var childList in _childLists.ToArray())
             {
@@ -336,8 +336,8 @@ namespace MudBlazor
             foreach (var listItem in _items.ToArray())
             {
                 var itemValue = listItem.GetValue();
-                var isSelected = itemValue is not null && selection.Contains(itemValue);
-                listItem.SetSelected(isSelected);
+                var selected = itemValue is not null && selection.Contains(itemValue);
+                listItem.SetSelected(selected);
             }
             foreach (var childList in _childLists.ToArray())
             {

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
                 _parent.CheckGenericTypeMatch(this);
                 if (MudSelect == null)
                     return;
-                var isSelected = MudSelect.Add(this);
+                var selected = MudSelect.Add(this);
                 if (_parent.MultiSelection)
                 {
                     MudSelect.SelectionChangedFromOutside += OnUpdateSelectionStateFromOutside;
@@ -41,13 +41,13 @@ namespace MudBlazor
                 }
                 else
                 {
-                    IsSelected = isSelected;
+                    Selected = selected;
                 }
             }
         }
 
         private IMudShadowSelect _shadowParent;
-        private bool _isSelected;
+        private bool _selected;
 
         [CascadingParameter]
         internal IMudShadowSelect IMudShadowSelect
@@ -73,9 +73,9 @@ namespace MudBlazor
         {
             if (selection == null)
                 return;
-            var old_is_selected = IsSelected;
-            IsSelected = selection.Contains(Value);
-            if (old_is_selected != IsSelected)
+            var old_selected = Selected;
+            Selected = selection.Contains(Value);
+            if (old_selected != Selected)
                 InvokeAsync(StateHasChanged);
         }
 
@@ -102,12 +102,12 @@ namespace MudBlazor
         /// <summary>
         /// Selected state of the option. Only works if the parent is a mulit-select
         /// </summary>
-        internal bool IsSelected
+        internal bool Selected
         {
-            get => _isSelected;
+            get => _selected;
             set
             {
-                _isSelected = value;
+                _selected = value;
             }
         }
 
@@ -120,7 +120,7 @@ namespace MudBlazor
             {
                 if (!MultiSelection)
                     return null;
-                return IsSelected ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank;
+                return Selected ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank;
             }
         }
 
@@ -138,7 +138,7 @@ namespace MudBlazor
         private void OnClicked()
         {
             if (MultiSelection)
-                IsSelected = !IsSelected;
+                Selected = !Selected;
 
             MudSelect?.SelectOption(Value);
             InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -348,9 +348,9 @@ namespace MudBlazor
             if (SelectionMode == SelectionMode.MultiSelection)
             {
                 var selectedValues = new HashSet<T?>(_values.Value ?? Array.Empty<T?>());
-                item.SetSelected(!item.IsSelected);
+                item.SetSelected(!item.Selected);
 
-                if (item.IsSelected)
+                if (item.Selected)
                 {
                     selectedValues.Add(itemValue);
                 }
@@ -363,7 +363,7 @@ namespace MudBlazor
             }
             else if (SelectionMode == SelectionMode.ToggleSelection)
             {
-                if (item.IsSelected)
+                if (item.Selected)
                 {
                     item.SetSelected(false);
                     await _value.SetValueAsync(default);

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor
@@ -10,7 +10,7 @@
     @if (ChildContent is not null)
     {
         <div class="mud-toggle-item-content">
-            @ChildContent(IsSelected)
+            @ChildContent(Selected)
         </div>
     }
     else

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -12,15 +12,15 @@ namespace MudBlazor
     public partial class MudToggleItem<T> : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-toggle-item")
-            .AddClass($"mud-theme-{Parent?.Color.ToDescriptionString()}", IsSelected && string.IsNullOrEmpty(Parent?.SelectedClass))
-            .AddClass(Parent?.SelectedClass, IsSelected && !string.IsNullOrEmpty(Parent?.SelectedClass))
-            .AddClass("mud-toggle-item-selected", IsSelected)
+            .AddClass($"mud-theme-{Parent?.Color.ToDescriptionString()}", Selected && string.IsNullOrEmpty(Parent?.SelectedClass))
+            .AddClass(Parent?.SelectedClass, Selected && !string.IsNullOrEmpty(Parent?.SelectedClass))
+            .AddClass("mud-toggle-item-selected", Selected)
             .AddClass($"mud-toggle-item-{Parent?.Color.ToDescriptionString()}")
             .AddClass("mud-toggle-item-vertical", Parent?.Vertical == true)
             .AddClass("mud-toggle-item-delimiter", Parent?.Delimiters == true)
             .AddClass("mud-ripple", Parent?.Ripple == true)
             .AddClass($"mud-border-{Parent?.Color.ToDescriptionString()} border-solid")
-            .AddClass("mud-toggle-delimiter-alternative", Parent?.SelectionMode == SelectionMode.MultiSelection && IsSelected && Parent?.Color != Color.Default)
+            .AddClass("mud-toggle-delimiter-alternative", Parent?.SelectionMode == SelectionMode.MultiSelection && Selected && Parent?.Color != Color.Default)
             .AddClass("mud-toggle-item-fixed", Parent?.CheckMark == true && Parent?.FixedContent == true)
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass(Class)
@@ -65,7 +65,7 @@ namespace MudBlazor
         [Category(CategoryTypes.List.Appearance)]
         public string? SelectedIcon { get; set; } = Icons.Material.Filled.Check;
 
-        private string? CurrentIcon => IsSelected ? SelectedIcon ?? UnselectedIcon : UnselectedIcon;
+        private string? CurrentIcon => Selected ? SelectedIcon ?? UnselectedIcon : UnselectedIcon;
 
         /// <summary>
         /// The text to show. You need to set this only if you want a text that differs from the Value. If null,
@@ -91,11 +91,11 @@ namespace MudBlazor
 
         public void SetSelected(bool selected)
         {
-            IsSelected = selected;
+            Selected = selected;
             StateHasChanged();
         }
 
-        protected internal bool IsSelected { get; private set; }
+        protected internal bool Selected { get; private set; }
 
         protected async Task HandleOnClickAsync()
         {


### PR DESCRIPTION
MudBlazor currently uses the `IsSelected` and `IsSelectedChanged` properties. This PR aims to standardise the use of `Selected` and `SelectedChanged` to align with other boolean properties in the library.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudChip**: replace `IsSelected` with `Selected`
**MudChip**: replace `IsSelectedChanged` with `SelectedChanged`
**CellContext**: replace `IsSelected` with `Selected`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.