### PR TITLE
Build: Use latest github actions

### DIFF
--- a/.github/workflows/deploy-mudblazor-nuget.yml
+++ b/.github/workflows/deploy-mudblazor-nuget.yml
@@ -41,19 +41,16 @@ jobs:
     name: Deploy mudblazor nuget to nuget.org
     needs: get-version
     runs-on: ubuntu-latest
-    env:
-      ASSEMBLY_VERSION: 1.0.0
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: 'refs/tags/v${{ needs.get-version.outputs.VERSION }}'
     - name: Setup dotnet version
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
+          8.0.x
     - name: Pack nuget package
       run: dotnet pack -c Release --output nupkgs /p:Version=${{ needs.get-version.outputs.VERSION }}
       working-directory: ./src/MudBlazor


### PR DESCRIPTION
## Description

- Use .NET 8.0.x
- Use the latest action version `@v4`
- Removed unused `ASSEMBLY_VERSION` env

Updating to the latest action version also removes the warning in the workflow:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-dotnet@v3

## How Has This Been Tested?
I ran the workflow in my fork, and it works (until the deploy job)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
