### PR TITLE
DataGrid: ServerData with Virtualization

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditVirtualizationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellEditVirtualizationTest.razor
@@ -1,0 +1,37 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="Item" ServerData="ServerDataFunc" Virtualize="true" ReadOnly="false" EditMode="@DataGridEditMode.Cell">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = @"Test editing values in cells of the DataGrid.";
+    
+    private readonly IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("John", 45), 
+        new Item("Johanna", 23), 
+        new Item("Steve", 32)
+    };
+
+    public record Item(string Name, int Age);
+    
+    private async Task<GridData<Item>> ServerDataFunc(GridState<Item> gridState)
+    {
+        await Task.CompletedTask;
+
+        var result = _items
+            .Skip(gridState.Page * gridState.PageSize)
+            .Take(gridState.PageSize)
+            .ToList();
+        
+        return new GridData<Item>
+        {
+            Items = result,
+            TotalItems = _items.Count()
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterableVirtualizationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterableVirtualizationTest.razor
@@ -1,0 +1,44 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid T="Item" ServerData="ServerDataFunc" Virtualize="true" Filterable="true" ItemSize="53.68f" Height="300px">
+    <Columns>
+        <PropertyColumn Property="x => x.Name"/>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = @"Test in-browser-filtering of DataGrid.";
+    
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("B"),
+        new Item("A"),
+        new Item("C"),
+        new Item("C")
+    };
+
+    public record Item(string Name);
+    
+    private async Task<GridData<Item>> ServerDataFunc(GridState<Item> gridState)
+    {
+        await Task.CompletedTask;
+        
+        var filterFunctions = gridState.FilterDefinitions.Select(x => x.GenerateFilterFunction());
+        var totalItems = _items
+            .Where(x => filterFunctions.All(f => f(x)))
+            .ToList();
+        
+        var limitedResult = totalItems
+            .Skip(gridState.PageSize * gridState.Page)
+            .Take(gridState.PageSize)
+            .ToList();
+        
+        return new GridData<Item>
+        {
+            Items = limitedResult,
+            TotalItems = totalItems.Count
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSortableVirtualizationItemsProviderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSortableVirtualizationItemsProviderTest.razor
@@ -28,19 +28,33 @@ Note that the 'Misc' column is being sorted by length and not by the content its
     private async Task<GridData<Item>> ServerDataFunc(GridState<Item> gridState)
     {
         await Task.CompletedTask;
-        var result = _items.ToList();
-        foreach (var s in gridState.SortDefinitions.OrderBy(o => o.Index))
+        var result = _items.AsEnumerable();
+
+        var sortDefinitions = gridState.SortDefinitions
+            .OrderBy(o => o.Index)
+            .ToList();
+
+        // Check if there are sort definitions.
+        if (sortDefinitions.Count > 0) 
         {
-            result = s.Descending 
-                ? _items.OrderByDescending(s.SortFunc).ToList()
-                : _items.OrderBy(s.SortFunc).ToList();
+            var firstSort = sortDefinitions.First();
+            result = firstSort.Descending 
+                ? result.OrderByDescending(firstSort.SortFunc) 
+                : result.OrderBy(firstSort.SortFunc);
+
+            foreach (var s in sortDefinitions.Skip(1))
+            {
+                result = s.Descending 
+                    ? ((IOrderedEnumerable<Item>)result).ThenByDescending(s.SortFunc) 
+                    : ((IOrderedEnumerable<Item>)result).ThenBy(s.SortFunc);
+            }
         }
 
         result = result
             .Skip(gridState.Page * gridState.PageSize)
             .Take(gridState.PageSize)
             .ToList();
-        
+
         return new GridData<Item>
         {
             Items = result,

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSortableVirtualizationItemsProviderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSortableVirtualizationItemsProviderTest.razor
@@ -1,0 +1,50 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid T="Item" ServerData="ServerDataFunc" Virtualize="true" Sortable="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Value" />
+        <PropertyColumn Property="x => x.Misc" SortBy="@(item => item.Misc.Length)" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = @"Test in-browser-sorting of DataGrid. Hold <Ctrl> key when clicking header to extend to multi sort. Hold <Alt> key to unsort a sorted column.
+Note that the 'Misc' column is being sorted by length and not by the content itself.";
+
+    private IEnumerable<Item> _items = new List<Item>()
+    {
+        new Item("B", 42, "555"), 
+        new Item("A", 73, "7"), 
+        new Item("A", 11, "4444"), 
+        new Item("C", 33, "33333"),
+        new Item("A", 99, "66"), 
+        new Item("C", 44, "1111111"),
+        new Item("C", 55, "222222")
+    };
+
+    public record Item(string Name, int Value, string Misc);
+
+    private async Task<GridData<Item>> ServerDataFunc(GridState<Item> gridState)
+    {
+        await Task.CompletedTask;
+        var result = _items.ToList();
+        foreach (var s in gridState.SortDefinitions.OrderBy(o => o.Index))
+        {
+            result = s.Descending 
+                ? _items.OrderByDescending(s.SortFunc).ToList()
+                : _items.OrderBy(s.SortFunc).ToList();
+        }
+
+        result = result
+            .Skip(gridState.Page * gridState.PageSize)
+            .Take(gridState.PageSize)
+            .ToList();
+        
+        return new GridData<Item>
+        {
+            Items = result,
+            TotalItems = _items.Count()
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -221,7 +221,7 @@ namespace MudBlazor.UnitTests.Components
             // Since Sortable is now false, the click handler (and element holding it) should no longer exist.
             dataGrid.FindAll(".column-header .sortable-column-header").Should().BeEmpty();
         }
-        
+
         [Test]
         public async Task DataGridSortableHeaderRowTest()
         {
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.Instance.Filterable = false;
         }
-        
+
         [Test]
         public async Task DataGridFilterableTest()
         {
@@ -632,7 +632,7 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll(".mud-table-body tr td input")[0].GetAttribute("value").Trim().Should().Be("Jonathan");
             dataGrid.FindAll(".mud-table-body tr td input")[1].GetAttribute("value").Trim().Should().Be("52");
         }
-        
+
         [Test]
         public async Task DataGridPaginationTest()
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -126,6 +126,103 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridSortableVirtualizationItemsProviderTest()
+        {
+            var comp = Context.RenderComponent<DataGridSortableVirtualizationItemsProviderTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableVirtualizationItemsProviderTest.Item>>();
+
+            // Count the number of rows including header.
+            var rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(9, because: "1 header row + 7 data rows + 1 footer row");
+
+            var cells = dataGrid.FindAll("td");
+            cells.Count.Should().Be(21, because: "We have 7 data rows with three columns");
+
+            // Check the values of rows without sorting
+            cells[0].TextContent.Should().Be("B"); cells[1].TextContent.Should().Be("42"); cells[2].TextContent.Should().Be("555");
+            cells[3].TextContent.Should().Be("A"); cells[4].TextContent.Should().Be("73"); cells[5].TextContent.Should().Be("7");
+            cells[6].TextContent.Should().Be("A"); cells[7].TextContent.Should().Be("11"); cells[8].TextContent.Should().Be("4444");
+            cells[9].TextContent.Should().Be("C"); cells[10].TextContent.Should().Be("33"); cells[11].TextContent.Should().Be("33333");
+            cells[12].TextContent.Should().Be("A"); cells[13].TextContent.Should().Be("99"); cells[14].TextContent.Should().Be("66");
+            cells[15].TextContent.Should().Be("C"); cells[16].TextContent.Should().Be("44"); cells[17].TextContent.Should().Be("1111111");
+            cells[18].TextContent.Should().Be("C"); cells[19].TextContent.Should().Be("55"); cells[20].TextContent.Should().Be("222222");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => { return x.Name; }));
+            cells = dataGrid.FindAll("td");
+
+            // Check the values of rows - should be sorted ascending by Name.
+            cells[0].TextContent.Should().Be("A"); cells[1].TextContent.Should().Be("73"); cells[2].TextContent.Should().Be("7");
+            cells[3].TextContent.Should().Be("A"); cells[4].TextContent.Should().Be("11"); cells[5].TextContent.Should().Be("4444");
+            cells[6].TextContent.Should().Be("A"); cells[7].TextContent.Should().Be("99"); cells[8].TextContent.Should().Be("66");
+            cells[9].TextContent.Should().Be("B"); cells[10].TextContent.Should().Be("42"); cells[11].TextContent.Should().Be("555");
+            cells[12].TextContent.Should().Be("C"); cells[13].TextContent.Should().Be("33"); cells[14].TextContent.Should().Be("33333");
+            cells[15].TextContent.Should().Be("C"); cells[16].TextContent.Should().Be("44"); cells[17].TextContent.Should().Be("1111111");
+            cells[18].TextContent.Should().Be("C"); cells[19].TextContent.Should().Be("55"); cells[20].TextContent.Should().Be("222222");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => { return x.Name; }));
+            cells = dataGrid.FindAll("td");
+
+            // Check the values of rows - should be sorted descending by Name.
+            cells[0].TextContent.Should().Be("C"); cells[1].TextContent.Should().Be("33"); cells[2].TextContent.Should().Be("33333");
+            cells[3].TextContent.Should().Be("C"); cells[4].TextContent.Should().Be("44"); cells[5].TextContent.Should().Be("1111111");
+            cells[6].TextContent.Should().Be("C"); cells[7].TextContent.Should().Be("55"); cells[8].TextContent.Should().Be("222222");
+            cells[9].TextContent.Should().Be("B"); cells[10].TextContent.Should().Be("42"); cells[11].TextContent.Should().Be("555");
+            cells[12].TextContent.Should().Be("A"); cells[13].TextContent.Should().Be("73"); cells[14].TextContent.Should().Be("7");
+            cells[15].TextContent.Should().Be("A"); cells[16].TextContent.Should().Be("11"); cells[17].TextContent.Should().Be("4444");
+            cells[18].TextContent.Should().Be("A"); cells[19].TextContent.Should().Be("99"); cells[20].TextContent.Should().Be("66");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.RemoveSortAsync("Name"));
+            cells = dataGrid.FindAll("td");
+
+            // Back to original order without sorting
+            cells[0].TextContent.Should().Be("B"); cells[1].TextContent.Should().Be("42"); cells[2].TextContent.Should().Be("555");
+            cells[3].TextContent.Should().Be("A"); cells[4].TextContent.Should().Be("73"); cells[5].TextContent.Should().Be("7");
+            cells[6].TextContent.Should().Be("A"); cells[7].TextContent.Should().Be("11"); cells[8].TextContent.Should().Be("4444");
+            cells[9].TextContent.Should().Be("C"); cells[10].TextContent.Should().Be("33"); cells[11].TextContent.Should().Be("33333");
+            cells[12].TextContent.Should().Be("A"); cells[13].TextContent.Should().Be("99"); cells[14].TextContent.Should().Be("66");
+            cells[15].TextContent.Should().Be("C"); cells[16].TextContent.Should().Be("44"); cells[17].TextContent.Should().Be("1111111");
+            cells[18].TextContent.Should().Be("C"); cells[19].TextContent.Should().Be("55"); cells[20].TextContent.Should().Be("222222");
+
+            var column = dataGrid.FindComponent<Column<DataGridSortableVirtualizationItemsProviderTest.Item>>();
+            await comp.InvokeAsync(() => column.Instance.SortBy = x => { return x.Name; });
+
+            // Check the values of rows - should not be sorted and should be in the original order.
+            cells[0].TextContent.Should().Be("B"); cells[1].TextContent.Should().Be("42"); cells[2].TextContent.Should().Be("555");
+            cells[3].TextContent.Should().Be("A"); cells[4].TextContent.Should().Be("73"); cells[5].TextContent.Should().Be("7");
+            cells[6].TextContent.Should().Be("A"); cells[7].TextContent.Should().Be("11"); cells[8].TextContent.Should().Be("4444");
+            cells[9].TextContent.Should().Be("C"); cells[10].TextContent.Should().Be("33"); cells[11].TextContent.Should().Be("33333");
+            cells[12].TextContent.Should().Be("A"); cells[13].TextContent.Should().Be("99"); cells[14].TextContent.Should().Be("66");
+            cells[15].TextContent.Should().Be("C"); cells[16].TextContent.Should().Be("44"); cells[17].TextContent.Should().Be("1111111");
+            cells[18].TextContent.Should().Be("C"); cells[19].TextContent.Should().Be("55"); cells[20].TextContent.Should().Be("222222");
+
+            // sort through the sort icon
+            dataGrid.Find(".column-options button").Click();
+            cells = dataGrid.FindAll("td");
+            // Check the values of rows - should be sorted ascending by Name.
+            cells[0].TextContent.Should().Be("A"); cells[1].TextContent.Should().Be("73"); cells[2].TextContent.Should().Be("7");
+            cells[3].TextContent.Should().Be("A"); cells[4].TextContent.Should().Be("11"); cells[5].TextContent.Should().Be("4444");
+            cells[6].TextContent.Should().Be("A"); cells[7].TextContent.Should().Be("99"); cells[8].TextContent.Should().Be("66");
+            cells[9].TextContent.Should().Be("B"); cells[10].TextContent.Should().Be("42"); cells[11].TextContent.Should().Be("555");
+            cells[12].TextContent.Should().Be("C"); cells[13].TextContent.Should().Be("33"); cells[14].TextContent.Should().Be("33333");
+            cells[15].TextContent.Should().Be("C"); cells[16].TextContent.Should().Be("44"); cells[17].TextContent.Should().Be("1111111");
+            cells[18].TextContent.Should().Be("C"); cells[19].TextContent.Should().Be("55"); cells[20].TextContent.Should().Be("222222");
+
+            // test other sort methods
+            var headerCell = dataGrid.FindComponent<HeaderCell<DataGridSortableVirtualizationItemsProviderTest.Item>>();
+            await comp.InvokeAsync(() => headerCell.Instance.SortChangedAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs()));
+            //await comp.InvokeAsync(() => headerCell.Instance.GetDataType());
+            await comp.InvokeAsync(() => headerCell.Instance.RemoveSortAsync());
+            await comp.InvokeAsync(() => headerCell.Instance.AddFilter());
+            await comp.InvokeAsync(() => headerCell.Instance.OpenFilters());
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SortMode = SortMode.None);
+            dataGrid.Render();
+            dataGrid.Instance.DropContainerHasChanged();
+            // Since Sortable is now false, the click handler (and element holding it) should no longer exist.
+            dataGrid.FindAll(".column-header .sortable-column-header").Should().BeEmpty();
+        }
+        
+        [Test]
         public async Task DataGridSortableHeaderRowTest()
         {
             var comp = Context.RenderComponent<DataGridSortableHeaderRowTest>();
@@ -225,6 +322,39 @@ namespace MudBlazor.UnitTests.Components
             cells[6].TextContent.Should().Be("C");
         }
 
