### PR TITLE
Docs: Update List Docs to replace Clickable with ReadOnly

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
@@ -10,7 +10,7 @@
             <SectionHeader Title="Simple List">
                 <Description>
                     <CodeInline>MudList</CodeInline> is used to display a collection of items which can contain an avatar, an icon, text or custom content.
-                    If you want the component to be interactive set parameter <CodeInline>Clickable</CodeInline> to true. You can also use the list for
+                    If you want the component to be readonly set parameter <CodeInline>ReadOnly</CodeInline> to true. You can also use the list for
                     navigation if you set parameter <CodeInline>Href</CodeInline> on its <CodeInline>MudListItems</CodeInline>. Use
                     <CodeInline Tag>MudDivider</CodeInline> to separate groups of items.
 


### PR DESCRIPTION
## Description
Clickable is now ReadOnly with inverted value. Docs still had a reference to Clickable.

## How Has This Been Tested?
Visually tested docs project

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
