### PR TITLE
Dialog: Fix possible deadlock

### DIFF
--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
 {
     public class DialogReference : IDialogReference
     {
-        private readonly TaskCompletionSource<DialogResult> _resultCompletion = new();
+        private readonly TaskCompletionSource<DialogResult> _resultCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private readonly IDialogService _dialogService;
 
@@ -46,7 +46,7 @@ namespace MudBlazor
 
         public Task<DialogResult> Result => _resultCompletion.Task;
 
-        TaskCompletionSource<bool> IDialogReference.RenderCompleteTaskCompletionSource { get; } = new();
+        TaskCompletionSource<bool> IDialogReference.RenderCompleteTaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void InjectDialog(object inst)
         {


### PR DESCRIPTION
## Description
Possible fix to https://github.com/MudBlazor/MudBlazor/discussions/8961?
According to Async Guidance it always preferable to create `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously` overload: https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously
Also similar thing was done in Blazored/Modal: https://github.com/Blazored/Modal/pull/408

## How Has This Been Tested?
Would be nice to have a bUnit test, but I don't have any example that runs into that problem.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