+        [Test]
+        public async Task DataGridFilterableVirtualizationTest()
+        {
+            var comp = Context.RenderComponent<DataGridFilterableVirtualizationTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterableVirtualizationTest.Item>>();
+
+            // Count the number of rows including header.
+            dataGrid.FindAll("tr").Count.Should().Be(6); // header row + four rows + footer row
+
+            // Check the values of rows
+            dataGrid.FindAll("td")[0].TextContent.Trim().Should().Be("B");
+            dataGrid.FindAll("td")[1].TextContent.Trim().Should().Be("A");
+            dataGrid.FindAll("td")[2].TextContent.Trim().Should().Be("C");
+            dataGrid.FindAll("td")[3].TextContent.Trim().Should().Be("C");
+
+            // Add a FilterDefinition to filter where the Name = "C".
+            await comp.InvokeAsync(() =>
+            {
+                return dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterableVirtualizationTest.Item>
+                {
+                    Column = dataGrid.Instance.RenderedColumns.First(),
+                    Operator = FilterOperator.String.Equal,
+                    Value = "C"
+                });
+            });
+
+            // Check the values of rows
+            dataGrid.FindAll("td")[0].TextContent.Trim().Should().Be("C");
+            dataGrid.FindAll("td")[1].TextContent.Trim().Should().Be("C");
+
+            dataGrid.Instance.Filterable = false;
+        }
+        
         [Test]
         public async Task DataGridFilterableTest()
         {
@@ -485,6 +615,24 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        [Test]
+        public async Task DataGridInlineEditVirtualizationTest()
+        {
+            var comp = Context.RenderComponent<DataGridCellEditVirtualizationTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditVirtualizationTest.Item>>();
+
+            dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
+            dataGrid.FindAll("td input")[1].GetAttribute("value").Trim().Should().Be("45");
+            dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("Johanna");
+            dataGrid.FindAll("td input")[3].GetAttribute("value").Trim().Should().Be("23");
+            dataGrid.FindAll("td input")[4].GetAttribute("value").Trim().Should().Be("Steve");
+            dataGrid.FindAll("td input")[5].GetAttribute("value").Trim().Should().Be("32");
+            dataGrid.FindAll(".mud-table-body tr td input")[0].Change("Jonathan");
+            dataGrid.FindAll(".mud-table-body tr td input")[1].Change(52d);
+            dataGrid.FindAll(".mud-table-body tr td input")[0].GetAttribute("value").Trim().Should().Be("Jonathan");
+            dataGrid.FindAll(".mud-table-body tr td input")[1].GetAttribute("value").Trim().Should().Be("52");
+        }
+        
         [Test]
         public async Task DataGridPaginationTest()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -201,7 +201,7 @@
                         }
 
                         @{var resolvedPageItems = CurrentPageItems.ToList();}
