### PR TITLE
Autocomplete: Treat all ways of closing overlay the same

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -112,4 +112,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay AutoClose Visible="Open" VisibleChanged="OnOverlayVisibleChanged" LockScroll="false" />
+<MudOverlay AutoClose Visible="Open" VisibleChanged="OnOverlayVisibleChangedAsync" LockScroll="false" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -112,4 +112,4 @@
     </div>
 </CascadingValue>
 
-<MudOverlay Visible="Open" OnClick="CloseMenuAsync" @ontouchstart="CloseMenuAsync" LockScroll="false" />
+<MudOverlay AutoClose Visible="Open" VisibleChanged="OnOverlayVisibleChanged" LockScroll="false" />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -913,7 +913,7 @@ namespace MudBlazor
             //base.OnBlurred(args);
         }
 
-        private Task OnOverlayVisibleChanged(bool willBeVisible)
+        private Task OnOverlayVisibleChangedAsync(bool willBeVisible)
         {
             if (!willBeVisible && Open)
             {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -913,9 +913,14 @@ namespace MudBlazor
             //base.OnBlurred(args);
         }
 
-        private Task OnOverlayVisibleChanged(bool visible)
+        private Task OnOverlayVisibleChanged(bool willBeVisible)
         {
-            return visible ? Task.CompletedTask : CloseMenuAsync();
+            if (!willBeVisible && Open)
+            {
+                return CloseMenuAsync();
+            }
+
+            return Task.CompletedTask;
         }
 
         private Task CoerceTextToValue()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -913,6 +913,11 @@ namespace MudBlazor
             //base.OnBlurred(args);
         }
 
+        private Task OnOverlayVisibleChanged(bool visible)
+        {
+            return visible ? Task.CompletedTask : CloseMenuAsync();
+        }
+
         private Task CoerceTextToValue()
         {
             if (!CoerceText)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Previously if you would click the overlay it would trigger the menu close handler, but not if you tabbed away or set it programmatically.
Now we listen to the overlay, so any event that makes that close will call our close handler.

Resolves #3825
Resolves #3824

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before (tabbing away does not coerce but clicking does):

https://github.com/MudBlazor/MudBlazor/assets/7112040/51e0f97e-fb42-4b85-9e2e-ecd561c32dfb

After (both tabbing away and clicking coerces):

https://github.com/MudBlazor/MudBlazor/assets/7112040/633e9a65-96e7-47cd-9e6a-4463c73cebab

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
