### PR TITLE
Add providers interactivity alerts

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -13,7 +13,9 @@
                     <MudAlert Severity="Severity.Info">
                         <b>Note:</b> If you use custom types as values, make sure they override <CodeInline>Equals</CodeInline> and <CodeInline>GetHashCode</CodeInline> as well as <CodeInline>ToString</CodeInline>. See the example below.
                     </MudAlert>
-                    <br />
+                    <MudAlert Severity="Severity.Warning" Class="mt-2">
+                        <b>Note:</b> If you use .NET 8 Make sure you have added interactivity (<b>Auto|Server|WebAssembly</b>) to <CodeInline>MudThemeProvider</CodeInline>
+                    </MudAlert>
                     <br />
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -14,7 +14,7 @@
                         <b>Note:</b> If you use custom types as values, make sure they override <CodeInline>Equals</CodeInline> and <CodeInline>GetHashCode</CodeInline> as well as <CodeInline>ToString</CodeInline>. See the example below.
                     </MudAlert>
                     <MudAlert Severity="Severity.Warning" Class="mt-2">
-                        <b>Note:</b> If you use .NET 8 Make sure you have added interactivity (<b>Auto|Server|WebAssembly</b>) to <CodeInline>MudThemeProvider</CodeInline>
+                        <b>Note:</b> If you use .NET 8 Make sure you have added interactivity (<b>Auto|Server|WebAssembly</b>) to <CodeInline>MudPopoverProvider</CodeInline>
                     </MudAlert>
                     <br />
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -117,7 +117,9 @@
 
             </SectionSubGroups>
         </DocsPageSection>
-        
+        <MudAlert Severity="Severity.Info" Class="mt-2">
+            <b>Note:</b> If you use .NET 8 Make sure you have added interactivity (<b>Auto|Server|WebAssembly</b>) to the providers.
+        </MudAlert>
         <DocsPageSection>
             <SectionHeader Title="Ready for More?">
                 <Description>Now you know how to install MudBlazor, but a common pitfall is to jump straight into different components. We recommend that you read our Layout page to learn about basic project structure and different ways to use our main layout components.</Description>


### PR DESCRIPTION
Providers interactivity alerts have been added
## Description
After the updates that occurred in .NET 8, many people started to lose confidence in the library because it became non-interactive, especially when they read the documents and follow all the steps in them, and yet the elements are still work unexpectedly.
Especially MudSelect and auto-complete...etc

Therefore, the user must be alerted about adding interactivity to the Providers.
I added the alert to the Installation and MudSelect pages

## How Has This Been Tested?
No test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
