### PR TITLE
MudLink, MudPagination, MudSnackbarElement: Improve accessibility

### DIFF
--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -17,17 +17,39 @@ namespace MudBlazor
                 // When Href is empty, link's hover cursor is text "I beam" even when OnClick has a delegate.
                 // To change this for more expected look change hover cursor to a pointer:
                 .AddClass("cursor-pointer", Href == default && OnClick.HasDelegate && !Disabled)
-                .AddClass($"mud-link-disabled", Disabled)
+                .AddClass("mud-link-disabled", Disabled)
                 .AddClass(Class)
                 .Build();
 
         private Dictionary<string, object?> Attributes
         {
-            get => Disabled ? UserAttributes : new Dictionary<string, object?>(UserAttributes)
+            get
             {
-                { "href", Href },
-                { "target", Target }
-            };
+                var attributes = new Dictionary<string, object?>();
+
+                if (Disabled)
+                {
+                    attributes["aria-disabled"] = "true";
+                }
+                else
+                {
+                    attributes["href"] = Href;
+                    attributes["target"] = Target;
+                }
+
+                if (OnClick.HasDelegate)
+                {
+                    attributes["role"] = "button";
+                }
+
+                // Apply user attributes last so they take precedence.
+                foreach (var attribute in UserAttributes)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+
+                return attributes;
+            }
         }
 
         /// <summary>
@@ -59,7 +81,8 @@ namespace MudBlazor
         public string? Href { get; set; }
 
         /// <summary>
-        /// The target attribute specifies where to open the link, if Href is specified. Possible values: _blank | _self | _parent | _top | <i>framename</i>
+        /// The target attribute specifies where to open the link, if Href is specified.
+        /// Possible values: _blank | _self | _parent | _top | <i>framename</i>
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Link.Behavior)]

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -1,18 +1,19 @@
 ﻿@namespace MudBlazor
-
+@using MudBlazor.Resources
 @inherits MudComponentBase
+@inject InternalMudLocalizer Localizer
 
 <MudElement HtmlTag="ul" Class="@Classname" Style="@Style" Tag="@Tag" UserAttributes="@UserAttributes">
     @if (ShowFirstButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.First))" aria-label="First page"></MudIconButton>
+            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.First))" aria-label="@Localizer[nameof(LanguageResource.MudPagination_FirstPage)]"></MudIconButton>
         </li>
     }
     @if (ShowPreviousButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.Previous))" aria-label="Previous page"></MudIconButton>
+            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(Selected == 1 || Disabled)" OnClick="@(() => OnClickControlButton(Page.Previous))" aria-label="@Localizer[nameof(LanguageResource.MudPagination_PreviousPage)]"></MudIconButton>
         </li>
     }
     @foreach (var state in GeneratePagination())
@@ -27,25 +28,26 @@
         else if (currentPage == Selected)
         {
             <li class="@SelectedItemClassname">
-                <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@Color" aria-current="page" aria-label="@($"Current page {currentPage}")">@currentPage</MudButton>
+                <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@Color" aria-current="page" aria-label="@Localizer[nameof(LanguageResource.MudPagination_CurrentPage), $"{currentPage}"]">@currentPage</MudButton>
             </li>
         }
-        else {
+        else
+        {
             <li class="@ItemClassname">
-                <MudButton OnClick="@(() => Selected = currentPage)" Variant="@Variant" Size="@Size" Ripple="false" Disabled="@Disabled" aria-label="@($"Page {currentPage}")">@currentPage</MudButton>
+                <MudButton OnClick="@(() => Selected = currentPage)" Variant="@Variant" Size="@Size" Ripple="false" Disabled="@Disabled" aria-label="@Localizer[nameof(LanguageResource.MudPagination_PageIndex), $"{currentPage}"]">@currentPage</MudButton>
             </li>
         }
     }
     @if (ShowNextButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Next))" aria-label="Next page"></MudIconButton>
+            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Next))" aria-label="@Localizer[nameof(LanguageResource.MudPagination_NextPage)]"></MudIconButton>
         </li>
     }
     @if (ShowLastButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Last))" aria-label="Last page"></MudIconButton>
+            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Last))" aria-label="@Localizer[nameof(LanguageResource.MudPagination_LastPage)]"></MudIconButton>
         </li>
     }
-</MudElement>
+    </MudElement>

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -50,4 +50,4 @@
             <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(Selected == Count || Disabled)" OnClick="@(() => OnClickControlButton(Page.Last))" aria-label="@Localizer[nameof(LanguageResource.MudPagination_LastPage)]"></MudIconButton>
         </li>
     }
