### PR TITLE
TaskExtensions: Rename AndForget() to CatchAndLog()

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelAsyncExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelAsyncExample.razor
@@ -19,7 +19,7 @@
         else
         {
             // Reset after a while to prevent sudden collapse.
-            Task.Delay(350).ContinueWith(t => _panelContent = null).AndForget(); 
+            Task.Delay(350).ContinueWith(t => _panelContent = null).CatchAndLog(); 
         }
     }
 

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -917,7 +917,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             //When its disabled, keys should not work
             timePicker.Disabled = true;
-            timePicker.FocusAsync().AndForget();
+            timePicker.FocusAsync().CatchAndLog();
             await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));

--- a/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Extensions
             string errorMessage = null;
             MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
             var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
-            task.AndForget();
+            task.CatchAndLog();
             var t = Stopwatch.StartNew();
             while (errorMessage == null)
             {
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Extensions
             string errorMessage = null;
             MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
             var task = AsyncValueTaskExceptionGenerator("Something bad is about to happen ...");
-            task.AndForget();
+            task.CatchAndLog();
             var t = Stopwatch.StartNew();
             while (errorMessage == null)
             {
@@ -72,7 +72,7 @@ namespace MudBlazor.UnitTests.Extensions
             string errorMessage = null;
             MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
             var task = AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...");
-            task.AndForget();
+            task.CatchAndLog();
             var t = Stopwatch.StartNew();
             while (errorMessage == null)
             {
@@ -88,7 +88,7 @@ namespace MudBlazor.UnitTests.Extensions
         {
             MudGlobal.UnhandledExceptionHandler = null;
             var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
-            task.AndForget();
+            task.CatchAndLog();
             var t = Stopwatch.StartNew();
             while (!(task.IsCompleted || task.IsCanceled || task.IsFaulted))
             {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -563,7 +563,7 @@ namespace MudBlazor
             var changed = base.SetConverter(value);
             if (changed)
             {
-                UpdateTextPropertyAsync(false).AndForget();      // refresh only Text property from current Value
+                UpdateTextPropertyAsync(false).CatchAndLog();      // refresh only Text property from current Value
             }
 
             return changed;
@@ -574,7 +574,7 @@ namespace MudBlazor
             var changed = base.SetCulture(value);
             if (changed)
             {
-                UpdateTextPropertyAsync(false).AndForget();      // refresh only Text property from current Value
+                UpdateTextPropertyAsync(false).CatchAndLog();      // refresh only Text property from current Value
             }
 
             return changed;
@@ -586,7 +586,7 @@ namespace MudBlazor
             if (changed)
             {
                 ((Converter<T>)Converter).Format = value;
-                UpdateTextPropertyAsync(false).AndForget();      // refresh only Text property from current Value
+                UpdateTextPropertyAsync(false).CatchAndLog();      // refresh only Text property from current Value
             }
 
             return changed;
@@ -632,7 +632,7 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
-            UpdateTextPropertyAsync(false).AndForget();
+            UpdateTextPropertyAsync(false).CatchAndLog();
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -115,7 +115,7 @@ namespace MudBlazor
             var changed = base.SetConverter(value);
             if (changed)
             {
-                SetBoolValueAsync(Converter.Set(Value)).AndForget();
+                SetBoolValueAsync(Converter.Set(Value)).CatchAndLog();
             }
 
             return changed;

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -451,7 +451,7 @@ namespace MudBlazor
                     return;
                 _open = value;
 
-                OpenChanged.InvokeAsync(_open).AndForget();
+                OpenChanged.InvokeAsync(_open).CatchAndLog();
             }
         }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -170,7 +170,7 @@ namespace MudBlazor
         public MudColor Value
         {
             get => _value;
-            set => SetColorAsync(value).AndForget();
+            set => SetColorAsync(value).CatchAndLog();
         }
 
         [Parameter] public EventCallback<MudColor> ValueChanged { get; set; }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -717,7 +717,7 @@ namespace MudBlazor
                         _groupExpansionsDict.Clear();
 
                         foreach (var column in RenderedColumns)
-                            column.RemoveGrouping().AndForget();
+                            column.RemoveGrouping().CatchAndLog();
                     }
                 }
             }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -24,7 +24,7 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            set => SetDateAsync(value, true).AndForget();
