### PR TITLE
Progress: Improve accessibility

### DIFF
--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -1,7 +1,15 @@
 ﻿@namespace MudBlazor
+@using MudBlazor.Extensions
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@DivClassname" role="progressbar" style="@Style" aria-valuenow="@_valueState.Value">
+<div role="progressbar"
+     aria-valuenow="@_valueState.Value.ToInvariantString()"
+     aria-valuemin="@Min.ToInvariantString()"
+     aria-valuemax="@Max.ToInvariantString()"
+     aria-live="@((Indeterminate ? null : "polite"))"
+     class="@Classname"
+     style="@Style"
+     @attributes="UserAttributes">
     <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
         @if (Indeterminate)
         {
@@ -9,8 +17,7 @@
         }
         else
         {
-            <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @_magicNumber; stroke-dashoffset: @_svgValue;"></circle>
+            <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @MagicNumber; stroke-dashoffset: @_svgValue;"></circle>
         }
     </svg>
 </div>
-

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -10,9 +10,9 @@ namespace MudBlazor
     {
         private int _svgValue;
         private readonly ParameterState<double> _valueState;
-        private const int _magicNumber = 126; // weird, but required for the SVG to work
+        private const int MagicNumber = 126; // weird, but required for the SVG to work
 
-        protected string DivClassname =>
+        protected string Classname =>
             new CssBuilder("mud-progress-circular")
                 .AddClass($"mud-{Color.ToDescriptionString()}-text")
                 .AddClass($"mud-progress-{Size.ToDescriptionString()}")
@@ -91,7 +91,7 @@ namespace MudBlazor
             // calculate fraction, which is a value between 0 and 1
             var fraction = (minValue - Min) / (Max - Min);
             // now project into the range of the SVG value (126 .. 0)
-            return (int)Math.Round(_magicNumber - (_magicNumber * fraction));
+            return (int)Math.Round(MagicNumber - (MagicNumber * fraction));
         }
     }
 }

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor
@@ -2,7 +2,14 @@
 @using MudBlazor.Extensions
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@DivClassname" style="@Style" role="progressbar" aria-valuenow="@_valueState.Value.ToInvariantString()" aria-valuemin="@_minState.Value.ToInvariantString()" aria-valuemax="@_maxState.Value.ToInvariantString()">
+<div role="progressbar"
+     aria-valuenow="@_valueState.Value.ToInvariantString()"
+     aria-valuemin="@_minState.Value.ToInvariantString()"
+     aria-valuemax="@_maxState.Value.ToInvariantString()"
+     aria-live="@((Indeterminate ? null : "polite"))"
+     class="@Classname" 
+     style="@Style" 
+     @attributes="UserAttributes">
     <div class="mud-progress-linear-bars">
         @if (Indeterminate)
         {
@@ -20,7 +27,8 @@
             <div class="mud-progress-linear-bar" style="@GetStyledBar1Transform()"></div>
         }
     </div>
-    @if(ChildContent is not null)
+
+    @if (ChildContent is not null)
     {
         <div class="mud-progress-linear-content">
             @ChildContent

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
         private readonly ParameterState<double> _valueState;
         private readonly ParameterState<double> _bufferValueState;
 
-        protected string DivClassname =>
+        protected string Classname =>
             new CssBuilder("mud-progress-linear")
                 .AddClass("mud-progress-linear-rounded", Rounded)
                 .AddClass($"mud-progress-linear-striped", Striped)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- Format razor
- Use `aria-live=polite` to announce changes to the screen reader.
- Use `ToInvariantString` in Circular like Linear
- Apply user attributes at the end so they can override our defaults
- Adds aria min and max values for Circular
- `DivClassname` -> `Classname`
- `MagicNumber` fix naming violation

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
