### PR TITLE
MudAutocomplete: Modify default autocomplete method (#9318)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1546,15 +1546,15 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>();
 
-            comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().StartWith("mud-disable-");
+            comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("off");
         }
 
         public void Should_Override_Autocomplete_Attribute_With_UserAttributes()
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
-                .Add(p => p.UserAttributes, new() { ["autocomplete"] = "off" }));
+                .Add(p => p.UserAttributes, new() { ["autocomplete"] = "on" }));
 
-            comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("off");
+            comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("on");
         }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -469,7 +469,7 @@ namespace MudBlazor
                 return userAutocomplete;
             }
 
-            return $"mud-disable-{Guid.NewGuid()}";
+            return "off";
         }
 
         public MudAutocomplete()


### PR DESCRIPTION
### Description
This PR introduces a new default method for autocompletion to ensure the autocorrect operates as expected on Chrome.

### Problem
The existing method of disabling autocomplete by appending a unique identifier to the autocomplete attribute no longer works in Chrome as of 2024. Recent changes in browser behavior have rendered this approach ineffective.

### Solution
The problem can be resolved by simply using "off" as the default value for the autocomplete attribute, this solution has been thoroughly tested to ensure compatibility with other browsers.

## References
Fixes: #9318 

## How Has This Been Tested?
- Updated existing unit tests.
- Visually on desktop and when possible iOS and Android using:  
   - Chrome 
   - Edge 
   - Firefox
   - Safari 

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
