### PR TITLE
MudTable: Use theme typography for font size

### DIFF
--- a/src/MudBlazor.Docs/Styles/core/_base.scss
+++ b/src/MudBlazor.Docs/Styles/core/_base.scss
@@ -80,7 +80,7 @@
 .docs-css-utility-header {
   margin-top: 8px;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: inherit;
   color: var(--mud-palette-action-default);
   padding-left: 34px;
   margin-bottom: 2px;

--- a/src/MudBlazor/Styles/components/_list.scss
+++ b/src/MudBlazor/Styles/components/_list.scss
@@ -93,7 +93,7 @@
 
 .mud-list-subheader {
   color: var(--mud-palette-action-default);
-  font-size: 0.875rem;
+  font-size: inherit;
   box-sizing: border-box;
   list-style: none;
   font-weight: 500;

--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -24,12 +24,12 @@
       > td, th {
         display: table-cell;
         padding: 16px;
-        font-size: 0.875rem;
+        font-size: inherit;
         text-align: start;
-        font-weight: 400;
-        line-height: 1.43;
+        font-weight: inherit;
+        line-height: inherit;
         border-bottom: 1px solid var(--mud-palette-table-lines);
-        letter-spacing: 0.01071em;
+        letter-spacing: inherit;
         vertical-align: inherit;
       }
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -104,9 +104,9 @@
   font-size: inherit;
   text-align: start;
   font-weight: inherit;
-  line-height: 1.43;
+  line-height: inherit;
   border-bottom: 1px solid var(--mud-palette-table-lines);
-  letter-spacing: 0.01071em;
+  letter-spacing: inherit;
   vertical-align: inherit;
 
   & .mud-checkbox {
@@ -444,8 +444,8 @@
     border: none;
     font-size: inherit;
     font-weight: inherit;
-    line-height: 1.43;
-    letter-spacing: .01071em;
+    line-height: inherit;
+    letter-spacing: inherit;
     color: var(--mud-theme-on-surface)
   }
 }

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -101,9 +101,9 @@
 .mud-table-cell {
   display: table-cell;
   padding: 16px;
-  font-size: 0.875rem;
+  font-size: inherit;
   text-align: start;
-  font-weight: 400;
+  font-weight: inherit;
   line-height: 1.43;
   border-bottom: 1px solid var(--mud-palette-table-lines);
   letter-spacing: 0.01071em;
@@ -325,7 +325,7 @@
   & > .mud-input-control {
     & > div.mud-input.mud-input-text {
       color: var(--mud-theme-on-surface);
-      font-size: 0.875rem;
+      font-size: inherit;
       margin-top: -14px;
       margin-bottom: -8px;
     }
@@ -335,7 +335,7 @@
     & > .mud-input-control {
       & > div.mud-input.mud-input-text {
         color: var(--mud-theme-on-surface);
-        font-size: 0.875rem;
+        font-size: inherit;
         margin-top: -14px;
         margin-bottom: -8px;
       }
@@ -388,7 +388,7 @@
 .mud-table-pagination {
   color: var(--mud-theme-on-surface);
   overflow: auto;
-  font-size: 0.875rem;
+  font-size: inherit;
   display: initial;
 }
 
@@ -442,8 +442,8 @@
     cursor: pointer;
     margin-top: 2px;
     border: none;
-    font-size: .875rem;
-    font-weight: 400;
+    font-size: inherit;
+    font-weight: inherit;
     line-height: 1.43;
     letter-spacing: .01071em;
     color: var(--mud-theme-on-surface)

--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -98,7 +98,7 @@
 }
 
 .mud-toggle-item-text {
-  font-size: 0.875em !important;
+  font-size: inherit;
 }
 
 .mud-toggle-item-check-icon {
@@ -108,6 +108,6 @@
 
 .mud-toggle-item-content {
   /*Restore initial scaling for custom content*/
-  font-size: 1rem !important;
+  font-size: inherit;
   display: contents;
 }


### PR DESCRIPTION

**Description:**

This PR modifies the `_table.scss` file by changing the `font-size` property from `0.875` to `inherit`. 

**Changes:**

- Updated `_table.scss`:
  - `font-size: 0.875` -> `font-size: inherit`

**Benefits:**

- This change allows the font size in tables and datagrids to be synchronized with the default font size defined in the Theme. This ensures consistency in typography across the application and makes it easier to manage font sizes through the Theme settings.

**Testing:**

- Verified that tables and datagrids now use the inherited font size from the Theme.
- Checked for any visual regressions to ensure the change does not negatively impact the UI.