-                        @if (resolvedPageItems is { Count: > 0 })
+                        @if (resolvedPageItems is { Count: > 0 } || VirtualItemsProvider != null)
                         {
                             if (GroupedColumn != null)
                             {
@@ -230,7 +230,7 @@
 
                                     @if (g.Expanded)
                                     {
-                                        <MudVirtualize Enabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                        <MudVirtualize @ref="_mudVirtualize" ItemsProvider="@VirtualItemsProvider" Enabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                             @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var tmpRowIndex = rowIndex; }
@@ -268,7 +268,7 @@
                             else
                             {
                                 var rowIndex = 0;
-                                <MudVirtualize Enabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                <MudVirtualize @ref="_mudVirtualize" ItemsProvider="@VirtualItemsProvider" Enabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -268,7 +268,7 @@
                             else
                             {
                                 var rowIndex = 0;
-                                <MudVirtualize @ref="_mudVirtualize" Enabled="@Virtualize" Items="@resolvedPageItems" ItemsProvider="@VirtualItemsProvider" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                <MudVirtualize @ref="_mudVirtualize" ItemsProvider="@VirtualItemsProvider" Enabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -201,7 +201,7 @@
                         }
 
                         @{var resolvedPageItems = CurrentPageItems.ToList();}
-                        @if (resolvedPageItems is { Count: > 0 })
+                        @if (resolvedPageItems is { Count: > 0 } || VirtualItemsProvider != null)
                         {
                             if (GroupedColumn != null)
                             {
@@ -230,7 +230,7 @@
 
                                     @if (g.Expanded)
                                     {
-                                        <MudVirtualize Enabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                        <MudVirtualize @ref="_mudVirtualize" ItemsProvider="@VirtualItemsProvider" Enabled="@Virtualize" Items="@g.Grouping.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                             @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                             @{ var tmpRowIndex = rowIndex; }
@@ -268,7 +268,7 @@
                             else
                             {
                                 var rowIndex = 0;
-                                <MudVirtualize Enabled="@Virtualize" Items="@resolvedPageItems" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                                <MudVirtualize @ref="_mudVirtualize" Enabled="@Virtualize" Items="@resolvedPageItems" ItemsProvider="@VirtualItemsProvider" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
                                     @{ var tmpRowIndex = rowIndex; }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Clone;
 
@@ -29,6 +30,7 @@ namespace MudBlazor
         private IEnumerable<T> _items;
         private T _selectedItem;
         private MudForm _editForm;
+        private MudVirtualize<T> _mudVirtualize;
         internal Dictionary<object, bool> _groupExpansionsDict = new Dictionary<object, bool>();
         private List<GroupDefinition<T>> _currentPageGroups = new List<GroupDefinition<T>>();
         private List<GroupDefinition<T>> _allGroups = new List<GroupDefinition<T>>();
@@ -789,6 +791,12 @@ namespace MudBlazor
         private IEnumerable<T> _currentRenderFilteredItemsCache = null;
 
         /// <summary>
+        /// Defines the ItemsProviderDelegate property, which is necessary for implementing the ServerData methodology with Virtualization.
+        /// This property is used to populate items virtually from the server.
+        /// </summary>
+        internal ItemsProviderDelegate<T> VirtualItemsProvider { get; set; }
+
+        /// <summary>
         /// For unit testing the filtering cache mechanism.
         /// </summary>
         internal uint FilteringRunCount { get; private set; }
@@ -890,6 +898,7 @@ namespace MudBlazor
             var sortModeBefore = SortMode;
             await base.SetParametersAsync(parameters);
 
+            VirtualItemsProviderInitialize();
             if (parameters.TryGetValue(nameof(SortMode), out SortMode sortMode) && sortMode != sortModeBefore)
                 await ClearCurrentSortings();
         }
@@ -916,27 +925,38 @@ namespace MudBlazor
             if (ServerData == null)
                 return;
 
-            Loading = true;
-            StateHasChanged();
-
-            var state = new GridState<T>
+            if (Virtualize)
             {
-                Page = CurrentPage,
-                PageSize = RowsPerPage,
-                SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
-                // Additional ToList() here to decouple clients from internal list avoiding runtime issues
-                FilterDefinitions = FilterDefinitions.ToList()
-            };
+                if (_mudVirtualize != null)
+                {
+                    await _mudVirtualize.RefreshDataAsync();
+                    StateHasChanged();
+                }
+            }
+            else
+            {
+                Loading = true;
+                StateHasChanged();
 
-            _server_data = await ServerData(state);
-            _currentRenderFilteredItemsCache = null;
+                var state = new GridState<T>
+                {
+                    Page = CurrentPage,
+                    PageSize = RowsPerPage,
+                    SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
+                    // Additional ToList() here to decouple clients from internal list avoiding runtime issues
+                    FilterDefinitions = FilterDefinitions.ToList()
+                };
 
-            if (CurrentPage * RowsPerPage > _server_data.TotalItems)
-                CurrentPage = 0;
+                _server_data = await ServerData(state);
+                _currentRenderFilteredItemsCache = null;
 
-            Loading = false;
-            StateHasChanged();
-            PagerStateHasChangedEvent?.Invoke();
+                if (CurrentPage * RowsPerPage > _server_data.TotalItems)
+                    CurrentPage = 0;
+
+                Loading = false;
+                StateHasChanged();
+                PagerStateHasChangedEvent?.Invoke();
+            }
         }
 
         internal void AddColumn(Column<T> column)
@@ -1296,6 +1316,33 @@ namespace MudBlazor
                     StateHasChanged();
             }
         }
+        
+        private void VirtualItemsProviderInitialize()
+        {
+            if (ServerData == null || !Virtualize)
+            {
+                return;
+            }
+            
+            VirtualItemsProvider = async request =>
+            {
+                var state = new GridState<T>
+                {
+                    Page = request.Count > 0 ? request.StartIndex / request.Count : 0,
+                    PageSize = request.Count,
+                    SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
+                    // Additional ToList() here to decouple clients from internal list avoiding runtime issues
+                    FilterDefinitions = FilterDefinitions.ToList()
+                };
+
+                _server_data = await ServerData(state);
+                _currentRenderFilteredItemsCache = null;
+                
+                return new ItemsProviderResult<T>(
+                    _server_data.Items,
+                    _server_data.TotalItems);
+            };
+        }
 
         /// <summary>
         /// Set the currently selected item in the data grid.
@@ -1563,7 +1610,7 @@ namespace MudBlazor
                 return _resizeService ??= new DataGridColumnResizeService<T>(this, EventListener);
             }
         }
