### PR TITLE
PopoverService: Add CheckForPopoverProvider

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
@@ -17,6 +17,7 @@ namespace MudBlazor.UnitTests
             {
                 options.SnackbarConfiguration.ShowTransitionDuration = 0;
                 options.SnackbarConfiguration.HideTransitionDuration = 0;
+                options.PopoverOptions.CheckForPopoverProvider = false;
             });
             ctx.Services.AddScoped(sp => new HttpClient());
             ctx.Services.AddOptions();

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -129,7 +129,7 @@ public class PopoverServiceTests
         var popover = new PopoverMock();
         var options = new PopoverOptions { CheckForPopoverProvider = checkForPopoverProvider };
         var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
-        
+
         // Act
         var create = () => service.CreatePopoverAsync(popover);
 

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
@@ -52,7 +53,8 @@ public class PopoverServiceTests
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
         var popover = new PopoverMock();
-        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var options = new PopoverOptions { CheckForPopoverProvider = false };
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
 
         // Assert
         service.IsInitialized.Should().BeFalse();
@@ -115,6 +117,31 @@ public class PopoverServiceTests
 
         // Assert
         service.IsInitialized.Should().BeFalse();
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task CreatePopoverAsync_CheckForPopoverProvider(bool checkForPopoverProvider)
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var popover = new PopoverMock();
+        var options = new PopoverOptions { CheckForPopoverProvider = checkForPopoverProvider };
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
+        
+        // Act
+        var create = () => service.CreatePopoverAsync(popover);
+
+        // Assert
+        if (checkForPopoverProvider)
+        {
+            await create.Should().ThrowAsync<InvalidOperationException>();
+        }
+        else
+        {
+            await create.Should().NotThrowAsync<InvalidOperationException>();
+        }
     }
 
     [Test]
@@ -393,7 +420,8 @@ public class PopoverServiceTests
         var popoverOne = new PopoverMock();
         var popoverTwo = new PopoverMock();
         var popoverThree = new PopoverMock();
-        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var options = new PopoverOptions { CheckForPopoverProvider = false };
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
 
         // Act
         await service.CreatePopoverAsync(popoverOne);
@@ -449,7 +477,8 @@ public class PopoverServiceTests
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
         var popover = new PopoverMock();
-        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var options = new PopoverOptions { CheckForPopoverProvider = false };
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
 
         // Act
         await service.CreatePopoverAsync(popover);
@@ -475,7 +504,8 @@ public class PopoverServiceTests
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
         var popover = new PopoverMock();
-        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock);
+        var options = new PopoverOptions { CheckForPopoverProvider = false };
+        var service = new PopoverService(NullLogger<PopoverService>.Instance, jsRuntimeMock, new OptionsWrapper<PopoverOptions>(options));
 
         // Act
         await service.CreatePopoverAsync(popover);

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -360,6 +360,7 @@ namespace MudBlazor.Services
                 .AddMudBlazorJsApi()
                 .AddMudPopoverService(popoverOptions =>
                 {
+                    popoverOptions.CheckForPopoverProvider = options.PopoverOptions.CheckForPopoverProvider;
                     popoverOptions.ContainerClass = options.PopoverOptions.ContainerClass;
                     popoverOptions.FlipMargin = options.PopoverOptions.FlipMargin;
                     popoverOptions.QueueDelay = options.PopoverOptions.QueueDelay;

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -13,6 +13,12 @@ namespace MudBlazor
     public class PopoverOptions
     {
         /// <summary>
+        /// Gets or sets a value indicating whether to check for the presence of a popover provider <see cref="MudPopoverProvider"/>.
+        /// The default value is <c>true</c>.
+        /// </summary>
+        public bool CheckForPopoverProvider { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the CSS class of the popover container.
         /// The default value is <c>mudblazor-main-content</c>.
         /// </summary>

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -113,7 +113,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
         {
             if (ObserversCount == 0)
             {
-                throw new InvalidOperationException($"The component requires to have at least one observer({nameof(MudPopoverProvider)}) to create a popover.");
+                throw new InvalidOperationException($"Missing <{nameof(MudPopoverProvider)} />, please add it to your layout. See https://mudblazor.com/getting-started/installation#manual-install-add-components");
             }
         }
 

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -109,6 +109,14 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             return;
         }
 
+        if (PopoverOptions.CheckForPopoverProvider)
+        {
+            if (ObserversCount == 0)
+            {
+                throw new InvalidOperationException($"The component requires to have at least one observer({nameof(MudPopoverProvider)}) to create a popover.");
+            }
+        }
+
         var holder = new MudPopoverHolder(popover.Id)
             .SetFragment(popover.ChildContent)
             .SetClass(popover.PopoverClass)


### PR DESCRIPTION
## Description

Adds as error: **Unhandled exception rendering component: Missing `<MudPopoverProvider/>`, please add it to your layout. See https://mudblazor.com/getting-started/installation#manual-install-add-components**

We adhere to the "fail fast" policy, so it makes sense to add a check to see if the `MudPopoverProvider` exists when trying to create a popover, tooltip, dropdown, etc.—anything that relies on the provider.

[Many of our users often forget](https://github.com/MudBlazor/MudBlazor/discussions/9376#discussioncomment-10036184) to add the `MudPopoverProvider` to the `MainLayout` or Page (in the case of per-page render mode) and then complain that we should add a hint that it's required. Many suggested adding an alert to the documentation for components that need it, but I think this approach is more effective.

If someone wants the old behavior, they should set:
```csharp
Services.AddMudServices(options =>
{
    options.PopoverOptions.CheckForPopoverProvider = false;
});
```
Or, if they are adding services individually for some reason:
```csharp
Services.AddMudPopoverService(options => options.CheckForPopoverProvider = false);
```

This is how it looks if `MudPopoverProvider` is missing:
![Exception](https://github.com/user-attachments/assets/66ac2aa4-b113-4e49-b840-d9f373e99db3)


## How Has This Been Tested?
Unit tests & visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
