### PR TITLE
MudSlider: Rename Culture and ValueLabelFormat

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderValueLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderValueLabelExample.razor
@@ -1,7 +1,7 @@
 ﻿@using System.Globalization
 @namespace MudBlazor.Docs.Examples
 
-<MudSlider T="decimal" Value="@_value" ValueLabel="true" Step="0.5m" ValueLabelCultureInfo="@_selectedCulture" ValueLabelStringFormat="@_selectedFormat" />
+<MudSlider T="decimal" Value="@_value" ValueLabel="true" Step="0.5m" Culture="@_selectedCulture" ValueLabelFormat="@_selectedFormat" />
 
 <MudSelect T="CultureInfo" @bind-Value="_selectedCulture">
     @foreach (var availableCulture in _availableCultures)

--- a/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
@@ -79,7 +79,7 @@
                 <Description>
                     Use the slider below to see the value label, this can be used by setting <CodeInline>@nameof(MudSlider<double>.ValueLabel)</CodeInline> property to true.
                     <br />
-                    Use <CodeInline>@nameof(MudSlider<double>.ValueLabelStringFormat)</CodeInline> and <CodeInline>@nameof(MudSlider<double>.ValueLabelCultureInfo)</CodeInline> to change the formatting.
+                    Use <CodeInline>@nameof(MudSlider<double>.ValueLabelFormat)</CodeInline> and <CodeInline>@nameof(MudSlider<double>.Culture)</CodeInline> to change the formatting.
                     <br />
                     For more customization use <CodeInline>@nameof(MudSlider<double>.ValueLabelContent)</CodeInline> RenderFragment.
                 </Description>

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -38,8 +38,8 @@ namespace MudBlazor.UnitTests.Components
             slider.Variant.Should().Be(Variant.Text);
 
             slider.Size.Should().Be(Size.Small);
-            slider.ValueLabelCultureInfo.Should().Be(CultureInfo.InvariantCulture);
-            slider.ValueLabelStringFormat.Should().BeNull();
+            slider.Culture.Should().Be(CultureInfo.InvariantCulture);
+            slider.ValueLabelFormat.Should().BeNull();
             slider.ValueLabelContent.Should().BeNull();
         }
 
@@ -483,8 +483,8 @@ namespace MudBlazor.UnitTests.Components
                 x.Add(p => p.Value, value);
                 x.Add(p => p.Step, 0.5m);
                 x.Add(p => p.ValueLabel, true);
-                x.Add(p => p.ValueLabelCultureInfo, customCulture);
-                x.Add(p => p.ValueLabelStringFormat, "C");
+                x.Add(p => p.Culture, customCulture);
+                x.Add(p => p.ValueLabelFormat, "C");
             });
 
             IElement ValueLabel() => comp.Find(".mud-slider-value-label");

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -42,7 +42,7 @@
             <div class="mud-slider-value-label" style="@($"left:{Width}%;")">
                 @if (ValueLabelContent is null)
                 {
-                    @_valueState.Value.ToString(ValueLabelStringFormat, ValueLabelCultureInfo)
+                    @_valueState.Value.ToString(ValueLabelFormat, Culture)
                 }
                 else
                 {

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -167,14 +167,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public CultureInfo ValueLabelCultureInfo { get; set; } = CultureInfo.InvariantCulture;
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
         /// Sets the formatting information used for ValueLabel. Default is no formatting.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public string? ValueLabelStringFormat { get; set; }
+        public string? ValueLabelFormat { get; set; }
 
         /// <summary>
         /// Sets custom RenderFragment for ValueLabel.


### PR DESCRIPTION
## Description

For consistency the new `ValueLabelCultureInfo` in `MudSlider` was renamed to just `Culture` like in all other inputs. 
For simplification, the `ValueLabelStringFormat` was renamed to `ValueLabelFormat` which is also more consistent with the `Format` property we have in other classes. I thought about just `Format` but then saw that there are a bunch of properties like `ValueLabelContent` etc, so `ValueLabelFormat` would best fit with them. 

## Type of Changes
Refactoring. We don't need to add these to the guide as these properties haven't existed before v7 I think.