### PR TITLE
Docs: Add another level of depth to the MudTreeView ServerData example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -26,25 +26,56 @@
     protected override void OnInitialized()
     {
         TreeItems.Add(new ExampleTreeItemData("All Mail") { Icon = Icons.Material.Filled.Email });
-        TreeItems.Add(new ExampleTreeItemData("Trash") { Icon = Icons.Material.Filled.Delete });
+        TreeItems.Add(new ExampleTreeItemData("Trash") { Icon = Icons.Material.Filled.Delete, Expandable = false });
         TreeItems.Add(new ExampleTreeItemData("Categories") {
                 Icon = Icons.Material.Filled.Label,
                 Expanded = true,
                 Children = [
-                        new ExampleTreeItemData("Social") { Icon = Icons.Material.Filled.Group, Number = 90 },
+                            new ExampleTreeItemData("Promotions") { 
+                                Icon = Icons.Material.Filled.Group, 
+                                Number = 69,
+                                Children = [
+                                    new ExampleTreeItemData("L.E.D Door Mats") { Icon = Icons.Material.Outlined.Lightbulb, Number = 10 },
+                                    new ExampleTreeItemData("Car Beauty Salon") { Icon = Icons.Material.Filled.CarRepair, Number = 20 },
+                                    new ExampleTreeItemData("Fakedoors.com") { Icon = Icons.Material.Outlined.DoorFront, Number = 30 },
+                                    new ExampleTreeItemData("Bluetooth Toilet") { Icon = Icons.Material.Filled.Wc, Number = 42 }
+                                ]},
                         new ExampleTreeItemData("Updates") { Icon = Icons.Material.Filled.Info, Number = 2294 },
                         new ExampleTreeItemData("Forums") { Icon = Icons.Material.Filled.QuestionAnswer, Number = 3566 },
-                        new ExampleTreeItemData("Promotions") { Icon = Icons.Material.Filled.LocalOffer, Number = 733 }
-                    ]
+                        new ExampleTreeItemData("Social") { Icon = Icons.Material.Filled.LocalOffer, Number = 733 }
+                ]
             });
-        TreeItems.Add(new ExampleTreeItemData("History") { Icon = Icons.Material.Filled.Label, Expandable = false });
+        TreeItems.Add(new ExampleTreeItemData("History") { Icon = Icons.Material.Filled.Label });
     }
 
     public async Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)
     {
+        // wait 500ms to simulate a server load, then recursively search through our tree to find the child items for the given value
         await Task.Delay(500);
-        var parentNode = TreeItems.FirstOrDefault(x => x.Value == parentValue);
-        return parentNode?.Children;
+        foreach (var item in TreeItems) {
+            if (item.Value == parentValue)
+                return item.Children;
+            if (!item.HasChildren)
+                continue;
+            var descendentItem = FindTreeItemData(parentValue, item);
+            if (descendentItem != null)
+                return descendentItem.Children;
+        }
+        return null;
+    }
+
+    private TreeItemData<string> FindTreeItemData(string value, TreeItemData<string> parent)
+    {
+        foreach (var child in parent.Children) {
+            if (child.Value == value)
+                return child;
+            if (!child.HasChildren)
+                continue;
+            var descendentItem = FindTreeItemData(value, child);
+            if (descendentItem != null)
+                return descendentItem;
+        }
+        return null;
     }
 
 }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -4,48 +4,31 @@
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView ServerData="LoadServerData" Items="TreeItems">
         <ItemTemplate>
