### PR TITLE
 MudAutocomplete: Make the autocomplete attribute configurable (#9334)

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -41,7 +41,7 @@
                           @onclick="@OnInputClickedAsync"
                           @onfocus="@OnInputFocusedAsync" OnBlur="OnInputBlurredAsync"
                           OnKeyDown="@OnInputKeyDownAsync"
-                          OnKeyUp="@OnInputKeyUpAsync" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
+                          OnKeyUp="@OnInputKeyUpAsync" autocomplete=@AutoComplete KeyUpPreventDefault="KeyUpPreventDefault"
                           Placeholder="@Placeholder" Immediate="true"
                           InputMode="@InputMode" Pattern="@Pattern"
                           ShrinkLabel="@ShrinkLabel"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -41,7 +41,7 @@
                           @onclick="@OnInputClickedAsync"
                           @onfocus="@OnInputFocusedAsync" OnBlur="OnInputBlurredAsync"
                           OnKeyDown="@OnInputKeyDownAsync"
-                          OnKeyUp="@OnInputKeyUpAsync" autocomplete=@AutoComplete KeyUpPreventDefault="KeyUpPreventDefault"
+                          OnKeyUp="@OnInputKeyUpAsync" autocomplete="@AutoComplete" KeyUpPreventDefault="KeyUpPreventDefault"
                           Placeholder="@Placeholder" Immediate="true"
                           InputMode="@InputMode" Pattern="@Pattern"
                           ShrinkLabel="@ShrinkLabel"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -435,11 +435,12 @@ namespace MudBlazor
         public EventCallback<int> ReturnedItemsCountChanged { get; set; }
 
         /// <summary>
-        /// Gets or sets the AutoComplete attribute for the AutocompleteComponent.
-        /// <remarks>
-        /// The default value is set to a unique identifier to disable the browser's autocomplete feature by default.
-        /// </remarks>
+        ///  Sets the autocomplete attribute.
         /// </summary>
+        /// <remarks>
+        /// The autocomplete attribute specifies whether the browser should enable autocomplete for the input field. 
+        /// By default, this attribute is set to a unique identifier to disable the browser's autocomplete feature. 
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string AutoComplete { get; set; } = "mud-disabled-" + Guid.NewGuid();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -435,6 +435,16 @@ namespace MudBlazor
         public EventCallback<int> ReturnedItemsCountChanged { get; set; }
 
         /// <summary>
+        /// Gets or sets the AutoComplete attribute for the AutocompleteComponent.
+        /// <remarks>
+        /// The default value is set to a unique identifier to disable the browser's autocomplete feature by default.
+        /// </remarks>
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public string AutoComplete { get; set; } = "mud-disabled-" + Guid.NewGuid();
+
+        /// <summary>
         /// Displays the search result drop-down.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
### Description
This PR introduces an `autocomplete` parameter to the `MudAutocomplete` component, allowing developers to configure the `autocomplete` attribute directly.

### Problem
The existing method of disabling autocomplete—by appending a unique identifier to the `autocomplete` attribute—no longer works in Chrome as of 2024. Recent changes in browser behavior for security and usability reasons have rendered this approach ineffective.

![image](https://github.com/MudBlazor/MudBlazor/assets/70571116/04b7138f-77ba-4822-ae39-cf2082ba6abf)

As shown in the screenshot, the hardcoded `autocomplete` value overrides other methods that developers might use to customize it, such as setting an HTML element attribute or using splatting.

### Solution
This change adds an `autocomplete` parameter to the `MudAutocomplete` component, enabling developers to configure this attribute as needed. This approach not only resolves the current issue but also future-proofs the component against further changes in browser behavior.

### Impact
- **Developers**: Provides flexibility to set the `autocomplete` attribute based on their specific needs, enhancing usability and accessibility.
- **Backward Compatibility**: The default value remains the same to avoid breaking existing implementations. Developers can opt-in to configure it differently.

### References
- Fixes: #9334
- Provides temporary workaround for #9318

## How Has This Been Tested?
Visually, I have run my build on a local test project and checked if everything works as intended.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