+            set => SetDateAsync(value, true).CatchAndLog();
         }
 
         private DateTime _lastSetTime = DateTime.MinValue;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -55,7 +55,7 @@ namespace MudBlazor
         public DateRange DateRange
         {
             get => _dateRange;
-            set => SetDateRangeAsync(value, true).AndForget();
+            set => SetDateRangeAsync(value, true).CatchAndLog();
         }
 
         protected async Task SetDateRangeAsync(DateRange range, bool updateValue)
@@ -113,7 +113,7 @@ namespace MudBlazor
 
                 Touched = true;
                 _rangeText = value;
-                SetDateRangeAsync(ParseDateRangeValue(value?.Start, value?.End), false).AndForget();
+                SetDateRangeAsync(ParseDateRangeValue(value?.Start, value?.End), false).CatchAndLog();
             }
         }
 

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -185,7 +185,7 @@ namespace MudBlazor
             _reference.Result.ContinueWith(t =>
             {
                 return InvokeAsync(() => _visibleState.SetValueAsync(false));
-            }).AndForget();
+            }).CatchAndLog();
 
             return _reference;
         }

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -238,7 +238,7 @@ namespace MudBlazor
 
                     if (IsJSRuntimeAvailable)
                     {
-                        BrowserViewportService.UnsubscribeAsync(this).AndForget();
+                        BrowserViewportService.UnsubscribeAsync(this).CatchAndLog();
                     }
                 }
             }

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -171,7 +171,7 @@ namespace MudBlazor
         {
             if (!_disabled)
             {
-                RestoreFocusAsync().AndForget(ignoreExceptions: true);
+                RestoreFocusAsync().CatchAndLog(ignoreExceptions: true);
             }
         }
     }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -48,7 +48,7 @@ namespace MudBlazor
             if (IsValid == value)
                 return;
             IsValid = value;
-            IsValidChanged.InvokeAsync(IsValid).AndForget();
+            IsValidChanged.InvokeAsync(IsValid).CatchAndLog();
         }
 
         // Note: w/o any children the form is automatically valid.
@@ -186,7 +186,7 @@ namespace MudBlazor
 
         void IForm.FieldChanged(IFormComponent formControl, object newValue)
         {
-            FieldChanged.InvokeAsync(new FormFieldChangedEventArgs { Field = formControl, NewValue = newValue }).AndForget();
+            FieldChanged.InvokeAsync(new FormFieldChangedEventArgs { Field = formControl, NewValue = newValue }).CatchAndLog();
         }
 
         void IForm.Add(IFormComponent formControl)

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -103,7 +103,7 @@ namespace MudBlazor
 
         private void OnTimerTick(object sender, ElapsedEventArgs e)
         {
-            InvokeAsync(OnTimerTickGuiThread).AndForget();
+            InvokeAsync(OnTimerTickGuiThread).CatchAndLog();
         }
 
         private async Task OnTimerTickGuiThread()
@@ -122,7 +122,7 @@ namespace MudBlazor
             _timer.Dispose();
             _timer = null;
             if (wasEnabled && !suppressTick)
-                OnTimerTickGuiThread().AndForget();
+                OnTimerTickGuiThread().CatchAndLog();
         }
 
         protected override void Dispose(bool disposing)

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -120,7 +120,7 @@ namespace MudBlazor
                 if (_textStart == value)
                     return;
                 _textStart = value;
-                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).AndForget();
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).CatchAndLog();
             }
         }
 
@@ -132,7 +132,7 @@ namespace MudBlazor
                 if (_textEnd == value)
                     return;
                 _textEnd = value;
-                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).AndForget();
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).CatchAndLog();
             }
         }
 

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -372,12 +372,12 @@ namespace MudBlazor
             _selection = selection;
             if (selection == null)
             {
-                _elementReference.MudSelectRangeAsync(caret, caret).AndForget();
+                _elementReference.MudSelectRangeAsync(caret, caret).CatchAndLog();
             }
             else
             {
                 var sel = selection.Value;
-                _elementReference.MudSelectRangeAsync(sel.Item1, sel.Item2).AndForget();
+                _elementReference.MudSelectRangeAsync(sel.Item1, sel.Item2).CatchAndLog();
             }
         }
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -193,7 +193,7 @@ namespace MudBlazor
                 }
 
                 await SetValueAsync(ConstrainBoundaries(nextValue).value);
