### PR TITLE
MudColor: Add uint support.

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Binary;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -746,9 +747,23 @@ namespace MudBlazor.UnitTests.Utilities
         public void UInt32(uint rgba)
         {
             MudColor mudColor = new(rgba);
-            mudColor.Value.Should().BeEquivalentTo("#" + rgba.ToString("X8"));
+
+            mudColor.Value.Should().BeEquivalentTo($"#{rgba:X8}");
             ((uint)mudColor).Should().Be(rgba);
-            (mudColor.UInt32).Should().Be(rgba);
+            mudColor.UInt32.Should().Be(rgba);
+        }
+
+        [Test]
+        public void UInt32_CheckAgainstBinaryPrimitive()
+        {
+            const byte R = 255, G = 128, B = 64, A = 192;
+            var mudColor = new MudColor(R, G, B, A);
+            var expectedUint = BinaryPrimitives.ReadUInt32BigEndian([mudColor.R, mudColor.G, mudColor.B, mudColor.A]);
+
+            var actualUint = (uint)mudColor;
+
+            actualUint.Should().Be(expectedUint);
+            mudColor.UInt32.Should().Be(mudColor.UInt32);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -737,5 +737,25 @@ namespace MudBlazor.UnitTests.Utilities
 
             palette.Should().NotBeNull();
         }
+
+        [Test]
+        [TestCase(0x000000FFu)]//Black
+        [TestCase(0xFF0000FFu)]//Red
+        [TestCase(0x00FF00FFu)]//Green
+        [TestCase(0x0000FFFFu)]//Blue
+        public void UInt32(uint rgba)
+        {
+            MudColor mudColor = new(rgba);
+            mudColor.Value.Should().BeEquivalentTo("#" + rgba.ToString("X8"));
+            ((uint)mudColor).Should().Be(rgba);
+            (mudColor.UInt32).Should().Be(rgba);
+            mudColor = new()
+            {
+                UInt32 = rgba
+            };
+            mudColor.Value.Should().BeEquivalentTo("#" + rgba.ToString("X8"));
+            ((uint)mudColor).Should().Be(rgba);
+            (mudColor.UInt32).Should().Be(rgba);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -749,13 +749,6 @@ namespace MudBlazor.UnitTests.Utilities
             mudColor.Value.Should().BeEquivalentTo("#" + rgba.ToString("X8"));
             ((uint)mudColor).Should().Be(rgba);
             (mudColor.UInt32).Should().Be(rgba);
-            mudColor = new()
-            {
-                UInt32 = rgba
-            };
-            mudColor.Value.Should().BeEquivalentTo("#" + rgba.ToString("X8"));
-            ((uint)mudColor).Should().Be(rgba);
-            (mudColor.UInt32).Should().Be(rgba);
         }
     }
 }

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -47,9 +47,15 @@ namespace MudBlazor.Utilities
         private const double Epsilon = 0.000000000000001;
         private readonly byte[] _valuesAsByte;
 
+        /// <summary>
+        /// Gets the hexadecimal representation of the color.
+        /// </summary>
         [JsonIgnore]
         public string Value => $"#{R:x2}{G:x2}{B:x2}{A:x2}";
 
+        /// <summary>
+        /// Gets the 32-bit unsigned integer representation of the color.
+        /// </summary>
         [JsonIgnore]
         public uint UInt32 => (uint)(R << 24 | G << 16 | B << 8 | A);
 

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -53,8 +53,6 @@ namespace MudBlazor.Utilities
         [JsonIgnore]
         public uint UInt32 => (uint)(R << 24 | G << 16 | B << 8 | A);
 
-        public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
-
         /// <summary>
         /// Gets the red component value of the color.
         /// </summary>
@@ -230,7 +228,10 @@ namespace MudBlazor.Utilities
         /// Initializes a new instance of the <see cref="MudColor"/> class with the specified color.
         /// </summary>
         /// <param name="rgba">the four bytes of this 32-bit unsigned integer contain the red, green, blue and alpha components</param>
-        public MudColor(uint rgba) : this(r: (byte)(rgba >> 24), g: (byte)(rgba >> 16), b: (byte)(rgba >> 8), a: (byte)rgba) { }
+        public MudColor(uint rgba)
+            : this(r: (byte)(rgba >> 24), g: (byte)(rgba >> 16), b: (byte)(rgba >> 8), a: (byte)rgba)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MudColor"/> class with the specified red, green, blue, and alpha values, copying the hue value from the provided color.
@@ -548,6 +549,13 @@ namespace MudBlazor.Utilities
         /// <param name="color">The MudColor instance to convert.</param>
         /// <returns>The string representation of the color.</returns>
         public static explicit operator string(MudColor? color) => color == null ? string.Empty : color.Value;
+
+        /// <summary>
+        /// Converts a <see cref="MudColor"/> instance to a 32-bit unsigned integer.
+        /// </summary>
+        /// <param name="mudColor">The MudColor instance to convert.</param>
+        /// <returns>The 32-bit unsigned integer representation of the color.</returns>
+        public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
 
         private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -51,17 +51,7 @@ namespace MudBlazor.Utilities
         public string Value => $"#{R:x2}{G:x2}{B:x2}{A:x2}";
 
         [JsonIgnore]
-        public uint UInt32
-        {
-            get => (uint)(R << 24 | G << 16 | B << 8 | A);
-            set
-            {
-                _valuesAsByte[0] = (byte)(value >> 24);
-                _valuesAsByte[1] = (byte)(value >> 16);
-                _valuesAsByte[2] = (byte)(value >> 8);
-                _valuesAsByte[3] = (byte)value;
-            }
-        }
+        public uint UInt32 => (uint)(R << 24 | G << 16 | B << 8 | A);
 
         public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
 

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -50,6 +50,21 @@ namespace MudBlazor.Utilities
         [JsonIgnore]
         public string Value => $"#{R:x2}{G:x2}{B:x2}{A:x2}";
 
+        [JsonIgnore]
+        public uint UInt32
+        {
+            get => (uint)(R << 24 | G << 16 | B << 8 | A);
+            set
+            {
+                _valuesAsByte[0] = (byte)(value >> 24);
+                _valuesAsByte[1] = (byte)(value >> 16);
+                _valuesAsByte[2] = (byte)(value >> 8);
+                _valuesAsByte[3] = (byte)value;
+            }
+        }
+
+        public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
+
         /// <summary>
         /// Gets the red component value of the color.
         /// </summary>
@@ -220,6 +235,12 @@ namespace MudBlazor.Utilities
             S = s;
             L = l;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MudColor"/> class with the specified color.
+        /// </summary>
+        /// <param name="rgba">the four bytes of this 32-bit unsigned integer contain the red, green, blue and alpha components</param>
+        public MudColor(uint rgba) : this(r: (byte)(rgba >> 24), g: (byte)(rgba >> 16), b: (byte)(rgba >> 8), a: (byte)rgba) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MudColor"/> class with the specified red, green, blue, and alpha values, copying the hue value from the provided color.


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Sometimes you just want a number. Converting colors from a `string` is awkward, inefficient and unreliable since lowercase vs uppercase makes comparing strings for equality ambiguous. `uint` is preferable as it stores the four bytes for the four color components, compares for equality unambiguously and can be written in hex directly in the C# code. (`0x00FF00FFu` is green)

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
