### PR TITLE
Datagrid: Add NumberFormat and NumberCulture to AggregateDefinition (#9112)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
@@ -286,6 +286,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void AggregateDefinition_NumberFormat_Test()
+        {
+            Expression<Func<AccountingNullableModel, decimal?>> propertyExpression = model => model.Salary;
+
+            var aggregateDefinitionAverage = AggregateDefinition<AccountingNullableModel>.SimpleAvg("C", CultureInfo.CurrentUICulture);
+            var aggregateDefinitionMin = AggregateDefinition<AccountingNullableModel>.SimpleMin("F", new CultureInfo("en-US"));
+            var aggregateDefinitionMax = AggregateDefinition<AccountingNullableModel>.SimpleMax("P", new CultureInfo("zh-CN"));
+            var aggregateDefinitionCount = AggregateDefinition<AccountingNullableModel>.SimpleCount("N", CultureInfo.InvariantCulture);
+            var aggregateDefinitionSum = AggregateDefinition<AccountingNullableModel>.SimpleSum("000000:00.00", new CultureInfo("da-DK"));
+
+            var valueAverage = aggregateDefinitionAverage.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMin = aggregateDefinitionMin.GetValue(propertyExpression, _accountingNullableModels);
+            var valueMax = aggregateDefinitionMax.GetValue(propertyExpression, _accountingNullableModels);
+            var valueCount = aggregateDefinitionCount.GetValue(propertyExpression, _accountingNullableModels);
+            var valueSum = aggregateDefinitionSum.GetValue(propertyExpression, _accountingNullableModels);
+
+            var expectedAverage = _accountingNullableModels.Select(x => x.Salary).Average();
+            var expectedMin = _accountingNullableModels.Select(x => x.Salary).Min();
+            var expectedMax = _accountingNullableModels.Select(x => x.Salary).Max();
+            var expectedCount = _accountingNullableModels.Select(x => x.Salary).Count();
+            var expectedSum = _accountingNullableModels.Select(x => x.Salary).Sum();
+
+            valueAverage.Should().Be($"Average {expectedAverage!.Value.ToString("C", CultureInfo.CurrentUICulture)}");
+            valueMin.Should().Be($"Min {expectedMin!.Value.ToString("F", new CultureInfo("en-US"))}");
+            valueMax.Should().Be($"Max {expectedMax!.Value.ToString("P", new CultureInfo("zh-CN"))}");
+            valueCount.Should().Be($"Total {expectedCount.ToString("N", CultureInfo.InvariantCulture)}");
+            valueSum.Should().Be($"Sum {expectedSum!.Value.ToString("000000:00.00", new CultureInfo("da-DK"))}");
+        }
+
+        [Test]
         public void AggregateDefinition_Custom_Test()
         {
             var aggregateDefinitionAverage = new AggregateDefinition<AccountingModel>

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using MudBlazor.Utilities.Expressions;
@@ -27,6 +28,8 @@ namespace MudBlazor
         /// Defaults to <see cref="AggregateType.Count"/>.  When <see cref="AggregateType.Custom"/>, the function defined in <see cref="CustomAggregate"/> is used.
         /// </remarks>
         public AggregateType Type { get; set; } = AggregateType.Count;
+        public string? NumberFormat { get; set; } = null;
+        public IFormatProvider? NumberFormatProvider { get; set; } = default;
 
         /// <summary>
         /// The format used to display aggregate values.
@@ -73,7 +76,7 @@ namespace MudBlazor
             if (Type == AggregateType.Count)
             {
                 var value = itemsArray.Length;
-                return DisplayFormat.Replace("{value}", value.ToString());
+                return DisplayFormat.Replace("{value}", value.ToString(NumberFormat, NumberFormatProvider));
             }
 
             var expression = propertyExpression.ChangeExpressionReturnType<T, decimal?>();
@@ -82,25 +85,25 @@ namespace MudBlazor
             if (Type == AggregateType.Avg)
             {
                 var value = itemsArray.Average(compiledExpression);
-                return DisplayFormat.Replace("{value}", value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
             }
 
             if (Type == AggregateType.Max)
             {
                 var value = itemsArray.Max(compiledExpression);
-                return DisplayFormat.Replace("{value}", value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
             }
 
             if (Type == AggregateType.Min)
             {
                 var value = itemsArray.Min(compiledExpression);
-                return DisplayFormat.Replace("{value}", value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
             }
 
             if (Type == AggregateType.Sum)
             {
                 var value = itemsArray.Sum(compiledExpression);
-                return DisplayFormat.Replace("{value}", value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
             }
 
             return DisplayFormat.Replace("{value}", "0");
@@ -122,6 +125,25 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Represents a basic average aggregate calculation with custom format.
+        /// </summary>
+        /// <param name="numberFormat">A numeric format string.</param>
+        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>
+        /// <returns>
+        /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Avg"/> and a <see cref="DisplayFormat"/> of <c>Average {value}</c>.
+        /// </returns>
+        public static AggregateDefinition<T> SimpleAvg(string numberFormat, CultureInfo numberFormatProvider)
+        {
+            return new AggregateDefinition<T>
+            {
+                Type = AggregateType.Avg,
+                DisplayFormat = "Average {value}",
+                NumberFormat = numberFormat,
+                NumberFormatProvider = numberFormatProvider
+            };
+        }
+
+        /// <summary>
         /// Represents a basic count aggregate calculation.
         /// </summary>
         /// <returns>
@@ -133,6 +155,25 @@ namespace MudBlazor
             {
                 Type = AggregateType.Count,
                 DisplayFormat = "Total {value}"
+            };
+        }
+
+        /// <summary>
+        /// Represents a basic count aggregate calculation with custom format.
+        /// </summary>
+        /// <param name="numberFormat">A numeric format string.</param>
+        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// 
+        /// <returns>
+        /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Count"/> and a <see cref="DisplayFormat"/> of <c>Total {value}</c>.
+        /// </returns>
+        public static AggregateDefinition<T> SimpleCount(string numberFormat, CultureInfo numberFormatProvider)
+        {
+            return new AggregateDefinition<T>
+            {
+                Type = AggregateType.Count,
+                DisplayFormat = "Total {value}",
+                NumberFormat = numberFormat,
+                NumberFormatProvider = numberFormatProvider
             };
         }
 
@@ -152,6 +193,25 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Represents a basic maximum aggregate calculation with custom format.
+        /// </summary>
+        /// <returns>
+        /// <param name="numberFormat">A numeric format string.</param>
+        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Max"/> and a <see cref="DisplayFormat"/> of <c>Max {value}</c>.
+        /// </returns>
+        public static AggregateDefinition<T> SimpleMax(string numberFormat, CultureInfo numberFormatProvider)
+        {
+            return new AggregateDefinition<T>
+            {
+                Type = AggregateType.Max,
+                DisplayFormat = "Max {value}",
+                NumberFormat = numberFormat,
+                NumberFormatProvider = numberFormatProvider
+            };
+        }
+
+        /// <summary>
         /// Represents a basic minimum aggregate calculation.
         /// </summary>
         /// <returns>
@@ -167,6 +227,25 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Represents a basic minimum aggregate calculation with custom format.
+        /// </summary>
+        /// <returns>
+        /// <param name="numberFormat">A numeric format string.</param>
+        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Min"/> and a <see cref="DisplayFormat"/> of <c>Min {value}</c>.
+        /// </returns>
+        public static AggregateDefinition<T> SimpleMin(string numberFormat, CultureInfo numberFormatProvider)
+        {
+            return new AggregateDefinition<T>
+            {
+                Type = AggregateType.Min,
+                DisplayFormat = "Min {value}",
+                NumberFormat = numberFormat,
+                NumberFormatProvider = numberFormatProvider
+            };
+        }
+
+        /// <summary>
         /// Represents a basic sum aggregate calculation.
         /// </summary>
         /// <returns>
@@ -178,6 +257,25 @@ namespace MudBlazor
             {
                 Type = AggregateType.Sum,
                 DisplayFormat = "Sum {value}"
+            };
+        }
+
+        /// <summary>
+        /// Represents a basic sum aggregate calculation with custom format.
+        /// </summary>
+        /// <returns>
+        /// <param name="numberFormat">A numeric format string.</param>
+        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// /// 
+        /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Sum"/> and a <see cref="DisplayFormat"/> of <c>Sum {value}</c>.
+        /// </returns>
+        public static AggregateDefinition<T> SimpleSum(string numberFormat, CultureInfo numberFormatProvider)
+        {
+            return new AggregateDefinition<T>
+            {
+                Type = AggregateType.Sum,
+                DisplayFormat = "Sum {value}",
+                NumberFormat = numberFormat,
+                NumberFormatProvider = numberFormatProvider
             };
         }
 

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -28,11 +28,25 @@ namespace MudBlazor
         /// Defaults to <see cref="AggregateType.Count"/>.  When <see cref="AggregateType.Custom"/>, the function defined in <see cref="CustomAggregate"/> is used.
         /// </remarks>
         public AggregateType Type { get; set; } = AggregateType.Count;
+
+        /// <summary>
+        /// A numeric format string.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to null.
+        /// </remarks>
         public string? NumberFormat { get; set; } = null;
+
+        /// <summary>
+        /// An object that supplies culture-specific formatting information.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to standard IFormatprovider.
+        /// </remarks>
         public IFormatProvider? NumberFormatProvider { get; set; } = default;
 
         /// <summary>
-        /// The format used to display aggregate values.
+        /// The format used to display aggregate values with prepended or appended text.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>{value}</c>.

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to null.
         /// </remarks>
-        public CultureInfo? NumberCulture { get; set; }
+        public CultureInfo? Culture { get; set; }
 
         /// <summary>
         /// The format used to display aggregate values with prepended or appended text.
@@ -90,7 +90,7 @@ namespace MudBlazor
             if (Type == AggregateType.Count)
             {
                 var value = itemsArray.Length;
-                return DisplayFormat.Replace("{value}", value.ToString(NumberFormat, NumberCulture));
+                return DisplayFormat.Replace("{value}", value.ToString(NumberFormat, Culture));
             }
 
             var expression = propertyExpression.ChangeExpressionReturnType<T, decimal?>();
@@ -99,25 +99,25 @@ namespace MudBlazor
             if (Type == AggregateType.Avg)
             {
                 var value = itemsArray.Average(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, Culture) : value.ToString());
             }
 
             if (Type == AggregateType.Max)
             {
                 var value = itemsArray.Max(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, Culture) : value.ToString());
             }
 
             if (Type == AggregateType.Min)
             {
                 var value = itemsArray.Min(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, Culture) : value.ToString());
             }
 
             if (Type == AggregateType.Sum)
             {
                 var value = itemsArray.Sum(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, Culture) : value.ToString());
             }
 
             return DisplayFormat.Replace("{value}", "0");
