### PR TITLE
Standardise the use of `Editable`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -7,7 +7,7 @@
     StartedEditingItem="@StartedEditingItem" CanceledEditingItem="@CanceledEditingItem" CommittedItemChanges="@CommittedItemChanges"
     Bordered="true" Dense="true" EditTrigger="@(_editTriggerRowClick ? DataGridEditTrigger.OnRowClick : DataGridEditTrigger.Manual)">
     <Columns>
-        <PropertyColumn Property="x => x.Number" Title="Nr" IsEditable="false" />
+        <PropertyColumn Property="x => x.Number" Title="Nr" Editable="false" />
         <PropertyColumn Property="x => x.Sign" />
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Position">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditableWithSelectColumnTest.razor
@@ -3,7 +3,7 @@
 <MudDataGrid Items=@_items ReadOnly=false EditMode=DataGridEditMode.Cell Dense FixedHeader=true MultiSelection="true">
     <Columns>
         <SelectColumn/>        
-        <PropertyColumn Property="x => x.Name" IsEditable=false/>
+        <PropertyColumn Property="x => x.Name" Editable=false/>
         <PropertyColumn Property="x => x.Value">
             <EditTemplate>
                 <MudSelect @bind-Value=context.Item.Value>
@@ -14,7 +14,7 @@
                 </MudSelect>
             </EditTemplate>
         </PropertyColumn>
-        <PropertyColumn Property="x => x.Misc" IsEditable=false/>
+        <PropertyColumn Property="x => x.Misc" Editable=false/>
     </Columns>
 </MudDataGrid>
 

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -363,6 +363,9 @@ namespace MudBlazor
                         case "IsCheckedChanged":
                         case "IsVisible":
                         case "IsVisibleChanged":
+                        case "IsEditable":
+                        case "IsEditing":
+                        case "IsEditSwitchBlocked":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         internal T _item;
         internal string? _valueString;
         internal double? _valueNumber;
-        internal bool _isEditing;
+        internal bool _editing;
         internal CellContext<T> _cellContext;
 
         #region Computed Properties
@@ -40,7 +40,7 @@ namespace MudBlazor
                     .AddClass("mud-table-cell-hide", _column.HideSmall)
                     .AddClass("sticky-left", _column.StickyLeft)
                     .AddClass("sticky-right", _column.StickyRight)
-                    .AddClass($"edit-mode-cell", _dataGrid.EditMode == DataGridEditMode.Cell && _column.IsEditable)
+                    .AddClass($"edit-mode-cell", _dataGrid.EditMode == DataGridEditMode.Cell && _column.Editable)
                     .Build();
             }
         }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -155,7 +155,7 @@ namespace MudBlazor
         [Parameter] public Func<T, string> CellClassFunc { get; set; }
         [Parameter] public string CellStyle { get; set; }
         [Parameter] public Func<T, string> CellStyleFunc { get; set; }
-        [Parameter] public bool IsEditable { get; set; } = true;
+        [Parameter] public bool Editable { get; set; } = true;
         [Parameter] public RenderFragment<CellContext<T>> EditTemplate { get; set; }
 
         #endregion

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-    Filterable="false" IsEditable="false">
+    Filterable="false" Editable="false">
     <CellTemplate>
          <MudIconButton 
             Class="ma-n3 pa-1"

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -355,12 +355,12 @@
                             if (propertyType == typeof(string))
                             {
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
-                                  Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.IsEditable || ReadOnly)" Class="mt-4" />
+                                  Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" />
                             }
                             else if (TypeIdentifier.IsNumber(propertyType))
                             {
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
-                                     Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.IsEditable || ReadOnly)" Class="mt-4" />
+                                     Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" />
                             }
                         }
                     }
@@ -416,7 +416,7 @@
                 var cell = new Cell<T>(this, column, item);
             }
             <td data-label="@column.Title" class="@cell.computedClass" style="@cell.computedStyle">
