### PR TITLE
DataGrid: Make extension methods to apply filters

### DIFF
--- a/src/MudBlazor/Extensions/DataGridExtensions.cs
+++ b/src/MudBlazor/Extensions/DataGridExtensions.cs
@@ -10,6 +10,18 @@ namespace MudBlazor
 #nullable enable
     public static class DataGridExtensions
     {
+        public static IEnumerable<T> ApplyFilters<T>(this IEnumerable<T> source,
+            GridState<T> state, FilterOptions? filterOptions = null)
+            => ApplyFilters(source, state.FilterDefinitions, filterOptions);
+
+        public static IEnumerable<T> ApplyFilters<T>(this IEnumerable<T> source,
+            ICollection<IFilterDefinition<T>> filterDefinitions, FilterOptions? filterOptions)
+        {
+            IEnumerable<T> sourceArray = source as T[] ?? source.ToArray();
+            return filterDefinitions.Aggregate(
+                sourceArray, (current, filterDefinition) => current.Where(filterDefinition.GenerateFilterFunction(filterOptions)));
+        }
+
         public static IEnumerable<T> OrderBySortDefinitions<T>(this IEnumerable<T> source, GridState<T> state)
             => OrderBySortDefinitions(source, state.SortDefinitions);
 


### PR DESCRIPTION
## Description
Added some extension methods on IEnumerable<T> in DataGridExtensions. 

This makes it more obvious and convenient to apply filters in cases such as when using the ServerData parameter. 
Instead of having to iterate over the IEnumerable and apply .Where(filter.GetnerateFilterFunction()) for each filter,
users will have a more obvious method to accomplish this common behaviour, which is precedented by the already 
existing IEnumerable.OrderBySortDefinitions extension method. 

## How Has This Been Tested?
Changes tested via integration and experimentation with my own code.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