@@ -142,18 +142,18 @@ namespace MudBlazor
         /// Represents a basic average aggregate calculation with custom format.
         /// </summary>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>
+        /// <param name="culture">An object that supplies culture-specific formatting information.</param>
         /// <returns>
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Avg"/> and a <see cref="DisplayFormat"/> of <c>Average {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleAvg(string? numberFormat, CultureInfo? numberCulture = null)
+        public static AggregateDefinition<T> SimpleAvg(string? numberFormat, CultureInfo? culture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Avg,
                 DisplayFormat = "Average {value}",
                 NumberFormat = numberFormat,
-                NumberCulture = numberCulture
+                Culture = culture
             };
         }
 
@@ -176,18 +176,18 @@ namespace MudBlazor
         /// Represents a basic count aggregate calculation with custom format.
         /// </summary>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// 
+        /// <param name="culture">An object that supplies culture-specific formatting information.</param>/// 
         /// <returns>
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Count"/> and a <see cref="DisplayFormat"/> of <c>Total {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleCount(string? numberFormat, CultureInfo? numberCulture = null)
+        public static AggregateDefinition<T> SimpleCount(string? numberFormat, CultureInfo? culture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Count,
                 DisplayFormat = "Total {value}",
                 NumberFormat = numberFormat,
-                NumberCulture = numberCulture
+                Culture = culture
             };
         }
 
