### PR TITLE
MudDialog: Add nullable annotation

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
@@ -7,6 +7,7 @@
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
         <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+        <MudButton Color="Color.Secondary" OnClick="CloseDefault">Ok Default</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -15,5 +16,6 @@
     public MudDialogInstance MudDialog { get; set; }
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    private void CloseDefault() => MudDialog.Close();
     private void Cancel() => MudDialog.Cancel();
 }

--- a/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
@@ -21,7 +21,7 @@ public sealed class DialogParametersTests
         dialogParameters._parameters.Should().BeEmpty();
 
         dialogParameters.Add(x => x.TestValue, "Test");
-        dialogParameters._parameters.Should().Contain(new KeyValuePair<string, object>("TestValue", "Test"));
+        dialogParameters._parameters.Should().Contain(new KeyValuePair<string, object?>("TestValue", "Test"));
     }
 
     [Test]
@@ -31,7 +31,7 @@ public sealed class DialogParametersTests
         dialogParameters._parameters.Should().BeEmpty();
 
         dialogParameters.Add("TestValue", "Test");
-        dialogParameters._parameters.Should().Contain(new KeyValuePair<string, object>("TestValue", "Test"));
+        dialogParameters._parameters.Should().Contain(new KeyValuePair<string, object?>("TestValue", "Test"));
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -80,6 +80,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.DismissAll());
             cont = comp.FindAll("div.mud-dialog-container");
             cont.Count.Should().Be(0);
+
+            // Close by using default close method
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>());
+            comp.FindAll("button")[2].Click();
+            result = await dialogReference.Result;
+            result.Data.Should().BeNull();
+            result.DataType.Should().BeNull();
+            result.Canceled.Should().BeFalse();
         }
 
         /// <summary>
@@ -895,6 +903,251 @@ namespace MudBlazor.UnitTests.Components
 
             var textField = comp.FindComponent<MudInput<string>>().Instance;
             textField.Text.Should().Be("test");
+        }
+
+        [Test]
+        public async Task ShowGeneric_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.Show<DialogOkCancel>("Custom title"));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Markup.Should().Contain("Custom title");
+            dialogInstance.Instance.Options.Position.Should().BeNull();
+            dialogInstance.Instance.Options.MaxWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackdropClick.Should().BeNull();
+            dialogInstance.Instance.Options.CloseOnEscapeKey.Should().BeNull();
+            dialogInstance.Instance.Options.NoHeader.Should().BeNull();
+            dialogInstance.Instance.Options.CloseButton.Should().BeNull();
+            dialogInstance.Instance.Options.FullWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackgroundClass.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ShowGeneric_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.Show<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Instance.Options.CloseButton.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Show_ShouldRenderComponent()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel)));
+
+            // Assert
+            provider.FindComponents<DialogOkCancel>().Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task Show_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel), "Custom title"));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Markup.Should().Contain("Custom title");
+            dialogInstance.Instance.Options.Position.Should().BeNull();
+            dialogInstance.Instance.Options.MaxWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackdropClick.Should().BeNull();
+            dialogInstance.Instance.Options.CloseOnEscapeKey.Should().BeNull();
+            dialogInstance.Instance.Options.NoHeader.Should().BeNull();
+            dialogInstance.Instance.Options.CloseButton.Should().BeNull();
+            dialogInstance.Instance.Options.FullWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackgroundClass.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Show_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel), "Custom title", new DialogOptions { CloseButton = true }));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Instance.Options.CloseButton.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Show_ShouldPassDialogParametersToDialog()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() =>
+                service.Show(typeof(DialogWithActionsClass), "Custom title", new DialogParameters<DialogWithActionsClass> { { x => x.ActionsClass, "custom-class" } }));
+
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.FindAll(".custom-class").Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task ShowGenericAsync_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.ShowAsync<DialogOkCancel>("Custom title"));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Markup.Should().Contain("Custom title");
+            dialogInstance.Instance.Options.Position.Should().BeNull();
+            dialogInstance.Instance.Options.MaxWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackdropClick.Should().BeNull();
+            dialogInstance.Instance.Options.CloseOnEscapeKey.Should().BeNull();
+            dialogInstance.Instance.Options.NoHeader.Should().BeNull();
+            dialogInstance.Instance.Options.CloseButton.Should().BeNull();
+            dialogInstance.Instance.Options.FullWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackgroundClass.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ShowGenericAsync_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.ShowAsync<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Instance.Options.CloseButton.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Close_ShouldCloseDialogAndInvokeOnDialogCloseRequested()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+            var reference = (DialogReference)service.CreateReference();
+            var invoked = false;
+            Type type = null;
+            service.OnDialogCloseRequested += (_, result) =>
+            {
+                invoked = true;
+                type = result.DataType;
+            };
+
+            // Act 
+            await provider.InvokeAsync(() => service.Close(reference));
+
+            // Assert
+            invoked.Should().BeTrue();
+            type.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ShowAsync_ShouldProvideDefaultOption()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel)));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Instance.Options.Position.Should().BeNull();
+            dialogInstance.Instance.Options.MaxWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackdropClick.Should().BeNull();
+            dialogInstance.Instance.Options.CloseOnEscapeKey.Should().BeNull();
+            dialogInstance.Instance.Options.NoHeader.Should().BeNull();
+            dialogInstance.Instance.Options.CloseButton.Should().BeNull();
+            dialogInstance.Instance.Options.FullWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackgroundClass.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ShowAsync_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel), "Custom title"));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Markup.Should().Contain("Custom title");
+            dialogInstance.Instance.Options.Position.Should().BeNull();
+            dialogInstance.Instance.Options.MaxWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackdropClick.Should().BeNull();
+            dialogInstance.Instance.Options.CloseOnEscapeKey.Should().BeNull();
+            dialogInstance.Instance.Options.NoHeader.Should().BeNull();
+            dialogInstance.Instance.Options.CloseButton.Should().BeNull();
+            dialogInstance.Instance.Options.FullWidth.Should().BeNull();
+            dialogInstance.Instance.Options.BackgroundClass.Should().BeNull();
+        }
+
+        [Test]
+        public async Task ShowAsync_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel), "Custom title", new DialogOptions { CloseButton = true }));
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.Instance.Options.CloseButton.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ShowAsync_ShouldPassDialogParametersToDialog()
+        {
+            // Arrange
+            var provider = Context.RenderComponent<MudDialogProvider>();
+            var service = (Context.Services.GetRequiredService<IDialogService>() as DialogService)!;
+
+            // Act 
+            await provider.InvokeAsync(() =>
+                service.ShowAsync(typeof(DialogWithActionsClass), "Custom title", new DialogParameters<DialogWithActionsClass> { { x => x.ActionsClass, "custom-class" } }));
+
+            var dialogInstance = provider.FindComponent<MudDialogInstance>();
+
+            // Assert
+            dialogInstance.FindAll(".custom-class").Should().HaveCount(1);
         }
 
         [TestCase("", false, "mud-dialog-content")]

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -7,7 +7,6 @@
 // See https://github.com/Blazored
 
 #nullable enable
