### PR TITLE
Update TreeItemData.cs

### DIFF
--- a/src/MudBlazor/Components/TreeView/TreeItemData.cs
+++ b/src/MudBlazor/Components/TreeView/TreeItemData.cs
@@ -31,7 +31,7 @@ public class TreeItemData<T> : IEquatable<TreeItemData<T>>
 
     public virtual List<TreeItemData<T>>? Children { get; set; }
 
-    public virtual bool HasChildren => Children is not null && Children.Count > 0;
+    public virtual bool HasChildren => Children is not null && Children.Count != 0;
 
     public virtual bool Equals(TreeItemData<T>? other)
     {


### PR DESCRIPTION
It's better to use `List.Count != 0`
productivity is higher. equality/inequality is simpler than more/less