### PR TITLE
MudForm: Support `For` expressions refering to non-nullable properties

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -736,6 +736,54 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Testing error handling of MudFormComponent.ValidateModelWithFullPathOfMember
+        /// Validation func throws an error, the error should contain the exception message
+        /// </summary>
+        [Test]
+        public async Task Form_Should_ValidateDatePickerWithNonNullableBackingFieldTest()
+        {
+            var comp = Context.RenderComponent<FormWithDatePickerTest>();
+            var formInstance = comp.FindComponent<MudForm>().Instance;
+            var model = new { date = DateTime.Now };
+            var dateComp = comp.FindComponent<MudDatePicker>();
+            var datepicker = comp.FindComponent<MudDatePicker>().Instance;
+
+            Expression<Func<DateTime?>> expression = () => model.date;
+            dateComp.SetParam(nameof(MudDatePicker.For), expression);
+
+            dateComp.Find("input").Change(DateTime.Now.ToShortDateString());
+            formInstance.IsValid.Should().Be(true);
+            formInstance.Errors.Length.Should().Be(0);
+            datepicker.Error.Should().BeFalse();
+            datepicker.ErrorText.Should().BeNullOrEmpty();
+
+
+            //var validationFunc = new Func<object, string, IEnumerable<string>>((obj, property) =>
+            //{
+            //    throw new InvalidOperationException("User error");
+            //});
+            //dateComp.SetParam(nameof(MudDatePicker.Validation), validationFunc);
+            //Expression <Func<DateTime?>> expression = () => model.date;
+            //dateComp.SetParam(nameof(MudDatePicker.For), expression);
+            //await comp.InvokeAsync(dateComp.Instance.Validate);
+            //dateComp.Instance.Error.Should().Be(true);
+            //dateComp.Instance.ErrorText.Should().Be("Error in validation func: User error");
+
+            //form.SetParam(nameof(MudForm.Model), model);
+            //var tf = comp.FindComponent<MudTextField<string>>();
+            //var validationFunc = new Func<object, string, IEnumerable<string>>((obj, property) =>
+            //{
+            //    throw new InvalidOperationException("User error");
+            //});
+            //tf.SetParam(nameof(MudTextField<string>.Validation), validationFunc);
+            //Expression<Func<DateTime?>> expression = () => model.date;
+            //tf.SetParam(nameof(MudTextField<string>.For), expression);
+            //await comp.InvokeAsync(tf.Instance.Validate);
+            //tf.Instance.Error.Should().Be(true);
+            //tf.Instance.ErrorText.Should().Be("Error in validation func: User error");
+        }
+
+        /// <summary>
         /// DateRangePicker should be validated like every other form component when the dateRange
         /// is changed via inputs
         /// </summary>

--- a/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
@@ -15,6 +15,9 @@ namespace MudBlazor.UnitTests.Extensions
             public string Field1 { get; set; }
 
             public TestClass1 TestClass1 { get; set; }
+
+            [Label("NonNullableDateTimeField Label Attribute")]
+            public DateTime NonNullableDateTimeField { get; set; }
         }
 
         private class TestClass1
@@ -37,6 +40,16 @@ namespace MudBlazor.UnitTests.Extensions
             Expression<Func<string>> expression = () => model.Field1;
 
             expression.GetFullPathOfMember().Should().Be("Field1");
+        }
+
+        [Test]
+        public void GetFullPathOfNonNullableMemberTest()
+        {
+            var model = new TestClass();
+
+            Expression<Func<DateTime?>> expression = () => model.NonNullableDateTimeField;
+
+            expression.GetFullPathOfMember().Should().Be("NonNullableDateTimeField");
         }
 
         [Test]
@@ -77,6 +90,16 @@ namespace MudBlazor.UnitTests.Extensions
             Expression<Func<string>> expression = () => model.Field1;
 
             expression.GetLabelString().Should().Be("");
