### PR TITLE
MudDrawer: Improve breakpoint logic

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -45,13 +45,13 @@ namespace MudBlazor.UnitTests.Components
         {
             return breakpoint switch
             {
-                Breakpoint.Xs => new BrowserWindowSize { Height = 0, Width = 0 },
-                Breakpoint.Sm => new BrowserWindowSize { Height = 400, Width = 600 },
-                Breakpoint.Md => new BrowserWindowSize { Height = 640, Width = 960 },
-                Breakpoint.Lg => new BrowserWindowSize { Height = 720, Width = 1280 },
-                Breakpoint.Xl => new BrowserWindowSize { Height = 1080, Width = 1920 },
-                Breakpoint.Xxl => new BrowserWindowSize { Height = 1440, Width = 2560 },
-                _ => throw new InvalidEnumArgumentException("Only acceptable breakpoints are: Xs, Sm, Md, Lg, Xl and Xxl")
+                Breakpoint.Xs or Breakpoint.None => new BrowserWindowSize { Height = 0, Width = 0 },
+                Breakpoint.Sm or Breakpoint.SmAndDown or Breakpoint.SmAndUp => new BrowserWindowSize { Height = 400, Width = 600 },
+                Breakpoint.Md or Breakpoint.MdAndDown or Breakpoint.MdAndUp => new BrowserWindowSize { Height = 640, Width = 960 },
+                Breakpoint.Lg or Breakpoint.LgAndDown or Breakpoint.LgAndUp => new BrowserWindowSize { Height = 720, Width = 1280 },
+                Breakpoint.Xl or Breakpoint.XlAndDown or Breakpoint.XlAndUp => new BrowserWindowSize { Height = 1080, Width = 1920 },
+                Breakpoint.Xxl or Breakpoint.Always => new BrowserWindowSize { Height = 1440, Width = 2560 },
+                _ => throw new InvalidEnumArgumentException("Not acceptable breakpoint")
             };
         }
 
@@ -198,6 +198,7 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Breakpoint.Xs)]
         [TestCase(Breakpoint.Sm)]
+        //[TestCase(Breakpoint.SmAndUp)]
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -198,10 +198,17 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Breakpoint.Xs)]
         [TestCase(Breakpoint.Sm)]
-        //[TestCase(Breakpoint.SmAndUp)]
+        [TestCase(Breakpoint.SmAndDown)]
+        [TestCase(Breakpoint.SmAndUp)]
         [TestCase(Breakpoint.Md)]
+        [TestCase(Breakpoint.MdAndDown)]
+        [TestCase(Breakpoint.MdAndUp)]
         [TestCase(Breakpoint.Lg)]
+        [TestCase(Breakpoint.LgAndDown)]
+        [TestCase(Breakpoint.LgAndUp)]
         [TestCase(Breakpoint.Xl)]
+        [TestCase(Breakpoint.XlAndDown)]
+        [TestCase(Breakpoint.XlAndUp)]
         public void ResponsiveClosed_StartLargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xl));
@@ -218,9 +225,17 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Breakpoint.Xs)]
         [TestCase(Breakpoint.Sm)]
+        [TestCase(Breakpoint.SmAndDown)]
+        [TestCase(Breakpoint.SmAndUp)]
         [TestCase(Breakpoint.Md)]
+        [TestCase(Breakpoint.MdAndDown)]
+        [TestCase(Breakpoint.MdAndUp)]
         [TestCase(Breakpoint.Lg)]
+        [TestCase(Breakpoint.LgAndDown)]
+        [TestCase(Breakpoint.LgAndUp)]
         [TestCase(Breakpoint.Xl)]
+        [TestCase(Breakpoint.XlAndDown)]
+        [TestCase(Breakpoint.XlAndUp)]
         public void ResponsiveClosed_StartSmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
@@ -243,40 +258,42 @@ namespace MudBlazor.UnitTests.Components
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
-            //open drawer
+            // Open drawer
             comp.Find("button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            //resize to small, drawer should close
+            // Resize to small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            //resize to large, drawer should open automatically
+            // Resize to large, drawer should open automatically
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            //close drawer
+            // Close drawer
             comp.Find("button").Click();
-
+            comp.Instance.Drawer.Open.Should().BeFalse();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
-            //resize to small, then open drawer
+            // Resize to small, then open drawer
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
+            // Open drawer
             comp.Find("button").Click();
-
+            comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
 
-            //resize to large, drawer should stays open
+            // Resize to large, drawer should stays open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
+            comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
         }
