### PR TITLE
Standardise the use of `Active`

### DIFF
--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -363,6 +363,7 @@ namespace MudBlazor
                         case "IsCheckedChanged":
                         case "IsVisible":
                         case "IsVisibleChanged":
+                        case "IsActive":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -29,7 +29,7 @@ namespace MudBlazor
         /// <summary>
         /// The currently active session. null if there is no section selected
         /// </summary>
-        public MudPageContentSection? ActiveSection => _sections.FirstOrDefault(x => x.IsActive);
+        public MudPageContentSection? ActiveSection => _sections.FirstOrDefault(x => x.Active);
 
         /// <summary>
         /// The text displayed about the section links. Defaults to "Contents"
@@ -98,7 +98,7 @@ namespace MudBlazor
 
         private string GetNavLinkClass(MudPageContentSection section) =>
             new CssBuilder("page-content-navigation-navlink")
-                .AddClass("active", section.IsActive)
+                .AddClass("active", section.Active)
                 .AddClass($"navigation-level-{section.Level}")
                 .Build();
 

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentSection.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentSection.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicating if the section is currently in the middle of the viewport
         /// </summary>
-        public bool IsActive { get; private set; }
+        public bool Active { get; private set; }
 
         /// <summary>
         /// create a new instance with a title and id and level set to zero
@@ -61,9 +61,9 @@ namespace MudBlazor
             Parent?._children.Add(this);
         }
 
-        protected internal void Activate() => IsActive = true;
+        protected internal void Activate() => Active = true;
 
-        protected internal void Deactive() => IsActive = false;
+        protected internal void Deactive() => Active = false;
 
         internal void SetLevelStructure(int counter, int diff)
         {

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
                 .AddClass($"mud-ripple mud-ripple-icon", Ripple)
                 .AddClass($"yellow-text.text-darken-3", Color == Color.Default)
                 .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default)
-                .AddClass($"mud-rating-item-active", IsActive)
+                .AddClass($"mud-rating-item-active", Active)
                 .AddClass($"mud-disabled", Disabled)
                 .AddClass($"mud-readonly", ReadOnly)
                 .AddClass(Class)
@@ -77,7 +77,7 @@ namespace MudBlazor
 
         internal string? ItemIcon { get; set; }
 
-        internal bool IsActive { get; set; }
+        internal bool Active { get; set; }
 
         private bool Checked => ItemValue == Rating?.GetState<int>(nameof(Rating.SelectedValue));
 
@@ -125,7 +125,7 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            IsActive = false;
+            Active = false;
 
             return ItemHovered.InvokeAsync(null);
         }
@@ -137,7 +137,7 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            IsActive = true;
+            Active = true;
 
             return ItemHovered.InvokeAsync(ItemValue);
         }
@@ -149,7 +149,7 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            IsActive = false;
+            Active = false;
             var ratingSelectedValue = Rating?.GetState<int>(nameof(Rating.SelectedValue));
 
             return ItemClicked.InvokeAsync(ratingSelectedValue == ItemValue ? 0 : ItemValue);


### PR DESCRIPTION
MudBlazor currently uses the `IsActive` property. This PR aims to standardise the use of `Active` to align with other boolean properties in the library.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudPageContentSection**: replace `IsActive` with `Active`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.