### PR TITLE
ParameterState: Add `IParameterStateUnsafe` and `SetValueAfterEventCallbackAsync`

### DIFF
--- a/src/MudBlazor.UnitTests/State/ParameterStateExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.State;
 public class ParameterStateExtensionsTests
 {
     [Test]
-    public async Task SetValueAfterEventCallbackAsync_UpdatesValue_And_EventCallbackFire()
+    public async Task SetValueAfterEventCallbackAsync_EventCallbackFireFirst_ThenUpdatesValue()
     {
         // Arrange
         const int InitialValue = 5;

--- a/src/MudBlazor.UnitTests/State/ParameterStateExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateExtensionsTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.State.Builder;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.State;
+
+#nullable enable
+[TestFixture]
+public class ParameterStateExtensionsTests
+{
+    [Test]
+    public async Task SetValueAfterEventCallbackAsync_UpdatesValue_And_EventCallbackFire()
+    {
+        // Arrange
+        const int InitialValue = 5;
+        const int NewValue = 10;
+        var eventFired = false;
+        var parameterStateBuilder = new RegisterParameterBuilder<int>()
+            .WithName(nameof(InitialValue))
+            .WithParameter(() => InitialValue);
+
+        var callback = new EventCallback<int>(null, new Action<int>(newValue =>
+        {
+            eventFired = true;
+            // We use the builder to get the parameter state because we have an instance of it.
+            // We cannot directly use ParameterState as it would result in an 'unassigned local variable' error.
+            // The Attach() method returns the same instance. This technique works with RegisterParameterBuilder 
+            // but not with ParameterAttachBuilder, as the latter returns a new instance of ParameterState, which would not be the same instance.
+            var existingParameterState = parameterStateBuilder.Attach();
+
+            // Verify that when the callback is fired, the value has not yet been updated to the new value.
+            existingParameterState.Value.Should().NotBe(newValue);
+        }));
+
+        var parameterState = parameterStateBuilder
+            .WithEventCallback(() => callback)
+            .Attach();
+
+        // Act
+        parameterState.OnInitialized();
+        await parameterState.SetValueAfterEventCallbackAsync(NewValue);
+
+        // Assert
+        parameterState.Value.Should().Be(NewValue);
+        eventFired.Should().BeTrue();
+    }
+}

--- a/src/MudBlazor/Extensions/ParameterStateExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterStateExtensions.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using MudBlazor.State;
 
 namespace MudBlazor.Extensions;

--- a/src/MudBlazor/Extensions/ParameterStateExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterStateExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using MudBlazor.State;
+
+namespace MudBlazor.Extensions;
+
+#nullable enable
+/// <summary>
+/// Provides extension methods for <see cref="ParameterState{T}"/>.
+/// </summary>
+internal static class ParameterStateExtensions
+{
+    /// <summary>
+    /// Converts the specified <see cref="ParameterState{T}"/> to an <see cref="IParameterStateUnsafe{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter.</typeparam>
+    /// <param name="parameterState">The parameter state to convert.</param>
+    /// <returns>The <see cref="IParameterStateUnsafe{T}"/> interface for the specified parameter state.</returns>
+    public static IParameterStateUnsafe<T> AsUnsafe<T>(this ParameterState<T> parameterState) => (IParameterStateUnsafe<T>)parameterState;
+
+    /// <summary>
+    /// Unlike the <see cref="ParameterState{T}.SetValueAsync"/> sets the value of the parameter state after invoking the event callback asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter.</typeparam>
+    /// <param name="parameterState">The parameter state to set the value for.</param>
+    /// <param name="value">The new value for the parameter state.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task SetValueAfterEventCallbackAsync<T>(this ParameterState<T> parameterState, T value)
+    {
+        var parameterStateUnsafe = parameterState.AsUnsafe();
+        if (!parameterStateUnsafe.Comparer.Equals(parameterState.Value, value))
+        {
+            var eventCallback = parameterStateUnsafe.ValueChanged;
+            if (eventCallback.HasDelegate)
+            {
+                await eventCallback.InvokeAsync(value);
+            }
+
+            parameterStateUnsafe.Value = value;
+        }
+    }
+}

--- a/src/MudBlazor/Extensions/ParameterStateExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterStateExtensions.cs
@@ -32,6 +32,7 @@ internal static class ParameterStateExtensions
         var parameterStateUnsafe = parameterState.AsUnsafe();
         if (!parameterStateUnsafe.Comparer.Equals(parameterState.Value, value))
         {
+            // Cache ValueChanged as behind it is a lambda.
             var eventCallback = parameterStateUnsafe.ValueChanged;
             if (eventCallback.HasDelegate)
             {

--- a/src/MudBlazor/State/IParameterStateUnsafe.cs
+++ b/src/MudBlazor/State/IParameterStateUnsafe.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.State;
+
+#nullable enable
+/// <summary>
+/// Represents an unsafe parameter state that allows getting or setting the parameter's value.
+/// </summary>
+/// <typeparam name="T">The type of the parameter.</typeparam>
+internal interface IParameterStateUnsafe<T>
+{
+    /// <summary>
+    /// Gets or sets the current value.
+    /// </summary>
+    T? Value { get; set; }
+
+    /// <summary>
+    /// Gets the callback that is invoked when the parameter's value changes.
+    /// </summary>
+    EventCallback<T> ValueChanged { get; }
+
+    /// <summary>
+    /// Gets the comparer for the parameter.
+    /// </summary>
+    IEqualityComparer<T> Comparer { get; }
+}

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.State;
 /// </remarks>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
 [DebuggerDisplay("ParameterName = {Metadata.ParameterName}, Value = {_value}")]
-internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponentLifeCycle, IEquatable<ParameterStateInternal<T>>
+internal class ParameterStateInternal<T> : ParameterState<T>, IParameterStateUnsafe<T>, IParameterComponentLifeCycle, IEquatable<ParameterStateInternal<T>>
 {
     private T? _value;
     private T? _lastValue;
@@ -62,6 +62,14 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     /// </summary>
     public IParameterEqualityComparerSwappable<T> Comparer => _comparer;
 
+    /// <inheritdoc />
+    IEqualityComparer<T> IParameterStateUnsafe<T>.Comparer => _comparer;
+
+    /// <inheritdoc />
+    EventCallback<T> IParameterStateUnsafe<T>.ValueChanged => _eventCallbackFunc();
+
+    T? IParameterStateUnsafe<T>.Value { get => _value; set { _value = value; } }
+
     private ParameterStateInternal(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterEqualityComparerSwappable<T>? comparer = null)
     {
         Metadata = metadata;
@@ -73,7 +81,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         _value = default;
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc cref="ParameterState{T}.SetValueAsync" />
     public override Task SetValueAsync(T value)
     {
         if (!_comparer.Equals(Value, value))

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -68,6 +68,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterStateUns
     /// <inheritdoc />
     EventCallback<T> IParameterStateUnsafe<T>.ValueChanged => _eventCallbackFunc();
 
+    /// <inheritdoc />
     T? IParameterStateUnsafe<T>.Value { get => _value; set { _value = value; } }
 
     private ParameterStateInternal(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterEqualityComparerSwappable<T>? comparer = null)


### PR DESCRIPTION
## Description
Needed for: https://github.com/MudBlazor/MudBlazor/pull/9262

This helps with interception of input actions. 

For example, consider a `MudSwitch` component that uses both `Value` and `ValueChanged` properties. Currently, when the `SetValueAsync` is executed the `ParameterState` sets the new value before firing the `EventCallback`. This sequence can lead to a situation where the UI immediately reflects the new value, but if the user then cancels the action (such as through a confirmation popup), the UI may flicker back and forth between states—potentially resulting in an undesired user experience.

## How Has This Been Tested?
unit test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
