### PR TITLE
Autocomplete: Add opt-out `OpenOnFocus` property

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
@@ -1,0 +1,37 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete T="string"
+                 Label="US States"
+                 @bind-Value="value"
+                 SearchFunc="@Search1"
+                 PopoverClass="autocomplete-popover-class"
+                 OpenOnFocus="@OpenOnFocus" />
+
+@code {
+    public static string __description__ = "Initial value should be shown and popup should not open.";
+
+    private string value = "Alabama";
+
+    private readonly string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+    };
+
+    [Parameter]
+    public bool OpenOnFocus { get; set; } = true;
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(50, token);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
@@ -22,7 +22,7 @@
     };
 
     [Parameter]
-    public bool OpenOnFocus { get; set; } = true;
+    public bool OpenOnFocus { get; set; }
 
     private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteFocusTest.razor
@@ -22,7 +22,7 @@
     };
 
     [Parameter]
-    public bool OpenOnFocus { get; set; }
+    public bool OpenOnFocus { get; set; } = true;
 
     private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
     {

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1295,14 +1295,39 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_OpenMenuOnFocus()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Autocomplete_Should_OpenMenuOnFocus(bool openOnFocus)
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.RenderComponent<AutocompleteFocusTest>();
+            comp.SetParam(a => a.OpenOnFocus, openOnFocus);
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             comp.Find("input.mud-input-root").Focus();
 
+            if (openOnFocus)
+            {
+                comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            }
+            else
+            {
+                comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick(bool openOnFocus)
+        {
+            var comp = Context.RenderComponent<AutocompleteFocusTest>();
+
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
+            comp.Find("input.mud-input-root").Click();
+
+            // OpenOnFocus isn't respected by clicks. This property added after the fact to restore v6 behavior via opt-in.
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
         }
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1317,18 +1317,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick(bool openOnFocus)
+        public async Task Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick()
         {
             var comp = Context.RenderComponent<AutocompleteFocusTest>();
-
-            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            comp.SetParam(a => a.OpenOnFocus, false);
 
             comp.Find("input.mud-input-root").Focus(); // Browser would focus first.
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
             comp.Find("input.mud-input-root").Click();
 
-            // OpenOnFocus isn't respected by clicks. This property added after the fact to restore v6 behavior via opt-in.
+            // OpenOnFocus=false isn't respected by clicks. It added after the fact to allow opting in to v6 behavior.
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
         }
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1325,6 +1325,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
+            comp.Find("input.mud-input-root").Focus(); // Browser would focus first.
             comp.Find("input.mud-input-root").Click();
 
             // OpenOnFocus isn't respected by clicks. This property added after the fact to restore v6 behavior via opt-in.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -410,11 +410,11 @@ namespace MudBlazor
         /// Opens the list when focus is received on the input element; otherwise only opens on click.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.
+        /// Defaults to <c>true</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool OpenOnFocus { get; set; } = false;
+        public bool OpenOnFocus { get; set; } = true;
 
         /// <summary>
         /// Displays the Clear icon button.
@@ -894,11 +894,11 @@ namespace MudBlazor
             }
         }
 
-        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocusAsync(true) : Task.CompletedTask;
+        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocus(true) : Task.CompletedTask;
 
-        private Task OnInputFocusedAsync() => ActivateByFocusAsync(false);
+        private Task OnInputFocusedAsync() => ActivateByFocus(false);
 
-        private async Task ActivateByFocusAsync(bool fromPointer)
+        private async Task ActivateByFocus(bool fromPointer)
         {
             _isFocused = true;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -410,11 +410,11 @@ namespace MudBlazor
         /// Opens the list when focus is received on the input element; otherwise only opens on click.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.
+        /// Defaults to <c>false</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool OpenOnFocus { get; set; } = true;
+        public bool OpenOnFocus { get; set; } = false;
 
         /// <summary>
         /// Displays the Clear icon button.
@@ -894,11 +894,11 @@ namespace MudBlazor
             }
         }
 
-        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocus(true) : Task.CompletedTask;
+        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocusAsync(true) : Task.CompletedTask;
 
-        private Task OnInputFocusedAsync() => ActivateByFocus(false);
+        private Task OnInputFocusedAsync() => ActivateByFocusAsync(false);
 
-        private async Task ActivateByFocus(bool fromPointer)
+        private async Task ActivateByFocusAsync(bool fromPointer)
         {
             _isFocused = true;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -894,11 +894,11 @@ namespace MudBlazor
             }
         }
 
-        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocus(true) : Task.CompletedTask;
+        private Task OnInputClickedAsync() => _isFocused ? ActivateByFocusAsync(true) : Task.CompletedTask;
 
-        private Task OnInputFocusedAsync() => ActivateByFocus(false);
+        private Task OnInputFocusedAsync() => ActivateByFocusAsync(false);
 
-        private async Task ActivateByFocus(bool fromPointer)
+        private async Task ActivateByFocusAsync(bool fromPointer)
         {
             _isFocused = true;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- https://github.com/MudBlazor/MudBlazor/issues/8447#issuecomment-2225791191
- https://github.com/MudBlazor/MudBlazor/pull/8758#issuecomment-2225906123

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

First two are `OpenOnFocus=false` and the rest are default.

https://github.com/user-attachments/assets/716442b9-bd60-4e14-9f41-5b7073b34af2

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