-                @if (column.IsEditable && !ReadOnly && EditMode == DataGridEditMode.Cell)
+                @if (column.Editable && !ReadOnly && EditMode == DataGridEditMode.Cell)
                 {
                     if (column.EditTemplate is not null)
                     {

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -2,7 +2,7 @@
 @typeparam T
 
 <TemplateColumn T="T" Tag="@("select-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-                Filterable="false" IsEditable="false" FooterTemplate="@GetFooterTemplate()">
+                Filterable="false" Editable="false" FooterTemplate="@GetFooterTemplate()">
     <HeaderTemplate>
         @if (ShowInHeader)
         {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -100,11 +100,11 @@
                                 <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
-                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" IsEditable="IsEditable"
+                               <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" Editable="@Editable"
                                       Checked="@(IsCheckedRow(item))"
                                       CheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
-                                   @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
+                                   @if ((!ReadOnly) && Editable && object.Equals(_editingItem, item))
                                    {
                                         <CascadingValue Value="@Validator" IsFixed="true">
                                            @if(RowEditingTemplate != null)
@@ -215,10 +215,10 @@
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
              } 
-             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" IsEditable="IsEditable" Expandable="expandable"
+             <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" Editable="@Editable" Expandable="expandable"
                         Checked="Context.Selection.Contains(item)" CheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
 
-                    @if ((!ReadOnly) && IsEditable && object.Equals(_editingItem, item))
+                    @if ((!ReadOnly) && Editable && object.Equals(_editingItem, item))
                     {
                         <CascadingValue Value="@Validator" IsFixed="true">
                             @if(RowEditingTemplate != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -418,7 +418,7 @@ namespace MudBlazor
             get
             {
                 if (_currentRenderFilteredItemsCached) return _preEditSort;
-                if (IsEditing && HasPreEditSort)
+                if (Editing && HasPreEditSort)
                     return _preEditSort;
                 if (HasServerData)
                     _preEditSort = _server_data.Items?.ToList();
@@ -633,7 +633,7 @@ namespace MudBlazor
             return InvokeServerLoadFunc();
         }
 
-        internal override bool IsEditable { get => (RowEditingTemplate != null) || (Columns != null); }
+        internal override bool Editable { get => (RowEditingTemplate != null) || (Columns != null); }
 
         //GROUPING:
         private IEnumerable<IGrouping<object, T>> GroupItemsPage

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
     public abstract class MudTableBase : MudComponentBase
     {
         internal object _editingItem = null;
-        internal bool IsEditing => _editingItem != null;
+        internal bool Editing => _editingItem != null;
 
         private int _currentPage = 0;
         internal int? _rowsPerPage;
@@ -360,14 +360,14 @@ namespace MudBlazor
         public bool CanCancelEdit { get; set; }
 
         /// <summary>
-        /// Set the positon of the CommitEdit and CancelEdit button, if <see cref="IsEditable"/> IsEditable is true. Defaults to the end of the row
+        /// Set the positon of the CommitEdit and CancelEdit button, if <see cref="Editable"/> is true. Defaults to the end of the row
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
         public TableApplyButtonPosition ApplyButtonPosition { get; set; } = TableApplyButtonPosition.End;
 
         /// <summary>
-        /// Set the positon of the StartEdit button, if <see cref="IsEditable"/> IsEditable is true. Defaults to the end of the row
+        /// Set the positon of the StartEdit button, if <see cref="Editable"/> is true. Defaults to the end of the row
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
@@ -548,7 +548,7 @@ namespace MudBlazor
         internal abstract void OnHeaderCheckboxClicked(bool checkedState);
         internal abstract bool HasRowMouseEnterEventHandler { get; }
         internal abstract bool HasRowMouseLeaveEventHandler { get; }
-        internal abstract bool IsEditable { get; }
+        internal abstract bool Editable { get; }
 
         public abstract bool ContainsItem(object item);
         public abstract void UpdateSelection();

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -30,7 +30,7 @@
         </MudTd>
     }
     @HeaderTemplate(new TableGroupData<object, T>(GroupDefinition.GroupName, Items.Key, Items.ToList()))
-    @if ((Context?.Table.IsEditable ?? false))
+    @if ((Context?.Table.Editable ?? false))
     {
         <MudTd />
     }
@@ -70,7 +70,7 @@ else
                 <MudTd/>
             }
             @FooterTemplate(new TableGroupData<object, T>(GroupDefinition.GroupName, Items.Key, Items.ToList()))
-            @if ((Context?.Table.IsEditable ?? false))
+            @if ((Context?.Table.Editable ?? false))
             {
                 <MudTd />
             }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -3,7 +3,7 @@
 @inherits MudComponentBase
 
 <tr class="@Classname" @onclick="@OnRowClickedAsync" @onmouseenter="@RowMouseEnterEventCallback" @onmouseleave="@RowMouseLeaveEventCallback" style="@Style" @attributes="@UserAttributes">
-    @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
+    @if (Editable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@
         <MudTd DataLabel="&nbsp;" Class="py-3">
@@ -46,7 +46,7 @@
         </MudElement>
     }
     @ChildContent
-    @if (IsEditable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtEnd() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd() == true))
+    @if (Editable && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtEnd() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@
         <MudTd DataLabel="&nbsp;" Class="py-3">

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
@@ -29,14 +28,9 @@ namespace MudBlazor
 
         [Parameter] public bool Checkable { get; set; }
 
-        [Parameter] public bool IsEditable { get; set; }
-
-        [Parameter] public bool IsEditing { get; set; }
-
-        [Parameter] public bool IsEditSwitchBlocked { get; set; }
+        [Parameter] public bool Editable { get; set; }
 
         [Parameter] public bool Expandable { get; set; }
-
 
         [Parameter]
         public EventCallback<bool> CheckedChanged { get; set; }
@@ -63,7 +57,7 @@ namespace MudBlazor
                 return;
             table.SetSelectedItem(Item);
             StartEditingItem(buttonClicked: false);
-            if (table.MultiSelection && table.SelectOnRowClick && !table.IsEditable)
+            if (table.MultiSelection && table.SelectOnRowClick && !table.Editable)
                 Checked = !Checked;
             await table.FireRowClickEventAsync(args, this, Item);
         }
@@ -114,7 +108,7 @@ namespace MudBlazor
 
         private void StartEditingItem(bool buttonClicked)
         {
-            if (Context?.Table.IsEditable == true && Context?.Table.IsEditing == true && Context?.Table.IsEditRowSwitchingBlocked == true) return;
+            if (Context?.Table.Editable == true && Context?.Table.Editing == true && Context?.Table.IsEditRowSwitchingBlocked == true) return;
 
             if ((Context?.Table.EditTrigger == TableEditTrigger.RowClick && buttonClicked) || (Context?.Table.EditTrigger == TableEditTrigger.EditButton && !buttonClicked)) return;
 
@@ -125,7 +119,7 @@ namespace MudBlazor
                 return;
 
             // Manage edition the first time the row is clicked and if the table is editable
-            if (!hasBeenClickedFirstTime && IsEditable)
+            if (!hasBeenClickedFirstTime && Editable)
             {
                 // Sets hasBeenClickedFirstTime to true
                 hasBeenClickedFirstTime = true;

--- a/src/MudBlazor/Components/Table/TableButtonPosition.cs
+++ b/src/MudBlazor/Components/Table/TableButtonPosition.cs
@@ -25,8 +25,8 @@ namespace MudBlazor
 
     public static class TableButtonPositionExtentions
     {
-        public static bool IsEditable(this TableContext context, bool ignoreEditable) =>
-            (context?.Table.IsEditable ?? false) && !ignoreEditable;
+        public static bool Editable(this TableContext context, bool ignoreEditable) =>
+            (context?.Table.Editable ?? false) && !ignoreEditable;
 
         public static bool DisplayApplyButtonAtStart(this TableApplyButtonPosition position) =>
             position is TableApplyButtonPosition.Start or TableApplyButtonPosition.StartAndEnd;
@@ -34,7 +34,7 @@ namespace MudBlazor
             position is TableEditButtonPosition.Start or TableEditButtonPosition.StartAndEnd;
 
         public static bool DisplayApplyButtonAtStart(this TableContext context, bool ignoreEditable) =>
-            context.IsEditable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtStart();
+            context.Editable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtStart();
 
         public static bool DisplayApplyButtonAtEnd(this TableApplyButtonPosition position) =>
             position is TableApplyButtonPosition.End or TableApplyButtonPosition.StartAndEnd;
@@ -42,12 +42,12 @@ namespace MudBlazor
             position is TableEditButtonPosition.End or TableEditButtonPosition.StartAndEnd;
 
         public static bool DisplayApplyButtonAtEnd(this TableContext context, bool ignoreEditable) =>
-            context.IsEditable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd();
+            context.Editable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd();
 
         public static bool DisplayEditbuttonAtStart(this TableContext context, bool ignoreEditable) =>
-            context.IsEditable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtStart() && context.Table.EditTrigger == TableEditTrigger.EditButton;
+            context.Editable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtStart() && context.Table.EditTrigger == TableEditTrigger.EditButton;
 
         public static bool DisplayEditbuttonAtEnd(this TableContext context, bool ignoreEditable) =>
-            context.IsEditable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtEnd() && context.Table.EditTrigger == TableEditTrigger.EditButton;
+            context.Editable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtEnd() && context.Table.EditTrigger == TableEditTrigger.EditButton;
     }
 }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -106,7 +106,7 @@ namespace MudBlazor
 
         public override void ManagePreviousEditedRow(MudTr row)
         {
-            if (Table.IsEditable)
+            if (Table.Editable)
             {
                 // Reset edition values of the edited row
                 // if another row is selected for edition


### PR DESCRIPTION
MudBlazor currently uses the `IsEditable` property. This PR aims to standardise the use of `Editable` to align with other boolean properties in the library and removes unused `IsEditing` and `IsEditSwitchBlocked` from `MudTr`.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**Column**: replace `IsEditable` with `Editable`
**MudTr**: replace `IsEditable` with `Editable`
**MudTr**: removed `IsEditing` and `IsEditSwitchBlocked`
**TableButtonPositionExtentions**: replace `IsEditable` with `Editable`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
