### PR TITLE
MudTabs: Add tab slider transitions after first render

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsHeadersWrapExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsHeadersWrapExample.razor
@@ -9,7 +9,7 @@
     <MudSelectItem T="Position" Value="@Position.Bottom">Bottom</MudSelectItem>
 </MudSelect>
 
-<MudTabs Elevation="4" Rounded="true" TabHeadersInline="true" Position="@Position">
+<MudTabs Elevation="4" Rounded="true" WrapHeaders="true" Position="@Position">
     <MudTabPanel Text="One" />
     <MudTabPanel Text="Two">
         <TabWrapperContent>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1132,21 +1132,15 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ToggleTabsSliderAnimation()
         {
-            //The first tab should be active because for the rest the slider position is calculated by JS
-            //and before the calculation the slider is hidden to avoid movement on first load
             var comp = Context.RenderComponent<ToggleTabsSlideAnimationTest>(p => p.Add(x => x.SelectedTab, 0));
 
-            //Set SliderAnimation to true
-            //Check if style attr does not contain transform: none
             comp.Instance.SliderAnimation = true;
             comp.Render();
-            comp.Find(".mud-tab-slider").GetAttribute("style").Contains("transition:none").Should().BeFalse();
+            comp.Find(".mud-tab-slider").ClassList.Should().Contain("mud-tab-slider-transition");
 
-            //Set SliderAnimation to false
-            //Check if style attr contains transform: none
             comp.Instance.SliderAnimation = false;
             comp.Render();
-            comp.Find(".mud-tab-slider").GetAttribute("style").Contains("transition:none").Should().BeTrue();
+            comp.Find(".mud-tab-slider").ClassList.Should().NotContain("mud-tab-slider-transition");
 
         }
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -533,6 +533,7 @@ namespace MudBlazor
             .AddClass($"mud-{SliderColor.ToDescriptionString()}", SliderColor != Color.Inherit)
             .AddClass($"mud-tab-slider-horizontal", IsHorizontalTabs())
             .AddClass($"mud-tab-slider-vertical", IsVerticalTabs())
+            .AddClass($"mud-tab-slider-transition", SliderAnimation && _isRendered)
             .Build();
 
         protected string MaxHeightStyles =>
@@ -546,7 +547,6 @@ namespace MudBlazor
             .AddStyle("height", _sliderSize.ToPx(), IsVerticalTabs())
             .AddStyle(RightToLeft ? "right" : "left", _sliderXaxis.ToPx())
             .AddStyle("top", _sliderYaxis.ToPx())
-            .AddStyle("transition", "none", SliderAnimation == false)
             .Build();
 
         private bool IsHorizontalTabs() => Position is Position.Top or Position.Bottom;

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -188,19 +188,21 @@
 .mud-tab-slider {
   position: absolute;
   background: var(--mud-palette-primary);
-  transition-duration: .3s;
-  transition-timing-function: cubic-bezier(.64,.09,.08,1);
 
   &.mud-tab-slider-horizontal {
     height: 2px;
     will-change: left;
-    transition-property: left,right,width,top;
   }
 
   &.mud-tab-slider-vertical {
     width: 2px;
     will-change: top;
-    transition-property: top,width;
+  }
+
+  &.mud-tab-slider-transition {
+    transition-duration: .3s;
+    transition-timing-function: cubic-bezier(.64,.09,.08,1);
+    transition-property: left,right,width,top;
   }
 }
 


### PR DESCRIPTION
## Description

After the first render of the `MudTabs` component, the tab slider transitions are added via a new `.mud-tab-slider-transition` class.

fixes #9167 
> The slider doesn't have an animation when first shown

## How Has This Been Tested?
visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
