### PR TITLE
ParameterState: Solve inheritance problem (Solution 1)

### DIFF
--- a/src/MudBlazor.UnitTests/State/Builder/ParameterRegistrationBuilderScopeTests.cs
+++ b/src/MudBlazor.UnitTests/State/Builder/ParameterRegistrationBuilderScopeTests.cs
@@ -43,6 +43,31 @@ public class ParameterRegistrationBuilderScopeTests
     }
 
     [Test]
+    public void KeepUnlocked_ShouldNotLock_WhenScopeIsEnded()
+    {
+        // Arrange
+        var scope = new ParameterRegistrationBuilderScope();
+
+        // Act
+        using (scope.SetScopeOption(ScopeOption.KeepUnlocked))
+        {
+            // Do nothing
+        }
+
+        // Assert
+        scope.IsLocked.Should().BeFalse();
+
+        // Act
+        using (scope.SetScopeOption(ScopeOption.Lock))
+        {
+            // Do nothing
+        }
+
+        // Assert
+        scope.IsLocked.Should().BeTrue();
+    }
+
+    [Test]
     public void Dispose_LocksScopeAndWritesParameters_WhenScopeNotEnded()
     {
         // Arrange

--- a/src/MudBlazor/Base/ComponentBaseWithState.cs
+++ b/src/MudBlazor/Base/ComponentBaseWithState.cs
@@ -50,14 +50,21 @@ public class ComponentBaseWithState : ComponentBase
     /// Creates a scope for registering parameters.
     /// </summary>
     /// <returns>A <see cref="ParameterRegistrationBuilderScope"/> instance for registering parameters.</returns>
-    protected IParameterRegistrationBuilderScope CreateRegisterScope()
+    protected IParameterRegistrationBuilderScope CreateRegisterScope() => CreateRegisterScope(ScopeOption.Lock);
+
+    /// <summary>
+    /// Creates a scope for registering parameters with the specified locking behavior.
+    /// </summary>
+    /// <param name="scopeOption">The locking behavior for the scope.</param>
+    /// <returns>A <see cref="ParameterRegistrationBuilderScope"/> instance for registering parameters.</returns>
+    internal IParameterRegistrationBuilderScope CreateRegisterScope(ScopeOption scopeOption)
     {
         if (_scope.IsLocked)
         {
             throw new InvalidOperationException($"You are not allowed to create more than one {nameof(CreateRegisterScope)} after the scope has ended!");
         }
 
-        return _scope;
+        return _scope.SetScopeOption(scopeOption);
     }
 
     private void OnScopeEndedAction() => Parameters.ForceParametersAttachment();

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.State;
+using MudBlazor.State.Builder;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -35,7 +36,7 @@ namespace MudBlazor
         protected MudBaseInput()
             : base(new DefaultConverter<T>())
         {
-            using var registerScope = CreateRegisterScope();
+            using var registerScope = CreateRegisterScope(ScopeOption.KeepUnlocked);
             InputIdState = registerScope.RegisterParameter<string?>(nameof(InputId))
                 .WithParameter(() => InputId)
                 .WithChangeHandler(UpdateInputIdStateAsync);

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -1,46 +1,42 @@
 ﻿using System.Threading.Tasks;
 using System.Timers;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+using MudBlazor.State.Builder;
 
 namespace MudBlazor
 {
     public abstract class MudDebouncedInput<T> : MudBaseInput<T>
     {
-        private System.Timers.Timer _timer;
-        private double _debounceInterval;
+        private Timer _timer;
+        private readonly ParameterState<double> _debounceIntervalState;
+
+        protected MudDebouncedInput()
+        {
+            using var registerScope = CreateRegisterScope(ScopeOption.KeepUnlocked);
+            _debounceIntervalState = registerScope.RegisterParameter<double>(nameof(DebounceInterval))
+                .WithParameter(() => DebounceInterval)
+                .WithComparer(DoubleEpsilonEqualityComparer.Default)
+                .WithChangeHandler(OnDebounceIntervalChanged);
+        }
 
         /// <summary>
         /// Interval to be awaited in milliseconds before changing the Text value
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public double DebounceInterval
-        {
-            get => _debounceInterval;
-            set
-            {
-                if (DoubleEpsilonEqualityComparer.Default.Equals(_debounceInterval, value))
-                    return;
-                _debounceInterval = value;
-                if (_debounceInterval == 0)
-                {
-                    // not debounced, dispose timer if any
-                    ClearTimer(suppressTick: false);
-                    return;
-                }
-                SetTimer();
-            }
-        }
+        public double DebounceInterval { get; set; }
 
         /// <summary>
         /// callback to be called when the debounce interval has elapsed
         /// receives the Text as a parameter
         /// </summary>
-        [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
+        [Parameter]
+        public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
 
         protected Task OnChange()
         {
-            if (DebounceInterval > 0 && _timer != null)
+            if (_debounceIntervalState.Value > 0 && _timer != null)
             {
                 _timer.Stop();
                 return base.UpdateValuePropertyAsync(false);
@@ -52,7 +48,7 @@ namespace MudBlazor
         protected override Task UpdateTextPropertyAsync(bool updateValue)
         {
             var suppressTextUpdate = !updateValue
-                                     && DebounceInterval > 0
+                                     && _debounceIntervalState.Value > 0
                                      && _timer is { Enabled: true }
                                      && (!Value?.Equals(Converter.Get(Text)) ?? false);
 
@@ -72,7 +68,7 @@ namespace MudBlazor
                 return base.UpdateValuePropertyAsync(updateText);
             }
             // if debounce interval is 0 we update immediately
-            if (DebounceInterval <= 0 || _timer == null)
+            if (_debounceIntervalState.Value <= 0 || _timer == null)
                 return base.UpdateValuePropertyAsync(updateText);
             // If a debounce interval is defined, we want to delay the update of Value property.
             _timer.Stop();
@@ -86,8 +82,19 @@ namespace MudBlazor
             base.OnParametersSet();
             // if input is to be debounced, makes sense to bind the change of the text to oninput
             // so we set Immediate to true
-            if (DebounceInterval > 0)
+            if (_debounceIntervalState.Value > 0)
                 Immediate = true;
+        }
+
+        private void OnDebounceIntervalChanged(ParameterChangedEventArgs<double> args)
+        {
+            if (args.Value == 0)
+            {
+                // not debounced, dispose timer if any
+                ClearTimer(suppressTick: false);
+                return;
+            }
+            SetTimer();
         }
 
         private void SetTimer()
@@ -98,7 +105,7 @@ namespace MudBlazor
                 _timer.Elapsed += OnTimerTick;
                 _timer.AutoReset = false;
             }
-            _timer.Interval = DebounceInterval;
+            _timer.Interval = _debounceIntervalState.Value;
         }
 
         private void OnTimerTick(object sender, ElapsedEventArgs e)

--- a/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
+++ b/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
@@ -47,7 +47,12 @@ internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilder
 
         return builder;
     }
-
+    
+    /// <summary>
+    /// Sets the scope option for the current instance.
+    /// </summary>
+    /// <param name="scopeOption">The scope option to be set.</param>
+    /// <returns>The current instance with the updated scope option.</returns>
     public ParameterRegistrationBuilderScope SetScopeOption(ScopeOption scopeOption)
     {
         _scopeOption = scopeOption;

--- a/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
+++ b/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
@@ -14,6 +14,7 @@ namespace MudBlazor.State.Builder;
 /// </summary>
 internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilderScope, IParameterStatesReader
 {
+    private ScopeOption _scopeOption;
     private readonly Action? _onScopeEndedAction;
     private readonly List<IParameterBuilderAttach> _builders;
 
@@ -47,6 +48,13 @@ internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilder
         return builder;
     }
 
+    public ParameterRegistrationBuilderScope SetScopeOption(ScopeOption scopeOption)
+    {
+        _scopeOption = scopeOption;
+
+        return this;
+    }
+
     /// <summary>
     /// Clears the list of parameter builders.
     /// </summary>
@@ -61,8 +69,11 @@ internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilder
     {
         if (!IsLocked)
         {
-            IsLocked = true;
-            _onScopeEndedAction?.Invoke();
+            if (_scopeOption == ScopeOption.Lock)
+            {
+                IsLocked = true;
+                _onScopeEndedAction?.Invoke();
+            }
         }
     }
 
@@ -70,5 +81,9 @@ internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilder
     IEnumerable<IParameterComponentLifeCycle> IParameterStatesReader.ReadParameters() => _builders.Select(parameter => parameter.Attach());
 
     /// <inheritdoc />
-    void IParameterStatesReader.Complete() => CleanUp();
+    void IParameterStatesReader.Complete()
+    {
+        IsLocked = true;
+        CleanUp();
+    }
 }

--- a/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
+++ b/src/MudBlazor/State/Builder/ParameterRegistrationBuilderScope.cs
@@ -47,7 +47,7 @@ internal class ParameterRegistrationBuilderScope : IParameterRegistrationBuilder
 
         return builder;
     }
-    
+
     /// <summary>
     /// Sets the scope option for the current instance.
     /// </summary>

--- a/src/MudBlazor/State/Builder/ScopeOption.cs
+++ b/src/MudBlazor/State/Builder/ScopeOption.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.State.Builder;
+
+/// <summary>
+/// Specifies the locking behavior for a scope.
+/// </summary>
+internal enum ScopeOption
+{
+    /// <summary>
+    /// Lock the scope when it ends.
+    /// </summary>
+    Lock = 0,
+
+    /// <summary>
+    /// Keep the scope unlocked after it ends.
+    /// </summary>
+    /// <remarks>
+    /// This option is useful when dealing with abstract classes or classes that will be inherited.
+    /// <br/>
+    /// It will remain unlocked until the parameters are read, or until the options are overridden with the <see cref="Lock"/> option and the scope ends.
+    /// </remarks>
+    KeepUnlocked = 1,
+}


### PR DESCRIPTION
## Description
The problem arises with the following hierarchy:
```
ComponentBaseWithState
└── MudBaseInput (uses ParameterState, an abstract class)
    └── MudDebouncedInput (could or could not use ParameterState, an abstract class)
        └── Another component (uses ParameterState)
```
The `CreateRegisterScope` that has `ComponentBaseWithState` points to the same instance of `IParameterRegistrationBuilderScope`.
So, when in this example `MudBaseInput` ends its scope in the constructor, it results that none of its descendants being able to call the `CreateRegisterScope` because base class has ended the scope and parameters were added to `ParameterSet`. It's not possible to add anything on top as the lazy read-only `FrozenSet` has been created at this point.

### Solution 1 (current one)
Add `CreateRegisterScope(ScopeOption.KeepUnlocked)` - that will instruct not to lock the parameters yet on scope end. Any descendant that calls parametless `CreateRegisterScope()` will completely lock and act as it did before.

**Advantages:**
Easy to implement.

**Disadvantages:**
Anyone who tries to inherit the "final" component, for example, `MudSlider`, and tries to use `ParameterState` for extended functionality will encounter the same problem. I'm not sure how legitimate this use case is. Do people inherit, or do they wrap the component? If they wrap, they wouldn't encounter the problem.

**NB!** For now, the `CreateRegisterScope(ScopeOption scopeOption)` and `ScopeOption` are **internal**. In case we want to merge Solution 1 but then to switch to Solution 2, it is intended for internal usage only.

**Q:** What if you don't set any component to final?
**A:** It will be finalized later anyway, for example, when any of the Blazor lifecycles are called. For the sake of optimization, the states are created when the scope ends (i.e., at the component creation aka ctor) and not during the lifecycles. However, if there is no one to finalize it, instead of getting locked in the constructor, it will be locked during the lifecycle.

### Solution 2 (https://github.com/MudBlazor/MudBlazor/pull/9033)
Allow people to create `CreateRegisterScope` as much as they want, but for each call of this function, it would create its own `IParameterRegistrationBuilderScope` and `ParameterSet`. `ComponentBaseWithState` would hold a list of `ParameterSet`, meaning the set of parameters would be isolated from each other.

**Advantages:**
Always works, no need for additional overloads with options, dummy free as no scope options provided.

**Disadvantages:**
Harder to implement.
What makes it especially hard to implement is the `SetParametersAsync` method. You can only call `base.SetParametersAsync` once. If there is a list of `ParameterSet`, it will be called multiple times. Even if you prevent this with some conditionals and boolean parameters, it will still break the logic of first checking if parameters have changed, then calling `base.SetParametersAsync`, and finally calling handlers for changed parameters. You need to come up how to unite everything, which means an overall code complexity. Check https://github.com/MudBlazor/MudBlazor/pull/9033
Also it would be possible to register same parameter multiple times in different scopes as they are isolated, but things wouldn't work as "expected" as handler would fire in first come - first served manner at the "union" level. However it will still throw exception if registered in same scope as it was previously.

## How Has This Been Tested?
New Unit test and manually
Also `MudDebouncedInput` is used as guinea pig

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
