### PR TITLE
Standardise the use of `ItemDisabled`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
@@ -134,7 +134,7 @@
         <DocsPageSection>
             <SectionHeader Title="Disabled items">
                 <Description>
-                    Drop items can be prevented from being dragged by using the <CodeInline>ItemIsDisabled</CodeInline> property.
+                    Drop items can be prevented from being dragged by using the <CodeInline>@nameof(MudDropZone<T>.ItemDisabled)</CodeInline> property.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(DropZoneDisabledExample)">

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDisabledExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneDisabledExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDropContainer T="FileItem" ItemIsDisabled="@(item => item.IsLocked)" Items="_items"
+<MudDropContainer T="FileItem" ItemDisabled="@(item => item.IsLocked)" Items="_items"
                   ItemsSelector="@((item, dropzone) => item.TransferSlot == dropzone)" ItemDropped="ItemUpdated" Class="d-flex flex-wrap">
     <ChildContent>
         <MudPaper Class="ma-4" Height="400px" Width="300px">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDisableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDisableTest.razor
@@ -3,11 +3,11 @@
 <MudDropContainer T="SimpleDropItem"
 				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
 				  Class="d-flex"
-				  DisabledClass="my-custom-disabled-class-from-container" ItemIsDisabled="@( (item) => item.Name == "First Item" || item.Name == "Third Item")"
+				  DisabledClass="my-custom-disabled-class-from-container" ItemDisabled="@( (item) => item.Name == "First Item" || item.Name == "Third Item")"
 				  ItemDropped="ItemUpdated">
 	<ChildContent>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
-					 ItemIsDisabled="@( (item) => item.Name == "Fourth Item")" DisabledClass="my-zone-based-custom-disabled">
+					 ItemDisabled="@( (item) => item.Name == "Fourth Item")" DisabledClass="my-zone-based-custom-disabled">
 			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
 		</MudDropZone>
 		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActivateDisabledTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActivateDisabledTabsTest.razor
@@ -5,7 +5,7 @@
     {
         int tempIndex = i;
 
-        <MudTabPanel @key="@Tabs[tempIndex].Name" @ref="Tabs[tempIndex].Panel" Text="@Tabs[tempIndex].Name" ID="@Tabs[tempIndex].Tag" @bind-Disabled="@Tabs[tempIndex].IsDisabled">
+        <MudTabPanel @key="@Tabs[tempIndex].Name" @ref="Tabs[tempIndex].Panel" Text="@Tabs[tempIndex].Name" ID="@Tabs[tempIndex].Tag" @bind-Disabled="@Tabs[tempIndex].Disabled">
             <MudText>@Tabs[tempIndex].Content</MudText>
         </MudTabPanel>
     }
@@ -17,7 +17,7 @@
     public class TabBindingHelper
     {
         public string Name { get; set; }
-        public bool IsDisabled { get; set; }
+        public bool Disabled { get; set; }
         public DummyPlaceHolder Tag { get; set; }
         public MudTabPanel Panel { get; set; }
         public int Index { get; set; }
@@ -42,7 +42,7 @@
         Tabs = new();
         for (int i = 0; i < 5; i++)
         {
-            Tabs.Add(new TabBindingHelper { Name = (i + 1).ToString(), IsDisabled = true, Tag = new DummyPlaceHolder { Id = Guid.NewGuid() }, Index = i, Content = $"Tab Content {i + 1}" });
+            Tabs.Add(new TabBindingHelper { Name = (i + 1).ToString(), Disabled = true, Tag = new DummyPlaceHolder { Id = Guid.NewGuid() }, Index = i, Content = $"Tab Content {i + 1}" });
         }
     }
 
