### PR TITLE
Docs: Fix regressions in v7

### DIFF
--- a/src/MudBlazor.Docs/Components/LandingPage/Browser.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/Browser.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Components.LandingPage
 
 <div class="lp-effect browser-shadow" aria-hidden="true"></div>
-<div class="lp-device browser" aria-hidden="true">
+<div class="lp-device browser">
     <div class="lp-device-toolbar">
         <div class="lp-device-toolbar-button"></div>
         <div class="lp-device-toolbar-button"></div>

--- a/src/MudBlazor.Docs/Components/LandingPage/CalculatorApp/Calculator.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/CalculatorApp/Calculator.razor
@@ -13,7 +13,7 @@
     </div>
 </MudPaper>
 <MudPaper Square="true" Elevation="0" Height="70%" Class="lp-calc-buttons pb-16">
-    <MudGrid Spacing="0" class="mud-height-full">
+    <MudGrid Spacing="0" Class="mud-height-full">
         <MudItem xs="3" Class="d-flex justify-center align-center pa-6">
             <MudButton OnClick="@(() => CalcExpression += "(")" Class="rounded-circle">(</MudButton>
         </MudItem>

--- a/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/MiniApp/MiniApp.razor
@@ -42,16 +42,10 @@
     </div>
     <div class="@ContentClassNames">
         <MudToolBar Gutters="false" Class="mud-text-secondary">
-            <MudTooltip Delay="1000" Text="Toggle Drawer">
-                <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@GetIcon()" Color="Color.Inherit" />
-            </MudTooltip>
-            <MudTooltip Delay="1000" Text="Search">
-                <MudIconButton Icon="@Icons.Material.Outlined.Search" Color="Color.Inherit" />
-            </MudTooltip>
+            <MudIconButton OnClick="@(() => ToggleMiniDrawer())" Icon="@GetIcon()" Color="Color.Inherit" />
+            <MudIconButton Icon="@Icons.Material.Outlined.Search" Color="Color.Inherit" />
             <MudSpacer />
-            <MudTooltip Delay="1000" Text="Notifications">
-                <MudIconButton Class="mud-text-secondary" Icon="@Icons.Material.Outlined.Notifications"/>
-            </MudTooltip>
+            <MudIconButton Class="mud-text-secondary" Icon="@Icons.Material.Outlined.Notifications"/>
             <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" PopoverClass="mudblazor-landingpage-scaled-menu mud-elevation-1">
                 <ActivatorContent>
                     <MiniAppAvatar />

--- a/src/MudBlazor.Docs/Components/LandingPage/Phone.razor
+++ b/src/MudBlazor.Docs/Components/LandingPage/Phone.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Components.LandingPage
 
 <div class="lp-effect phone-shadow" aria-hidden="true"></div>
-<div class="lp-device phone" aria-hidden="true">
+<div class="lp-device phone">
     <div class="lp-device-screen">
         <div class="lp-app-scale">
             <div class="relative mud-height-full mud-width-full">

--- a/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
@@ -68,7 +68,7 @@
                     <SectionHeader Title="List of Material Colors">
                         <Description>Below is a list of the Material design color palette grouped by primary color</Description>
                     </SectionHeader>
-                    <MudGrid Spacing="4">
+                    <MudGrid Spacing="8">
                         @foreach (var color in MaterialColors)
                         {
                             <MudItem md="6" lg="4" xs="12">

--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Content/Examples/Content3WireframeExample.razor
@@ -4,7 +4,7 @@
 
 <MudContainer Class="mt-16" MaxWidth="MaxWidth.Medium">
     <MudText Typo="Typo.h3" Align="Align.Center" GutterBottom="true">Checkout</MudText>
-    <MudGrid Spacing="6" Class="mt-16">
+    <MudGrid Spacing="12" Class="mt-16">
         <MudItem xs="7">
             <MudText Typo="Typo.h5" GutterBottom="true">Billing address</MudText>
             <MudGrid>

--- a/src/MudBlazor.Docs/Pages/Index.razor
+++ b/src/MudBlazor.Docs/Pages/Index.razor
@@ -40,7 +40,7 @@
     <MudText Typo="Typo.subtitle2" Align="Align.Center" Class="mb-16" Style="color: #8898aa;">
         The continued development and maintenance of MudBlazor is secured by our sponsors
     </MudText>
-    <MudGrid Spacing="5" Justify="Justify.Center">
+    <MudGrid Spacing="10" Justify="Justify.Center">
         <MudItem xs="6" md="4">
             <Sponsor LandingPage="true" Name="Adaris" Image="Adaris.png" Website="https://www.adaris.ch/"/>
         </MudItem>
@@ -83,7 +83,7 @@
         <div class="absolute z-20 d-flex justify-center align-end mud-width-full mud-height-full">
             <MudButton OnClick="ToggleTestimonials" Color="Color.Primary" Variant="Variant.Filled" DropShadow="false" Size="Size.Large" Class="mb-12">@(_showTestimonials? "Show less" : "Show more")</MudButton>
         </div>
-        <MudGrid Spacing="4">
+        <MudGrid Spacing="8">
             <MudItem md="5">
                 <MudCard Elevation="24">
                     <MudCardHeader Class="px-6 pt-6">

--- a/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_landingpage.scss
@@ -463,8 +463,8 @@
 
     .graphic-wrapper {
       position: absolute;
-      top: 0;
-      right: 0;
+      top: 12px;
+      right: -12px;
     }
   }
 
@@ -564,8 +564,8 @@
 
   .world-map {
     position: absolute;
-    top: 0;
-    left: 0;
+    top: 12px;
+    left: 12px;
     height: 100%;
     width: 100%;
     z-index: -1;
@@ -808,9 +808,9 @@
 
   .mudblazor-landingpage .top-section .graphic-wrapper {
     position: absolute;
-    top: 0;
+    top: 12px;
     right: unset;
-    left: 0;
+    left: 12px;
 
     .lp-device.phone, .lp-effect.phone-shadow {
       top: 128px;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes some regressions found during the v7 release cycle.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Grid layouts were changed in #8910 but not updated in the docs, leading to differences:

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/1bc27e79-7453-4e81-9674-5e88bf51fac9)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/b9579c92-96e2-401d-b132-59a2cdf6ccbc)

The grid change also impacted position of the graphics due to them using absolute but the margins are now weighted toward the top left

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/ffbc04d2-c5d1-4363-9bc5-257632e533f6)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/06fbc864-ffa1-48d2-b2a1-a6e917902960)


Certain graphics were hidden from screen readers in #9075 without realizing elements inside were interactive and focusable.

Tooltips were removed from the MiniApp due to inconsistency with no other elements having them inside

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
