### PR TITLE
MudAlert: Remove `alert` role

### DIFF
--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -3,7 +3,7 @@
 @inherits MudComponentBase
 @inject InternalMudLocalizer Localizer
 
-<div role="alert" aria-live="assertive" @attributes="UserAttributes" class="@Classname" Style="@Style" @onclick="EventUtil.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)">
+<div @attributes="UserAttributes" class="@Classname" Style="@Style" @onclick="EventUtil.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)">
 <div class="@ClassPosition">
     @if (!NoIcon)
     {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Removes the role and assertiveness that was previously added for accessibility reasons but I believe is actually a negative due to the way most people use this control. If you look at the docs you will find it used as a notice:

https://mudblazor.com/api/MudAppBar#properties

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/a5eef7f7-bf5b-4b5f-b682-54a787a0bbb3)

https://mudblazor.com/components/togglegroup#api

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/db806953-3f62-4847-a36c-2d5186bb96dc)

I don't see any reason to force the screen reader's attention and neither does

[MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/ce6eb08f-b2e7-4239-82fe-879f43bf2cea)

[MUI](https://mui.com/material-ui/react-alert/)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/0186a780-65d2-44c4-9031-6a8fbde0519d)

(Note the MUI alerts themselves have the role)

[MSFT](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?view=aspnetcore-8.0)

![image](https://github.com/MudBlazor/MudBlazor/assets/7112040/d5f5aa39-ecf2-410d-8c15-f497379a1801)

Ideally we would have a separate control or even a property on this one, but I think the current behavior is niche and can easily be added back through `UserAttributes`.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
