### PR TITLE
MudDataGrid: Fix Column ungroup

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj" />
     <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
   </ItemGroup>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
-@using System.Collections.ObjectModel
 
 <MudPopoverProvider />
 <MudDataGrid T="Model" ShowMenuIcon="true" Items="@_items" Groupable="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataColumnGroupingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataColumnGroupingTest.razor
@@ -1,0 +1,89 @@
+﻿@using MudBlazor.Examples.Data
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid @ref="_dataGrid" MultiSelection="true" Items="@_elements" Filterable="true"
+             Hideable="true" Groupable="true" GroupExpanded="false" GroupClassFunc="GroupClassFunc">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Number" HeaderClass="number" Title="Nr" Filterable="false" Groupable="false" />
+        <PropertyColumn Property="x => x.Sign" HeaderClass="sign" />
+        <PropertyColumn Property="x => x.Name" HeaderClass="name" />
+        <PropertyColumn Property="x => x.Position" HeaderClass="position" />
+        <PropertyColumn Property="x => x.Molar" HeaderClass="molar" Title="Molar mass" />
+        <PropertyColumn Property="x => x.Group" HeaderClass="group" Title="Category" Grouping GroupBy="@_groupBy">
+            <GroupTemplate>
+                @if (_customizeGroupTemplate)
+                {
+                    <span style="font-weight:bold">Group: @context.Grouping.Key <MudChip Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small">total @context.Grouping.Count()</MudChip></span>
+                }
+                else
+                {
+                    <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+                }
+            </GroupTemplate>
+        </PropertyColumn>
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Element" />
+    </PagerContent>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudSwitch T="bool" @bind-Value="_customizeGroupTemplate" Color="@Color.Primary">Customize Group Template</MudSwitch>
+    <MudSwitch T="bool" Value="@_customizeGroupBy" Color="@Color.Primary" ValueChanged="@CustomizeByGroupChanged">Customize Group By</MudSwitch>
+    <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
+</div>
+
+@code {
+    private readonly PeriodicTableService _periodicTableService = new();
+    private IEnumerable<Element> _elements = new List<Element>();
+    private MudDataGrid<Element> _dataGrid;
+    private bool _customizeGroupTemplate;
+    private static bool _customizeGroupBy;
+    private static readonly string[] NonMetals = ["H", "He", "N", "O", "F", "Ne", "Cl", "Ar", "Kr", "Xe", "Rn", "Br", "C", "P", "Se", "Se", "I"];
+    private readonly Func<Element, object> _groupBy = static x =>
+    {
+        if (_customizeGroupBy)
+        {
+            return NonMetals.Contains(x.Sign) ? "Nonmetal" : "Metal";
+        }
+
+        return x.Group;
+    };
+
+    private static string GroupClassFunc(GroupDefinition<Element> item)
+    {
+        return item.Grouping.Key?.ToString() == "Nonmetal" || item.Grouping.Key?.ToString() == "Other"
+                ? "mud-theme-warning"
+                : string.Empty;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        _elements = await _periodicTableService.GetElements();
+    }
+
+    private void ExpandAllGroups()
+    {
+        _dataGrid?.ExpandAllGroups();
+    }
+
+    private void CollapseAllGroups()
+    {
+        _dataGrid?.CollapseAllGroups();
+    }
+
+    private void CustomizeByGroupChanged(bool isChecked)
+    {
+        _customizeGroupBy = isChecked;
+        _dataGrid.GroupItems();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4087,6 +4087,48 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridServerGroupUngroupingTest()
+        {
+            var comp = Context.RenderComponent<DataGridServerDataColumnGroupingTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<Examples.Data.Models.Element>>();
+            var popoverProvider = comp.FindComponent<MudPopoverProvider>();
+
+            //click name grouping in grid
+            var headerOption = comp.Find("th.name .mud-menu button");
+            headerOption.Click();
+            var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems.Count.Should().Be(4);
+            var clickablePopover = listItems[3].Find(".mud-list-item");
+            clickablePopover.Click();
+            var cells = dataGrid.FindAll("td");
+
+            //checking cell content is the most reliable way to verify grouping
+            cells[0].TextContent.Should().Be("Name: Hydrogen");
+            cells[1].TextContent.Should().Be("Name: Helium");
+            cells[2].TextContent.Should().Be("Name: Lithium");
+            cells[3].TextContent.Should().Be("Name: Beryllium");
+            cells[4].TextContent.Should().Be("Name: Boron");
+            cells[5].TextContent.Should().Be("Name: Carbon");
+            cells[6].TextContent.Should().Be("Name: Nitrogen");
+            cells[7].TextContent.Should().Be("Name: Oxygen");
+            cells[8].TextContent.Should().Be("Name: Fluorine");
+            cells[9].TextContent.Should().Be("Name: Neon");
+            dataGrid.Instance.GroupedColumn.Should().NotBeNull();
+
+            //click name ungrouping in grid
+            headerOption = comp.Find("th.name .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems.Count.Should().Be(4);
+            clickablePopover = listItems[3].Find(".mud-list-item");
+            clickablePopover.Click();
+            cells = dataGrid.FindAll("td");
+            // We do not need check all 10 rows as it's clear that it's ungrouped if first row pass
+            cells[0].TextContent.Should().Be("1"); cells[1].TextContent.Should().Be("H"); cells[2].TextContent.Should().Be("Hydrogen"); cells[3].TextContent.Should().Be("0"); cells[4].TextContent.Should().Be("1.00794"); cells[5].TextContent.Should().Be("Other");
+            dataGrid.Instance.GroupedColumn.Should().BeNull();
+        }
+
+        [Test]
         public async Task DataGridGroupingTestBoundAndUnboundScenarios()
         {
             var comp = Context.RenderComponent<DataGridColumnGroupingTest>();

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -628,12 +628,14 @@ namespace MudBlazor
         }
 
         // Allows child components to change column grouping.
-        internal async Task SetGrouping(bool g)
+        internal async Task SetGroupingAsync(bool group)
         {
-            await GroupingState.SetValueAsync(g);
+            await GroupingState.SetValueAsync(group);
 
-            if (GroupingState.Value)
-                await DataGrid?.ChangedGrouping(this);
+            if (DataGrid is not null)
+            {
+                await DataGrid.ChangedGrouping(this);
+            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -116,11 +116,11 @@ else if (Column != null && !Column.HiddenState.Value)
                         {
                             if (Column?.GroupingState.Value ?? false)
                             {
-                                <MudMenuItem OnClick="@UngroupColumn">@Localizer[LanguageResource.MudDataGrid_Ungroup]</MudMenuItem>
+                                <MudMenuItem OnClick="@UngroupColumnAsync">@Localizer[LanguageResource.MudDataGrid_Ungroup]</MudMenuItem>
                             }
                             else
                             {
-                                <MudMenuItem OnClick="@GroupColumn">@Localizer[LanguageResource.MudDataGrid_Group]</MudMenuItem>
+                                <MudMenuItem OnClick="@GroupColumnAsync">@Localizer[LanguageResource.MudDataGrid_Group]</MudMenuItem>
                             }
                         }
                     </MudMenu>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -305,7 +305,12 @@ namespace MudBlazor
         private async Task OnResizerPointerOver()
         {
             if (!_isResizing)
-                _resizerHeight = await DataGrid?.GetActualHeight();
+            {
+                if (DataGrid is not null)
+                {
+                    _resizerHeight = await DataGrid.GetActualHeight();
+                }
+            }
         }
 
         private void OnResizerPointerLeave()
@@ -479,27 +484,38 @@ namespace MudBlazor
 
         private async Task CheckedChangedAsync(bool value)
         {
-            await DataGrid?.SetSelectAllAsync(value);
+            if (DataGrid is not null)
+            {
+                await DataGrid.SetSelectAllAsync(value);
+            }
         }
 
         internal async Task HideColumnAsync()
         {
-            if (Column != null)
+            if (Column is not null)
             {
                 await Column.HideAsync();
                 ((IMudStateHasChanged)DataGrid).StateHasChanged();
             }
         }
 
-        internal async Task GroupColumn()
+        internal async Task GroupColumnAsync()
         {
-            await Column?.SetGrouping(true);
+            if (Column is not null)
+            {
+                await Column.SetGroupingAsync(true);
+            }
+
             DataGrid.DropContainerHasChanged();
         }
 
-        internal async Task UngroupColumn()
+        internal async Task UngroupColumnAsync()
         {
-            await Column?.SetGrouping(false);
+            if (Column is not null)
+            {
+                await Column.SetGroupingAsync(false);
+            }
+
             DataGrid.DropContainerHasChanged();
         }
 
@@ -516,7 +532,7 @@ namespace MudBlazor
         /// </summary>
         public void Dispose()
         {
-            if (DataGrid != null)
+            if (DataGrid is not null)
             {
                 DataGrid.SortChangedEvent -= OnGridSortChanged;
                 DataGrid.SelectedAllItemsChangedEvent -= OnSelectedAllItemsChanged;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -112,11 +112,11 @@
 
                                                         @if (context?.GroupingState.Value ?? false)
                                                         {
-                                                            <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.AccountTree" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Ungroup] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.UngroupColumn())"></MudIconButton>
+                                                            <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.AccountTree" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Ungroup] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.UngroupColumnAsync())"></MudIconButton>
                                                         }
                                                         else
                                                         {
-                                                            <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.TableRows" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Group] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.GroupColumn())"></MudIconButton>
+                                                            <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.TableRows" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Group] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.GroupColumnAsync())"></MudIconButton>
                                                         }
                                                         <MudSwitch T="bool" Ripple="false" Class="flex-grow-1" Color="Color.Primary" Disabled="@(!context.hideable)" Value="@context.HiddenState.Value" ValueChanged="@context.ToggleAsync" Converter="_oppositeBoolConverter" Label="@context.Title" />
                                                         <MudSpacer />


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/9341

Also replacing (where noticed):
```csharp
await property?.MethodAsync();
```
with:
```csharp
if (property is not null)
{
    await property.MethodAsync(true);
}
```

Because the first version generates:
```csharp
awaiter = ((property != null) ? property.MethodAsync() : null).GetAwaiter();
if (!awaiter.IsCompleted)
```
which is equivalent to:
```csharp
var task = property?.MethodAsync();
await task;
```
This means that `task` can be `null` and will lead to an exception. The second version avoids this problem.

## How Has This Been Tested?
Will add later

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