-
 namespace MudBlazor
 {
     /// <summary>

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -22,6 +22,12 @@ namespace MudBlazor
     public class DialogOptions
     {
         /// <summary>
+        /// The default dialog options.
+        /// This field is only intended for options that do not differ from their default values.
+        /// </summary>
+        internal static readonly DialogOptions Default = new();
+
+        /// <summary>
         /// The location of the dialog.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Dialog/DialogParameters.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParameters.cs
@@ -4,12 +4,13 @@
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable enable
 namespace MudBlazor
 {
     /// <summary>
     /// The parameters passed into a <see cref="MudDialog"/> instance.
     /// </summary>
-    public class DialogParameters : IEnumerable<KeyValuePair<string, object>>
+    public class DialogParameters : IEnumerable<KeyValuePair<string, object?>>
     {
         /// <summary>
         /// The default dialog parameters.
@@ -17,14 +18,14 @@ namespace MudBlazor
         /// </summary>
         internal static readonly DialogParameters Default = new();
 
-        internal Dictionary<string, object> _parameters = new();
+        internal Dictionary<string, object?> _parameters = new();
 
         /// <summary>
         /// Adds or updates a parameter.
         /// </summary>
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="value">The value to add or update.</param>
-        public void Add(string parameterName, object value)
+        public void Add(string parameterName, object? value)
         {
             _parameters[parameterName] = value;
         }
@@ -35,11 +36,11 @@ namespace MudBlazor
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="parameterName">The name of the parameter to find.</param>
         /// <returns>The parameter value, if it exists.</returns>
-        public T Get<T>(string parameterName)
+        public T? Get<T>(string parameterName)
         {
             if (_parameters.TryGetValue(parameterName, out var value))
             {
-                return (T)value;
+                return (T?)value;
             }
 
             throw new KeyNotFoundException($"{parameterName} does not exist in Dialog parameters");
@@ -51,11 +52,11 @@ namespace MudBlazor
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="parameterName">The name of the parameter to find.</param>
         /// <returns>The parameter value, if it exists.</returns>
-        public T TryGet<T>(string parameterName)
+        public T? TryGet<T>(string parameterName)
         {
             if (_parameters.TryGetValue(parameterName, out var value))
             {
-                return (T)value;
+                return (T?)value;
             }
 
             return default;
@@ -71,9 +72,9 @@ namespace MudBlazor
         /// </summary>
         /// <param name="parameterName">The name of the parameter to find.</param>
         /// <returns>The parameter value.</returns>
-        public object this[string parameterName]
+        public object? this[string parameterName]
         {
-            get => Get<object>(parameterName);
+            get => Get<object?>(parameterName);
             set => _parameters[parameterName] = value;
         }
 
@@ -81,7 +82,7 @@ namespace MudBlazor
         /// Gets an enumerator for all parameters.
         /// </summary>
         /// <returns>An enumerator of <see cref="KeyValuePair{TKey, TValue}"/> values.</returns>
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
             return _parameters.GetEnumerator();
         }

--- a/src/MudBlazor/Components/Dialog/DialogParameters.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParameters.cs
@@ -11,6 +11,12 @@ namespace MudBlazor
     /// </summary>
     public class DialogParameters : IEnumerable<KeyValuePair<string, object>>
     {
+        /// <summary>
+        /// The default dialog parameters.
+        /// This field is only intended for parameters that do not differ from their default values.
+        /// </summary>
+        internal static readonly DialogParameters Default = new();
+
         internal Dictionary<string, object> _parameters = new();
 
         /// <summary>

--- a/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParametersGeneric.cs
@@ -7,7 +7,6 @@ using System.Linq.Expressions;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
 /// The parameters passed into a <see cref="MudDialog"/> instance.
 /// </summary>
@@ -42,7 +41,7 @@ public class DialogParameters<T> : DialogParameters
     /// <typeparam name="TParam">The type of parameter to get.</typeparam>
     /// <param name="propertyExpression">The property to get as a parameter.</param>
     /// <returns>The parameter value.</returns>
-    public TParam Get<TParam>(Expression<Func<T, TParam>> propertyExpression)
+    public TParam? Get<TParam>(Expression<Func<T, TParam>> propertyExpression)
     {
         ArgumentNullException.ThrowIfNull(propertyExpression);
         if (propertyExpression.Body is not MemberExpression memberExpression)
@@ -50,7 +49,7 @@ public class DialogParameters<T> : DialogParameters
             throw new ArgumentException($"Argument '{nameof(propertyExpression)}' must be a '{nameof(MemberExpression)}'");
         }
 
-        return Get<TParam>(memberExpression.Member.Name);
+        return Get<TParam?>(memberExpression.Member.Name);
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
+#nullable enable
 namespace MudBlazor
 {
     /// <summary>
@@ -60,10 +61,10 @@ namespace MudBlazor
         public Guid Id { get; }
 
         /// <inheritdoc />
-        public object Dialog { get; private set; }
+        public object? Dialog { get; private set; }
 
         /// <inheritdoc />
-        public RenderFragment RenderFragment { get; set; }
+        public RenderFragment? RenderFragment { get; set; }
 
         /// <inheritdoc />
         public Task<DialogResult> Result => _resultCompletion.Task;
@@ -83,12 +84,12 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public async Task<T> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+        public async Task<T?> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
         {
             var result = await Result;
             try
             {
-                return (T)result.Data;
+                return (T?)result.Data;
             }
             catch (InvalidCastException)
             {

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -24,7 +24,7 @@ namespace MudBlazor
     /// <seealso cref="DialogService"/>
     public class DialogReference : IDialogReference
     {
-        private readonly TaskCompletionSource<DialogResult> _resultCompletion = new();
+        private readonly TaskCompletionSource<DialogResult?> _resultCompletion = new();
 
         private readonly IDialogService _dialogService;
 
@@ -46,13 +46,13 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public void Close(DialogResult result)
+        public void Close(DialogResult? result)
         {
             _dialogService.Close(this, result);
         }
 
         /// <inheritdoc />
-        public virtual bool Dismiss(DialogResult result)
+        public virtual bool Dismiss(DialogResult? result)
         {
             return _resultCompletion.TrySetResult(result);
         }
@@ -67,7 +67,7 @@ namespace MudBlazor
         public RenderFragment? RenderFragment { get; set; }
 
         /// <inheritdoc />
-        public Task<DialogResult> Result => _resultCompletion.Task;
+        public Task<DialogResult?> Result => _resultCompletion.Task;
 
         TaskCompletionSource<bool> IDialogReference.RenderCompleteTaskCompletionSource { get; } = new();
 
@@ -89,7 +89,7 @@ namespace MudBlazor
             var result = await Result;
             try
             {
-                return (T?)result.Data;
+                return (T?)result?.Data;
             }
             catch (InvalidCastException)
             {

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
         /// <summary>
         /// The result of closing the dialog.
         /// </summary>
-        Task<DialogResult> Result { get; }
+        Task<DialogResult?> Result { get; }
 
         TaskCompletionSource<bool> RenderCompleteTaskCompletionSource { get; }
 
@@ -44,14 +44,14 @@ namespace MudBlazor
         /// Hides the dialog and returns a result.
         /// </summary>
         /// <param name="result">The result of closing the dialog.</param>
-        void Close(DialogResult result);
+        void Close(DialogResult? result);
 
         /// <summary>
         /// Notifies that this dialog has been dismissed.
         /// </summary>
         /// <param name="result">The result of closing the dialog.</param>
         /// <returns>Returns <c>true</c> if the result was set successfully.</returns>
-        bool Dismiss(DialogResult result);
+        bool Dismiss(DialogResult? result);
 
         /// <summary>
         /// The dialog linked to this reference.

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
+#nullable enable
 namespace MudBlazor
 {
     /// <summary>
@@ -25,7 +26,7 @@ namespace MudBlazor
         /// <summary>
         /// The content within this dialog.
         /// </summary>
-        RenderFragment RenderFragment { get; set; }
+        RenderFragment? RenderFragment { get; set; }
 
         /// <summary>
         /// The result of closing the dialog.
@@ -55,7 +56,7 @@ namespace MudBlazor
         /// <summary>
         /// The dialog linked to this reference.
         /// </summary>
-        object Dialog { get; }
+        object? Dialog { get; }
 
         /// <summary>
         /// Replaces the dialog content.
@@ -74,6 +75,6 @@ namespace MudBlazor
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <returns>The results of closing the dialog.</returns>
-        Task<T> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
+        Task<T?> GetReturnValueAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
     }
 }

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor
@@ -2,6 +2,10 @@
 
 @inherits MudComponentBase
 
+@{
+    #nullable enable
+}
+
 @*this makes dialog inlineable, it will only render inside a MudDialogInstance*@
 @if (!IsInline)
 {

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -11,7 +11,6 @@ using MudBlazor.State;
 using MudBlazor.Utilities;
 
 #nullable enable
-
 namespace MudBlazor
 {
     /// <summary>

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -10,6 +10,8 @@ using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
+#nullable enable
+
 namespace MudBlazor
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace MudBlazor
     /// <seealso cref="DialogService"/>
     public partial class MudDialog : MudComponentBase
     {
-        private IDialogReference _reference;
+        private IDialogReference? _reference;
         private readonly ParameterState<bool> _visibleState;
 
         /// <summary>
@@ -47,13 +49,13 @@ namespace MudBlazor
             .Build();
 
         [CascadingParameter]
-        private MudDialogInstance DialogInstance { get; set; }
+        private MudDialogInstance? DialogInstance { get; set; }
 
         [CascadingParameter(Name = "IsNested")]
         private bool IsNested { get; set; }
 
         [Inject]
-        protected IDialogService DialogService { get; set; }
+        protected IDialogService DialogService { get; set; } = null!;
 
         /// <summary>
         /// The custom content for this dialog's title.
@@ -63,21 +65,21 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public RenderFragment TitleContent { get; set; }
+        public RenderFragment? TitleContent { get; set; }
 
         /// <summary>
         /// The main content for this dialog.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public RenderFragment DialogContent { get; set; }
+        public RenderFragment? DialogContent { get; set; }
 
         /// <summary>
         /// The custom actions for this dialog.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public RenderFragment DialogActions { get; set; }
+        public RenderFragment? DialogActions { get; set; }
 
         /// <summary>
         /// The default options for this dialog.
@@ -87,7 +89,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Misc)]  // Behavior and Appearance
-        public DialogOptions Options { get; set; }
+        public DialogOptions? Options { get; set; }
 
         /// <summary>
         /// Occurs when the area outside the dialog has been clicked if <see cref="DialogOptions.BackdropClick"/> is <c>true</c>.
@@ -117,7 +119,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string TitleClass { get; set; }
+        public string? TitleClass { get; set; }
 
         /// <summary>
         /// The CSS classes applied to the main dialog content.
@@ -127,7 +129,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string ContentClass { get; set; }
+        public string? ContentClass { get; set; }
 
         /// <summary>
         /// The CSS classes applied to the action buttons content.
@@ -137,14 +139,14 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string ActionsClass { get; set; }
+        public string? ActionsClass { get; set; }
 
         /// <summary>
         /// The CSS styles applied to the main dialog content.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Appearance)]
-        public string ContentStyle { get; set; }
+        public string? ContentStyle { get; set; }
 
         /// <summary>
         /// For inline dialogs, shows this dialog.
@@ -181,7 +183,7 @@ namespace MudBlazor
         /// <param name="title">The title of this dialog.</param>
         /// <param name="options">The options for this dialog.</param>
         /// <returns>The reference to the displayed instance of this dialog.</returns>
-        public async Task<IDialogReference> ShowAsync(string title = null, DialogOptions options = null)
+        public async Task<IDialogReference> ShowAsync(string? title = null, DialogOptions? options = null)
         {
             if (!IsInline)
             {
@@ -230,7 +232,7 @@ namespace MudBlazor
         /// For inlined dialogs, hides this dialog.
         /// </summary>
         /// <param name="result">The optional data to include.</param>
-        public async Task CloseAsync(DialogResult result = null)
+        public async Task CloseAsync(DialogResult? result = null)
         {
             if (!IsInline || _reference is null)
             {

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -3,6 +3,10 @@
 @inherits MudComponentBase
 @inject InternalMudLocalizer Localizer
 
+@{
+#nullable enable
+}
+
 <div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @Position">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" />
     <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style">

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -9,7 +9,6 @@ using MudBlazor.Services;
 using MudBlazor.Utilities;
 
 #nullable enable
-
 namespace MudBlazor
 {
     /// <summary>

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
 
+#nullable enable
+
 namespace MudBlazor
 {
     /// <summary>
@@ -24,21 +26,21 @@ namespace MudBlazor
     /// <seealso cref="DialogService"/>
     public partial class MudDialogInstance : MudComponentBase, IDisposable
     {
-        private DialogOptions _options = new();
-        private string _elementId = "dialog_" + Guid.NewGuid().ToString().Substring(0, 8);
-        private IKeyInterceptor _keyInterceptor;
+        private DialogOptions? _options = new();
+        private readonly string _elementId = "dialog_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private IKeyInterceptor? _keyInterceptor;
 
         [Inject]
-        private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
+        private IKeyInterceptorFactory KeyInterceptorFactory { get; set; } = null!;
 
         [CascadingParameter(Name = "RightToLeft")]
         public bool RightToLeft { get; set; }
 
         [CascadingParameter]
-        private MudDialogProvider Parent { get; set; }
+        private MudDialogProvider Parent { get; set; } = null!;
 
         [CascadingParameter]
-        private DialogOptions GlobalDialogOptions { get; set; } = new DialogOptions();
+        private DialogOptions GlobalDialogOptions { get; set; } = DialogOptions.Default;
 
         /// <summary>
         /// The options used for this dialog.
@@ -64,7 +66,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// The custom content at the top of this dialog.
@@ -74,7 +76,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public RenderFragment TitleContent { get; set; }
+        public RenderFragment? TitleContent { get; set; }
 
         /// <summary>
         /// The content within this dialog.
@@ -84,7 +86,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]
-        public RenderFragment Content { get; set; }
+        public RenderFragment? Content { get; set; }
 
         /// <summary>
         /// The unique ID for this instance.
@@ -103,8 +105,8 @@ namespace MudBlazor
         [Category(CategoryTypes.Dialog.Appearance)]
         public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
 
-        private string Position { get; set; }
-        private string DialogMaxWidth { get; set; }
+        private string Position { get; set; } = null!;
+        private string DialogMaxWidth { get; set; } = null!;
         private bool BackdropClick { get; set; } = true;
         private bool CloseOnEscapeKey { get; set; }
         private bool NoHeader { get; set; }
@@ -124,7 +126,7 @@ namespace MudBlazor
                 //Since CloseOnEscapeKey is the only thing to be handled, turn interceptor off
                 if (CloseOnEscapeKey)
                 {
-                    _keyInterceptor = _keyInterceptorFactory.Create();
+                    _keyInterceptor = KeyInterceptorFactory.Create();
 
                     await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
                     {
@@ -184,7 +186,7 @@ namespace MudBlazor
         /// </summary>
         public void Close()
         {
-            Close(DialogResult.Ok<object>(null));
+            Close(DialogResult.Ok<object?>(null));
         }
 
         /// <summary>
@@ -363,7 +365,7 @@ namespace MudBlazor
             await _dialog.OnBackdropClick.InvokeAsync(args);
         }
 
-        private MudDialog _dialog;
+        private MudDialog? _dialog;
         private bool _disposedValue;
 
         /// <summary>
@@ -375,8 +377,6 @@ namespace MudBlazor
         /// </remarks>
         public void Register(MudDialog dialog)
         {
-            if (dialog == null)
-                return;
             _dialog = dialog;
             Class = dialog.Class;
             Style = dialog.Style;

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -167,7 +167,7 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        private void DismissInstance(IDialogReference dialog, DialogResult result)
+        private void DismissInstance(IDialogReference dialog, DialogResult? result)
         {
             if (!dialog.Dismiss(result)) return;
 

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -6,8 +6,6 @@
 // License: MIT
 // See https://github.com/Blazored
 
-#nullable enable
-
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -15,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 
+#nullable enable
 namespace MudBlazor
 {
     /// <summary>
@@ -191,14 +190,9 @@ namespace MudBlazor
         /// </summary>
         public void Dispose()
         {
-            if (NavigationManager != null)
-                NavigationManager.LocationChanged -= LocationChanged;
-
-            if (DialogService != null)
-            {
-                DialogService.OnDialogInstanceAdded -= AddInstance;
-                DialogService.OnDialogCloseRequested -= DismissInstance;
-            }
+            NavigationManager.LocationChanged -= LocationChanged;
+            DialogService.OnDialogInstanceAdded -= AddInstance;
+            DialogService.OnDialogCloseRequested -= DismissInstance;
         }
     }
 }

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -1,6 +1,10 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
+@{
+#nullable enable
+}
+
 <MudDialog @attributes="UserAttributes" Class="@Classname">
     <TitleContent>
         @if (TitleContent is null)

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -165,6 +165,12 @@ namespace MudBlazor
             };
             _reference = await DialogService.ShowAsync<MudMessageBox>(title: Title, parameters: parameters, options: options);
             var result = await _reference.Result;
+
+            if (result is null)
+            {
+                return null;
+            }
+
             if (result.Canceled || result.Data is not bool data)
             {
                 return null;

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -5,9 +5,10 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
+#nullable enable
+
 namespace MudBlazor
 {
-#nullable enable
     public partial class MudMessageBox : MudComponentBase
     {
         private readonly ParameterState<bool> _visibleState;

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -6,7 +6,6 @@ using MudBlazor.State;
 using MudBlazor.Utilities;
 
 #nullable enable
-
 namespace MudBlazor
 {
     public partial class MudMessageBox : MudComponentBase

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
     public interface IDialogService
     {
         public event Action<IDialogReference>? OnDialogInstanceAdded;
-        public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
+        public event Action<IDialogReference, DialogResult?>? OnDialogCloseRequested;
 
         /// <summary>
         /// Displays a dialog.
@@ -248,6 +248,6 @@ namespace MudBlazor
         /// </summary>
         /// <param name="dialog">The reference of the dialog to hide.</param>
         /// <param name="result">The result to include.</param>
-        void Close(IDialogReference dialog, DialogResult result);
+        void Close(IDialogReference dialog, DialogResult? result);
     }
 }

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -10,6 +10,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
+#nullable enable
+
 namespace MudBlazor
 {
     /// <summary>
@@ -20,8 +22,8 @@ namespace MudBlazor
     /// </remarks>
     public interface IDialogService
     {
-        public event Action<IDialogReference> OnDialogInstanceAdded;
-        public event Action<IDialogReference, DialogResult> OnDialogCloseRequested;
+        public event Action<IDialogReference>? OnDialogInstanceAdded;
+        public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
         /// <summary>
         /// Displays a dialog.
@@ -36,7 +38,7 @@ namespace MudBlazor
         /// <typeparam name="TComponent">The type of dialog to display.</typeparam>
         /// <param name="title">The text at the top of the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title) where TComponent : IComponent;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with a custom title and options.
@@ -45,7 +47,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogOptions options) where TComponent : IComponent;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogOptions options) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with custom parameters.
@@ -54,7 +56,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters) where TComponent : IComponent;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogParameters parameters) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with custom options and parameters.
@@ -64,7 +66,7 @@ namespace MudBlazor
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters, DialogOptions options) where TComponent : IComponent;
+        IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogParameters parameters, DialogOptions? options) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog.
@@ -79,7 +81,7 @@ namespace MudBlazor
         /// <param name="component">The type of dialog to display.</param>
         /// <param name="title">The text at the top of the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title);
 
         /// <summary>
         /// Displays a dialog with a custom title and options.
@@ -88,7 +90,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogOptions options);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogOptions options);
 
         /// <summary>
         /// Displays a dialog with a custom title and options.
@@ -97,7 +99,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogParameters parameters);
 
         /// <summary>
         /// Displays a dialog with a custom title, parameters, and options.
@@ -107,7 +109,7 @@ namespace MudBlazor
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters, DialogOptions options);
+        IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogParameters parameters, DialogOptions options);
 
         /// <summary>
         /// Displays a dialog.
@@ -122,7 +124,7 @@ namespace MudBlazor
         /// <typeparam name="TComponent">The dialog to display.</typeparam>
         /// <param name="title">The text at the top of the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title) where TComponent : IComponent;
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with a custom title and options.
@@ -131,7 +133,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogOptions options) where TComponent : IComponent;
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogOptions options) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with a custom title and parameters.
@@ -140,7 +142,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters) where TComponent : IComponent;
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogParameters parameters) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog with a custom title, parameters, and options.
@@ -150,7 +152,7 @@ namespace MudBlazor
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string title, DialogParameters parameters, DialogOptions options) where TComponent : IComponent;
+        Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent>(string? title, DialogParameters parameters, DialogOptions? options) where TComponent : IComponent;
 
         /// <summary>
         /// Displays a dialog.
@@ -165,7 +167,7 @@ namespace MudBlazor
         /// <param name="component">The dialog to display.</param>
         /// <param name="title">The text at the top of the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title);
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title);
 
         /// <summary>
         /// Displays a dialog with a custom title and options.
@@ -174,7 +176,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogOptions options);
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogOptions options);
 
         /// <summary>
         /// Displays a dialog with a custom title and parameters.
@@ -183,7 +185,7 @@ namespace MudBlazor
         /// <param name="title">The text at the top of the dialog.</param>
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters);
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogParameters parameters);
 
         /// <summary>
         /// Displays a dialog with a custom title, parameters, and options.
@@ -193,7 +195,7 @@ namespace MudBlazor
         /// <param name="parameters">The custom parameters to set within the dialog.</param>
         /// <param name="options">The custom display options for the dialog.</param>
         /// <returns>A reference to the dialog.</returns>
-        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string title, DialogParameters parameters, DialogOptions options);
+        Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type component, string? title, DialogParameters parameters, DialogOptions options);
 
         /// <summary>
         /// Creates a reference to a dialog.
