### PR TITLE
Dialog: Fix visibility of inline dialogs using Show method

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@inject IDialogService DialogService
+
+<MudButton OnClick="OpenDialog" Class="open-dialog-button">
+    Options Dialog
+</MudButton>
+
+<MudDialog @ref="dialog">
+    <DialogContent>
+        <p>Here be dragons</p>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Class="close-dialog-button" OnClick="Close">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private MudDialog dialog;
+
+    private async Task OpenDialog()
+    {
+        var dialogInstance = dialog.Show("Options Dialog");
+
+        try
+        {
+            var result = await dialogInstance.Result;
+
+            if (result != null)
+                await DialogService.ShowMessageBox("result", result.Data as string);
+            else
+                await DialogService.ShowMessageBox("error", "result was null");
+        }
+        catch (Exception e)
+        {
+            await DialogService.ShowMessageBox("error", e.ToString());
+        }
+    }
+
+    private void Close()
+    {
+        dialog.Close(DialogResult.Ok("dialog was successfully closed"));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
@@ -1,43 +1,44 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 @inject IDialogService DialogService
 
-<MudButton OnClick="OpenDialog" Class="open-dialog-button">
+<MudButton OnClick="OpenDialogAsync" Class="open-dialog-button">
     Options Dialog
 </MudButton>
 
-<MudDialog @ref="dialog">
+<MudDialog @ref="_dialog">
     <DialogContent>
         <p>Here be dragons</p>
     </DialogContent>
     <DialogActions>
-        <MudButton Class="close-dialog-button" OnClick="Close">Ok</MudButton>
+        <MudButton Class="close-dialog-button" OnClick="CloseAsync">Ok</MudButton>
     </DialogActions>
 </MudDialog>
 
 @code {
-    private MudDialog dialog;
+    private MudDialog _dialog;
 
-    private async Task OpenDialog()
+    private async Task OpenDialogAsync()
     {
-        var dialogInstance = dialog.Show("Options Dialog");
+        var dialogInstance = await _dialog.ShowAsync("Options Dialog");
 
         try
         {
             var result = await dialogInstance.Result;
 
-            if (result != null)
+            if (result is not null)
+            {
                 await DialogService.ShowMessageBox("result", result.Data as string);
+            }
             else
+            {
                 await DialogService.ShowMessageBox("error", "result was null");
+            }
         }
-        catch (Exception e)
+        catch (Exception exception)
         {
-            await DialogService.ShowMessageBox("error", e.ToString());
+            await DialogService.ShowMessageBox("error", exception.ToString());
         }
     }
 
-    private void Close()
-    {
-        dialog.Close(DialogResult.Ok("dialog was successfully closed"));
-    }
+    private Task CloseAsync() => _dialog.CloseAsync(DialogResult.Ok("dialog was successfully closed"));
 }

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -112,6 +112,40 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/4098
+        /// https://github.com/MudBlazor/MudBlazor/issues/8746
+        /// </summary>
+        [Test]
+        public void InlineDialogShowMethodTest()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = Context.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+
+            var comp1 = Context.RenderComponent<InlineDialogShowMethod>();
+
+            comp.Markup.Should().NotContain("Here be dragons");
+
+            // open the dialog
+            comp1.Find(".open-dialog-button").Click();
+            comp1.WaitForAssertion(() => comp.Find("div.mud-dialog-container").Should().NotBe(null));
+
+            comp.Markup.Should().Contain("Here be dragons");
+
+            // close the dialog
+            comp.Find(".close-dialog-button").Click();
+
+            // messagebox should have opened
+            comp.Markup.Should().Contain("dialog was successfully closed");
+
+            // close by click on ok button
+            comp.Find(".mud-message-box button").Click();
+
+            comp.Markup.Trim().Should().BeEmpty();
+        }
+
+        /// <summary>
         /// Nested dialogs should not appear unless manually shown
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -182,10 +182,10 @@ namespace MudBlazor
             // ReSharper restore MethodHasAsyncOverload
 
             // Do not await this!
