### PR TITLE
MudPopover: Add DropShadow property

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
@@ -1,36 +1,35 @@
 ﻿<MudPopoverProvider></MudPopoverProvider>
 
 <div class="popoverparent">
-	<p>Some Text</p>
-	<MudPopover Open="true" Style="my-custom-style:3px"
-				MaxHeight="@MaxHeight"
-				Paper="Paper"
+    <p>Some Text</p>
+    <MudPopover Open="true" Style="my-custom-style:3px"
+                MaxHeight="@MaxHeight"
+                Paper="Paper"
                 DropShadow=@DropShadow
-				Elevation="Elevation"
-				Square="Square"
-				Fixed="Fixed"
-				Class="my-custom-class"
-				AnchorOrigin="AnchorOrigin"
-				RelativeWidth="RelativeWidth"
-				TransformOrigin="TransformOrigin"
-				OverflowBehavior="OverflowBehavior"
-				Duration="Duration"
-				>
-		<MudText Class="test-popover-content">Popover content</MudText>
-	</MudPopover>
+                Elevation="Elevation"
+                Square="Square"
+                Fixed="Fixed"
+                Class="my-custom-class"
+                AnchorOrigin="AnchorOrigin"
+                RelativeWidth="RelativeWidth"
+                TransformOrigin="TransformOrigin"
+                OverflowBehavior="OverflowBehavior"
+                Duration="Duration">
+        <MudText Class="test-popover-content">Popover content</MudText>
+    </MudPopover>
 </div>
 
 
 @code {
-	[Parameter] public int? MaxHeight { get; set; } = null;
-	[Parameter] public bool Paper { get; set; } = true;
-	[Parameter] public int Elevation { set; get; } = 8;
-	[Parameter] public bool Square { get; set; }
-	[Parameter] public bool Fixed { get; set; }
-	[Parameter] public Origin AnchorOrigin { get; set; } = Origin.TopLeft;
-	[Parameter] public Origin TransformOrigin { get; set; } = Origin.TopLeft;
-	[Parameter] public bool RelativeWidth { get; set; } = false;
-	[Parameter] public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
-	[Parameter] public double Duration { get; set; } = 251;
+    [Parameter] public int? MaxHeight { get; set; } = null;
+    [Parameter] public bool Paper { get; set; } = true;
+    [Parameter] public int Elevation { set; get; } = 8;
+    [Parameter] public bool Square { get; set; }
+    [Parameter] public bool Fixed { get; set; }
+    [Parameter] public Origin AnchorOrigin { get; set; } = Origin.TopLeft;
+    [Parameter] public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+    [Parameter] public bool RelativeWidth { get; set; } = false;
+    [Parameter] public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
+    [Parameter] public double Duration { get; set; } = 251;
     [Parameter] public bool DropShadow { get; set; } = true; // Default
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
@@ -3,9 +3,9 @@
 <div class="popoverparent">
     <p>Some Text</p>
     <MudPopover Open="true" Style="my-custom-style:3px"
-                MaxHeight="@MaxHeight"
+                MaxHeight="MaxHeight"
                 Paper="Paper"
-                DropShadow=@DropShadow
+                DropShadow="DropShadow"
                 Elevation="Elevation"
                 Square="Square"
                 Fixed="Fixed"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
@@ -5,6 +5,7 @@
 	<MudPopover Open="true" Style="my-custom-style:3px"
 				MaxHeight="@MaxHeight"
 				Paper="Paper"
+                DropShadow=@DropShadow
 				Elevation="Elevation"
 				Square="Square"
 				Fixed="Fixed"
@@ -31,4 +32,5 @@
 	[Parameter] public bool RelativeWidth { get; set; } = false;
 	[Parameter] public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
 	[Parameter] public double Duration { get; set; } = 251;
+    [Parameter] public bool DropShadow { get; set; } = true; // Default
 }

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -1041,7 +1041,7 @@ namespace MudBlazor.UnitTests.Components
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
 
-            popoverElement.ClassList.Should().NotContain("mud-elevation-8");
+            popoverElement.ClassList.Should().NotContainMatch("mud-elevation-*");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -855,6 +855,7 @@ namespace MudBlazor.UnitTests.Components
 
             popover.MaxHeight.Should().BeNull();
             popover.Paper.Should().BeTrue();