@@ -211,8 +213,8 @@ namespace MudBlazor
         /// <param name="cancelText">The text of the "Cancel" button.  Defaults to <c>null</c>.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(string title, string message, string yesText = "OK",
-            string noText = null, string cancelText = null, DialogOptions options = null);
+        Task<bool?> ShowMessageBox(string? title, string message, string yesText = "OK",
+            string? noText = null, string? cancelText = null, DialogOptions? options = null);
 
         /// <summary>
         /// Shows a simple dialog with a title, HTML message, and up to three custom buttons.
@@ -224,8 +226,8 @@ namespace MudBlazor
         /// <param name="cancelText">The text of the "Cancel" button.  Defaults to <c>null</c>.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(string title, MarkupString markupMessage, string yesText = "OK",
-            string noText = null, string cancelText = null, DialogOptions options = null);
+        Task<bool?> ShowMessageBox(string? title, MarkupString markupMessage, string yesText = "OK",
+            string? noText = null, string? cancelText = null, DialogOptions? options = null);
 
         /// <summary>
         /// Shows a simple dialog with custom options.
@@ -233,7 +235,7 @@ namespace MudBlazor
         /// <param name="messageBoxOptions">The options for the message box.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions options = null);
+        Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions? options = null);
 
         /// <summary>
         /// Hides an existing dialog.

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -241,13 +241,13 @@ namespace MudBlazor
         /// Hides an existing dialog.
         /// </summary>
         /// <param name="dialog">The reference of the dialog to hide.</param>