@@ -211,17 +211,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// <param name="culture">An object that supplies culture-specific formatting information.</param>/// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Max"/> and a <see cref="DisplayFormat"/> of <c>Max {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleMax(string? numberFormat, CultureInfo? numberCulture = null)
+        public static AggregateDefinition<T> SimpleMax(string? numberFormat, CultureInfo? culture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Max,
                 DisplayFormat = "Max {value}",
                 NumberFormat = numberFormat,
-                NumberCulture = numberCulture
+                Culture = culture
             };
         }
 
@@ -245,17 +245,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// <param name="culture">An object that supplies culture-specific formatting information.</param>/// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Min"/> and a <see cref="DisplayFormat"/> of <c>Min {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleMin(string? numberFormat, CultureInfo? numberCulture = null)
+        public static AggregateDefinition<T> SimpleMin(string? numberFormat, CultureInfo? culture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Min,
                 DisplayFormat = "Min {value}",
                 NumberFormat = numberFormat,
-                NumberCulture = numberCulture
+                Culture = culture
             };
         }
 
@@ -279,17 +279,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// /// 
+        /// <param name="culture">An object that supplies culture-specific formatting information.</param>/// /// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Sum"/> and a <see cref="DisplayFormat"/> of <c>Sum {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleSum(string? numberFormat, CultureInfo? numberCulture = null)
+        public static AggregateDefinition<T> SimpleSum(string? numberFormat, CultureInfo? culture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Sum,
                 DisplayFormat = "Sum {value}",
                 NumberFormat = numberFormat,
-                NumberCulture = numberCulture
+                Culture = culture
             };
         }
 

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -35,15 +35,15 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to null.
         /// </remarks>