-
+        
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX)
             => await ResizeService.StartResizeColumn(headerCell, clientX, RenderedColumns, ColumnResizeMode);
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1316,14 +1316,14 @@ namespace MudBlazor
                     StateHasChanged();
             }
         }
-        
+
         private void VirtualItemsProviderInitialize()
         {
             if (ServerData == null || !Virtualize)
             {
                 return;
             }
-            
+
             VirtualItemsProvider = async request =>
             {
                 var state = new GridState<T>
@@ -1337,7 +1337,7 @@ namespace MudBlazor
 
                 _server_data = await ServerData(state);
                 _currentRenderFilteredItemsCache = null;
-                
+
                 return new ItemsProviderResult<T>(
                     _server_data.Items,
                     _server_data.TotalItems);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1319,7 +1319,7 @@ namespace MudBlazor
 
         private void VirtualItemsProviderInitialize()
         {
-            if (ServerData == null || !Virtualize)
+            if (VirtualItemsProvider != null || ServerData == null || !Virtualize)
             {
                 return;
             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Clone;
 
@@ -29,6 +30,7 @@ namespace MudBlazor
         private IEnumerable<T> _items;
         private T _selectedItem;
         private MudForm _editForm;
+        private MudVirtualize<T> _mudVirtualize;
         internal Dictionary<object, bool> _groupExpansionsDict = new Dictionary<object, bool>();
         private List<GroupDefinition<T>> _currentPageGroups = new List<GroupDefinition<T>>();
         private List<GroupDefinition<T>> _allGroups = new List<GroupDefinition<T>>();
@@ -789,6 +791,12 @@ namespace MudBlazor
         private IEnumerable<T> _currentRenderFilteredItemsCache = null;
 
         /// <summary>
+        /// Defines the ItemsProviderDelegate property, which is necessary for implementing the ServerData methodology with Virtualization.
+        /// This property is used to populate items virtually from the server.
+        /// </summary>
+        internal ItemsProviderDelegate<T> VirtualItemsProvider { get; set; }
+
+        /// <summary>
         /// For unit testing the filtering cache mechanism.
         /// </summary>
         internal uint FilteringRunCount { get; private set; }
@@ -890,6 +898,7 @@ namespace MudBlazor
             var sortModeBefore = SortMode;
             await base.SetParametersAsync(parameters);
 
+            VirtualItemsProviderInitialize();
             if (parameters.TryGetValue(nameof(SortMode), out SortMode sortMode) && sortMode != sortModeBefore)
                 await ClearCurrentSortings();
         }
@@ -916,27 +925,38 @@ namespace MudBlazor
             if (ServerData == null)
                 return;
 
-            Loading = true;
-            StateHasChanged();
-
-            var state = new GridState<T>
+            if (Virtualize)
             {
-                Page = CurrentPage,
-                PageSize = RowsPerPage,
-                SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
-                // Additional ToList() here to decouple clients from internal list avoiding runtime issues
-                FilterDefinitions = FilterDefinitions.ToList()
-            };
+                if (_mudVirtualize != null)
+                {
+                    await _mudVirtualize.RefreshDataAsync();
+                    StateHasChanged();
+                }
+            }
+            else
+            {
+                Loading = true;
+                StateHasChanged();
 
-            _server_data = await ServerData(state);
-            _currentRenderFilteredItemsCache = null;
+                var state = new GridState<T>
+                {
+                    Page = CurrentPage,
+                    PageSize = RowsPerPage,
+                    SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
+                    // Additional ToList() here to decouple clients from internal list avoiding runtime issues
+                    FilterDefinitions = FilterDefinitions.ToList()
+                };
 
-            if (CurrentPage * RowsPerPage > _server_data.TotalItems)
-                CurrentPage = 0;
+                _server_data = await ServerData(state);
+                _currentRenderFilteredItemsCache = null;
 
-            Loading = false;
-            StateHasChanged();
-            PagerStateHasChangedEvent?.Invoke();
+                if (CurrentPage * RowsPerPage > _server_data.TotalItems)
+                    CurrentPage = 0;
+
+                Loading = false;
+                StateHasChanged();
+                PagerStateHasChangedEvent?.Invoke();
+            }
         }
 
         internal void AddColumn(Column<T> column)
@@ -1295,6 +1315,33 @@ namespace MudBlazor
                 if (ServerData == null)
                     StateHasChanged();
             }
