### PR TITLE
MudFocusTrap: Don't hide focusable elements from accessibility tree

### DIFF
--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor
@@ -12,15 +12,13 @@
 
     <div class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"
-         @onfocus="OnTopFocusAsync"
-         aria-hidden="true">
+         @onfocus="OnTopFocusAsync">
     </div>
 
     <div @ref="_firstBumper"
          class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"
-         @onfocus="OnBumperFocusAsync"
-         aria-hidden="true">
+         @onfocus="OnBumperFocusAsync">
     </div>
 
     <div @ref="_fallback"
@@ -37,14 +35,11 @@
     <div @ref="_lastBumper"
          class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"
-         @onfocus="OnBumperFocusAsync"
-         aria-hidden="true">
+         @onfocus="OnBumperFocusAsync">
     </div>
 
     <div class="fixed pointer-events-none"
          tabindex="@TrapTabIndex"
-         @onfocus="OnBottomFocusAsync"
-         aria-hidden="true">
+         @onfocus="OnBottomFocusAsync">
     </div>
-
 </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Reverts parts of #9007

> The problem is: Removing a focusable element like a link from the accessibility tree does not remove it from tab order. A screen reader user tabbing through the website will arrive at the link and hear “empty” or something similar. Please, don't do this!

Going to err on the side of caution because it's easy to make accessibility worse unintentionally.

https://oidaisdes.org/common-aria-mistakes.en/

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
