### PR TITLE
MudAvatarGroup: Fix Max default value behavior (#9267)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupMaxDefaultTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupMaxDefaultTest.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudAvatarGroup>
+    <MudAvatar Color="Color.Primary">AA</MudAvatar>
+    <MudAvatar Color="Color.Secondary">BB</MudAvatar>
+    <MudAvatar Color="Color.Tertiary">CC</MudAvatar>
+    <MudAvatar Color="Color.Info">DD</MudAvatar>
+    <MudAvatar Color="Color.Secondary">FF</MudAvatar>
+    <MudAvatar Color="Color.Warning">GG</MudAvatar>
+    <MudAvatar Color="Color.Error">HH</MudAvatar>
+</MudAvatarGroup>
+
+@code {
+    public static string __description__ = "When not provided, Max should default to int.MaxValue (2147483647), so all 7 Avatars should display here.";
+}

--- a/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
@@ -34,6 +34,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void AvatarGroupMaxDefaultTest()
+        {
+            var comp = Context.RenderComponent<AvatarGroupMaxDefaultTest>();
+            // select elements needed for the test
+            var group = comp.FindComponent<MudAvatarGroup>();
+            var avatars = group.FindAll(".mud-avatar").ToArray();
+
+            // check initial group settings
+            group.Instance.Max.Should().Be(int.MaxValue); // should default to 2147483647 when not provided
+            group.Instance._avatars.Should().HaveCount(7);
+
+            // verify MaxGroupReached is false for each avatar
+            foreach (var avatar in group.Instance._avatars)
+            {
+                group.Instance.MaxGroupReached(avatar).Should().Be(false);
+            }
+
+            // check initial avatars
+            avatars.Should().HaveCount(7);  // all 7 avatars should display
+            avatars[0].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[1].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[2].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[3].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[4].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[5].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+            avatars[6].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
+
+        }
+
+        [Test]
         public void AvatarGroupChangeMaxTest()
         {
             var comp = Context.RenderComponent<AvatarGroupChangeMaxTest>();

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-@if(AvatarGroup == null || AvatarGroup.MaxGroupReached(this))
+@if(AvatarGroup == null || !AvatarGroup.MaxGroupReached(this))
 {
     <div role="img" @attributes="UserAttributes" class="@Classname" style="@Stylesname">
         @ChildContent

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -115,11 +115,11 @@ namespace MudBlazor
         /// The maximum allowed avatars to display.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>0</c>.  When <c>0</c>, no maximum is enforced.  Otherwise, a "+#" avatar is shown for the number of avatars exceeding this number.
+        /// Avatars above this limit are hidden, and a "+#" is shown for the number of avatars in excess. Defaults to <see cref="int.MaxValue" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Behavior)]
-        public int Max { get; set; }
+        public int Max { get; set; } = int.MaxValue;
 
         /// <summary>
         /// The CSS class applied when the number of avatars exceeds <see cref="Max"/>.
@@ -179,7 +179,7 @@ namespace MudBlazor
 
         internal bool MaxGroupReached(MudAvatar avatar)
         {
-            return _avatars.IndexOf(avatar) < Max;
+            return _avatars.IndexOf(avatar) >= Max;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description
Changed default value of Max from 0 to int.MaxValue, allowing for the edge use case of an intentional, explicit zero Max avatar display while still providing intuitive default behavior when no Max value provided (unlimited).
Corrected the inverted result from the [MaxGroupReached](https://github.com/brian-lagerman/fix-avatar-group-max/blob/7c6214f6925752064d01e69c319e53d4ef94e3a8/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs#L180) function
Resolves: #9267

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
New [AvatarGroupMaxDefaultTest](https://github.com/brian-lagerman/fix-avatar-group-max/blob/cb9985e734430e6ab3d4d4771f4011d2754dee53/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs#L37) added to verify Avatars are fully displayed when no limit set.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