+        }
+        
+        private void VirtualItemsProviderInitialize()
+        {
+            if (ServerData == null || !Virtualize)
+            {
+                return;
+            }
+            
+            VirtualItemsProvider = async request =>
+            {
+                var state = new GridState<T>
+                {
+                    Page = request.Count > 0 ? request.StartIndex / request.Count : 0,
+                    PageSize = request.Count,
+                    SortDefinitions = SortDefinitions.Values.OrderBy(sd => sd.Index).ToList(),
+                    // Additional ToList() here to decouple clients from internal list avoiding runtime issues
+                    FilterDefinitions = FilterDefinitions.ToList()
+                };
+
+                _server_data = await ServerData(state);
+                _currentRenderFilteredItemsCache = null;
+                
+                return new ItemsProviderResult<T>(
+                    _server_data.Items,
+                    _server_data.TotalItems);
+            };
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1610,7 +1610,7 @@ namespace MudBlazor
                 return _resizeService ??= new DataGridColumnResizeService<T>(this, EventListener);
             }
         }
-        
+
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX)
             => await ResizeService.StartResizeColumn(headerCell, clientX, RenderedColumns, ColumnResizeMode);
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1610,7 +1610,7 @@ namespace MudBlazor
                 return _resizeService ??= new DataGridColumnResizeService<T>(this, EventListener);
             }
         }