-        public string? NumberFormat { get; set; } = null;
+        public string? NumberFormat { get; set; }
 
         /// <summary>
         /// An object that supplies culture-specific formatting information.
         /// </summary>
         /// <remarks>
-        /// Defaults to standard IFormatprovider.
+        /// Defaults to null.
         /// </remarks>
-        public IFormatProvider? NumberFormatProvider { get; set; } = default;
+        public CultureInfo? NumberCulture { get; set; }
 
         /// <summary>
         /// The format used to display aggregate values with prepended or appended text.
@@ -90,7 +90,7 @@ namespace MudBlazor
             if (Type == AggregateType.Count)
             {
                 var value = itemsArray.Length;
-                return DisplayFormat.Replace("{value}", value.ToString(NumberFormat, NumberFormatProvider));
+                return DisplayFormat.Replace("{value}", value.ToString(NumberFormat, NumberCulture));
             }
 
             var expression = propertyExpression.ChangeExpressionReturnType<T, decimal?>();
@@ -99,25 +99,25 @@ namespace MudBlazor
             if (Type == AggregateType.Avg)
             {
                 var value = itemsArray.Average(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
             }
 
             if (Type == AggregateType.Max)
             {
                 var value = itemsArray.Max(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
             }
 
             if (Type == AggregateType.Min)
             {
                 var value = itemsArray.Min(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
             }
 
             if (Type == AggregateType.Sum)
             {
                 var value = itemsArray.Sum(compiledExpression);
-                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberFormatProvider) : value.ToString());
+                return DisplayFormat.Replace("{value}", value != null ? value.Value.ToString(NumberFormat, NumberCulture) : value.ToString());
             }
 
             return DisplayFormat.Replace("{value}", "0");
@@ -142,18 +142,18 @@ namespace MudBlazor
         /// Represents a basic average aggregate calculation with custom format.
         /// </summary>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>
         /// <returns>
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Avg"/> and a <see cref="DisplayFormat"/> of <c>Average {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleAvg(string numberFormat, CultureInfo numberFormatProvider)
+        public static AggregateDefinition<T> SimpleAvg(string? numberFormat, CultureInfo? numberCulture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Avg,
                 DisplayFormat = "Average {value}",
                 NumberFormat = numberFormat,
-                NumberFormatProvider = numberFormatProvider
+                NumberCulture = numberCulture
             };
         }
 