@@ -284,7 +301,6 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Resize screen to small in two steps: first to SM, then to XS. After restoring the original screen size, the drawer should reopen automatically.
         /// </summary>
-        /// <returns></returns>
         [Test]
         public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
         {
@@ -293,25 +309,25 @@ namespace MudBlazor.UnitTests.Components
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
-            //open drawer
+            // Open drawer
             comp.Find("button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            //resize to small, drawer should close
+            // Resize to small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            //resize to extra small, drawer should close
+            // Resize to extra small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            //resize to large, drawer should open automatically
+            // Resize to large, drawer should open automatically
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -321,7 +337,6 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Resize screen from small to big. Once the screen is large enough, the drawer should open automatically.
         /// </summary>
-        /// <returns></returns>
         [Test]
         public async Task Responsive_ResizeFromSmall_ToLarge_CheckStates()
         {
@@ -330,21 +345,175 @@ namespace MudBlazor.UnitTests.Components
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
-            //drawer should be closed
+            // Drawer should be closed
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            //resize to small, drawer should stay closed
+            // Resize to small, drawer should stay closed
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            //resize above breakpoint - drawer should open
+            // Resize above breakpoint - drawer should open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Responsive_AlwaysOpen_BreakpointAlways()
+        {
+            var breakpoint = Breakpoint.Always;
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
+            var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
+
+            // Initial state
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to small, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to extra extra large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 1440, Width = 2560 }, Breakpoint.Xxl, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to small, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Close drawer manually to check if it opens again
+            comp.Find("button").Click();
+
+            // Resize to small, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to extra extra large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 1440, Width = 2560 }, Breakpoint.Xxl, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to large, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Resize to small, drawer should be open
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Responsive_AlwaysClose_BreakpointNone()
+        {
+            var breakpoint = Breakpoint.None;
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
+            var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
+
+            // Initial state
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to small, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to extra extra large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 1440, Width = 2560 }, Breakpoint.Xxl, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to small, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Open drawer manually to check if it closes again
+            comp.Find("button").Click();
+
+            // Resize to small, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to extra extra large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 1440, Width = 2560 }, Breakpoint.Xxl, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to large, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            // Resize to small, drawer should be closed
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -344,7 +344,7 @@ namespace MudBlazor
 
         private bool IsBelowCurrentBreakpoint() => IsBelowBreakpoint(_lastUpdatedBreakpoint);
 
-        private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < BreakpointNormalize(_breakpointState.Value);
+        private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < NormalizeBreakpoint(_breakpointState.Value);
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
 
@@ -438,7 +438,7 @@ namespace MudBlazor
             }
         }
 
-        private static Breakpoint BreakpointNormalize(Breakpoint breakpoint)
+        private static Breakpoint NormalizeBreakpoint(Breakpoint breakpoint)
         {
             // Historically, MudDrawer only functioned with breakpoints like Xs, Sm, Md, Lg, Xl, and Xxl.
             // However, some users may supply additional breakpoints such as SmAndDown, MdAndDown, LgAndDown, XlAndDown, SmAndUp, MdAndUp, LgAndUp, XlAndUp, None, and Always.

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -146,6 +146,29 @@ namespace MudBlazor
         /// <summary>
         /// Switching point for responsive drawers
         /// </summary>
+        /// <remarks>
+        /// The <see cref="Breakpoint"/> enum represents the breakpoints at which the drawer behavior changes. Supported breakpoints are:
+        /// <list type="bullet">
+        /// <item><description><see cref="Breakpoint.Xs"/></description></item>
+        /// <item><description><see cref="Breakpoint.Sm"/></description></item>
+        /// <item><description><see cref="Breakpoint.Md"/></description></item>
+        /// <item><description><see cref="Breakpoint.Lg"/></description></item>
+        /// <item><description><see cref="Breakpoint.Xl"/></description></item>
+        /// <item><description><see cref="Breakpoint.Xxl"/></description></item>
+        /// </list>
+        /// For convenience, other breakpoint combinations are aliased as follows:
+        /// <list type="bullet">
+        /// <item><description><see cref="Breakpoint.SmAndDown"/>: Aliases to <see cref="Breakpoint.Sm"/></description></item>
+        /// <item><description><see cref="Breakpoint.MdAndDown"/>: Aliases to <see cref="Breakpoint.Md"/></description></item>
+        /// <item><description><see cref="Breakpoint.LgAndDown"/>: Aliases to <see cref="Breakpoint.Lg"/></description></item>
+        /// <item><description><see cref="Breakpoint.XlAndDown"/>: Aliases to <see cref="Breakpoint.Xl"/></description></item>
+        /// <item><description><see cref="Breakpoint.SmAndUp"/>: Aliases to <see cref="Breakpoint.Sm"/></description></item>
+        /// <item><description><see cref="Breakpoint.MdAndUp"/>: Aliases to <see cref="Breakpoint.Md"/></description></item>
+        /// <item><description><see cref="Breakpoint.LgAndUp"/>: Aliases to <see cref="Breakpoint.Lg"/></description></item>
+        /// <item><description><see cref="Breakpoint.XlAndUp"/>: Aliases to <see cref="Breakpoint.Xl"/></description></item>
+        /// </list>
+        /// Setting the value to <see cref="Breakpoint.None"/> will always close the drawer, while <see cref="Breakpoint.Always"/> will always keep it open.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
         public Breakpoint Breakpoint { get; set; } = Breakpoint.Md;

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -421,7 +421,7 @@ namespace MudBlazor
             // However, some users may supply additional breakpoints such as SmAndDown, MdAndDown, LgAndDown, XlAndDown, SmAndUp, MdAndUp, LgAndUp, XlAndUp, None, and Always.
             // The IBrowserViewportService provides an IsBreakpointWithinReferenceSizeAsync method that considers these additional breakpoints.
             // However, utilizing it would constitute a breaking change.
-            // For instance, users who previously specified Sm would find that their drawer opens only on screens of that size but not on any larger ones.
+            // For instance, users who previously specified Sm would find that their drawer opens only on screens of that size but not on any larger ones and switch to SmAndUp.
             // To maintain backward compatibility, we decided to alias SmAndUp and SmAndDown to simply Sm, and similarly for other breakpoints.
 
             return breakpoint switch

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -421,7 +421,7 @@ namespace MudBlazor
             // However, some users may supply additional breakpoints such as SmAndDown, MdAndDown, LgAndDown, XlAndDown, SmAndUp, MdAndUp, LgAndUp, XlAndUp, None, and Always.
             // The IBrowserViewportService provides an IsBreakpointWithinReferenceSizeAsync method that considers these additional breakpoints.
             // However, utilizing it would constitute a breaking change.
-            // For instance, users who previously specified Sm would find that their drawer opens only on screens of that size but not on any larger ones and switch to SmAndUp.
+            // For instance, users who previously specified Sm would find that their drawer opens only on screens of that size but not on any larger ones, requiring them to switch to SmAndUp.
             // To maintain backward compatibility, we decided to alias SmAndUp and SmAndDown to simply Sm, and similarly for other breakpoints.
 
             return breakpoint switch

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -37,7 +37,7 @@ namespace MudBlazor
 
         internal void Add(MudDrawer drawer)
         {
-            if (Fixed && !drawer.Fixed)
+            if (Fixed && !drawer.IsFixed)
                 return;
 
             _drawers.Add(drawer);


### PR DESCRIPTION
## Description
Read my comment here: https://github.com/MudBlazor/MudBlazor/pull/8833#issuecomment-2104286480

This is self-explanatory:
https://github.com/MudBlazor/MudBlazor/blob/6d8e521467477362696c53103f80f4c7463c2c7e/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs#L420-L425

Now that we allow specifying breakpoints beyond `Xs`, `Sm`, `Md`, `Lg`, `Xl`, `Xxl`, I also need to handle `None` and `Always`.
Now the behavior is that if you set `MudDrawer.Breakpoint = None`, the drawer will always close regardless of the size,
and `Always` is the opposite, meaning always open. I think this is logical and intuitive.

However, this makes the internal logic harder to understand than before. I hope there won't be any additional breakpoints logic request or we will drown in the complexity.
 
## How Has This Been Tested?
New bUnit test + existing that I didn't break old logic

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