-            _ = _reference.Result.ContinueWith(t =>
+            _reference.Result.ContinueWith(t =>
             {
                 return InvokeAsync(() => _visibleState.SetValueAsync(false));
-            });
+            }).AndForget();
 
             return _reference;
         }

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -182,7 +182,7 @@ namespace MudBlazor
             // ReSharper restore MethodHasAsyncOverload
 
             // Do not await this!
-            _= _reference.Result.ContinueWith(t =>
+            _ = _reference.Result.ContinueWith(t =>
             {
                 return InvokeAsync(() => _visibleState.SetValueAsync(false));
             });

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
         protected IDialogService DialogService { get; set; }
 
         /// <summary>
-        /// Define the dialog title as a renderfragment (overrides Title)
+        /// Define the dialog title as a RenderFragment (overrides Title)
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
@@ -137,14 +137,14 @@ namespace MudBlazor
         [Category(CategoryTypes.Dialog.Behavior)]
         public DefaultFocus DefaultFocus { get; set; } = MudGlobal.DialogDefaults.DefaultFocus;
 
-        private bool IsInline => IsNested || DialogInstance == null;
+        private bool IsInline => IsNested || DialogInstance is null;
 
         /// <summary>
-        /// Show this inlined dialog
+        /// Shows this inlined dialog asynchronously.
         /// </summary>
-        /// <param name="title"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <param name="title">The title of the dialog.</param>
+        /// <param name="options">The options for the dialog.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<IDialogReference> ShowAsync(string title = null, DialogOptions options = null)
         {
             if (!IsInline)
@@ -190,6 +190,24 @@ namespace MudBlazor
             return _reference;
         }
 
+        /// <summary>
+        /// Closes the currently open inlined dialog asynchronously.
+        /// </summary>
+        /// <param name="result">The result to be passed to the dialog's completion task.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task CloseAsync(DialogResult result = null)
+        {
+            if (!IsInline || _reference is null)
+            {
+                return;
+            }
+
+            await _visibleState.SetValueAsync(false);
+            _reference.Close(result);
+            _reference = null;
+        }
+
+        /// <inheritdoc/>
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (IsInline)
@@ -199,7 +217,7 @@ namespace MudBlazor
                     // If visible and we don't have any reference we need to call Show
                     await ShowAsync();
                 }
-                else if (_reference != null)
+                else if (_reference is not null)
                 {
                     if (_visibleState.Value)
                     {
@@ -217,22 +235,7 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        /// <summary>
-        /// Close the currently open inlined dialog
-        /// </summary>
-        /// <param name="result"></param>
-        public async Task CloseAsync(DialogResult result = null)
-        {
-            if (!IsInline || _reference is null)
-            {
-                return;
-            }
-
-            await _visibleState.SetValueAsync(false);
-            _reference.Close(result);
-            _reference = null;
-        }
-
+        /// <inheritdoc/>
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -163,11 +163,11 @@ namespace MudBlazor
                 [nameof(ContentStyle)] = ContentStyle,
                 [nameof(DefaultFocus)] = DefaultFocus,
             };
+            Visible = true;
             _reference = DialogService.Show<MudDialog>(title, parameters, options ?? Options);
             _reference.Result.ContinueWith(t =>
             {
-                _visible = false;
-                InvokeAsync(() => VisibleChanged.InvokeAsync(false));
+                return InvokeAsync(() => Visible = false);
             });
             return _reference;
         }
@@ -176,7 +176,7 @@ namespace MudBlazor
         {
             if (IsInline)
             {
-                if (_visible && _reference == null)
+                if (Visible && _reference == null)
                 {
                     Show(); // if visible and we don't have any reference we need to call Show
                 }
@@ -199,6 +199,7 @@ namespace MudBlazor
         {
             if (!IsInline || _reference == null)
                 return;
+            Visible = false;
             _reference.Close(result);
             _reference = null;
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

The inline dialog was not being set to visible and thus `Close()` was called immediately in `OnAfterRenderAsync`.

Resolves #4098 
Should Resolves #8746
Resolves: #6173

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

https://github.com/MudBlazor/MudBlazor/assets/7112040/82cbd998-a702-4442-ade5-0d7ebebcf939

https://github.com/MudBlazor/MudBlazor/assets/7112040/38e55110-f3d6-481e-959d-edc1a3525c3f

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
