### PR TITLE
Build: Add sonar workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,17 @@
+name: sonar
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze solution
+    uses: MudBlazor/Workflows/.github/workflows/template-sonar.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR introduces the initial version of the SonarCloud workflow. https://github.com/MudBlazor/MudBlazor/issues/9236

Related PR https://github.com/MudBlazor/Workflows/pull/2

- Analyzes only the `dev` branch on push events.

### Not included
- This PR does not include PR analysis features.


### Open todos

- ~We need a new GitHub secret  `SONAR_TOKEN` for the workflow before we merge this. We can create a token [here](https://sonarcloud.io/account/security/). Unfortunately, this is a personal access token of a user. There is no token for a project.~ Done.
- Configure/Update the Quality Gate and Quality profile to our needs. Currently, the build defaults are used.