### PR TITLE
MudContainer: Add `Gutters` property

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ContainerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ContainerTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ContainerTests : BunitTest
+    {
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void GuttersProperty_AddsClass(bool gutters)
+        {
+            // Arrange
+            var component = Context.RenderComponent<MudContainer>(builder => builder
+                .Add(p => p.Gutters, gutters)
+            );
+
+            // Assert
+            if (gutters)
+            {
+                component.Markup.Should().Contain("mud-container--gutters");
+            }
+            else
+            {
+                component.Markup.Should().NotContain("mud-container--gutters");
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/Container/MudContainer.razor
+++ b/src/MudBlazor/Components/Container/MudContainer.razor
@@ -12,22 +12,33 @@
         new CssBuilder("mud-container")
             .AddClass($"mud-container-fixed", Fixed)
             .AddClass($"mud-container-maxwidth-{MaxWidth.ToDescriptionString()}", !Fixed)
+            .AddClass($"mud-container--gutters", Gutters)
             .AddClass(Class)
             .Build();
 
     /// <summary>
     /// Set the max-width to match the min-width of the current breakpoint. This is useful if you'd prefer to design for a fixed set of sizes instead of trying to accommodate a fully fluid viewport. It's fluid by default.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.Container.Behavior)]
     public bool Fixed { get; set; } = false;
 
     /// <summary>
     /// Determine the max-width of the container. The container width grows with the size of the screen. Set to false to disable maxWidth.
     /// </summary>
-    [Parameter] 
+    [Parameter]
     [Category(CategoryTypes.Container.Behavior)]
     public MaxWidth MaxWidth { get; set; } = MaxWidth.Large;
+
+    /// <summary>
+    /// Adds left and right padding to the container itself.
+    /// </summary>
+    /// <remarks>
+    /// Default is <c>true</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Container.Behavior)]
+    public bool Gutters { get; set; } = true;
 
     /// <summary>
     /// Child content of component.

--- a/src/MudBlazor/Styles/layout/_container.scss
+++ b/src/MudBlazor/Styles/layout/_container.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-container {
   width: 100%;
@@ -6,20 +6,18 @@
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
+}
+
+.mud-container--gutters {
   padding-left: 16px;
   padding-right: 16px;
 }
 
 @media (min-width:$breakpoint-sm) {
-  .mud-container {
+  .mud-container--gutters {
     padding-left: 24px;
     padding-right: 24px;
   }
-}
-
-.mud-container-disable-gutters {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 @media (min-width:$breakpoint-sm) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

I use the MudContainer and currently have to override the styles to avoid the extra padding added. This lets you control it with a property like several other controls.

Interestingly there was an unused `mud-container-disable-gutters`, but I reversed the way the padding is handled in a fashion like #8586. Normally it's added then removed but this way it's only added if Gutters is actually enabled in the first place. This should be the general convention IMO because it avoid usage of `!important` which messes with consumers' overrides.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Default vs Gutters=false

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/b7d9f9d4-ddaf-4ce5-bd76-6342531f2be8)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
