### PR TITLE
Standardise the use of `Open` and `OpenChanged`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelTitleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelTitleExample.razor
@@ -29,11 +29,11 @@
                 Panel Content
             </ChildContent>
         </MudExpansionPanel>
-        <MudExpansionPanel @bind-Expanded="isOpen" HideIcon="true">
+        <MudExpansionPanel @bind-Expanded="@open" HideIcon="true">
             <TitleContent>
                 <div class="d-flex">
                     <MudText>Overriding standard icon with own icon</MudText>
-                    <MudIcon Icon="@(isOpen ? Icons.Material.Filled.Close : Icons.Material.Filled.Add)" class="ml-auto"></MudIcon>
+                    <MudIcon Icon="@(open ? Icons.Material.Filled.Close : Icons.Material.Filled.Add)" class="ml-auto"></MudIcon>
                 </div>
             </TitleContent>
             <ChildContent>
@@ -45,5 +45,5 @@
 
 @code
 {
-    bool isOpen;
+    bool open;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverComplexContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverComplexContentExample.razor
@@ -2,9 +2,9 @@
 
 <div class="d-flex">
 	<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ToggleOpen">
-		@(_isOpen? "Close" : "Open")
+		@(_open? "Close" : "Open")
 	</MudButton>
-	<MudPopover Open="@_isOpen" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
+	<MudPopover Open="@_open" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
 		<div class="d-flex flex-column pa-1">
 			<PopoverDynamicContentExample />
 		</div>
@@ -13,13 +13,13 @@
 
 @code {
 
-	public bool _isOpen;
+	public bool _open;
 
 	public void ToggleOpen()
 	{
-		if (_isOpen)
-			_isOpen = false;
+		if (_open)
+			_open = false;
 		else
-			_isOpen = true;
+			_open = true;
 	}
 }

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverInceptionExampleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverInceptionExampleExample.razor
@@ -28,11 +28,3 @@
         </MudTooltip>
     </div>
 </MudMenu>
-
-
-@code {
-	private bool _isOpen = false;
-
-	public void ToggleOpen() => _isOpen = !_isOpen;
-
-}

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverOverflowBehaviorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverOverflowBehaviorExample.razor
@@ -1,24 +1,16 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-
 <MudPaper Outlined="true" Class="px-12 py-6">
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@ToggleOpen">@(_isOpen? "Close" : "Open")</MudButton>
-	<MudPopover Open="_isOpen" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Paper="false">
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@ToggleOpen">@(_open? "Close" : "Open")</MudButton>
+	<MudPopover Open="_open" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Paper="false">
         <MudPaper Outlined="true" Class="px-4 py-8">
             <MudText>Scroll your browser to see effect.</MudText>
         </MudPaper>
 	</MudPopover>
 </MudPaper>
 
-
 @code {
-    public bool _isOpen = true;
+    private bool _open = true;
 
-    public void ToggleOpen()
-    {
-        if (_isOpen)
-            _isOpen = false;
-        else
-            _isOpen = true;
-    }
+    private void ToggleOpen() => _open = !_open;
 }

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverSimpleExample.razor
@@ -1,25 +1,18 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ToggleOpen">Open</MudButton>
-<MudSwitch @bind-Value="_isOpen" Color="Color.Primary" />
-<MudToggleIconButton @bind-Toggled="@_isOpen" Icon="@Icons.Material.Filled.Fullscreen" Color="@Color.Primary" ToggledIcon="@Icons.Material.Filled.FullscreenExit" ToggledColor="@Color.Secondary" />
+<MudSwitch @bind-Value="_open" Color="Color.Primary" />
+<MudToggleIconButton @bind-Toggled="@_open" Icon="@Icons.Material.Filled.Fullscreen" Color="@Color.Primary" ToggledIcon="@Icons.Material.Filled.FullscreenExit" ToggledColor="@Color.Secondary" />
 
-<MudPopover Open="@_isOpen" Fixed="true" Class="px-4 pt-4">
+<MudPopover Open="@_open" Fixed="true" Class="px-4 pt-4">
     <div class="d-flex flex-column">
         <MudText>Content of the popover can be anything.</MudText>
         <MudButton OnClick="@ToggleOpen" Class="ml-auto mr-n3 mb-1" Color="Color.Error">Close</MudButton>
     </div>
 </MudPopover>
 
-
 @code{
-    public bool _isOpen;
+    private bool _open;
 
-    public void ToggleOpen()
-    {
-        if (_isOpen)
-            _isOpen = false;
-        else
-            _isOpen = true;
-    }
+    private void ToggleOpen() => _open = !_open;
 }

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -88,7 +88,7 @@
         <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
                          AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
-                         ValueChanged="OnSearchResult" IsOpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
+                         ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDrawer @ref="@Drawer" @bind-Open="@isOpen" Variant="@Variant" Overlay="@Overlay" ClipMode="@ClipMode"></MudDrawer>
+<MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Overlay="@Overlay" ClipMode="@ClipMode"></MudDrawer>
 <button @onclick="@HandleButtonClick" />
 
 @code {
-    bool isOpen = false;
+    private bool _open = false;
 
     public MudDrawer Drawer { get; set; }
 
@@ -17,8 +17,5 @@
     [Parameter]
     public DrawerClipMode ClipMode { get; set; }
 
-    public void HandleButtonClick()
-    {
-        isOpen = !isOpen;
-    }
+    public void HandleButtonClick() => _open = !_open;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuIsOpenChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuIsOpenChangedTest.razor
@@ -4,7 +4,7 @@
 
 <MudMenu
     @ref="Menu"
-    IsOpenChanged="@(o => _ = o ? TrueInvocationCount++ : FalseInvocationCount++)"/>
+    OpenChanged="@(o => _ = o ? TrueInvocationCount++ : FalseInvocationCount++)"/>
 
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDuplicationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDuplicationTest.razor
@@ -4,7 +4,7 @@
 
 <div class="popoverparent">
     <p>Some Text</p>
-    <MudPopover @ref="_popover" Open="_isOpen">
+    <MudPopover @ref="_popover" Open="_open">
         <MudText>Popover content</MudText>
     </MudPopover>
 </div>
@@ -13,17 +13,17 @@
     public static string __description__ = "Duplicate MudPopoverProviders should throw";
     private MudPopover _popover;
 
-    private bool _isOpen;
+    private bool _open;
 
     public async Task Open()
     {
-        _isOpen = true;
+        _open = true;
         await InvokeAsync(StateHasChanged);
     }
 
     public async Task Close()
     {
-        _isOpen = false;
+        _open = false;
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverTest.razor
@@ -2,7 +2,7 @@
 
 <div class="popoverparent">
 	<p>Some Text</p>
-	<MudPopover @ref="_popover" Open="_isOpen">
+	<MudPopover @ref="_popover" Open="_open">
 		<MudText>Popover content</MudText>
 	</MudPopover>
 </div>
@@ -11,17 +11,17 @@
 @code {
 	private MudPopover _popover;
 
-	private bool _isOpen;
+	private bool _open;
 
 	public async Task Open()
 	{
-		_isOpen = true;
+		_open = true;
 		await InvokeAsync(StateHasChanged);
 	}
 
 	public async Task Close()
 	{
-		_isOpen = false;
+		_open = false;
 		await InvokeAsync(StateHasChanged);
 	}
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -133,8 +133,8 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
             autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S.
-            // IsOpen must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
-            autocompletecomp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+            // Open must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
+            autocompletecomp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             autocomplete.Value.Should().Be("Alabama");
@@ -302,7 +302,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("California"));
 
             //and the autocomplete it's closed
-            autocomplete.IsOpen.Should().BeFalse();
+            autocomplete.Open.Should().BeFalse();
         }
 
         /// <summary>
@@ -426,15 +426,15 @@ namespace MudBlazor.UnitTests.Components
             var autocomplete = autocompletecomp.Instance;
 
             // Should be closed
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Lets type something to cause it to open
             autocompletecomp.Find("input").Input("Calif");
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
             autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and does not select the selected value (California)
             // because SelectValueOnTab is false by default
@@ -451,15 +451,15 @@ namespace MudBlazor.UnitTests.Components
             var autocomplete = autocompletecomp.Instance;
 
             // Should be closed
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Lets type something to cause it to open
             autocompletecomp.Find("input").Input("Calif");
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
             autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
-            comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and selects the selected value (California)
             // because SelectValueOnTab is true
@@ -571,7 +571,7 @@ namespace MudBlazor.UnitTests.Components
             autocompleteComponent.Find(TagNames.Input).Focus();
 
             // ensure popup is open
-            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeTrue("Input has been focused and should open the popup"));
+            component.WaitForAssertion(() => autocompleteInstance.Open.Should().BeTrue("Input has been focused and should open the popup"));
 
             // get the matching states
             var matchingStates = component.FindComponents<MudListItem<string>>().ToArray();
@@ -647,7 +647,7 @@ namespace MudBlazor.UnitTests.Components
             autocompleteComponent.Find(TagNames.Input).Focus();
 
             // ensure popup is open
-            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeTrue("Input has been focused and should open the popup"));
+            component.WaitForAssertion(() => autocompleteInstance.Open.Should().BeTrue("Input has been focused and should open the popup"));
 
             // get the matching states
             var matchingStates = component.FindComponents<MudListItem<string>>().ToArray();