-
+        
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX)
             => await ResizeService.StartResizeColumn(headerCell, clientX, RenderedColumns, ColumnResizeMode);
 

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -7,7 +7,7 @@
 {
     if (ItemsProvider != null)
     {
-        <Virtualize @ref="@VirtualizeContainerReference" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
+        <Virtualize @ref="@_virtualizeContainerReference" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
             <ChildContent>
                 @if (ChildContent is not null)
                 {
@@ -22,7 +22,7 @@
     }
     else
     {
-        <Virtualize @ref="@VirtualizeContainerReference" Items="@Items" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
+        <Virtualize @ref="@_virtualizeContainerReference" Items="@Items" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
             <ChildContent>
                 @if (ChildContent is not null)
                 {

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor
@@ -5,18 +5,36 @@
 
 @if (Enabled)
 {
-    <Virtualize Items="@Items" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
-        <ChildContent>
-            @if (ChildContent is not null)
-            {
-                @ChildContent(item)
-            }
-        </ChildContent>
+    if (ItemsProvider != null)
+    {
+        <Virtualize @ref="@VirtualizeContainerReference" ItemsProvider="@ItemsProvider" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
+            <ChildContent>
+                @if (ChildContent is not null)
+                {
+                    @ChildContent(item)
+                }
+            </ChildContent>
 
-        <Placeholder>
-            @Placeholder
-        </Placeholder>
-    </Virtualize>
+            <Placeholder>
+                @Placeholder
+            </Placeholder>
+        </Virtualize>
+    }
+    else
+    {
+        <Virtualize @ref="@VirtualizeContainerReference" Items="@Items" Context="item" OverscanCount="@OverscanCount" ItemSize="@ItemSize" SpacerElement="@SpacerElement">
+            <ChildContent>
+                @if (ChildContent is not null)
+                {
+                    @ChildContent(item)
+                }
+            </ChildContent>
+
+            <Placeholder>
+                @Placeholder
+            </Placeholder>
+        </Virtualize>
+    }
 }
 else
 {

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
         /// Represents a virtualized container for rendering a large list of items efficiently.
         /// </summary>
         private Virtualize<T>? _virtualizeContainerReference;
-        
+
         /// <summary>
         /// Set false to turn off virtualization
         /// </summary>

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 
@@ -61,5 +62,21 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public string SpacerElement { get; set; } = "div";
+
+        /// <summary>
+        /// Represents a virtualized container for rendering a large list of items efficiently.
+        /// </summary>
+        private Virtualize<T>? VirtualizeContainerReference { get; set; }
+
+        /// <summary>
+        /// Refreshes the data in the Virtualize component asynchronously.
+        /// </summary>
+        public async Task RefreshDataAsync()
+        {
+            if (VirtualizeContainerReference != null)
+            {
+                await VirtualizeContainerReference.RefreshDataAsync();
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
+++ b/src/MudBlazor/Components/Virtualize/MudVirtualize.razor.cs
@@ -13,6 +13,11 @@ namespace MudBlazor
     public partial class MudVirtualize<T> : ComponentBase
     {
         /// <summary>
+        /// Represents a virtualized container for rendering a large list of items efficiently.
+        /// </summary>
+        private Virtualize<T>? _virtualizeContainerReference;
+        
+        /// <summary>
         /// Set false to turn off virtualization
         /// </summary>
         [Parameter]
@@ -64,18 +69,13 @@ namespace MudBlazor
         public string SpacerElement { get; set; } = "div";
 
         /// <summary>
-        /// Represents a virtualized container for rendering a large list of items efficiently.
-        /// </summary>
-        private Virtualize<T>? VirtualizeContainerReference { get; set; }
-
-        /// <summary>
         /// Refreshes the data in the Virtualize component asynchronously.
         /// </summary>
         public async Task RefreshDataAsync()
         {
-            if (VirtualizeContainerReference != null)
+            if (_virtualizeContainerReference != null)
             {
-                await VirtualizeContainerReference.RefreshDataAsync();
+                await _virtualizeContainerReference.RefreshDataAsync();
             }
         }
     }


### PR DESCRIPTION
Adding virtualization support to the DataGrid when fetching data from the server via ServerData.

## Description

Adding an ItemsProvider delegate to the DataGrid and passing it to the virtualization component for asynchronous fetching of list items during scrolling without a paginator.

This PR is a modification and, in my opinion, an improvement/simplification of the code from PR #7258 . In my approach, to implement virtualization combined with loading items from the server, it is sufficient to specify the ServerData and Virtualization parameters.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
