### PR TITLE
MudDataGridPager: When no items, Pager now shows "0-0 of 0" (#9247)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationNoItemsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationNoItemsTest.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDataGrid Items="@_items">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager PageSizeSelector="@PageSizeDropDown" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    [Parameter]
+    public bool PageSizeDropDown { get; set; } = true;
+
+    private List<Item> _items = new List<Item>();
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public Item(string name)
+        {
+            Name = name;
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -818,6 +818,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridPaginationNoItemsTest()
+        {
+            var comp = Context.RenderComponent<DataGridPaginationNoItemsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationNoItemsTest.Item>>();
+            // check that the page size dropdown is shown
+            comp.FindComponents<MudSelect<int>>().Count.Should().Be(1);
+
+            dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("0-0 of 0");
+        }
+
+        [Test]
         public void DataGridHideNavigationTest()
         {
             var comp = Context.RenderComponent<DataGridPaginationTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -96,7 +96,7 @@ namespace MudBlazor
                 if (DataGrid == null)
                     return "DataGrid==null";
                 Debug.Assert(DataGrid != null);
-                var firstItem = DataGrid.CurrentPage * DataGrid.RowsPerPage + 1;
+                var firstItem = DataGrid?.GetFilteredItemsCount() == 0 ? 0 : DataGrid.CurrentPage * DataGrid.RowsPerPage + 1;
                 var lastItem = Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount());
                 var allItems = DataGrid?.GetFilteredItemsCount();
                 return InfoFormat.Replace("{first_item}", $"{firstItem}").Replace("{last_item}", $"{lastItem}").Replace("{all_items}", $"{allItems}");


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes #9247 
In MudDataGrid, if there is no data/ the data is empty, meaning the total number of records is 0, MudDataGridPager shows the info as "1-0 of 0."

This has been changed in the MudDataGridPager `Info` logic so that when the grid has empty data, it will show "0-0 of 0" instead now.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Added a new unit test in DataGridTests.cs called DataGridPagingNoItemsTest() which uses the new DataGridPaginationNoItemsTest component.
I confirmed visually that the pager now shows "0-0 of 0" when there are no items in the data list.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/MudBlazor/MudBlazor/assets/87720362/7c63e6df-2669-482b-aae2-169d71e70655)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
-  [x] I've added relevant tests.
