### PR TITLE
Docs: Link to the related pull request on Release page

### DIFF
--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -60,7 +60,7 @@
         value = Regex.Replace(value, @"((##\s)(?<title>.+))(?<items>.*(?:\r?\n[*] .*)*)", "<h5 class=\"mud-typography mud-typography-h5\">${title}</h5><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
         value = Regex.Replace(value, @"(([*]\s)(?<row>.+))", "<li>${row}</li>");
         value = Regex.Replace(value, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"mud-link mud-default-text mud-link-underline-hover\"><b>@$2</b></a>");
-        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
+        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
         value = Regex.Replace(value, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<p class=\"mud-typography mud-typography-body1\">Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a></p>");
         return value;
     }


### PR DESCRIPTION
While reading through some of the docs pages, I stumbled upon the release page and wanted to checkout the changes. This PR just makes sure that the pull request tags opens the related PR.

## Description
Link to the related PR on Release page

## How Has This Been Tested?
Visually and manually (Was unable to find any related tests)

## Type of Changes
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
