### PR TITLE
Standardise the use of `Hidden` and `HiddenChanged`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudHidden Invert="@Invert" Breakpoint="@Breakpoint" IsHiddenChanged="@( x => HiddenChangedHistory.Add(x) )" >
+<MudHidden Invert="@Invert" Breakpoint="@Breakpoint" HiddenChanged="@( x => HiddenChangedHistory.Add(x) )" >
 	<MudText>MudHidden content</MudText>
 </MudHidden>
 

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -391,6 +391,8 @@ namespace MudBlazor
                         case "IsEditable":
                         case "IsEditing":
                         case "IsEditSwitchBlocked":
+                        case "IsHidden":
+                        case "IsHiddenChanged":
                             NotifyIllegalParameter(parameter);
                             break;
                     }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-@if (!_isHiddenState.Value)
+@if (!_hiddenState.Value)
 {
     @ChildContent
 }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 #nullable enable
     public partial class MudHidden : MudComponentBase, IBrowserViewportObserver, IAsyncDisposable
     {
-        private readonly ParameterState<bool> _isHiddenState;
+        private readonly ParameterState<bool> _hiddenState;
         private bool _serviceIsReady = false;
         private Breakpoint _currentBreakpoint = Breakpoint.None;
 
@@ -33,17 +33,17 @@ namespace MudBlazor
         public bool Invert { get; set; }
 
         /// <summary>
-        /// True if the component is not visible (two-way bindable)
+        /// True if the component is hidden (two-way bindable)
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Hidden.Behavior)]
-        public bool IsHidden { get; set; } = true;
+        public bool Hidden { get; set; } = true;
 
         /// <summary>
         /// Fires when the breakpoint changes visibility of the component
         /// </summary>
         [Parameter]
-        public EventCallback<bool> IsHiddenChanged { get; set; }
+        public EventCallback<bool> HiddenChanged { get; set; }
 
         /// <summary>
         /// Child content of component.
@@ -55,9 +55,9 @@ namespace MudBlazor
         public MudHidden()
         {
             using var registerScope = CreateRegisterScope();
-            _isHiddenState = registerScope.RegisterParameter<bool>(nameof(IsHidden))
-                .WithParameter(() => IsHidden)
-                .WithEventCallback(() => IsHiddenChanged);
+            _hiddenState = registerScope.RegisterParameter<bool>(nameof(Hidden))
+                .WithParameter(() => Hidden)
+                .WithEventCallback(() => HiddenChanged);
         }
 
         protected override async Task OnParametersSetAsync()
@@ -127,7 +127,7 @@ namespace MudBlazor
                 hidden = !hidden;
             }
 
-            await _isHiddenState.SetValueAsync(hidden);
+            await _hiddenState.SetValueAsync(hidden);
         }
     }
 }


### PR DESCRIPTION
MudBlazor currently uses the `IsHidden` and `IsHiddenChanged` properties. This PR aims to standardise the use of `Hidden` and `HiddenChanged` to align with other boolean properties in the library.

## Description
If this PR is approved, the v7 migration guide must also be updated, as this makes a breaking change:

**MudHidden**: replace `IsHidden` with `Hidden`
**MudHidden**: replace `IsHiddenChanged` with `HiddenChanged`

Linked issues:
Negative property names should be discouraged #6131
v7.0.0 Migration Guide #8447

Standardise the use of `IsEnabled` and `Enabled` #8764
Standardise the use of `ItemDisabled` #8887
Standardise the use of `Checked`, `CheckedChanged` and `Checkable` #8825
Standardise the use of `Visible` #8832
Standardise the use of `Selected` and `SelectedChanged` #8886
Standardise the use of `Expanded`, `Expandable`, `IsExpanded` and `IsExpandable` #8718
Standardise the use of `Active` #8888
Standardise the use of `Open` and `OpenChanged` #8891
Standardise the use of `Editable` #8892
Standardise the use of `Hidden` and `HiddenChanged` #8952

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