@@ -664,7 +664,7 @@ namespace MudBlazor.UnitTests.Components
             autocompleteComponent.Find(TagNames.Input).Input(string.Empty);
 
             // wait till popup is visible
-            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeTrue());
+            component.WaitForAssertion(() => autocompleteInstance.Open.Should().BeTrue());
 
             // update found elements
             matchingStates = component.FindComponents<MudListItem<string>>().ToArray();
@@ -724,31 +724,31 @@ namespace MudBlazor.UnitTests.Components
                 //press Enter key
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 //ensure autocomplete is closed and new value is committed/bound
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "NumpadEnter" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
 
@@ -771,7 +771,7 @@ namespace MudBlazor.UnitTests.Components
                 autocomplete.Text.Should().Be("Alabama");
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
                 comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Alabama"));
@@ -779,7 +779,7 @@ namespace MudBlazor.UnitTests.Components
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Tab" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
                 autocompletecomp.SetParam("SelectValueOnTab", true);
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
@@ -790,21 +790,21 @@ namespace MudBlazor.UnitTests.Components
                 comp.WaitForAssertion(() => autocompletecomp.Instance.Value.Should().Be(null));
 
                 await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
                 //Check popover is closed if coerce text is true (it fixed with a PR)
                 autocomplete.CoerceText = true;
                 await comp.InvokeAsync(() => autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
                 await comp.InvokeAsync(() => autocomplete.OnEnterKey());
                 autocompletecomp.Find("input").Input("abc");
                 await comp.InvokeAsync(async () => await autocomplete.SelectAsync());
                 await comp.InvokeAsync(async () => await autocomplete.SelectRangeAsync(0, 1));
                 autocompletecomp.Find("input").Input("");
                 await comp.InvokeAsync(() => autocomplete.ToggleMenuAsync());
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(() => autocomplete.OnEnterKey());
-                comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeFalse());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
             });
         }
 