-                _elementReference.SetText(Text).CatchAndLog();
+                await _elementReference.SetText(Text);
             }
             catch (OverflowException)
             {
@@ -281,15 +281,14 @@ namespace MudBlazor
                     await Decrement();
                     break;
             }
-            OnKeyDown.InvokeAsync(obj).CatchAndLog();
+            await OnKeyDown.InvokeAsync(obj);
         }
 
         protected Task HandleKeyUp(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return Task.CompletedTask;
-            OnKeyUp.InvokeAsync(obj).CatchAndLog();
-            return Task.CompletedTask;
+            return OnKeyUp.InvokeAsync(obj);
         }
 
         protected async Task OnMouseWheel(WheelEventArgs obj)

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -193,7 +193,7 @@ namespace MudBlazor
                 }
 
                 await SetValueAsync(ConstrainBoundaries(nextValue).value);
-                _elementReference.SetText(Text).AndForget();
+                _elementReference.SetText(Text).CatchAndLog();
             }
             catch (OverflowException)
             {
@@ -281,14 +281,14 @@ namespace MudBlazor
                     await Decrement();
                     break;
             }
-            OnKeyDown.InvokeAsync(obj).AndForget();
+            OnKeyDown.InvokeAsync(obj).CatchAndLog();
         }
 
         protected Task HandleKeyUp(KeyboardEventArgs obj)
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return Task.CompletedTask;
-            OnKeyUp.InvokeAsync(obj).AndForget();
+            OnKeyUp.InvokeAsync(obj).CatchAndLog();
             return Task.CompletedTask;
         }
 

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -150,7 +150,7 @@ namespace MudBlazor
             else if (_sections.Count == 1 && ActivateFirstSectionAsDefault)
             {
                 section.Activate();
-                _scrollSpy?.SetSectionAsActive(section.Id).AndForget();
+                _scrollSpy?.SetSectionAsActive(section.Id).CatchAndLog();
             }
 
             if (forceUpdate)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -277,7 +277,7 @@ namespace MudBlazor
         public string Text
         {
             get => _text;
-            set => SetTextAsync(value, true).AndForget();
+            set => SetTextAsync(value, true).CatchAndLog();
         }
 
         private string _text;

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -74,7 +74,7 @@ namespace MudBlazor
         public T? Value
         {
             get => _value;
-            set => SetSelectedOptionAsync(value, true).AndForget();
+            set => SetSelectedOptionAsync(value, true).CatchAndLog();
         }
 
         [Parameter]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -270,7 +270,7 @@ namespace MudBlazor
                 _selectedValues = new HashSet<T>(set, _comparer);
                 SelectionChangedFromOutside?.Invoke(_selectedValues);
                 if (!MultiSelection)
-                    SetValueAsync(_selectedValues.FirstOrDefault()).AndForget();
+                    SetValueAsync(_selectedValues.FirstOrDefault()).CatchAndLog();
                 else
                 {
                     //Warning. Here the Converter was not set yet
@@ -278,16 +278,16 @@ namespace MudBlazor
                     {
                         SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))),
                             selectedConvertedValues: SelectedValues.Select(x => Converter.Set(x)).ToList(),
-                            multiSelectionTextFunc: MultiSelectionTextFunc).AndForget();
+                            multiSelectionTextFunc: MultiSelectionTextFunc).CatchAndLog();
                     }
                     else
                     {
-                        SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))), updateValue: false).AndForget();
+                        SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))), updateValue: false).CatchAndLog();
                     }
                 }
                 SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer));
                 if (MultiSelection && typeof(T) == typeof(string))
-                    SetValueAsync((T)(object)Text, updateText: false).AndForget();
+                    SetValueAsync((T)(object)Text, updateText: false).CatchAndLog();
             }
         }
 
@@ -454,7 +454,7 @@ namespace MudBlazor
                 if (value != _multiSelection)
                 {
                     _multiSelection = value;
-                    UpdateTextPropertyAsync(false).AndForget();
+                    UpdateTextPropertyAsync(false).CatchAndLog();
                 }
             }
         }