@@ -176,18 +176,18 @@ namespace MudBlazor
         /// Represents a basic count aggregate calculation with custom format.
         /// </summary>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// 
+        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// 
         /// <returns>
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Count"/> and a <see cref="DisplayFormat"/> of <c>Total {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleCount(string numberFormat, CultureInfo numberFormatProvider)
+        public static AggregateDefinition<T> SimpleCount(string? numberFormat, CultureInfo? numberCulture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Count,
                 DisplayFormat = "Total {value}",
                 NumberFormat = numberFormat,
-                NumberFormatProvider = numberFormatProvider
+                NumberCulture = numberCulture
             };
         }
 
@@ -211,17 +211,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Max"/> and a <see cref="DisplayFormat"/> of <c>Max {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleMax(string numberFormat, CultureInfo numberFormatProvider)
+        public static AggregateDefinition<T> SimpleMax(string? numberFormat, CultureInfo? numberCulture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Max,
                 DisplayFormat = "Max {value}",
                 NumberFormat = numberFormat,
-                NumberFormatProvider = numberFormatProvider
+                NumberCulture = numberCulture
             };
         }
 
@@ -245,17 +245,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// 
+        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Min"/> and a <see cref="DisplayFormat"/> of <c>Min {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleMin(string numberFormat, CultureInfo numberFormatProvider)
+        public static AggregateDefinition<T> SimpleMin(string? numberFormat, CultureInfo? numberCulture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Min,
                 DisplayFormat = "Min {value}",
                 NumberFormat = numberFormat,
-                NumberFormatProvider = numberFormatProvider
+                NumberCulture = numberCulture
             };
         }
 
@@ -279,17 +279,17 @@ namespace MudBlazor
         /// </summary>
         /// <returns>
         /// <param name="numberFormat">A numeric format string.</param>
-        /// <param name="numberFormatProvider">An object that supplies culture-specific formatting information.</param>/// /// /// 
+        /// <param name="numberCulture">An object that supplies culture-specific formatting information.</param>/// /// /// 
         /// An aggregate definition with a <see cref="Type"/> of <see cref="AggregateType.Sum"/> and a <see cref="DisplayFormat"/> of <c>Sum {value}</c>.
         /// </returns>
-        public static AggregateDefinition<T> SimpleSum(string numberFormat, CultureInfo numberFormatProvider)
+        public static AggregateDefinition<T> SimpleSum(string? numberFormat, CultureInfo? numberCulture = null)
         {
             return new AggregateDefinition<T>
             {
                 Type = AggregateType.Sum,
                 DisplayFormat = "Sum {value}",
                 NumberFormat = numberFormat,
-                NumberFormatProvider = numberFormatProvider
+                NumberCulture = numberCulture
             };
         }
 


### PR DESCRIPTION
## Description
Fixes: #9112
The `AggregateDefinition` for `PropertyColumn` in the datagrid lacks the possibility to format the numbers like rounding or culturespecific rules.

The codechanges of this pullrequest add additional parameters :
numberFormat: A numeric format string.
numberFormatProvider: An object that supplies culture-specific formatting information.

The aggregates are formatted accordingly.

## How Has This Been Tested?
There is a new unittest in AggregateDefinitionTests -> AggregateDefinition_NumberFormat_Test
Visual tests have been done too


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
