### PR TITLE
MudTable: add QuickColumns as illegal parameter

### DIFF
--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -316,6 +316,15 @@ namespace MudBlazor
                             break;
                     }
                 }
+                else if (MatchTypes(typeof(MudTable<>)))
+                {
+                    switch (parameter)
+                    {
+                        case "QuickColumns":
+                            NotifyIllegalParameter(parameter);
+                            break;
+                    }
+                }
                 else
                 {
                     switch (parameter)


### PR DESCRIPTION
## Description
Follow up: https://github.com/MudBlazor/MudBlazor/pull/8927