@@ -52,7 +52,7 @@
         {
             foreach (var item in Tabs)
             {
-                item.IsDisabled = false;
+                item.Disabled = false;
             }
 
             StateHasChanged();
@@ -63,14 +63,14 @@
     {
         base.OnParametersSet();
 
-        Tabs[InitialStartIndex].IsDisabled = false;
+        Tabs[InitialStartIndex].Disabled = false;
     }
 
     public void EnableTab(int index)
     {
         InvokeAsync(() =>
         {
-            Tabs[index].IsDisabled = false;
+            Tabs[index].Disabled = false;
             StateHasChanged();
         });
     }
@@ -95,7 +95,7 @@
     {
         InvokeAsync(() =>
         {
-            Tabs[index].IsDisabled = true;
+            Tabs[index].Disabled = true;
             StateHasChanged();
         });
     }

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
             container.DisabledClass.Should().Be("disabled");
             container.DraggingClass.Should().BeNullOrEmpty();
             container.ItemDraggingClass.Should().BeNullOrEmpty();
-            container.ItemIsDisabled.Should().BeNull();
+            container.ItemDisabled.Should().BeNull();
             container.Items.Should().BeEmpty();
             container.ItemsSelector.Should().BeNull();
             container.NoDropClass.Should().BeNullOrEmpty();
@@ -46,7 +46,7 @@ namespace MudBlazor.UnitTests.Components
             zone.DisabledClass.Should().BeNullOrEmpty();
             zone.DraggingClass.Should().BeNullOrEmpty();
             zone.ItemDraggingClass.Should().BeNullOrEmpty();
-            zone.ItemIsDisabled.Should().BeNull();
+            zone.ItemDisabled.Should().BeNull();
             zone.ItemsSelector.Should().BeNull();
             zone.NoDropClass.Should().BeNullOrEmpty();
             zone.OnlyZone.Should().BeFalse();

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -363,6 +363,7 @@ namespace MudBlazor
                         case "IsCheckedChanged":
                         case "IsVisible":
                         case "IsVisibleChanged":
+                        case "ItemIsDisabled":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -15,7 +15,7 @@ else if (Column != null && !Column.HiddenState.Value)
     <th @ref=@_headerElement scope="col" class="@_classname" style="@_style" colspan="@Column.HeaderColSpan" @attributes="@UserAttributes">
         @if (DataGrid.DragDropColumnReordering)
         {
-            <MudDropZone CanDrop="@((item) => (Column.DragAndDropEnabled ?? true))" ItemIsDisabled="@((item) => !item.DragAndDropEnabled ?? false)" T="Column<T>" Identifier="@(Column.PropertyName ?? $"mud-header-cell-{_id}")">
+            <MudDropZone CanDrop="@((item) => (Column.DragAndDropEnabled ?? true))" ItemDisabled="@((item) => !item.DragAndDropEnabled ?? false)" T="Column<T>" Identifier="@(Column.PropertyName ?? $"mud-header-cell-{_id}")">
 
             </MudDropZone>
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -87,7 +87,7 @@
                                         </MudStack>
 
                                         <MudDropContainer @ref="_columnsPanelDropContainer" T="Column<T>" Items="@RenderedColumns" ItemsSelector="(item, dropzone) => true" 
-                                            ItemIsDisabled="@((item) => !this.ColumnsPanelReordering)" ItemDropped="ColumnOrderUpdated">
+                                            ItemDisabled="@((item) => !this.ColumnsPanelReordering)" ItemDropped="ColumnOrderUpdated">
                                             <ChildContent>
                                                 <MudDropZone T="Column<T>" Class="flex-grow-1" AllowReorder=this.ColumnsPanelReordering />
                                             </ChildContent>

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -101,10 +101,10 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
-        public Func<T, bool>? ItemIsDisabled { get; set; }
+        public Func<T, bool>? ItemDisabled { get; set; }
 
         /// <summary>
-        /// If a drop item is disabled (determinate by <see cref="ItemIsDisabled"/>). This class is applied to the element
+        /// If a drop item is disabled (determinate by <see cref="ItemDisabled"/>). This class is applied to the element
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -89,10 +89,10 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
-        public Func<T, bool>? ItemIsDisabled { get; set; }
+        public Func<T, bool>? ItemDisabled { get; set; }
 
         /// <summary>
-        /// If a drop item is disabled (determinate by <see cref="ItemIsDisabled"/>). This class is applied to the element. Overrides value provided by drop container
+        /// If a drop item is disabled (determinate by <see cref="ItemDisabled"/>). This class is applied to the element. Overrides value provided by drop container
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.DropZone.Disabled)]
@@ -180,7 +180,7 @@ namespace MudBlazor
         private bool GetItemDisabledStatus(T item)
         {
             var result = false;
-            var predicate = ItemIsDisabled ?? Container?.ItemIsDisabled;
+            var predicate = ItemDisabled ?? Container?.ItemDisabled;
             if (predicate is not null)
             {
                 result = predicate(item);


### PR DESCRIPTION
MudBlazor currently uses the `ItemIsDisabled` property. This PR aims to standardise the use of `ItemDisabled` to align with other boolean properties in the library.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudDropZone**: replace `ItemIsDisabled` with `ItemDisabled`
**MudDropContainer**: replace `ItemIsDisabled` with `ItemDisabled`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.