-            <MudTreeViewItem Text="@context.Text" Value="@context.Value" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.Expandable"
-                             EndText="@((context as ExampleTreeItemData).Number?.ToString())" EndTextTypo="@Typo.caption" />
+            <MudTreeViewItem Value="@context.Value" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.Expandable"/>
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>
 
 @code {
-    private List<ExampleTreeItemData> TreeItems { get; set; } = new();
-
-    public class ExampleTreeItemData : TreeItemData<string>
-    {
-        public ExampleTreeItemData(string value) : base(value)
-        {
-            Text = value;
-        }
-
-        public int? Number { get; set; }
-    }
+    private List<TreeItemData<string>> TreeItems { get; set; } = new();
 
     protected override void OnInitialized()
     {
-        TreeItems.Add(new ExampleTreeItemData("All Mail") { Icon = Icons.Material.Filled.Email, Number = 2345 });
-        TreeItems.Add(new ExampleTreeItemData("Trash") { Icon = Icons.Material.Filled.Delete, Expandable = false });
-        TreeItems.Add(new ExampleTreeItemData("Categories") {
-                Icon = Icons.Material.Filled.Label,
-                Expanded = true,
+        TreeItems.Add(new TreeItemData<string> {
+                Value = "All Mail", Icon = Icons.Material.Filled.Label, Expanded = true,
                 Children = [
-                            new ExampleTreeItemData("Promotions") { 
-                                Icon = Icons.Material.Filled.Group, 
-                                Number = 4,
+                        new TreeItemData<string> { Value = "Promotions", Icon = Icons.Material.Filled.Group, 
                                 Children = [
-                                    new ExampleTreeItemData("L.E.D Door Mats") { Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
-                                    new ExampleTreeItemData("Car Beauty Salon") { Icon = Icons.Material.Filled.CarRepair, Expandable = false },
-                                    new ExampleTreeItemData("Fakedoors.com") { Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
-                                    new ExampleTreeItemData("Bluetooth Toilet") { Icon = Icons.Material.Filled.Wc, Expandable = false }
+                                    new TreeItemData<string> { Value = "L.E.D Door Mats", Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
+                                    new TreeItemData<string> { Value = "Car Beauty Salon", Icon = Icons.Material.Filled.CarRepair, Expandable = false },
+                                    new TreeItemData<string> { Value = "Fakedoors.com", Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
+                                    new TreeItemData<string> { Value = "Bluetooth Toilet", Icon = Icons.Material.Filled.Wc, Expandable = false }
                                 ]},
-                        new ExampleTreeItemData("Updates") { Icon = Icons.Material.Filled.Info, Number = 2294, Expandable = false },
-                        new ExampleTreeItemData("Forums") { Icon = Icons.Material.Filled.QuestionAnswer, Number = 3566, Expandable = false },
-                        new ExampleTreeItemData("Social") { Icon = Icons.Material.Filled.LocalOffer, Number = 733, Expandable = false }
-                    ]
-            });
-        TreeItems.Add(new ExampleTreeItemData("History") { Icon = Icons.Material.Filled.Label, Number = 69 });
+                    new TreeItemData<string> { Value = "Updates", Icon = Icons.Material.Filled.Info, Expandable = false },
+                    new TreeItemData<string> { Value = "Forums", Icon = Icons.Material.Filled.QuestionAnswer, Expandable = false },
+                    new TreeItemData<string> { Value = "Social", Icon = Icons.Material.Filled.LocalOffer, Expandable = false }
+                ]});
+        TreeItems.Add(new TreeItemData<string> { Value = "Trash", Icon = Icons.Material.Filled.Delete });
     }
 
     public async Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -25,7 +25,7 @@
 
     protected override void OnInitialized()
     {
-        TreeItems.Add(new ExampleTreeItemData("All Mail") { Icon = Icons.Material.Filled.Email });
+        TreeItems.Add(new ExampleTreeItemData("All Mail") { Icon = Icons.Material.Filled.Email, Number = 2345 });
         TreeItems.Add(new ExampleTreeItemData("Trash") { Icon = Icons.Material.Filled.Delete, Expandable = false });
         TreeItems.Add(new ExampleTreeItemData("Categories") {
                 Icon = Icons.Material.Filled.Label,
@@ -33,19 +33,19 @@
                 Children = [
                             new ExampleTreeItemData("Promotions") { 
                                 Icon = Icons.Material.Filled.Group, 
-                                Number = 69,
+                                Number = 4,
                                 Children = [
-                                    new ExampleTreeItemData("L.E.D Door Mats") { Icon = Icons.Material.Outlined.Lightbulb, Number = 10 },
-                                    new ExampleTreeItemData("Car Beauty Salon") { Icon = Icons.Material.Filled.CarRepair, Number = 20 },
-                                    new ExampleTreeItemData("Fakedoors.com") { Icon = Icons.Material.Outlined.DoorFront, Number = 30 },
-                                    new ExampleTreeItemData("Bluetooth Toilet") { Icon = Icons.Material.Filled.Wc, Number = 42 }
+                                    new ExampleTreeItemData("L.E.D Door Mats") { Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
+                                    new ExampleTreeItemData("Car Beauty Salon") { Icon = Icons.Material.Filled.CarRepair, Expandable = false },
+                                    new ExampleTreeItemData("Fakedoors.com") { Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
+                                    new ExampleTreeItemData("Bluetooth Toilet") { Icon = Icons.Material.Filled.Wc, Expandable = false }
                                 ]},
-                        new ExampleTreeItemData("Updates") { Icon = Icons.Material.Filled.Info, Number = 2294 },
-                        new ExampleTreeItemData("Forums") { Icon = Icons.Material.Filled.QuestionAnswer, Number = 3566 },
-                        new ExampleTreeItemData("Social") { Icon = Icons.Material.Filled.LocalOffer, Number = 733 }
-                ]
+                        new ExampleTreeItemData("Updates") { Icon = Icons.Material.Filled.Info, Number = 2294, Expandable = false },
+                        new ExampleTreeItemData("Forums") { Icon = Icons.Material.Filled.QuestionAnswer, Number = 3566, Expandable = false },
+                        new ExampleTreeItemData("Social") { Icon = Icons.Material.Filled.LocalOffer, Number = 733, Expandable = false }
+                    ]
             });
-        TreeItems.Add(new ExampleTreeItemData("History") { Icon = Icons.Material.Filled.Label });
+        TreeItems.Add(new ExampleTreeItemData("History") { Icon = Icons.Material.Filled.Label, Number = 69 });
     }
 
     public async Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)


### PR DESCRIPTION
The tree in the server loading example is quite shallow. Added a third level to it for demonstration purposes. Also removed some unnecessary clutter that adds nothing of value to the example. The didactic value should be much greater now.

![image](https://github.com/MudBlazor/MudBlazor/assets/44090/b9bce955-f010-4703-93eb-6461f9f3cce4)

@dennisrahmen FYI