### PR TITLE
MudRating: Fix Color regression #5463

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -173,35 +173,36 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.FullIconColor, Color.Primary));
 
             // Select elements needed for the test
+            IRefreshableElementCollection<IElement> SvgColors() => comp.FindAll("svg.mud-icon-root");
             IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
 
             // Check initial state
-            RatingItemsSpans()[0].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[1].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[2].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[3].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[4].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[0].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[1].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[2].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[3].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[4].ClassName.Should().Contain("mud-tertiary-text");
 
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
             RatingItemsSpans()[0].Click();
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(1);
 
-            RatingItemsSpans()[0].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[1].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[2].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[3].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[4].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[0].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[1].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[2].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[3].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[4].ClassName.Should().Contain("mud-tertiary-text");
 
             RatingItemsSpans()[2].PointerOver();
             comp.Instance.HoveredValue.Should().Be(3);
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(1);
             comp.Instance.IsRatingHover.Should().Be(true);
 
-            RatingItemsSpans()[0].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[1].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[2].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[3].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[4].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[0].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[1].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[2].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[3].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[4].ClassName.Should().Contain("mud-tertiary-text");
             RatingItemsSpans()[2].ClassName.Should().Contain("mud-rating-item-active");
 
             RatingItemsSpans()[2].PointerOut();
@@ -212,11 +213,11 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(5);
             comp.Instance.IsRatingHover.Should().Be(true);
 
-            RatingItemsSpans()[0].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[1].ClassName.Should().Contain("mud-primary-text");
-            RatingItemsSpans()[2].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[3].ClassName.Should().Contain("mud-tertiary-text");
-            RatingItemsSpans()[4].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[0].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[1].ClassName.Should().Contain("mud-primary-text");
+            SvgColors()[2].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[3].ClassName.Should().Contain("mud-tertiary-text");
+            SvgColors()[4].ClassName.Should().Contain("mud-tertiary-text");
             RatingItemsSpans()[1].ClassName.Should().Contain("mud-rating-item-active");
 
             RatingItemsSpans()[1].PointerOut();

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -73,14 +73,14 @@ namespace MudBlazor
         public string EmptyIcon { get; set; } = Icons.Material.Filled.StarBorder;
 
         /// <summary>
-        /// Selected or hovered icon color. Default @Color.Default.
+        /// Selected or hovered icon color.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Rating.Appearance)]
         public Color? FullIconColor { get; set; }
 
         /// <summary>
-        /// Non-selected item icon color. Default @Color.Dark.
+        /// Non-selected item icon color.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Rating.Appearance)]

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor
@@ -8,7 +8,7 @@
           class="@ClassName"
           style="@Style">
 
-        <MudIcon Icon="@ItemIcon" Color="@Color" Size="@Size" />
+        <MudIcon Icon="@ItemIcon" Color="@ItemColor" Size="@Size" />
     </span>
 }
 else
@@ -29,6 +29,6 @@ else
                checked="@Checked"
                @attributes="UserAttributes" />
 
-        <MudIcon Icon="@ItemIcon" Color="@Color" Size="@Size" />
+        <MudIcon Icon="@ItemIcon" Color="@ItemColor" Size="@Size" />
     </span>
 }

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -78,6 +78,8 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<int?> ItemHovered { get; set; }
 
+        internal Color ItemColor { get; set; }
+
         internal string? ItemIcon { get; set; }
 
         internal bool Active { get; set; }
@@ -88,7 +90,7 @@ namespace MudBlazor
         {
             base.OnParametersSet();
             ItemIcon = SelectIcon();
-            Color = SelectIconColor();
+            ItemColor = SelectIconColor();
         }
 
         internal string? SelectIcon()
@@ -125,12 +127,12 @@ namespace MudBlazor
         {
             if (Rating is null)
             {
-                return Color.Default;
+                return Color.Inherit;
             }
 
             if (Rating.FullIconColor is null || Rating.EmptyIconColor is null)
             {
-                return Rating.Color;
+                return Color.Inherit;
             }
 
             if (Rating.HoveredValue.HasValue && Rating.HoveredValue.Value >= ItemValue)


### PR DESCRIPTION
## Description
Regression was done here: https://github.com/MudBlazor/MudBlazor/pull/5463
Fix: https://github.com/MudBlazor/MudBlazor/issues/9062

First of all, it should not modify the external parameter `Color`.
Second, we should only fill the SVG colors and not change the class `mud-{Color.ToDescriptionString()}-text`.
Third, we should use `Color.Inherit` as it is the default for `MudIcon`.

## How Has This Been Tested?
Visual, adjusted test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
