### PR TITLE
MudText: Revert removal of parameter Inline

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextInlineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextInlineExample.razor
@@ -1,0 +1,9 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudText>The text after here is: <MudText Inline="@_inline" Color="Color.Primary">@(_inline ? "inline." : "block.")</MudText></MudText>
+
+<MudSwitch @bind-Value="_inline" Color="Color.Primary" Label="Inline" />
+
+@code {
+    bool _inline;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
@@ -36,5 +36,16 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Inline">
+                <Description>
+                    This demonstrates the <CodeInline>@nameof(MudText.Inline)</CodeInline> property.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextInlineExample)" Block="true" FullWidth="true">
+                <TextInlineExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Typography/TextInlineTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Typography/TextInlineTest.razor
@@ -1,0 +1,9 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>The text after here is: <MudText Inline="@_inline" Color="Color.Primary">@(_inline ? "inline." : "block.")</MudText></MudText>
+
+@* <MudSwitch @bind-Value="_inline" Color="Color.Primary" Label="Inline" /> *@
+
+@code {
+    bool _inline = false;
+}

--- a/src/MudBlazor.UnitTests/Components/TypographyTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TypographyTests.cs
@@ -1,0 +1,27 @@
+﻿#pragma warning disable CS1998 // async without await
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class TypographyTests : BunitTest
+    {
+        [Test]
+        public void MudTextInlineTest()
+        {
+            var comp = Context.RenderComponent<TextInlineTest>();
+            comp.FindComponents<MudText>().Count.Should().Be(2);
+            comp.Markup.Should().NotContain("d-inline");
+            var secondText = comp.FindComponents<MudText>().Last();
+            secondText.SetParam("Inline", true);
+            comp.Markup.Should().Contain("d-inline");
+        }
+    }
+}

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -310,15 +310,6 @@ namespace MudBlazor
                             break;
                     }
                 }
-                else if (this is MudText)
-                {
-                    switch (parameter)
-                    {
-                        case "Inline":
-                            NotifyIllegalParameter(parameter);
-                            break;
-                    }
-                }
                 else if (MatchTypes(typeof(MudTable<>)))
                 {
                     switch (parameter)

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -12,6 +12,7 @@ public partial class MudText : MudComponentBase
             .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit)
             .AddClass("mud-typography-gutterbottom", GutterBottom)
             .AddClass($"mud-typography-align-{ConvertAlign(Align).ToDescriptionString()}", Align != Align.Inherit)
+            .AddClass("d-inline", Inline)
             .AddClass(Class)
             .Build();
 
@@ -54,6 +55,13 @@ public partial class MudText : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Text.Appearance)]
     public bool GutterBottom { get; set; }
+
+    /// <summary>
+    /// If true, text will continue after previous text instead of placing in a new line.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Text.Appearance)]
+    public bool Inline { get; set; }
 
     /// <summary>
     /// The child content to display.


### PR DESCRIPTION
## Description

This PR returns back `Inline` parameter for MudText which was removed in https://github.com/MudBlazor/MudBlazor/pull/8916. We decided that removing the parameter was unnecessary, having to remove it everywhere is too much work for no gains.

Added docs and test.


https://github.com/MudBlazor/MudBlazor/assets/78308169/8a797368-03e2-4d8f-9dae-0403a39b1d98



## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