@@ -603,7 +603,7 @@ namespace MudBlazor
                 }
 
                 await SetValueAsync(value);
-                _elementReference.SetText(Text).AndForget();
+                _elementReference.SetText(Text).CatchAndLog();
                 _selectedValues.Clear();
                 _selectedValues.Add(value);
             }
@@ -710,7 +710,7 @@ namespace MudBlazor
             {
                 StateHasChanged();
                 await OnBlur.InvokeAsync(new FocusEventArgs());
-                _elementReference.FocusAsync().AndForget(ignoreExceptions: true);
+                _elementReference.FocusAsync().CatchAndLog(ignoreExceptions: true);
                 StateHasChanged();
             }
 
@@ -964,13 +964,13 @@ namespace MudBlazor
                     }
                     break;
             }
-            OnKeyDown.InvokeAsync(obj).AndForget();
+            OnKeyDown.InvokeAsync(obj).CatchAndLog();
 
         }
 
         internal void HandleKeyUp(KeyboardEventArgs obj)
         {
-            OnKeyUp.InvokeAsync(obj).AndForget();
+            OnKeyUp.InvokeAsync(obj).CatchAndLog();
         }
 
         /// <summary>
@@ -1023,7 +1023,7 @@ namespace MudBlazor
             await BeginValidateAsync();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
-                SetValueAsync((T)(object)Text, updateText: false).AndForget();
+                SetValueAsync((T)(object)Text, updateText: false).CatchAndLog();
         }
 
         public void RegisterShadowItem(MudSelectItem<T> item)

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -146,7 +146,7 @@ namespace MudBlazor
                 }
 
                 Touched = true;
-                SetTextAsync(Converter.Set(_value), false).AndForget();
+                SetTextAsync(Converter.Set(_value), false).CatchAndLog();
             }
         }
 
@@ -172,7 +172,7 @@ namespace MudBlazor
                 }
 
                 Touched = true;
-                SetTextAsync(Converter.Set(_value), false).AndForget();
+                SetTextAsync(Converter.Set(_value), false).CatchAndLog();
             }
         }
 
@@ -184,7 +184,7 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            set => SetTimeAsync(value, true).AndForget();
+            set => SetTimeAsync(value, true).CatchAndLog();
         }
 
         protected async Task SetTimeAsync(TimeSpan? time, bool updateValue)

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -140,7 +140,7 @@ namespace MudBlazor
                 if (value == _visible)
                     return;
                 _visible = value;
