### PR TITLE
Build: Add LangVersion latest property

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,5 +2,6 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj
+++ b/src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <WarningsAsErrors>true</WarningsAsErrors>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   


### PR DESCRIPTION
## Description
I enabled the `<LangVersion>latest</LangVersion` property. It's now possible to use the latest C# features in older target frameworks. For instance, collection expressions now also working in .NET 7:

```c#
public List<TChildComponent> Items { get; } = [];
```

 I also removed the `<WarningsAsErrors>true</WarningsAsErrors>` property, as `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` is enabled across all projects.

## How Has This Been Tested?
I checked if the latest C#12 features are also available in .NET 7 target.

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