@@ -1208,7 +1208,7 @@ namespace MudBlazor.UnitTests.Components
             autocompleteComponent.Find(TagNames.Input).Focus();
 
             // ensure popup is open
-            component.WaitForAssertion(() => autocompleteInstance.IsOpen.Should().BeTrue("Input has been focused and should open the popup"));
+            component.WaitForAssertion(() => autocompleteInstance.Open.Should().BeTrue("Input has been focused and should open the popup"));
 
             // get the matching states
             var matchingStates = component.FindComponents<MudListItem<string>>().ToArray();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2935,10 +2935,10 @@ namespace MudBlazor.UnitTests.Components
 
             await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().Contain(item);
-            cell._cellContext.IsOpened.Should().Be(true);
+            cell._cellContext.Open.Should().Be(true);
             await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
             cell._cellContext.OpenHierarchies.Should().NotContain(item);
-            cell._cellContext.IsOpened.Should().Be(false);
+            cell._cellContext.Open.Should().Be(false);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -101,14 +101,14 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTest1>();
             var menu = comp.FindComponent<MudMenu>().Instance;
-            menu.IsOpen.Should().BeFalse();
+            menu.Open.Should().BeFalse();
 
             var args = new MouseEventArgs { OffsetX = 1.0, OffsetY = 1.0 };
             await comp.InvokeAsync(() => menu.OpenMenuAsync(args));
-            menu.IsOpen.Should().BeTrue();
+            menu.Open.Should().BeTrue();
 
             await comp.InvokeAsync(() => menu.CloseMenuAsync());
-            menu.IsOpen.Should().BeFalse();
+            menu.Open.Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1036,7 +1036,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
             comp.Find("div.mud-input-control").Click();