-    </MudElement>
+</MudElement>

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -7,8 +7,18 @@
 @inherits MudComponentBase
 
 @Css
-<div @attributes="UserAttributes" class="@SnackbarClass" style="@AnimationStyle" @onclick="EventUtil.AsNonRenderingEventHandler(SnackbarClicked)"
-     @onpointerenter="InteractionStartHandler" @onpointerleave="InteractionEndHandler" @ontouchstart="InteractionStartHandler" @ontouchend="InteractionEndHandler" @ontouchcancel="InteractionEndHandler">
+<div role="alert"
+     aria-live="assertive"
+     class="@SnackbarClass"
+     style="@AnimationStyle"
+     @onclick="EventUtil.AsNonRenderingEventHandler(SnackbarClicked)"
+     @onpointerenter="InteractionStartHandler"
+     @onpointerleave="InteractionEndHandler"
+     @ontouchstart="InteractionStartHandler"
+     @ontouchend="InteractionEndHandler"
+     @ontouchcancel="InteractionEndHandler"
+     @attributes="UserAttributes">
+
     @if (!HideIcon)
     {
         <div class="mud-snackbar-icon">
@@ -26,10 +36,11 @@
     @if (ShowCloseIcon || ShowActionButton)
     {
         <div class="mud-snackbar-content-action">
-
             @if (ShowActionButton)
             {
-                <MudButton Class="mud-snackbar-action-button" Variant="@ActionVariant" Color="@ActionColor" OnClick="ActionClicked" DropShadow="false">@Action</MudButton>
+                <MudButton Class="mud-snackbar-action-button" Variant="@ActionVariant" Color="@ActionColor" OnClick="ActionClicked" DropShadow="false">
+                    @Action
+                </MudButton>
             }
 
             @if (ShowCloseIcon)

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -8,7 +8,7 @@
 
 @Css
 <div role="alert"
-     aria-live="assertive"
+     aria-live="polite"
      class="@SnackbarClass"
      style="@AnimationStyle"
      @onclick="EventUtil.AsNonRenderingEventHandler(SnackbarClicked)"

--- a/src/MudBlazor/Resources/LanguageResource.Designer.cs
+++ b/src/MudBlazor/Resources/LanguageResource.Designer.cs
@@ -763,6 +763,60 @@ namespace MudBlazor.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Current page {0}.
+        /// </summary>
+        public static string MudPagination_CurrentPage {
+            get {
+                return ResourceManager.GetString("MudPagination_CurrentPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to First page.
+        /// </summary>
+        public static string MudPagination_FirstPage {
+            get {
+                return ResourceManager.GetString("MudPagination_FirstPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Last page.
+        /// </summary>
+        public static string MudPagination_LastPage {
+            get {
+                return ResourceManager.GetString("MudPagination_LastPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Next page.
+        /// </summary>
+        public static string MudPagination_NextPage {
+            get {
+                return ResourceManager.GetString("MudPagination_NextPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Page {0}.
+        /// </summary>
+        public static string MudPagination_PageIndex {
+            get {
+                return ResourceManager.GetString("MudPagination_PageIndex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Previous page.
+        /// </summary>
+        public static string MudPagination_PreviousPage {
+            get {
+                return ResourceManager.GetString("MudPagination_PreviousPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select AM.
         /// </summary>
         public static string MudTimePicker_AmClick {

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -420,4 +420,22 @@
   <data name="MudBaseDatePicker_Close" xml:space="preserve">
     <value>Close Picker</value>
   </data>
+  <data name="MudPagination_CurrentPage" xml:space="preserve">
+    <value>Current page {0}</value>
+  </data>
+  <data name="MudPagination_FirstPage" xml:space="preserve">
+    <value>First page</value>
+  </data>
+  <data name="MudPagination_LastPage" xml:space="preserve">
+    <value>Last page</value>
+  </data>
+  <data name="MudPagination_NextPage" xml:space="preserve">
+    <value>Next page</value>
+  </data>
+  <data name="MudPagination_PageIndex" xml:space="preserve">
+    <value>Page {0}</value>
+  </data>
+  <data name="MudPagination_PreviousPage" xml:space="preserve">
+    <value>Previous page</value>
+  </data>
 </root>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

MudLink
- Add `aria-disabled=true` when Disabled
- Add `role=button` when OnClick has delegate
- Always apply user attributes last so they take precedence

MudPagination
- Use localizer for all aria labels
- Other accessibility concerns not addressed in this PR

MudSnackbarElement
- Add `role=alert`
- Add `aria-live=polite`
- Lightly format markup

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