+        }
+
+        [Test]
+        public void GetLabelStringTest3()
+        {
+            var model = new TestClass();
+
+            Expression<Func<DateTime?>> expression = () => model.NonNullableDateTimeField;
+
+            expression.GetLabelString().Should().Be("NonNullableDateTimeField Label Attribute");
         }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Data.SqlTypes;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Data.SqlTypes;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -651,7 +652,8 @@ namespace MudBlazor
                 // Extract validation attributes
                 // Sourced from https://stackoverflow.com/a/43076222/4839162
                 // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
-                var expression = (MemberExpression)For.Body;
+                // Add handling for validation expressions that refer to non-nullable properties (#8931):
+                var expression = (For.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)For.Body).Operand);
 
                 // Currently we have no solution for this which is trimming incompatible
                 // A possible solution is to use source gen
@@ -660,7 +662,28 @@ namespace MudBlazor
 #pragma warning restore IL2075                
                 _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
-                _fieldIdentifier = FieldIdentifier.Create(For);
+                // Add handling for validation expressions that refer to non-nullable properties (#8931):
+                if (For.Body is UnaryExpression unaryExpression
+                    && unaryExpression.NodeType == ExpressionType.Convert
+                    && unaryExpression.Operand is MemberExpression memberExpression
+                    && memberExpression.Expression is MemberExpression member
+                    && member.Expression is ConstantExpression model
+                )
+                {
+                    var fieldName = memberExpression.Member.Name;
+                    object? value = model.Value ?? throw new ArgumentException("The provided expression must evaluate to a non-null value.");
+                    Func<object, object>? accessor = CreateAccessor((value.GetType(), member.Member.Name));
+                    if (accessor == null)
+                    {
+                        throw new InvalidOperationException($"Unable to compile expression: {member}");
+                    }
+                    _fieldIdentifier = new FieldIdentifier(model, fieldName);
+                }
+                else
+                {
+                    _fieldIdentifier = FieldIdentifier.Create(For);
+                }
+
                 _currentFor = For;
             }
 
@@ -669,6 +692,22 @@ namespace MudBlazor
                 DetachValidationStateChangedListener();
                 EditContext.OnValidationStateChanged += OnValidationStateChanged;
                 _currentEditContext = EditContext;
+            }
+
+            [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Application code does not get trimmed. We expect the members in the expression to not be trimmed.")]
+            static Func<object, object> CreateAccessor((Type model, string member) arg)
+            {
+                var parameter = Expression.Parameter(typeof(object), "value");
+                Expression expression = Expression.Convert(parameter, arg.model);
+                expression = Expression.PropertyOrField(expression, arg.member);
+                expression = Expression.Convert(expression, typeof(object));
+                var lambda = Expression.Lambda<Func<object, object>>(expression, parameter);
+
+                var func = lambda.Compile();
+                return func;
             }
         }
 

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
         /// </summary>
         public static string GetLabelString<T>(this Expression<Func<T>> expression)
         {
-            var memberExpression = (MemberExpression)expression.Body;
+            var memberExpression = (expression.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)expression.Body).Operand);
 
             // Currently we have no solution for this which is trimming incompatible
             // A possible solution is to use source gen

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -14,7 +14,8 @@ namespace MudBlazor
         public static string GetFullPathOfMember<T>(this Expression<Func<T>> property)
         {
             var resultingString = string.Empty;
-            var p = property.Body as MemberExpression;
+            // Add handling for validation expressions that refer to non-nullable properties (#8931):
+            var p = (property.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)property.Body).Operand);
 
             while (p is not null)
             {


### PR DESCRIPTION
## Description

If a _For_ validation property refers to a non-nullable field, then currently the framework throws errors such as "'Unable to cast object of type 'System.Linq.Expressions.UnaryExpression' to type 'System.Linq.Expressions.MemberExpression'."

This PR fixes this by properly handling validation Expressions that refer to non-nullable properties, more specifically, where For.Body is not a MemberExpression but a UnaryExpression and For.Body.Operand is the MemberExpression.

Resolves #8931

## How Has This Been Tested?
visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [ ] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

Submitting to branch v6 since I am working on a live project and v7 is not ready for production. I can create a new PR for dev if this PR is accepted. 