-            select.Instance._isOpen.Should().BeTrue();
+            select.Instance._open.Should().BeTrue();
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[0].Click();
             items[2].Click();

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -866,7 +866,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(02, 00, 00)));
             await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.Time.Should().Be(new TimeSpan(01, 59, 00)));
-            //If IsOpen is false, arrowkeys should now change TimeIntermediate
+            //If Open is false, arrowkeys should now change TimeIntermediate
             await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             comp.WaitForAssertion(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
 

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -363,6 +363,9 @@ namespace MudBlazor
                         case "IsCheckedChanged":
                         case "IsVisible":
                         case "IsVisibleChanged":
+                        case "IsOpen":
+                        case "IsOpened":
+                        case "IsOpenChanged":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -43,7 +43,7 @@
                     }
                 }
 
-                <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
+                <MudPopover Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
                     @if (ProgressIndicatorInPopoverTemplate != null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate
@@ -112,4 +112,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="IsOpen" OnClick="CloseMenuAsync" @ontouchstart="CloseMenuAsync" LockScroll="false" />
+<MudOverlay Visible="Open" OnClick="CloseMenuAsync" @ontouchstart="CloseMenuAsync" LockScroll="false" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
         private int _selectedListItemIndex;
         private int _elementKey = 0;
         private int _returnedItemsCount;
-        private bool _isOpen;
+        private bool _open;
         private bool _doNotOpenMenuOnNextFocus;
         private MudInput<string> _elementReference;
         private CancellationTokenSource _cancellationTokenSrc;
@@ -391,10 +391,10 @@ namespace MudBlazor
         public Func<T, bool> ItemDisabledFunc { get; set; }
 
         /// <summary>
-        /// Occurs when the <see cref="IsOpen"/> property has changed.
+        /// Occurs when the <see cref="Open"/> property has changed.
         /// </summary>
         [Parameter]
-        public EventCallback<bool> IsOpenChanged { get; set; }
+        public EventCallback<bool> OpenChanged { get; set; }
 
         /// <summary>
         /// Whether pressing the <c>Tab</c> key updates the Value to the currently selected item.
@@ -438,26 +438,26 @@ namespace MudBlazor
         /// Whether the search result drop-down is currently displayed.
         /// </summary>
         /// <remarks>
-        /// When this property changes, the <see cref="IsOpenChanged"/> event will occur.
+        /// When this property changes, the <see cref="OpenChanged"/> event will occur.
         /// </remarks>
-        public bool IsOpen
+        public bool Open
         {
-            get => _isOpen;
+            get => _open;
             // Note: the setter is protected because it was needed by a user who derived his own autocomplete from this class.
-            // Note: setting IsOpen will not open or close it. Use ToggleMenu() for that.
+            // Note: setting Open will not open or close it. Use ToggleMenu() for that.
             protected set
             {
-                if (_isOpen == value)
+                if (_open == value)
                     return;
-                _isOpen = value;
+                _open = value;
 
-                IsOpenChanged.InvokeAsync(_isOpen).AndForget();
+                OpenChanged.InvokeAsync(_open).AndForget();
             }
         }
 
         private bool IsLoading => _currentSearchTask is { IsCompleted: false };
 
-        private string CurrentIcon => !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
+        private string CurrentIcon => !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _open ? CloseIcon : OpenIcon;
 
         public MudAutocomplete()
         {
@@ -485,7 +485,7 @@ namespace MudBlazor
                     await SetTextAsync(optionText, false);
 
                 _debounceTimer?.Dispose();
-                IsOpen = false;
+                Open = false;
 
                 await BeginValidateAsync();
 
@@ -588,12 +588,12 @@ namespace MudBlazor
         /// </remarks>
         public Task ToggleMenuAsync()
         {
-            if ((GetDisabledState() || GetReadOnlyState()) && !IsOpen)
+            if ((GetDisabledState() || GetReadOnlyState()) && !Open)
             {
                 return Task.CompletedTask;
             }
 
-            return IsOpen ? CloseMenuAsync() : OpenMenuAsync();
+            return Open ? CloseMenuAsync() : OpenMenuAsync();
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace MudBlazor
             _debounceTimer?.Dispose();
             await RestoreScrollPositionAsync();
             await CoerceTextToValue();
-            IsOpen = false;
+            Open = false;
             StateHasChanged();
         }
 
@@ -619,7 +619,7 @@ namespace MudBlazor
         {
             if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
             {
-                IsOpen = false;
+                Open = false;
                 StateHasChanged();
                 return;
             }
@@ -634,7 +634,7 @@ namespace MudBlazor
                 if (ProgressIndicatorInPopoverTemplate != null)
                 {
                     // Open before searching if a progress indicator is defined.
-                    IsOpen = true;
+                    Open = true;
                 }
 
                 // Search while selected if enabled and the Text is equivalent to the Value.
@@ -683,7 +683,7 @@ namespace MudBlazor
             if (_isFocused || !wasFocused)
             {
                 // Open after the search has finished if we're still focused (UI), or were never focused in the first place (programmatically).
-                IsOpen = true;
+                Open = true;
             }
 
             if (_items?.Length == 0)
@@ -710,7 +710,7 @@ namespace MudBlazor
             try
             {
                 _isCleared = true;
-                IsOpen = false;
+                Open = false;
 
                 await SetTextAsync(null, updateValue: false);
                 await CoerceValueToText();
@@ -747,16 +747,16 @@ namespace MudBlazor
             {
                 // We need to catch Tab here because a tab will move focus to the next element and thus we'd never get the tab key in OnInputKeyUp.
                 case "Tab":
-                    if (IsOpen)
+                    if (Open)
                     {
                         if (SelectValueOnTab)
                             await OnEnterKey();
                         else
-                            IsOpen = false;
+                            Open = false;
                     }
                     break;
                 case "ArrowDown":
-                    if (IsOpen)
+                    if (Open)
                     {
                         var increment = _enabledItemIndices.ElementAtOrDefault(_enabledItemIndices.IndexOf(_selectedListItemIndex) + 1) - _selectedListItemIndex;
                         await SelectNextItem(increment < 0 ? 1 : increment);
@@ -771,7 +771,7 @@ namespace MudBlazor
                     {
                         await CloseMenuAsync();
                     }
-                    else if (!IsOpen)
+                    else if (!Open)
                     {
                         await ToggleMenuAsync();
                     }
@@ -792,7 +792,7 @@ namespace MudBlazor
             {
                 case "Enter":
                 case "NumpadEnter":
-                    if (IsOpen)
+                    if (Open)
                     {
                         await OnEnterKey();
                     }
@@ -853,7 +853,7 @@ namespace MudBlazor
 
         internal async Task OnEnterKey()
         {
-            if (!IsOpen)
+            if (!Open)
                 return;
 
             try
@@ -866,8 +866,8 @@ namespace MudBlazor
             }
             finally
             {
-                if (IsOpen)
-                    IsOpen = false;
+                if (Open)
+                    Open = false;
             }
         }
 
@@ -880,7 +880,7 @@ namespace MudBlazor
         {
             _isFocused = true;
 
-            if (_doNotOpenMenuOnNextFocus || IsOpen || GetDisabledState() || GetReadOnlyState())
+            if (_doNotOpenMenuOnNextFocus || Open || GetDisabledState() || GetReadOnlyState())
             {
                 _doNotOpenMenuOnNextFocus = false;
                 return;

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
             }
         }
 
-        public bool IsOpened
+        public bool Open
         {
             get
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -229,25 +229,25 @@ namespace MudBlazor
             switch (args.Key)
             {
                 case "ArrowRight":
-                    if (IsOpen)
+                    if (Open)
                     {
 
                     }
                     break;
                 case "ArrowLeft":
-                    if (IsOpen)
+                    if (Open)
                     {
 
                     }
                     break;
                 case "ArrowUp":
-                    if (IsOpen == false && Editable == false)
+                    if (Open == false && Editable == false)
                     {
-                        IsOpen = true;
+                        Open = true;
                     }
                     else if (args.AltKey)
                     {
-                        IsOpen = false;
+                        Open = false;
                     }
                     else if (args.ShiftKey)
                     {
@@ -259,9 +259,9 @@ namespace MudBlazor
                     }
                     break;
                 case "ArrowDown":
-                    if (IsOpen == false && Editable == false)
+                    if (Open == false && Editable == false)
                     {
-                        IsOpen = true;
+                        Open = true;
                     }
                     else if (args.ShiftKey)
                     {
@@ -277,7 +277,7 @@ namespace MudBlazor
                     break;
                 case "Enter":
                 case "NumpadEnter":
-                    if (!IsOpen)
+                    if (!Open)
                     {
                         await OpenAsync();
                     }
@@ -291,7 +291,7 @@ namespace MudBlazor
                 case " ":
                     if (!Editable)
                     {
-                        if (!IsOpen)
+                        if (!Open)
                         {
                             await OpenAsync();
                         }

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -55,7 +55,7 @@ namespace MudBlazor
             foreach (var attribute in UserAttributes)
             {
                 // checking if the value is null, we can get rid of null event handlers
-                // for example `@onmouseenter=@(IsOpen ? HandleEnter : null)`
+                // for example `@onmouseenter=@(Open ? HandleEnter : null)`
                 // this is a powerful feature that in normal HTML elements doesn't work, because
                 // Blazor adds always the attribute value and creates an EventCallback
                 if (attribute.Value != null)

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -35,7 +35,7 @@
                        aria-label="@AriaLabel" />
     }
     @* The portal has to include  the cascading values inside, because it's not able to teletransport the cascade *@
-    <MudPopover Open="@_isOpen" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@_popoverStyle" @ontouchend:preventDefault>
+    <MudPopover Open="@_open" Class="@PopoverClass" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" RelativeWidth="@FullWidth" Style="@_popoverStyle" @ontouchend:preventDefault>
         <CascadingValue Value="@this">
             <MudList T="object" Class="@ListClass" Dense="@Dense"
                 @onmouseenter="@MouseEnterAsync"
@@ -44,5 +44,5 @@
             </MudList>
         </CascadingValue>
     </MudPopover>
-    <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenuAsync" LockScroll="LockScroll" />
+    <MudOverlay Visible="@(_open && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenuAsync" LockScroll="LockScroll" />
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 #nullable enable
     public partial class MudMenu : MudComponentBase, IActivatable
     {
-        private bool _isOpen;
+        private bool _open;
         private string? _popoverStyle;
         private bool _isMouseOver = false;
 
@@ -192,18 +192,18 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Fired when the menu IsOpen property changes.
+        /// Fired when the menu <see cref="Open"/> property changes.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Menu.PopupBehavior)]
-        public EventCallback<bool> IsOpenChanged { get; set; }
+        public EventCallback<bool> OpenChanged { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the menu is currently open or not.
         /// </summary>
-        public bool IsOpen
+        public bool Open
         {
-            get { return _isOpen; }
+            get { return _open; }
         }
 
         /// <summary>
@@ -211,12 +211,12 @@ namespace MudBlazor
         /// </summary>
         public Task CloseMenuAsync()
         {
-            _isOpen = false;
+            _open = false;
             _isMouseOver = false;
             _popoverStyle = null;
             StateHasChanged();
 
-            return IsOpenChanged.InvokeAsync(_isOpen);
+            return OpenChanged.InvokeAsync(_open);
         }
 
         /// <summary>
@@ -240,10 +240,10 @@ namespace MudBlazor
                 }
             }
 
-            _isOpen = true;
+            _open = true;
             StateHasChanged();
 
-            return IsOpenChanged.InvokeAsync(_isOpen);
+            return OpenChanged.InvokeAsync(_open);
         }
 
         /// <summary>
@@ -269,18 +269,18 @@ namespace MudBlazor
             // oncontextmenu turns a touch event into MouseEventArgs but with a button of -1.
             if (args is MouseEventArgs mouseEventArgs && mouseEventArgs.Button != -1)
             {
-                if (ActivationEvent == MouseEvent.LeftClick && mouseEventArgs.Button != 0 && !_isOpen)
+                if (ActivationEvent == MouseEvent.LeftClick && mouseEventArgs.Button != 0 && !_open)
                 {
                     return;
                 }
 
-                if (ActivationEvent == MouseEvent.RightClick && mouseEventArgs.Button != 2 && !_isOpen)
+                if (ActivationEvent == MouseEvent.RightClick && mouseEventArgs.Button != 2 && !_open)
                 {
                     return;
                 }
             }
 
-            if (_isOpen)
+            if (_open)
             {
                 await CloseMenuAsync();
             }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -52,7 +52,7 @@
             }
             @if (PickerVariant == PickerVariant.Inline)
             {
-				<MudPopover Open="IsOpen" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" OverflowBehavior="OverflowBehavior.FlipOnOpen" Paper="false">
+				<MudPopover Open="@Open" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" OverflowBehavior="OverflowBehavior.FlipOnOpen" Paper="false">
 				   <div @ref="_pickerInlineRef" class="@PickerInlineClassname">
 					   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Elevation="@_pickerElevation" Square="@_pickerSquare">
 						   <div class="@PickerContainerClassname">
@@ -86,9 +86,9 @@
                     }
                </MudPaper>
             }
-            else if(IsOpen && PickerVariant == PickerVariant.Dialog)
+            else if(Open && PickerVariant == PickerVariant.Dialog)
             {
-               <MudOverlay Visible="IsOpen" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
+               <MudOverlay Visible="@Open" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
                    <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Elevation="@_pickerElevation" Square="@_pickerSquare">
                        <div class="@PickerContainerClassname">
 							@if(PickerContent != null){
@@ -107,7 +107,7 @@
         </div>
         @if (PickerVariant == PickerVariant.Inline)
         {
-            <MudOverlay Visible="IsOpen" OnClick="CloseOverlayAsync" LockScroll="false" />
+            <MudOverlay Visible="@Open" OnClick="CloseOverlayAsync" LockScroll="false" />
         }
     </CascadingValue>;
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
             new CssBuilder("mud-picker")
                 .AddClass("mud-picker-paper")
                 .AddClass("mud-picker-view", PickerVariant == PickerVariant.Inline)
-                .AddClass("mud-picker-open", IsOpen && PickerVariant == PickerVariant.Inline)
+                .AddClass("mud-picker-open", Open && PickerVariant == PickerVariant.Inline)
                 .AddClass("mud-picker-popover-paper", PickerVariant == PickerVariant.Inline)
                 .AddClass("mud-dialog", PickerVariant == PickerVariant.Dialog)
                 .Build();
@@ -349,11 +349,11 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        protected bool IsOpen { get; set; }
+        protected bool Open { get; set; }
 
         public Task ToggleOpenAsync()
         {
-            if (IsOpen)
+            if (Open)
             {
                 return CloseAsync();
             }
@@ -365,7 +365,7 @@ namespace MudBlazor
 
         public async Task CloseAsync(bool submit = true)
         {
-            IsOpen = false;
+            Open = false;
 
             if (submit)
             {
@@ -378,7 +378,7 @@ namespace MudBlazor
 
         public Task OpenAsync()
         {
-            IsOpen = true;
+            Open = true;
             StateHasChanged();
 
             return OnOpenedAsync();
@@ -425,7 +425,7 @@ namespace MudBlazor
             base.OnInitialized();
             if (PickerVariant == PickerVariant.Static)
             {
-                IsOpen = true;
+                Open = true;
                 if (Elevation == 8)
                 {
                     _pickerElevation = 0;
@@ -515,14 +515,14 @@ namespace MudBlazor
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            if (IsOpen)
+            if (Open)
             {
-                IsOpen = false;
+                Open = false;
                 await OnClosedAsync();
             }
             else
             {
-                IsOpen = true;
+                Open = true;
                 await OnOpenedAsync();
                 await FocusAsync();
             }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -51,7 +51,7 @@
                         @GetSelectedValuePresenter()
                     }
                 </MudInput>
-                <MudPopover Open=@(_isOpen)
+                <MudPopover Open=@(_open)
                             MaxHeight="@MaxHeight"
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
@@ -88,4 +88,4 @@
 
 </CascadingValue>
 <!-- mousedown instead of click needed to close the menu before OnLostFocus runs -->
-<MudOverlay Visible="_isOpen" @onmousedown="@(() => CloseMenu(false))" LockScroll="@LockScroll" />
+<MudOverlay Visible="_open" @onmousedown="@(() => CloseMenu(false))" LockScroll="@LockScroll" />

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -550,7 +550,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
-        internal bool _isOpen;
+        internal bool _open;
 
         public string _currentIcon { get; set; }
 
@@ -672,7 +672,7 @@ namespace MudBlazor
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            if (_isOpen)
+            if (_open)
                 await CloseMenu(true);
             else
                 await OpenMenu();
@@ -682,7 +682,7 @@ namespace MudBlazor
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            _isOpen = true;
+            _open = true;
             UpdateIcon();
             StateHasChanged();
             await HilightSelectedValue();
@@ -704,7 +704,7 @@ namespace MudBlazor
 
         public async Task CloseMenu(bool focusAgain = true)
         {
-            _isOpen = false;
+            _open = false;
             UpdateIcon();
             if (focusAgain)
             {
@@ -722,7 +722,7 @@ namespace MudBlazor
 
         private void UpdateIcon()
         {
-            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _open ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()
@@ -865,7 +865,7 @@ namespace MudBlazor
             if (GetDisabledState() || GetReadOnlyState())
                 return;
             var key = obj.Key.ToLowerInvariant();
-            if (_isOpen && key.Length == 1 && key != " " && !(obj.CtrlKey || obj.ShiftKey || obj.AltKey || obj.MetaKey))
+            if (_open && key.Length == 1 && key != " " && !(obj.CtrlKey || obj.ShiftKey || obj.AltKey || obj.MetaKey))
             {
                 await SelectFirstItem(key);
                 return;
@@ -881,7 +881,7 @@ namespace MudBlazor
                         await CloseMenu();
                         break;
                     }
-                    else if (_isOpen == false)
+                    else if (_open == false)
                     {
                         await OpenMenu();
                         break;
@@ -897,7 +897,7 @@ namespace MudBlazor
                         await OpenMenu();
                         break;
                     }
-                    else if (_isOpen == false)
+                    else if (_open == false)
                     {
                         await OpenMenu();
                         break;
@@ -924,7 +924,7 @@ namespace MudBlazor
                     var index = _items.FindIndex(x => x.ItemId == (string)_activeItemId);
                     if (!MultiSelection)
                     {
-                        if (!_isOpen)
+                        if (!_open)
                         {
                             await OpenMenu();
                             return;
@@ -935,7 +935,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        if (_isOpen == false)
+                        if (_open == false)
                         {
                             await OpenMenu();
                             break;
@@ -1042,7 +1042,7 @@ namespace MudBlazor
 
         private async Task OnFocusOutAsync(FocusEventArgs focusEventArgs)
         {
-            if (_isOpen)
+            if (_open)
             {
                 // when the menu is open we immediately get back the focus if we lose it (i.e. because of checkboxes in multi-select)
                 // otherwise we can't receive key strokes any longer

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -658,7 +658,7 @@ namespace MudBlazor
             switch (obj.Key)
             {
                 case "ArrowRight":
-                    if (IsOpen)
+                    if (Open)
                     {
                         if (obj.CtrlKey)
                         {
@@ -686,7 +686,7 @@ namespace MudBlazor
 
                     break;
                 case "ArrowLeft":
-                    if (IsOpen)
+                    if (Open)
                     {
                         if (obj.CtrlKey)
                         {
@@ -714,13 +714,13 @@ namespace MudBlazor
 
                     break;
                 case "ArrowUp":
-                    if (!IsOpen && !Editable)
+                    if (!Open && !Editable)
                     {
-                        IsOpen = true;
+                        Open = true;
                     }
                     else if (obj.AltKey)
                     {
-                        IsOpen = false;
+                        Open = false;
                     }
                     else if (obj.ShiftKey)
                     {
@@ -733,9 +733,9 @@ namespace MudBlazor
 
                     break;
                 case "ArrowDown":
-                    if (!IsOpen && !Editable)
+                    if (!Open && !Editable)
                     {
-                        IsOpen = true;
+                        Open = true;
                     }
                     else if (obj.ShiftKey)
                     {
@@ -752,7 +752,7 @@ namespace MudBlazor
                     break;
                 case "Enter":
                 case "NumpadEnter":
-                    if (!IsOpen)
+                    if (!Open)
                     {
                         await OpenAsync();
                     }
@@ -767,7 +767,7 @@ namespace MudBlazor
                 case " ":
                     if (!Editable)
                     {
-                        if (!IsOpen)
+                        if (!Open)
                         {
                             await OpenAsync();
                         }


### PR DESCRIPTION
MudBlazor currently uses the `IsOpen`, `IsOpened` and `IsOpenChanged` properties. This PR aims to standardise the use of `Open` and `OpenChanged` to align with other boolean properties in the library.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudAutocomplete**: replace `IsOpenChanged` with `OpenChanged`
**MudAutocomplete**: replace `IsOpen` with `Open`
**CellContext**: replace `IsOpened` with `Open`
**MudMenu**: replace `IsOpenChanged` with `OpenChanged`
**MudMenu**: replace `IsOpen` with `Open`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
