### PR TITLE
MudDataGridPager: Add AllItemsText Parameter (#9235)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationAllItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationAllItemsTest.razor
@@ -1,0 +1,32 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager PageSizeOptions="new int[] {10, 25, int.MaxValue }" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    private List<Item> _items = new List<Item>();
+
+    protected override void OnInitialized()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            _items.Add(new Item(i.ToString()));
+        }
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public Item(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationAllItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationAllItemsTest.razor
@@ -5,7 +5,7 @@
         <PropertyColumn Property="x => x.Name" />
     </Columns>
     <PagerContent>
-        <MudDataGridPager PageSizeOptions="new int[] {10, 25, int.MaxValue }" />
+        <MudDataGridPager PageSizeOptions="new int[] { 10, 25, int.MaxValue }" />
     </PagerContent>
 </MudDataGrid>
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -745,7 +745,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DataGridPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
             // check that the page size dropdown is shown
-            comp.FindComponents<MudSelect<string>>().Count.Should().Be(1);
+            comp.FindComponents<MudSelect<int>>().Count.Should().Be(1);
 
             dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -791,6 +791,31 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudSelect<string>>().Should().BeEmpty();
         }
 
+        /// <summary>
+        /// Tests that the "All" data grid pager option shows all items
+        /// </summary>
+        [Test]
+        public async Task DataGridPagingAllTest()
+        {
+            var comp = Context.RenderComponent<DataGridPaginationAllItemsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationAllItemsTest.Item>>();
+            var pager = comp.FindComponent<MudSelect<int>>().Instance;
+
+            dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20"); //check initial value
+            // change page size
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetRowsPerPageAsync(int.MaxValue));
+            pager.Value.Should().Be(int.MaxValue);
+            dataGrid.Instance.RowsPerPage.Should().Be(int.MaxValue);
+            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 20");
+
+            comp.FindAll(".mud-table-pagination-actions button")[0].IsDisabled().Should().Be(true); //buttons are disabled
+            comp.FindAll(".mud-table-pagination-actions button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll(".mud-table-pagination-actions button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll(".mud-table-pagination-actions button")[3].IsDisabled().Should().Be(true);
+
+            comp.FindAll(".mud-table-pagination-select")[^1].TextContent.Trim().Should().Be("All");
+        }
+
         [Test]
         public void DataGridHideNavigationTest()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -12,7 +12,14 @@
         <MudSelect T="string" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid?.RowsPerPage.ToString()" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
             @foreach (int pageSize in PageSizeOptions)
             {
-                <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
+                if (pageSize == int.MaxValue)
+                {
+                    <MudSelectItem T="int" Value="@pageSize">@AllItemsText</MudSelectItem>
+                }
+                else 
+                {
+                    <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
+                }
             }
         </MudSelect>
     }

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -9,7 +9,7 @@
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString
         </MudText>
-        <MudSelect T="int" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid.RowsPerPage" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
+        <MudSelect T="int" ValueChanged="@SetRowsPerPageAsync" Value="@(DataGrid?.RowsPerPage ?? 0)" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
             @foreach (int pageSize in PageSizeOptions)
             {
                 if (pageSize == int.MaxValue)

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -9,7 +9,7 @@
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString
         </MudText>
-        <MudSelect T="string" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid?.RowsPerPage.ToString()" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
+        <MudSelect T="int" ValueChanged="@SetRowsPerPageAsync" Value="@DataGrid.RowsPerPage" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
             @foreach (int pageSize in PageSizeOptions)
             {
                 if (pageSize == int.MaxValue)
@@ -18,7 +18,7 @@
                 }
                 else 
                 {
-                    <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
+                    <MudSelectItem T="int" Value="@pageSize">@pageSize.ToString().ToUpper()</MudSelectItem>
                 }
             }
         </MudSelect>

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -83,6 +83,12 @@ namespace MudBlazor
         [Parameter]
         public bool ShowPageNumber { get; set; } = true;
 
+        /// <summary>
+        /// Defines the text shown in the items per page dropdown when a user provides int.MaxValue as an option
+        /// </summary>
+        [Parameter]
+        public string AllItemsText { get; set; } = "All";
+
         private string Info
         {
             get

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -112,11 +112,11 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
-        private async Task SetRowsPerPageAsync(string size)
+        private async Task SetRowsPerPageAsync(int size)
         {
             if (DataGrid != null)
             {
-                await DataGrid.SetRowsPerPageAsync(int.Parse(size));
+                await DataGrid.SetRowsPerPageAsync(size);
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Fixes #9235 
`MudTablePager` has the `AllItemsText` property to allow custom naming of int.MaxValue when it is given as a page size option. This gets rid of the ugly '2147483647' and replaces it with "All" by default in the options.

`AllItemsText` has been added as a parameter to `MudDataGridPager`, a string value with "All" as its' default.
`MudDataGridPager` has been changed to mirror that of `MudTable` by converting the page size `MudSelect` from `T="string"` to `T="int"` and `SetRowsPerPageAsync` has been changed to accept an int `size` instead of string.


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Added a new unit test in DataGridTests.cs called DataGridPagingAllTest() which uses the new DataGridPaginationAllItemsTest component.
I confirmed visually that "All" is an option and selection shows all rows.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/MudBlazor/MudBlazor/assets/87720362/e454c4bb-2cd4-4333-832e-fb488baa7c39)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
