### PR TITLE
DataGrid: Leverage IQueryable for better performance when available

### DIFF
--- a/src/MudBlazor/Extensions/DataGridExtensions.cs
+++ b/src/MudBlazor/Extensions/DataGridExtensions.cs
@@ -13,6 +13,9 @@ namespace MudBlazor
         public static IEnumerable<T> OrderBySortDefinitions<T>(this IEnumerable<T> source, GridState<T> state)
             => OrderBySortDefinitions(source, state.SortDefinitions);
 
+        public static IQueryable<T> OrderBySortDefinitions<T>(this IQueryable<T> source, GridState<T> state)
+            => OrderBySortDefinitions(source, state.SortDefinitions);
+
         public static IEnumerable<T> OrderBySortDefinitions<T>(this IEnumerable<T> source, ICollection<SortDefinition<T>> sortDefinitions)
         {
             //avoid multiple enumeration
@@ -41,6 +44,40 @@ namespace MudBlazor
                 {
                     orderedEnumerable = sortDefinition.Descending ? orderedEnumerable.ThenByDescending(sortDefinition.SortFunc)
                         : orderedEnumerable.ThenBy(sortDefinition.SortFunc);
+                }
+            }
+
+            return orderedEnumerable ?? source;
+        }
+
+        public static IQueryable<T> OrderBySortDefinitions<T>(this IQueryable<T> source, ICollection<SortDefinition<T>> sortDefinitions)
+        {
+            if (!source.Any())
+            {
+                return source;
+            }
+
+            if (sortDefinitions.Count == 0)
+            {
+                return source;
+            }
+
+            var sourceOrderedIQueryable = source.OrderBy(x => x);
+            IOrderedQueryable<T>? orderedEnumerable = null;
+
+            foreach (var sortDefinition in sortDefinitions)
+            {
+                if (orderedEnumerable is null)
+                {
+                    orderedEnumerable = sortDefinition.Descending
+                        ? sourceOrderedIQueryable.OrderByDescending(x => sortDefinition.SortFunc)
+                        : sourceOrderedIQueryable.OrderBy(x => sortDefinition.SortFunc); 
+                }
+                else
+                {
+                    orderedEnumerable = sortDefinition.Descending
+                        ? orderedEnumerable.ThenByDescending(x => sortDefinition.SortFunc, sortDefinition.Comparer)
+                        : orderedEnumerable.ThenBy(x => sortDefinition.SortFunc, sortDefinition.Comparer);
                 }
             }
 


### PR DESCRIPTION
## Description
Added functionality in DataGridExtensions that leverages the features of IQueryable to provide better performance when working with providers such as Entity Framework. 

Prior to these changes, attempting to use an IQueryable with sort definitions would treat the passed object as an IEnumerable, causing Entity Framework to request all relevant records from the server. 

Now, the overloads for IQueryable will be preferred when providing an IQueryable. This improves performance with existing implementations when IQueryable is provided, while keeping the functionality and public API identical. 

This change has no effect on the Items property of the DataGrid, but is useful when using ServerData, and could likely be extended to work with DataGrid.Items where available in future. 

## How Has This Been Tested?
Tested via integration with my own projects. 

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
