### PR TITLE
BrowserViewportService: Allow ReportRate of 0 to disable debounce

### DIFF
--- a/src/MudBlazor/Services/Browser/ResizeOptions.cs
+++ b/src/MudBlazor/Services/Browser/ResizeOptions.cs
@@ -14,6 +14,9 @@ namespace MudBlazor.Services
         /// Setting this value too low can cause poor application performance.
         /// Default value is <c>100</c>.
         /// </summary>
+        /// <remarks>
+        /// If set to <c>0</c>, the resize event will report instantaneously.
+        /// </remarks>
         public int ReportRate { get; set; } = 100;
 
         /// <summary>

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -23,7 +23,7 @@ class MudResizeListener {
         this.options = options;
         this.dotnet = dotnetRef;
         this.logger = options.enableLogging ? console.log : (message) => { };
-        this.logger(`[MudBlazor] Reporting resize events at rate of: ${(this.options || {}).reportRate || 100}ms`);
+        this.logger(`[MudBlazor] Reporting resize events at rate of: ${this.options.reportRate}ms`);
         window.addEventListener("resize", this.handleResize, false);
         if (!this.options.suppressInitEvent) {
             this.resizeHandler();
@@ -33,7 +33,10 @@ class MudResizeListener {
 
     throttleResizeHandler() {
         clearTimeout(this.throttleResizeHandlerId);
-        this.throttleResizeHandlerId = window.setTimeout(this.resizeHandler.bind(this), ((this.options || {}).reportRate || 100));
+        this.throttleResizeHandlerId = window.setTimeout(
+            this.resizeHandler.bind(this),
+            this.options.reportRate
+        );
     }
 
     resizeHandler() {


### PR DESCRIPTION
## Description
Someone expressed a desire to have an instantaneous report, but due to this line:
```
((this.options || {}).reportRate || 100)
```
the JavaScript will fallback to 100 when `reportRate` is 0.

I assume this was intended as a kind of null protection, but `BrowserViewportService` always sends options. Any third-party usage is at their own risk, and we shouldn't be concerned about it.

**NB!** The name `throttle` in JS side is incorrect, it's debounce, but I guess I'm not going to rename that for now.

## How Has This Been Tested?
Manually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
