### PR TITLE
ComponentBase, Field, DateRangePicker: fix unreliable field id

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
@@ -2,13 +2,17 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.Components;
+using MudBlazor.UnitTests.Dummy;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests
 {
     [TestFixture]
-    public class ComponentBaseTests
+    public class ComponentBaseTests : BunitTest
     {
         [Test]
         public void MatchTypes()
@@ -17,6 +21,69 @@ namespace MudBlazor.UnitTests
             new MudAvatar().MatchTypes(typeof(MudButton)).Should().Be(false);
             new MudList<string>().MatchTypes(typeof(MudList<>), typeof(MudListItem<>)).Should().Be(true);
             new MudList<int>().MatchTypes(typeof(MudList<>), typeof(MudListItem<>)).Should().Be(true);
+        }
+
+        [Test]
+        public void Should_have_consistent_field_id_when_user_id_is_not_provided()
+        {
+            var comp = Context.RenderComponent<DummyComponentBase>();
+
+            comp.Instance.FieldId.Should().Be(comp.Instance.FieldId);
+        }
+
+        [Test]
+        public void Should_prefer_user_id_over_internal_field_id()
+        {
+            var id = "this-is-an-id";
+            var comp = Context.RenderComponent<DummyComponentBase>(parameters =>
+            {
+                parameters.Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    {
+                        "id", id
+                    }
+                });
+            });
+
+            comp.Instance.FieldId.Should().Be(id);
+        }
+
+        [Test]
+        public void Should_prefer_user_id_over_internal_field_id_when_set_after_initialization()
+        {
+            var id = "this-is-an-id";
+            var comp = Context.RenderComponent<DummyComponentBase>();
+
+            comp.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    {
+                        "id", id
+                    }
+                });
+            });
+
+            comp.Instance.FieldId.Should().Be(id);
+        }
+
+        [Test]
+        public void Should_fallback_to_internal_field_id_if_user_id_is_invalid()
+        {
+            var comp = Context.RenderComponent<DummyComponentBase>();
+            var internalId = comp.Instance.FieldId;
+
+            comp.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    {
+                        "id", null
+                    }
+                });
+            });
+
+            comp.Instance.FieldId.Should().Be(internalId);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Dummy/DummyComponentBase.cs
+++ b/src/MudBlazor.UnitTests/Dummy/DummyComponentBase.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+namespace MudBlazor.UnitTests.Dummy;
+
+public class DummyComponentBase : MudComponentBase
+{
+}

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -73,12 +73,13 @@ namespace MudBlazor
         /// </remarks>
         protected bool IsJSRuntimeAvailable { get; set; }
 
+        private readonly string _id = $"mudinput-{Guid.NewGuid()}";
         /// <summary>
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>
-        public string FieldId => UserAttributes.TryGetValue("id", out var id) && id != null
-                    ? id.ToString() ?? $"mudinput-{Guid.NewGuid()}"
-                    : $"mudinput-{Guid.NewGuid()}";
+        public string FieldId => UserAttributes.TryGetValue("id", out var id) && id is not null
+            ? id.ToString() ?? _id
+            : _id;
 
         /// <inheritdoc />
         protected override void OnAfterRender(bool firstRender)


### PR DESCRIPTION
## Description
As mentioned in #9158.

Fixing it for consistency/correctness but considering removing it in future PRs since only `MudField` and `MudDateRangePicker` use it currently.

## How Has This Been Tested?
Added some basic regression tests just in case.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
