### PR TITLE
MudDataGrid: With VirtualizeServerData, reset StartIndex if beyond TotalItemsCount boundaries.

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
-using Microsoft.Extensions.Logging;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Clone;
 
@@ -1755,7 +1754,7 @@ namespace MudBlazor
                 _server_data = await VirtualizeServerData(
                     stateFunc(request.StartIndex, request.Count),
                     request.CancellationToken
-                    );
+                );
 
                 if (request.StartIndex > 0 && _server_data.TotalItems < request.StartIndex + request.Count)
                 {


### PR DESCRIPTION
Reset the StartIndex if it extends beyond the TotalItemsCount boundaries.

## Description

### Problem
If an external filter is applied to MudDataGrid using VirtualizeServerData, a situation may arise where the user has scrolled down the table data, applied a filter, and then sees 0 records in the table instead of, for example, 10. This occurs because the StartIndex changes when scrolling the table body, and after applying the filter, this StartIndex remains the same. If TotalItemsCount is returned less than StartIndex, an empty collection is returned to the user.

### Solution
After the query, check the relationship between StartIndex and TotalItemsCount and send a repeated request with StartIndex equal to 0 if the condition is met.

### Testing
I tried adding a test, but for some unknown reason, the MudDataGrid component in the test displays all the table rows in the HTML markup, instead of a small batch of elements corresponding to the StartIndex and Count parameters. Under such conditions, I was unable to create a suitable test. However, in the Viewer on the component I created for the test, the fixes work as intended.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
