### PR TITLE
ElementReferenceExtensions: Use delegate for retrieving JSRuntime

### DIFF
--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -41,7 +41,6 @@ namespace MudBlazor
             }
 
             return null;
-
         }
 
         public static ValueTask MudFocusFirstAsync(this ElementReference elementReference, int skip = 0, int min = 0) =>


### PR DESCRIPTION
## Description

This is an optimization. Components heavily use this trick to access the internal `JSRuntime` from the `ElementReference`.

We are forced to use reflection, but instead of invoking reflection each time (which is not optimal for WASM), we compile a delegate. Once the delegate is compiled, the performance is the same as regular code without reflection, as if we had direct access to `JSRuntime`. The only downside is that the first usage is slow due to reflection and compiling the expression, but considering that this is a hot path used multiple times, it's worth it.

**FYI**: There is a ticket in aspnetcore requesting to make the `JSRuntime` public: https://github.com/dotnet/aspnetcore/issues/47197. However, I don't have much faith that this will ever happen.