+            popover.DropShadow.Should().BeTrue();
             popover.Elevation.Should().Be(8);
             popover.Square.Should().BeFalse();
             popover.Open.Should().BeFalse();
@@ -1030,6 +1031,17 @@ namespace MudBlazor.UnitTests.Components
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
 
             popoverElement.ClassList.Should().Contain(new[] { "mud-popover-open", $"mud-popover-overflow-{expectedClass}", "my-custom-class" });
+        }
+
+        [Test]
+        public void MudPopover_Property_DropShadow_False_NoElevation()
+        {
+            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+                x => x.DropShadow, false));
+
+            var popoverElement = comp.Find(".test-popover-content").ParentElement;
+
+            popoverElement.ClassList.Should().NotContain("mud-elevation-8");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -18,7 +16,7 @@ namespace MudBlazor
                 .AddClass($"mud-popover-relative-width", RelativeWidth)
                 .AddClass($"mud-paper", Paper)
                 .AddClass($"mud-paper-square", Paper && Square)
-                .AddClass($"mud-elevation-{Elevation}", Paper)
+                .AddClass($"mud-elevation-{Elevation}", Paper && DropShadow)
                 .AddClass($"overflow-y-auto", MaxHeight != null)
                 .AddClass(Class)
                 .Build();
@@ -59,11 +57,18 @@ namespace MudBlazor
         public bool Paper { get; set; } = true;
 
         /// <summary>
+        /// Determines whether the popover has a drop-shadow. Default is true.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Menu.Appearance)]
+        public bool DropShadow { get; set; } = true;
+
+        /// <summary>
         /// The higher the number, the heavier the drop-shadow.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public int Elevation { set; get; } = 8;
+        public int Elevation { set; get; } = MudGlobal.Popover.Elevation;
 
         /// <summary>
         /// If true, border-radius is set to 0.

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -60,7 +60,7 @@ namespace MudBlazor
         /// Determines whether the popover has a drop-shadow. Default is true.
         /// </summary>
         [Parameter]
-        [Category(CategoryTypes.Menu.Appearance)]
+        [Category(CategoryTypes.Popover.Appearance)]
         public bool DropShadow { get; set; } = true;
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public int Elevation { set; get; } = MudGlobal.Popover.Elevation;
+        public int Elevation { set; get; } = MudGlobal.PopoverDefaults.Elevation;
 
         /// <summary>
         /// If true, border-radius is set to 0.

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -54,6 +54,14 @@ public static class MudGlobal
         public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
     }
 
+    public static class PopoverDefaults
+    {
+        /// <summary>
+        /// The default elevation level for <see cref="MudPopover"/>.
+        /// </summary>
+        public static int Elevation { get; set; } = 8;
+    }
+
     public static class TooltipDefaults
     {
         /// <summary>
@@ -107,13 +115,5 @@ public static class MudGlobal
     private static void OnDefaultExceptionHandler(Exception ex)
     {
         Console.Write(ex);
-    }
-
-    public static class Popover
-    {
-        /// <summary>
-        /// The default elevation level for <see cref="MudPopover"/>.
-        /// </summary>
-        public static int Elevation { get; set; } = 8;
     }
 }

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -96,4 +96,12 @@ public static class MudGlobal
     {
         Console.Write(ex);
     }
+
+    public static class Popover
+    {
+        /// <summary>
+        /// The default elevation level for <see cref="MudPopover"/>.
+        /// </summary>
+        public static int Elevation { get; set; } = 8;
+    }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added `bool` property `DropShadow` to MudPopover (in preparation of a PR for #6995)
Added `int` property `Elevation` to `MudGlobal.Popover` class with a default value of: `8`.

DropShadow true (default)

![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/4a1a3009-a5a8-4676-b99c-15ed04cd80ba)

DropShadow false (Elevation 0)

![image](https://github.com/MudBlazor/MudBlazor/assets/10358198/1d841098-0d09-4ab6-aaf6-849e408b7783)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit: Added two tests
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