-        void Close(DialogReference dialog);
+        void Close(IDialogReference dialog);
 
         /// <summary>
         /// Hides an existing dialog.
         /// </summary>
         /// <param name="dialog">The reference of the dialog to hide.</param>
         /// <param name="result">The result to include.</param>
-        void Close(DialogReference dialog, DialogResult result);
+        void Close(IDialogReference dialog, DialogResult result);
     }
 }

--- a/src/MudBlazor/Services/DialogResult.cs
+++ b/src/MudBlazor/Services/DialogResult.cs
@@ -8,6 +8,8 @@
 
 using System;
 
+#nullable enable
+
 namespace MudBlazor
 {
     /// <summary>
@@ -21,19 +23,19 @@ namespace MudBlazor
         /// <remarks>
         /// This value is typically a custom object related to the dialog, such as the object which will be affected by the user's response.
         /// </remarks>
-        public object Data { get; }
+        public object? Data { get; }
 
         /// <summary>
         /// The type of object in the <see cref="Data"/> property.
         /// </summary>
-        public Type DataType { get; }
+        public Type? DataType { get; }
 
         /// <summary>
         /// Indicates whether the user clicked a cancel button.
         /// </summary>
         public bool Canceled { get; }
 
-        protected internal DialogResult(object data, Type resultType, bool canceled)
+        protected internal DialogResult(object? data, Type? resultType, bool canceled)
         {
             Data = data;
             DataType = resultType;
@@ -55,7 +57,7 @@ namespace MudBlazor
         /// <param name="result">The value included.</param>
         /// <param name="dialogType">The type of dialog which the user responded to.</param>
         /// <returns>The dialog result.</returns>
-        public static DialogResult Ok<T>(T result, Type dialogType) => new(result, dialogType, false);
+        public static DialogResult Ok<T>(T result, Type? dialogType) => new(result, dialogType, false);
 
         /// <summary>
         /// The result when the user clicks the cancel button.

--- a/src/MudBlazor/Services/DialogResult.cs
+++ b/src/MudBlazor/Services/DialogResult.cs
@@ -9,7 +9,6 @@
 using System;
 
 #nullable enable
-
 namespace MudBlazor
 {
     /// <summary>

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -286,13 +286,13 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public void Close(DialogReference dialog)
+        public void Close(IDialogReference dialog)
         {
             Close(dialog, DialogResult.Ok<object?>(null));
         }
 
         /// <inheritdoc />
-        public virtual void Close(DialogReference dialog, DialogResult result)
+        public virtual void Close(IDialogReference dialog, DialogResult result)
         {
             OnDialogCloseRequested?.Invoke(dialog, result);
         }

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -4,14 +4,13 @@
 // See https://github.com/Blazored
 // License: MIT
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
+#nullable enable
 namespace MudBlazor
 {
     /// <summary>

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -4,6 +4,8 @@
 // See https://github.com/Blazored
 // License: MIT
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -33,21 +35,21 @@ namespace MudBlazor
         private class DialogHelperComponent : IComponent
         {
             private const string ChildContent = nameof(ChildContent);
-            private RenderFragment _renderFragment;
+            private RenderFragment? _renderFragment;
             private RenderHandle _renderHandle;
             void IComponent.Attach(RenderHandle renderHandle) => _renderHandle = renderHandle;
+
             Task IComponent.SetParametersAsync(ParameterView parameters)
             {
-                if (_renderFragment == null)
+                if (_renderFragment is null && parameters.TryGetValue<RenderFragment>(ChildContent, out var renderFragment))
                 {
-                    if (parameters.TryGetValue(ChildContent, out _renderFragment))
-                    {
-                        _renderHandle.Render(_renderFragment);
-                    }
+                    _renderFragment = renderFragment;
+                    _renderHandle.Render(_renderFragment);
                 }
 
                 return Task.CompletedTask;
             }
+
             public static RenderFragment Wrap(RenderFragment renderFragment)
                 => new(builder =>
                 {
@@ -60,69 +62,71 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when a new dialog instance is created.
         /// </summary>
-        public event Action<IDialogReference> OnDialogInstanceAdded;
+        public event Action<IDialogReference>? OnDialogInstanceAdded;
 
         /// <summary>
         /// Occurs when a request is made to close a dialog.
         /// </summary>
-        public event Action<IDialogReference, DialogResult> OnDialogCloseRequested;
+        public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
 
         /// <inheritdoc />
         public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : IComponent
         {
-            return Show<T>(string.Empty, new DialogParameters(), new DialogOptions());
+            return Show<T>(string.Empty, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title) where T : IComponent
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title) where T : IComponent
         {
-            return Show<T>(title, new DialogParameters(), new DialogOptions());
+            return Show<T>(title, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogOptions options) where T : IComponent
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogOptions options) where T : IComponent
         {
-            return Show<T>(title, new DialogParameters(), options);
+            return Show<T>(title, DialogParameters.Default, options);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters) where T : IComponent
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogParameters parameters) where T : IComponent
         {
-            return Show<T>(title, parameters, new DialogOptions());
+            return Show<T>(title, parameters, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters, DialogOptions options) where T : IComponent
+        public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogParameters parameters, DialogOptions? options)
+            where T : IComponent
         {
-            return Show(typeof(T), title, parameters, options);
+            return Show(typeof(T), title, parameters, options ?? DialogOptions.Default);
         }
 
         /// <inheritdoc />
         public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent)
         {
-            return Show(contentComponent, string.Empty, new DialogParameters(), new DialogOptions());
+            return Show(contentComponent, string.Empty, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title)
         {
-            return Show(contentComponent, title, new DialogParameters(), new DialogOptions());
+            return Show(contentComponent, title, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogOptions options)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title, DialogOptions options)
         {
-            return Show(contentComponent, title, new DialogParameters(), options);
+            return Show(contentComponent, title, DialogParameters.Default, options);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title, DialogParameters parameters)
         {
-            return Show(contentComponent, title, parameters, new DialogOptions());
+            return Show(contentComponent, title, parameters, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters, DialogOptions options)
+        public IDialogReference Show([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title, DialogParameters parameters,
+            DialogOptions options)
         {
             if (!typeof(IComponent).IsAssignableFrom(contentComponent))
             {
@@ -162,59 +166,61 @@ namespace MudBlazor
         /// <inheritdoc />
         public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : IComponent
         {
-            return ShowAsync<T>(string.Empty, new DialogParameters(), new DialogOptions());
+            return ShowAsync<T>(string.Empty, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title) where T : IComponent
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title) where T : IComponent
         {
-            return ShowAsync<T>(title, new DialogParameters(), new DialogOptions());
+            return ShowAsync<T>(title, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogOptions options) where T : IComponent
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogOptions options) where T : IComponent
         {
-            return ShowAsync<T>(title, new DialogParameters(), options);
+            return ShowAsync<T>(title, DialogParameters.Default, options);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters) where T : IComponent
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogParameters parameters) where T : IComponent
         {
-            return ShowAsync<T>(title, parameters, new DialogOptions());
+            return ShowAsync<T>(title, parameters, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, DialogParameters parameters, DialogOptions options) where T : IComponent
+        public Task<IDialogReference> ShowAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string? title, DialogParameters parameters,
+            DialogOptions? options) where T : IComponent
         {
-            return ShowAsync(typeof(T), title, parameters, options);
+            return ShowAsync(typeof(T), title, parameters, options ?? DialogOptions.Default);
         }
 
         /// <inheritdoc />
         public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent)
         {
-            return ShowAsync(contentComponent, string.Empty, new DialogParameters(), new DialogOptions());
+            return ShowAsync(contentComponent, string.Empty, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title)
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title)
         {
-            return ShowAsync(contentComponent, title, new DialogParameters(), new DialogOptions());
+            return ShowAsync(contentComponent, title, DialogParameters.Default, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogOptions options)
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title, DialogOptions options)
         {
-            return ShowAsync(contentComponent, title, new DialogParameters(), options);
+            return ShowAsync(contentComponent, title, DialogParameters.Default, options);
         }
 
         /// <inheritdoc />
-        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters)
+        public Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title, DialogParameters parameters)
         {
-            return ShowAsync(contentComponent, title, parameters, new DialogOptions());
+            return ShowAsync(contentComponent, title, parameters, DialogOptions.Default);
         }
 
         /// <inheritdoc />
-        public async Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string title, DialogParameters parameters, DialogOptions options)
+        public async Task<IDialogReference> ShowAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type contentComponent, string? title,
+            DialogParameters parameters, DialogOptions options)
         {
             var dialogReference = Show(contentComponent, title, parameters, options);
 
@@ -230,8 +236,8 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public Task<bool?> ShowMessageBox(string title, string message, string yesText = "OK",
-            string noText = null, string cancelText = null, DialogOptions options = null)
+        public Task<bool?> ShowMessageBox(string? title, string message, string yesText = "OK",
+            string? noText = null, string? cancelText = null, DialogOptions? options = null)
         {
             return ShowMessageBox(new MessageBoxOptions
             {
@@ -244,8 +250,8 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public Task<bool?> ShowMessageBox(string title, MarkupString markupMessage, string yesText = "OK",
-            string noText = null, string cancelText = null, DialogOptions options = null)
+        public Task<bool?> ShowMessageBox(string? title, MarkupString markupMessage, string yesText = "OK",
+            string? noText = null, string? cancelText = null, DialogOptions? options = null)
         {
             return ShowMessageBox(new MessageBoxOptions
             {
@@ -258,7 +264,7 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public async Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions options = null)
+        public async Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions? options = null)
         {
             var parameters = new DialogParameters()
             {
@@ -282,7 +288,7 @@ namespace MudBlazor
         /// <inheritdoc />
         public void Close(DialogReference dialog)
         {
-            Close(dialog, DialogResult.Ok<object>(null));
+            Close(dialog, DialogResult.Ok<object?>(null));
         }
 
         /// <inheritdoc />
@@ -307,12 +313,12 @@ namespace MudBlazor
         /// <summary>
         /// The text at the top of the message box.
         /// </summary>
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// The main content of the message box.
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// The main HTML content of the message box.
@@ -333,7 +339,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  When <c>null</c>, this button will be hidden.
         /// </remarks>
-        public string NoText { get; set; }
+        public string? NoText { get; set; }
 
         /// <summary>
         /// The default label of the cancel button.
@@ -341,6 +347,6 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  When <c>null</c>, this button will be hidden.
         /// </remarks>
-        public string CancelText { get; set; }
+        public string? CancelText { get; set; }
     }
 }

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -66,7 +66,7 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when a request is made to close a dialog.
         /// </summary>
-        public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
+        public event Action<IDialogReference, DialogResult?>? OnDialogCloseRequested;
 
         /// <inheritdoc />
         public IDialogReference Show<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : IComponent
@@ -276,6 +276,12 @@ namespace MudBlazor
             };
             var reference = await ShowAsync<MudMessageBox>(title: messageBoxOptions.Title, parameters: parameters, options: options);
             var result = await reference.Result;
+
+            if (result is null)
+            {
+                return null;
+            }
+
             if (result.Canceled || result.Data is not bool data)
             {
                 return null;
@@ -291,7 +297,7 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public virtual void Close(IDialogReference dialog, DialogResult result)
+        public virtual void Close(IDialogReference dialog, DialogResult? result)
         {
             OnDialogCloseRequested?.Invoke(dialog, result);
         }


### PR DESCRIPTION
Hey ✋,

I'll try to contribute to MudBlazor more often. This time with nullable annoations.

## Description

Part of #6535 

- Add nullable annotation for dialog related classes
- Introduced an internal static instance of `DialogOptions` and `DialogParameters` called `Default` to reduce some allocations


~There is one thing to discuss:~

~The `MudMessageBox` defines the `Title` parameter as nullable. That's why the `Show` methods of the `IDialogService`  now accept a nullable title because I would rather not suppress nullable here. But IMO, it would be better to not make the title nullable as the title will always be rendered right now in `MudDialogInstance`. 
So we basically have to answer only one question: Should the Title be nullable or not?~

## How Has This Been Tested?
Added missing tests.


## Type of Changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.