### PR TITLE
MudBadge: Center content with flex instead of negative margins

### DIFF
--- a/src/MudBlazor/Styles/components/_badge.scss
+++ b/src/MudBlazor/Styles/components/_badge.scss
@@ -1,4 +1,4 @@
-﻿
+
 .mud-badge-root {
   position: relative;
   display: inline-block;
@@ -95,13 +95,6 @@
 
     &.mud-badge-icon {
       padding: 4px 6px;
-
-      & .mud-icon-badge {
-        margin-left: -4px;
-        margin-inline-start: -4px;
-        margin-inline-end: unset;
-        margin-top: -4px;
-      }
     }
   }
 
@@ -112,9 +105,6 @@
     & .mud-icon-badge {
       color: inherit;
       font-size: 12px;
-      margin-left: -2px;
-      margin-inline-start: -2px;
-      margin-inline-end: unset;
     }
   }
 
@@ -127,6 +117,9 @@
   }
 
   &.mud-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     &-top {
       &.left {


### PR DESCRIPTION
## Description
MudBadge component currently uses margins to calculate the proper center position of the icon (or content in general).
When changing the browser zoom the icon inside of the MudBadge has been misplaced due to this calculations.
This PR uses flexbox to center the elements vertically and horizontally without any specific pixel definitions, which is more stable.  
It is known that the misalignment is still happening, but according to my current knowledge this is caused by calculations of the positions that might end up being subpixel and browser shifts it to the left or right.

Resolves #9294 

## How Has This Been Tested?
Issue can be tested on https://mudblazor.com/components/badge#usage page with "Security issues" badge. 

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
