### PR TITLE
Docs: Remove alias Hiliter for Highlighter

### DIFF
--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -112,7 +112,6 @@ namespace MudBlazor.Docs.Services
             RegisterPage("Expander", subtitle: "Go to Collapse", componentType: typeof(MudCollapse));
             RegisterPage("Harmonica", subtitle: "Go to Expansion Panels", componentType: typeof(MudExpansionPanels));
             RegisterPage("Horizontal Line", subtitle: "Go to Divider", componentType: typeof(MudDivider));
-            RegisterPage("Highlighter", subtitle: "Go to Highlighter", componentType: typeof(MudHighlighter));
             RegisterPage("Notification", subtitle: "Go to Snackbar", componentType: typeof(MudSnackbarProvider));
             RegisterPage("Popup", subtitle: "Go to Popover", componentType: typeof(MudPopover));
             RegisterPage("Side Panel", subtitle: "Go to Drawer", componentType: typeof(MudDrawer));

--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -112,7 +112,7 @@ namespace MudBlazor.Docs.Services
             RegisterPage("Expander", subtitle: "Go to Collapse", componentType: typeof(MudCollapse));
             RegisterPage("Harmonica", subtitle: "Go to Expansion Panels", componentType: typeof(MudExpansionPanels));
             RegisterPage("Horizontal Line", subtitle: "Go to Divider", componentType: typeof(MudDivider));
-            RegisterPage("Hiliter", subtitle: "Go to Highlighter", componentType: typeof(MudHighlighter));
+            RegisterPage("Highlighter", subtitle: "Go to Highlighter", componentType: typeof(MudHighlighter));
             RegisterPage("Notification", subtitle: "Go to Snackbar", componentType: typeof(MudSnackbarProvider));
             RegisterPage("Popup", subtitle: "Go to Popover", componentType: typeof(MudPopover));
             RegisterPage("Side Panel", subtitle: "Go to Drawer", componentType: typeof(MudDrawer));


### PR DESCRIPTION
## Description
Simple misspelling in MudBlazor\src\MudBlazor.Docs\Services\ApiLink\ApiLinkService.cs
in RegisterAliases() the string was saying "Hiliter" this is now changed to "Highlighter"

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/MudBlazor/MudBlazor/assets/48321388/5a3b69e5-cbce-4045-b26a-3733fbcd435e)
![image](https://github.com/MudBlazor/MudBlazor/assets/48321388/0a342191-2460-4051-b0b4-5d3cd92c66aa)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