-                VisibleChanged.InvokeAsync(_visible).AndForget();
+                VisibleChanged.InvokeAsync(_visible).CatchAndLog();
             }
         }
 

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -12,8 +12,10 @@ namespace MudBlazor
     public static class TaskExtensions
     {
         /// <summary>
-        /// Task will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
+        /// Executes the <see cref="Task"/> asynchronously as a fire-and-forget operation and forwards any exceptions to <see cref="MudGlobal.UnhandledExceptionHandler"/>.
         /// </summary>
+        /// <param name="task">The task to be executed.</param>
+        /// <param name="ignoreExceptions">If set to true, exceptions are ignored; otherwise, exceptions are forwarded to the global exception handler.</param>
         public static async void CatchAndLog(this Task task, bool ignoreExceptions = false)
         {
             try
@@ -30,8 +32,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// ValueTask will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
+        /// Executes the <see cref="ValueTask"/> asynchronously as a fire-and-forget operation and forwards any exceptions to <see cref="MudGlobal.UnhandledExceptionHandler"/>.
         /// </summary>
+        /// <param name="task">The task to be executed.</param>
+        /// <param name="ignoreExceptions">If set to true, exceptions are ignored; otherwise, exceptions are forwarded to the global exception handler.</param>
         public static async void CatchAndLog(this ValueTask task, bool ignoreExceptions = false)
         {
             try
@@ -48,8 +52,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// ValueTask(bool) will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
+        /// Executes the <see cref="ValueTask{T}"/> asynchronously as a fire-and-forget operation and forwards any exceptions to <see cref="MudGlobal.UnhandledExceptionHandler"/>.
         /// </summary>
+        /// <param name="task">The task to be executed.</param>
+        /// <param name="ignoreExceptions">If set to true, exceptions are ignored; otherwise, exceptions are forwarded to the global exception handler.</param>
         public static async void CatchAndLog<T>(this ValueTask<T> task, bool ignoreExceptions = false)
         {
             try

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
         /// <summary>
         /// Task will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget(this Task task, bool ignoreExceptions = false)
+        public static async void CatchAndLog(this Task task, bool ignoreExceptions = false)
         {
             try
             {
@@ -32,7 +32,7 @@ namespace MudBlazor
         /// <summary>
         /// ValueTask will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget(this ValueTask task, bool ignoreExceptions = false)
+        public static async void CatchAndLog(this ValueTask task, bool ignoreExceptions = false)
         {
             try
             {
@@ -50,7 +50,7 @@ namespace MudBlazor
         /// <summary>
         /// ValueTask(bool) will be awaited and exceptions will be forwarded to MudBlazorGlobal.UnhandledExceptionHandler.
         /// </summary>
-        public static async void AndForget<T>(this ValueTask<T> task, bool ignoreExceptions = false)
+        public static async void CatchAndLog<T>(this ValueTask<T> task, bool ignoreExceptions = false)
         {
             try
             {

--- a/src/MudBlazor/Services/JsEvent/JsEvent.cs
+++ b/src/MudBlazor/Services/JsEvent/JsEvent.cs
@@ -84,7 +84,7 @@ namespace MudBlazor.Services
                 return;
             try
             {
-                _jsRuntime.InvokeVoidAsync("mudJsEvent.subscribe", _elementId, eventName).AndForget();
+                _jsRuntime.InvokeVoidAsync("mudJsEvent.subscribe", _elementId, eventName).CatchAndLog();
                 _subscribedEvents.Add(eventName);
             }
             catch (JSDisconnectedException) { }
@@ -138,8 +138,8 @@ namespace MudBlazor.Services
                     return;
                 if (_caretPositionChangedHandlers.Count == 1)
                 {
-                    Unsubscribe("click").AndForget();
-                    Unsubscribe("keyup").AndForget();
+                    Unsubscribe("click").CatchAndLog();
+                    Unsubscribe("keyup").CatchAndLog();
                 }
                 _caretPositionChangedHandlers.Remove(value);
             }
@@ -175,7 +175,7 @@ namespace MudBlazor.Services
                 if (_pasteHandlers.Count == 0)
                     return;
                 if (_pasteHandlers.Count == 1)
-                    Unsubscribe("paste").AndForget();
+                    Unsubscribe("paste").CatchAndLog();
                 _pasteHandlers.Remove(value);
             }
         }
@@ -210,7 +210,7 @@ namespace MudBlazor.Services
                 if (_selectHandlers.Count == 0)
                     return;
                 if (_selectHandlers.Count == 1)
-                    Unsubscribe("select").AndForget();
+                    Unsubscribe("select").CatchAndLog();
                 _selectHandlers.Remove(value);
             }
         }
@@ -232,7 +232,7 @@ namespace MudBlazor.Services
             if (!disposing || _isDisposed)
                 return;
             _isDisposed = true;
-            Disconnect().AndForget();
+            Disconnect().CatchAndLog();
             _dotNetRef.Dispose();
         }
 

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptor.cs
@@ -99,7 +99,7 @@ namespace MudBlazor.Services
             _isDisposed = true;
             KeyDown = null;
             KeyUp = null;
-            Disconnect().AndForget();
+            Disconnect().CatchAndLog();
             _dotNetRef.Dispose();
         }
 


### PR DESCRIPTION
## Description

The name `Task.AndForget()` implies discarding the task. However, `AndForget()` does something very important, it observes the task in the background and catches any exceptions which are then forwarded to the global unhandled exception handler in `MudGlobal`. If we can not await a task we should never simply discard it like this: `_ = SomeMethodAsync();`. Instead we should do `SomeMethodAsync().AndForget();`. To make the significance of not discarding more evident I renamed the method `AndForget` to `CatchAndLog` ...

`SomeMethodAsync().CatchAndLog();`  ... discards the task in a safe manner.

## Type of Changes
Refactor