### PR TITLE
MudInputControl: Fix `HelperTextOnFocus` regression

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -115,7 +115,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             comp.Find("input").Change("seventeen");
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(3);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
         }
 
@@ -845,12 +845,12 @@ namespace MudBlazor.UnitTests.Components
             // user puts in a invalid integer value
             comp.Find("input").Change("invalid");
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(1);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // user does not change invalid input value but changes focus
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(1);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // reset (must reset dirty state)
@@ -864,7 +864,7 @@ namespace MudBlazor.UnitTests.Components
             // user puts in a invalid integer value
             comp.Find("input").Change("invalid");
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(1);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // user corrects input
@@ -883,13 +883,13 @@ namespace MudBlazor.UnitTests.Components
 
             // user does not change input value but changes focus
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(3);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
 
             // user puts in a invalid integer value
             comp.Find("input").Change("invalid");
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(3);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
 
             // reset
@@ -898,7 +898,7 @@ namespace MudBlazor.UnitTests.Components
 
             // user does not change input value but changes focus
             comp.Find("input").Blur();
-            comp.FindAll("div.mud-input-error").Count.Should().Be(2);
+            comp.FindAll("div.mud-input-error").Count.Should().Be(3);
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
 
             // user corrects input

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
          .AddClass("mud-input-label-animated")
          .AddClass($"mud-input-label-{Variant.ToDescriptionString()}")
          .AddClass($"mud-input-label-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
-         .AddClass($"mud-disabled", Disabled)
+         .AddClass("mud-disabled", Disabled)
          .AddClass("mud-input-error", Error)
          .AddClass(Class)
        .Build();
@@ -38,7 +38,7 @@ namespace MudBlazor
         [Parameter] public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        ///  Will adjust vertical spacing. 
+        ///  Will adjust vertical spacing.
         /// </summary>
         [Parameter] public Margin Margin { get; set; } = Margin.None;
 

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -15,28 +15,26 @@
     @if (Error || !string.IsNullOrEmpty(HelperText) || !string.IsNullOrEmpty(CounterText))
     {
         <div class="@HelperContainer">
-            <span class="@HelperClass">
-                <div class="d-flex">
-                    @if (Error)
-                    {
-                        <div class="me-auto" id="@ErrorId">
-                            @ErrorText
-                        </div>
-                    }
-                    else if (!string.IsNullOrEmpty(HelperText))
-                    {
-                        <div class="me-auto" id="@HelperId">
-                            @HelperText
-                        </div>
-                    }
-                    @if (!string.IsNullOrEmpty(CounterText))
-                    {
-                        <div class="ms-auto">
-                            @CounterText
-                        </div>
-                    }
-                </div>
-            </span>
+            <div class="d-flex @HelperClass">
+                @if (Error)
+                {
+                    <div class="me-auto" id="@ErrorId">
+                        @ErrorText
+                    </div>
+                }
+                else if (!string.IsNullOrEmpty(HelperText))
+                {
+                    <div class="me-auto" id="@HelperId">
+                        @HelperText
+                    </div>
+                }
+                @if (!string.IsNullOrEmpty(CounterText))
+                {
+                    <div class="ms-auto">
+                        @CounterText
+                    </div>
+                }
+            </div>
         </div>
     }
     @ChildContent

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -17,8 +17,8 @@ namespace MudBlazor
 
         protected string HelperContainer =>
             new CssBuilder("mud-input-control-helper-container")
-                .AddClass($"px-1", Variant == Variant.Filled)
-                .AddClass($"px-2", Variant == Variant.Outlined)
+                .AddClass("px-1", Variant == Variant.Filled)
+                .AddClass("px-2", Variant == Variant.Outlined)
                 .Build();
 
         protected string HelperClass =>


### PR DESCRIPTION
## Description

Fixes a regression on the `HelperTextOnFocus` parameter. Setting the parameter to `true` would no longer only show the helper/error/counter text only when a field is focused. This is a regression from #8871 because `span` is an `inline` element which is not `transform`able (and the `HelperTextOnFocus` parameter relies on a `transform`).

As discovered in #8447 by @mathieufournier.

## How Has This Been Tested?
Visually -- didn't retest for the #8871 fix but that shouldn't be necessary as the original issue was only caused by an incorrect `p > div` nesting.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
