### PR TITLE
MudTabs: Fix tab slider position

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -624,7 +624,8 @@ namespace MudBlazor
 
         private async void OnResized(IDictionary<ElementReference, BoundingClientRect> changes)
         {
-            if (changes.Count == 1 && changes.ContainsKey(_tabsContentSize) && _panels.Count > 0)
+            // parent resized and children are missing from the event
+            if (changes.ContainsKey(_tabsContentSize) && _panels.Any(x => changes.ContainsKey(x.PanelRef) == false))
                 await _resizeObserver.Resync();
 
             Rerender();

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -53,7 +53,7 @@ class MudResizeObserver {
         this.options = options;
         this._dotNetRef = dotNetRef
 
-        this.tranformRegex = /(?<axis>[XY])\(-?(?<amount>\d+)/;
+        this.tranformRegex = /^translate([XY])\(-?([1-9]\d*)/;
 
         var delay = (this.options || {}).reportRate || 200;
 

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -97,15 +97,12 @@ class MudResizeObserver {
     getBoundingClientRect(element) {
         var rect = window.mudElementRef.getBoundingClientRect(element);
 
-        var transform = element.parentNode.style.transform.match(this.tranformRegex);
-        if (transform !== null) {
-            var amount = parseInt(transform.groups.amount);
+        var [, axis, amount] = element.parentNode.style.transform.match(this.tranformRegex) || [];
 
-            if (transform.groups.axis == 'X')
-                rect.scrollX += amount;
-            else
-                rect.scrollY += amount;
-        }
+        if (axis == 'X')
+            rect.scrollX += parseInt(amount);
+        else if (axis == 'Y')
+            rect.scrollY += parseInt(amount);
 
         return rect;
     }


### PR DESCRIPTION
## Description
fixes #9167

> The slider [not] always renders in the correct position

When the window is resized after the tabs are scrolled, the slider is misaligned. The `ResizeObserver` now takes into account the amount the tabs are scrolled over for calculating the absolute position.

> ... slider is completely broken when selecting the option `nine with a long title`.

When the width of the element stays the same, but the position changed, there is no event triggered so the slider is misaligned for that element. This can occur when live switching from Top to Start/Left. The `OnResized` event now triggers a position resync if any of the panels are missing from the JavaScript event when the parent resizes.

## How Has This Been Tested?
visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
