### PR TITLE
Docs: Update TreeViewUsageExample.razor Fixed variable names in markup

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewUsageExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView T="string" ReadOnly="@ReadOnly" Hover="@Hover" Dense="@Dense" Disabled="@Disabled"
-                 ExpandOnClick="ExpandOnClick" ExpandOnDoubleClick="ExpandOnDoubleClick">
+                 ExpandOnClick="@ExpandOnClick" ExpandOnDoubleClick="@ExpandOnDoubleClick">
         <MudTreeViewItem Text="Applications" Expanded>
             <MudTreeViewItem Text="Terminal" />
         </MudTreeViewItem>


### PR DESCRIPTION
ExpandOnClick & ExpandOnDoubleClick needed @ preceeding the markup variable names.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

## Description
Added @ before ExpandOnClick and ExpandOnDoubleClick so that they are properly shown as variables in markup. This will correct both those sliders in the example from not working.

## How Has This Been Tested?
Visually tested

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
