### PR TITLE
MudTable: Use InvokeAsync() in method InvokeServerLoadFunc

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -567,7 +567,7 @@ namespace MudBlazor
                 CurrentPage = 0;
 
             Loading = false;
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
             Context?.PagerStateHasChanged?.Invoke();
         }
 


### PR DESCRIPTION
## Description
In the `MudTable` class, there are two method calls of `StateHasChanged` in the `InvokeServerLoadFunc` method.  One with `InvokeAsync()` and the other without. 

The following error occurs:
```
 Unhandled exception in circuit 'csdeJXMxhUv92EmWV4I-aQzC5uulQQa6FuQ0HbD5svg'.
      System.InvalidOperationException: The current thread is not associated with the Dispatcher. Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.
         at Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged()
         at MudBlazor.MudTable`1.InvokeServerLoadFunc()
```



## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
