### PR TITLE
MudFileUpload: Use ParameterState

### DIFF
--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
@@ -33,7 +33,7 @@
         }
         @if (SelectedTemplate != null)
         {
-            @SelectedTemplate(_value)
+            @SelectedTemplate(_filesState.Value)
         }
     </InputContent>
 </MudInputControl>

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -24,13 +25,21 @@ namespace MudBlazor
     /// <typeparam name="T">Either <see cref="IBrowserFile"/> for a single file or <see cref="IReadOnlyCollection{IBrowserFile}">IReadOnlyCollection&lt;IBrowserFile&gt;</see> for multiple files.</typeparam>
     public partial class MudFileUpload<T> : MudFormComponent<T, string>, IActivatable
     {
+        private readonly ParameterState<T?> _filesState;
+
         [Inject]
         private IJSRuntime JsRuntime { get; set; } = null!;
 
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        public MudFileUpload() : base(new DefaultConverter<T>()) { }
+        public MudFileUpload() : base(new DefaultConverter<T>())
+        {
+            using var registerScope = CreateRegisterScope();
+            _filesState = registerScope.RegisterParameter<T?>(nameof(Files))
+                .WithParameter(() => Files)
+                .WithEventCallback(() => FilesChanged);
+        }
 
         private readonly string _id = $"mud_fileupload_{Guid.NewGuid()}";
 
@@ -48,16 +57,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
-        public T? Files
-        {
-            get => _value;
-            set
-            {
-                if (_value != null && _value.Equals(value))
-                    return;
-                _value = value;
-            }
-        }
+        public T? Files { get; set; }
 
         /// <summary>
         /// Occurs when <see cref="Files"/> has changed.
@@ -177,7 +177,7 @@ namespace MudBlazor
 
         public async Task ClearAsync()
         {
-            _value = default;
+            await _filesState.SetValueAsync(default);
             await NotifyValueChangedAsync();
             await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInput.resetValue", _id);
         }
@@ -206,19 +206,19 @@ namespace MudBlazor
             if (typeof(T) == typeof(IReadOnlyList<IBrowserFile>))
             {
                 var newFiles = args.GetMultipleFiles(MaximumFileCount);
-                if (AppendMultipleFiles && _value is IReadOnlyList<IBrowserFile> oldFiles)
+                if (AppendMultipleFiles && _filesState.Value is IReadOnlyList<IBrowserFile> oldFiles)
                 {
                     var allFiles = oldFiles.Concat(newFiles).ToList();
-                    _value = (T)(object)allFiles.AsReadOnly();
+                    await _filesState.SetValueAsync((T)(object)allFiles.AsReadOnly());
                 }
                 else
                 {
-                    _value = (T)newFiles;
+                    await _filesState.SetValueAsync((T)newFiles);
                 }
             }
             else if (typeof(T) == typeof(IBrowserFile))
             {
-                _value = args.FileCount == 1 ? (T)args.File : default;
+                await _filesState.SetValueAsync(args.FileCount == 1 ? (T)args.File : default);
             }
             else
             {
@@ -246,9 +246,13 @@ namespace MudBlazor
         private async Task NotifyValueChangedAsync()
         {
             Touched = true;
-            await FilesChanged.InvokeAsync(_value);
+            await FilesChanged.InvokeAsync(_filesState.Value);
             await BeginValidateAsync();
-            FieldChanged(_value);
+            FieldChanged(_filesState.Value);
         }
+
+        protected override T? ReadValue() => _filesState.Value;
+
+        protected override Task WriteValueAsync(T? value) => _filesState.SetValueAsync(value);
     }
 }

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -177,7 +177,6 @@ namespace MudBlazor
 
         public async Task ClearAsync()
         {
-            //await _filesState.SetValueAsync(default);
             await NotifyValueChangedAsync(default);
             await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInput.resetValue", _id);
         }


### PR DESCRIPTION
## Description
The main problem is that `MudFileUpload` uses the `MudFormComponent`, which contains this pesky `_value` property that `MudFileUpload` uses as its main value.

The `ParameterState` doesn't have any mechanism to keep multiple backing fields in sync (and I don't think it should have any). Therefore, I came up with a proxy mechanism:

```diff
+protected virtual T? ReadValue()
+protected virtual Task WriteValueAsync(T? value)
```

This uses `_value` by default. However, if you want to use any other property as the main backing field for the `MudFormComponent`, you can override it. This is a good solution because it's not a breaking change, and you don't have to change other components that use `MudFormComponent`. With this, you can slowly move away from `_value`, which **forces** you to use logic in parameters.

## How Has This Been Tested?
Manually and current unit tests.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
