### PR TITLE
MudToggleIconButton: Fall back to regular property if toggled version not set

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -47,5 +47,81 @@ namespace MudBlazor.UnitTests.Components
             comp1.Instance.Toggled.Should().BeTrue();
             comp2.Instance.Toggled.Should().BeTrue();
         }
+
+        [TestCase("icon-default", "icon-toggled", "icon-default", "icon-toggled")]
+        [TestCase("icon-default", null, "icon-default", "icon-default")]
+        public void GetIcon_ShouldReturnCorrectIcon(string icon, string toggledIcon, string expectedIcon, string expectedToggledIcon)
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+                .Add(p => p.Icon, icon)
+                .Add(p => p.ToggledIcon, toggledIcon)
+            );
+
+            // Check initial state
+            comp.Instance.GetIcon().Should().Be(expectedIcon);
+
+            // Toggle state
+            comp.Find("button").Click();
+
+            // Check toggled state
+            comp.Instance.GetIcon().Should().Be(expectedToggledIcon);
+        }
+
+        [TestCase(Size.Medium, Size.Large, Size.Medium, Size.Large)]
+        [TestCase(Size.Medium, null, Size.Medium, Size.Medium)]
+        public void GetSize_ShouldReturnCorrectSize(Size size, Size? toggledSize, Size expectedSize, Size expectedToggledSize)
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+                .Add(p => p.Size, size)
+                .Add(p => p.ToggledSize, toggledSize)
+            );
+
+            // Check initial state
+            comp.Instance.GetSize().Should().Be(expectedSize);
+
+            // Toggle state
+            comp.Find("button").Click();
+
+            // Check toggled state
+            comp.Instance.GetSize().Should().Be(expectedToggledSize);
+        }
+
+        [TestCase(Color.Default, Color.Primary, Color.Default, Color.Primary)]
+        [TestCase(Color.Default, null, Color.Default, Color.Default)]
+        public void GetColor_ShouldReturnCorrectColor(Color color, Color? toggledColor, Color expectedColor, Color expectedToggledColor)
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+                .Add(p => p.Color, color)
+                .Add(p => p.ToggledColor, toggledColor)
+            );
+
+            // Check initial state
+            comp.Instance.GetColor().Should().Be(expectedColor);
+
+            // Toggle state
+            comp.Find("button").Click();
+
+            // Check toggled state
+            comp.Instance.GetColor().Should().Be(expectedToggledColor);
+        }
+
+        [TestCase(Variant.Text, Variant.Filled, Variant.Text, Variant.Filled)]
+        [TestCase(Variant.Text, null, Variant.Text, Variant.Text)]
+        public void GetVariant_ShouldReturnCorrectVariant(Variant variant, Variant? toggledVariant, Variant expectedVariant, Variant expectedToggledVariant)
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+                .Add(p => p.Variant, variant)
+                .Add(p => p.ToggledVariant, toggledVariant)
+            );
+
+            // Check initial state
+            comp.Instance.GetVariant().Should().Be(expectedVariant);
+
+            // Toggle state
+            comp.Find("button").Click();
+
+            // Check toggled state
+            comp.Instance.GetVariant().Should().Be(expectedToggledVariant);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -67,8 +67,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetIcon().Should().Be(expectedToggledIcon);
         }
 
-        [TestCase(Size.Medium, Size.Large, Size.Medium, Size.Large)]
-        [TestCase(Size.Medium, null, Size.Medium, Size.Medium)]
+        [TestCase(Size.Small, Size.Large, Size.Small, Size.Large)]
+        [TestCase(Size.Small, null, Size.Small, Size.Small)]
         public void GetSize_ShouldReturnCorrectSize(Size size, Size? toggledSize, Size expectedSize, Size expectedToggledSize)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
@@ -86,8 +86,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetSize().Should().Be(expectedToggledSize);
         }
 
-        [TestCase(Color.Default, Color.Primary, Color.Default, Color.Primary)]
-        [TestCase(Color.Default, null, Color.Default, Color.Default)]
+        [TestCase(Color.Tertiary, Color.Secondary, Color.Tertiary, Color.Secondary)]
+        [TestCase(Color.Tertiary, null, Color.Tertiary, Color.Tertiary)]
         public void GetColor_ShouldReturnCorrectColor(Color color, Color? toggledColor, Color expectedColor, Color expectedToggledColor)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
@@ -105,8 +105,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetColor().Should().Be(expectedToggledColor);
         }
 
-        [TestCase(Variant.Text, Variant.Filled, Variant.Text, Variant.Filled)]
-        [TestCase(Variant.Text, null, Variant.Text, Variant.Text)]
+        [TestCase(Variant.Outlined, Variant.Filled, Variant.Outlined, Variant.Filled)]
+        [TestCase(Variant.Outlined, null, Variant.Outlined, Variant.Outlined)]
         public void GetVariant_ShouldReturnCorrectVariant(Variant variant, Variant? toggledVariant, Variant expectedVariant, Variant expectedToggledVariant)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -9,25 +9,55 @@ namespace MudBlazor.UnitTests.Components
     public class ToggleIconButtonTest : BunitTest
     {
         [Test]
-        public void DefaultValueTest()
+        public void DefaultState()
         {
             var comp = Context.RenderComponent<MudToggleIconButton>();
             comp.Instance.Toggled.Should().BeFalse();
+            comp.Instance.Icon.Should().BeNull();
+            comp.Instance.ToggledIcon.Should().BeNull();
+            comp.Instance.Color.Should().Be(Color.Default);
+            comp.Instance.ToggledColor.Should().BeNull();
+            comp.Instance.Size.Should().Be(Size.Medium);
+            comp.Instance.ToggledSize.Should().BeNull();
+            comp.Instance.Variant.Should().Be(Variant.Text);
+            comp.Instance.ToggledVariant.Should().BeNull();
+            comp.Instance.Edge.Should().Be(Edge.False);
+            comp.Instance.Ripple.Should().BeTrue();
+            comp.Instance.DropShadow.Should().BeTrue();
+            comp.Instance.Disabled.Should().BeFalse();
+            comp.Instance.ClickPropagation.Should().BeFalse();
         }
 
         [Test]
-        public void ToggleTest()
+        public void ShouldToggleOnClick()
         {
             var boundValue = false;
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Toggled, boundValue)
                 .Add(p => p.ToggledChanged, (toggleValue) => boundValue = toggleValue)
-                );
+            );
+
             comp.Find("button").Click();
             boundValue.Should().BeTrue();
+
             comp.Find("button").Click();
             boundValue.Should().BeFalse();
+
             comp.RenderCount.Should().Be(3);
+        }
+
+        [Test]
+        public void ShouldSetAriaPressedAttribute()
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>();
+
+            comp.Find("button").GetAttribute("aria-pressed").Should().Be("false");
+
+            comp.Find("button").Click();
+            comp.Find("button").GetAttribute("aria-pressed").Should().Be("true");
+
+            comp.Find("button").Click();
+            comp.Find("button").GetAttribute("aria-pressed").Should().Be("false");
         }
 
         [Test]
@@ -48,9 +78,27 @@ namespace MudBlazor.UnitTests.Components
             comp2.Instance.Toggled.Should().BeTrue();
         }
 
+        [Test]
+        public void Disabled_ShouldPreventInteraction()
+        {
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+                .Add(p => p.Disabled, true)
+            );
+
+            // Verify that the button is disabled
+            var button = comp.Find("button");
+            button.HasAttribute("disabled").Should().BeTrue();
+
+            // Try to toggle the button
+            button.Click();
+
+            // Verify that the toggled state has not changed
+            comp.Instance.Toggled.Should().BeFalse();
+        }
+
         [TestCase("icon-default", "icon-toggled", "icon-default", "icon-toggled")]
         [TestCase("icon-default", null, "icon-default", "icon-default")]
-        public void GetIcon_ShouldReturnCorrectIcon(string icon, string toggledIcon, string expectedIcon, string expectedToggledIcon)
+        public void GetIcon_ShouldReturnCorrectValue(string icon, string toggledIcon, string expectedIcon, string expectedToggledIcon)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Icon, icon)
@@ -69,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Size.Small, Size.Large, Size.Small, Size.Large)]
         [TestCase(Size.Small, null, Size.Small, Size.Small)]
-        public void GetSize_ShouldReturnCorrectSize(Size size, Size? toggledSize, Size expectedSize, Size expectedToggledSize)
+        public void GetSize_ShouldReturnCorrectValue(Size size, Size? toggledSize, Size expectedSize, Size expectedToggledSize)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Size, size)
@@ -88,7 +136,7 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Color.Tertiary, Color.Secondary, Color.Tertiary, Color.Secondary)]
         [TestCase(Color.Tertiary, null, Color.Tertiary, Color.Tertiary)]
-        public void GetColor_ShouldReturnCorrectColor(Color color, Color? toggledColor, Color expectedColor, Color expectedToggledColor)
+        public void GetColor_ShouldReturnCorrectValue(Color color, Color? toggledColor, Color expectedColor, Color expectedToggledColor)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Color, color)
@@ -107,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
 
         [TestCase(Variant.Outlined, Variant.Filled, Variant.Outlined, Variant.Filled)]
         [TestCase(Variant.Outlined, null, Variant.Outlined, Variant.Outlined)]
-        public void GetVariant_ShouldReturnCorrectVariant(Variant variant, Variant? toggledVariant, Variant expectedVariant, Variant expectedToggledVariant)
+        public void GetVariant_ShouldReturnCorrectValue(Variant variant, Variant? toggledVariant, Variant expectedVariant, Variant expectedToggledVariant)
         {
             var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Variant, variant)

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<MudIconButton Icon="@(Toggled ? ToggledIcon : Icon)"
-               Size="(Toggled ? ToggledSize : Size)"
-               Color="(Toggled ? ToggledColor : Color)"
-               Variant="Variant"
+<MudIconButton Icon="@GetIcon()"
+               Size="@GetSize()"
+               Color="@GetColor()"
+               Variant="@GetVariant()"
                Disabled="Disabled"
                Edge="Edge"
                Ripple="@Ripple"
@@ -13,5 +13,5 @@
                Style="@Style"
                DropShadow="@DropShadow"
                ClickPropagation="ClickPropagation"
-               aria-pressed="@((Toggled ? "true" : "false"))"
+               aria-pressed="@Toggled.ToString().ToLowerInvariant()"
                @attributes="UserAttributes" />

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -44,6 +44,9 @@ namespace MudBlazor
         /// <summary>
         /// The color of the icon.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Color Color { get; set; } = Color.Default;
@@ -58,6 +61,9 @@ namespace MudBlazor
         /// <summary>
         /// The size of the button.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Size Size { get; set; } = Size.Medium;
@@ -72,6 +78,9 @@ namespace MudBlazor
         /// <summary>
         /// The variant to use in the regular state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
@@ -86,6 +95,9 @@ namespace MudBlazor
         /// <summary>
         /// Applies a negative margin.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Edge.False"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Edge Edge { get; set; }
@@ -113,6 +125,9 @@ namespace MudBlazor
         /// <summary>
         /// Disables interaction with the button.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public bool Disabled { get; set; }

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -94,7 +94,7 @@ namespace MudBlazor
         /// Shows a ripple effect when the user clicks the button.
         /// </summary>
         /// <remarks>
-        /// Default is <c>true</c>.
+        /// Defaults to <c>true</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
@@ -118,20 +118,50 @@ namespace MudBlazor
         public bool Disabled { get; set; }
 
         /// <summary>
-        /// If <c>true</c>, the click event bubbles up to the containing/parent component.
+        /// Allows the click event to bubble up to the parent component.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public bool ClickPropagation { get; set; }
 
+        /// <summary>
+        /// Gets the icon to display based on the toggled state.
+        /// </summary>
+        /// <returns>
+        /// <see cref="ToggledIcon"/> if toggled and that property is set; otherwise, <see cref="Icon"/>.
+        /// </returns>
         public string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
 
+        /// <summary>
+        /// Gets the size to use based on the toggled state.
+        /// </summary>
+        /// <returns>
+        /// <see cref="ToggledSize"/> if toggled and that property is set; otherwise, <see cref="Size"/>.
+        /// </returns>
         public Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
 
+        /// <summary>
+        /// Gets the color to use based on the toggled state.
+        /// </summary>
+        /// <returns>
+        /// <see cref="ToggledColor"/> if toggled and that property is set; otherwise, <see cref="Color"/>.
+        /// </returns>
         public Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
 
+        /// <summary>
+        /// Gets the variant to use based on the toggled state.
+        /// </summary>
+        /// <returns>
+        /// <see cref="ToggledVariant"/> if toggled and that property is set; otherwise, <see cref="Variant"/>.
+        /// </returns>
         public Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
 
+        /// <summary>
+        /// Toggles the state of the button.
+        /// </summary>
         public Task Toggle() => SetToggledAsync(!Toggled);
 
         protected internal async Task SetToggledAsync(bool toggled)

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -15,106 +15,124 @@ namespace MudBlazor
     public partial class MudToggleIconButton : MudComponentBase
     {
         /// <summary>
-        /// The toggled value.
+        /// Whether the icon is in the toggled state.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public bool Toggled { get; set; }
 
         /// <summary>
-        /// Fires whenever toggled is changed.
+        /// Occurs when <see cref="Toggled"/> is changed.
         /// </summary>
         [Parameter]
         public EventCallback<bool> ToggledChanged { get; set; }
 
         /// <summary>
-        /// The Icon that will be used in the untoggled state.
+        /// The icon to use.
         /// </summary>
         [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
+        [Category(CategoryTypes.Button.Appearance)]
         public string? Icon { get; set; }
 
         /// <summary>
-        /// The Icon that will be used in the toggled state.
+        /// An alternative icon to use in the toggled state.
         /// </summary>
         [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
+        [Category(CategoryTypes.Button.Appearance)]
         public string? ToggledIcon { get; set; }
 
         /// <summary>
-        /// The color of the icon in the untoggled state. It supports the theme colors.
+        /// The color of the icon.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The color of the icon in the toggled state. It supports the theme colors.
+        /// An alternative color to use in the toggled state.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Color ToggledColor { get; set; } = Color.Default;
+        public Color? ToggledColor { get; set; }
 
         /// <summary>
-        /// The Size of the component in the untoggled state.
+        /// The size of the button.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// The Size of the component in the toggled state.
+        /// An alternative size to use in the toggled state.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Size ToggledSize { get; set; } = Size.Medium;
+        public Size? ToggledSize { get; set; }
 
         /// <summary>
-        /// If set uses a negative margin.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Edge Edge { get; set; }
-
-        /// <summary>
-        /// Whether to show a ripple effect when the user clicks the button. Default is true.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public bool Ripple { get; set; } = true;
-
-        /// <summary>
-        /// If true, the button will be disabled.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
-        public bool Disabled { get; set; }
-
-        /// <summary>
-        /// The variant to use.
+        /// The variant to use in the regular state.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        /// Determines whether the component has a drop-shadow. Default is true
+        /// An alternative variant to use in the toggled state.
         /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public Variant? ToggledVariant { get; set; }
+
+        /// <summary>
+        /// Applies a negative margin.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public Edge Edge { get; set; }
+
+        /// <summary>
+        /// Shows a ripple effect when the user clicks the button.
+        /// </summary>
+        /// <remarks>
+        /// Default is <c>true</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public bool Ripple { get; set; } = true;
+
+        /// <summary>
+        /// Displays a shadow.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public bool DropShadow { get; set; } = true;
 
         /// <summary>
-        /// If true, the click event bubbles up to the containing/parent component.
+        /// Disables interaction with the button.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Button.Behavior)]
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the click event bubbles up to the containing/parent component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public bool ClickPropagation { get; set; }
 
-        public Task Toggle()
-        {
-            return SetToggledAsync(!Toggled);
-        }
+        public string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
+
+        public Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
+
+        public Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
+
+        public Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
+
+        public Task Toggle() => SetToggledAsync(!Toggled);
 
         protected internal async Task SetToggledAsync(bool toggled)
         {

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -148,7 +148,7 @@ namespace MudBlazor
         /// <returns>
         /// <see cref="ToggledIcon"/> if toggled and that property is set; otherwise, <see cref="Icon"/>.
         /// </returns>
-        public string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
+        internal string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
 
         /// <summary>
         /// Gets the size to use based on the toggled state.
@@ -156,7 +156,7 @@ namespace MudBlazor
         /// <returns>
         /// <see cref="ToggledSize"/> if toggled and that property is set; otherwise, <see cref="Size"/>.
         /// </returns>
-        public Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
+        internal Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
 
         /// <summary>
         /// Gets the color to use based on the toggled state.
@@ -164,7 +164,7 @@ namespace MudBlazor
         /// <returns>
         /// <see cref="ToggledColor"/> if toggled and that property is set; otherwise, <see cref="Color"/>.
         /// </returns>
-        public Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
+        internal Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
 
         /// <summary>
         /// Gets the variant to use based on the toggled state.
@@ -172,7 +172,7 @@ namespace MudBlazor
         /// <returns>
         /// <see cref="ToggledVariant"/> if toggled and that property is set; otherwise, <see cref="Variant"/>.
         /// </returns>
-        public Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
+        internal Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
 
         /// <summary>
         /// Toggles the state of the button.

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -1,193 +1,192 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
-namespace MudBlazor
-{
+namespace MudBlazor;
+
 #nullable enable
+/// <summary>
+/// Represents a button consisting of an icon that can be toggled between two distinct states.
+/// </summary>
+/// <remarks>
+/// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
+/// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+/// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
+/// </remarks>
+public partial class MudToggleIconButton : MudComponentBase
+{
     /// <summary>
-    /// Represents a button consisting of an icon that can be toggled between two distinct states.
+    /// Whether the icon is in the toggled state.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Behavior)]
+    public bool Toggled { get; set; }
+
+    /// <summary>
+    /// Occurs when <see cref="Toggled"/> is changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> ToggledChanged { get; set; }
+
+    /// <summary>
+    /// The icon to use.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// An alternative icon to use in the toggled state.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public string? ToggledIcon { get; set; }
+
+    /// <summary>
+    /// The color of the icon.
     /// </summary>
     /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
-    /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
+    /// Defaults to <see cref="Color.Default"/>.
     /// </remarks>
-    public partial class MudToggleIconButton : MudComponentBase
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Color Color { get; set; } = Color.Default;
+
+    /// <summary>
+    /// An alternative color to use in the toggled state.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Color? ToggledColor { get; set; }
+
+    /// <summary>
+    /// The size of the button.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Size.Medium"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Size Size { get; set; } = Size.Medium;
+
+    /// <summary>
+    /// An alternative size to use in the toggled state.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Size? ToggledSize { get; set; }
+
+    /// <summary>
+    /// The variant to use in the regular state.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Variant.Text"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Variant Variant { get; set; } = Variant.Text;
+
+    /// <summary>
+    /// An alternative variant to use in the toggled state.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Variant? ToggledVariant { get; set; }
+
+    /// <summary>
+    /// Applies a negative margin.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Edge.False"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public Edge Edge { get; set; }
+
+    /// <summary>
+    /// Shows a ripple effect when the user clicks the button.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public bool Ripple { get; set; } = true;
+
+    /// <summary>
+    /// Displays a shadow.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public bool DropShadow { get; set; } = true;
+
+    /// <summary>
+    /// Disables interaction with the button.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Behavior)]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Allows the click event to bubble up to the parent component.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Behavior)]
+    public bool ClickPropagation { get; set; }
+
+    /// <summary>
+    /// Gets the icon to display based on the toggled state.
+    /// </summary>
+    /// <returns>
+    /// <see cref="ToggledIcon"/> if toggled and that property is set; otherwise, <see cref="Icon"/>.
+    /// </returns>
+    internal string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
+
+    /// <summary>
+    /// Gets the size to use based on the toggled state.
+    /// </summary>
+    /// <returns>
+    /// <see cref="ToggledSize"/> if toggled and that property is set; otherwise, <see cref="Size"/>.
+    /// </returns>
+    internal Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
+
+    /// <summary>
+    /// Gets the color to use based on the toggled state.
+    /// </summary>
+    /// <returns>
+    /// <see cref="ToggledColor"/> if toggled and that property is set; otherwise, <see cref="Color"/>.
+    /// </returns>
+    internal Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
+
+    /// <summary>
+    /// Gets the variant to use based on the toggled state.
+    /// </summary>
+    /// <returns>
+    /// <see cref="ToggledVariant"/> if toggled and that property is set; otherwise, <see cref="Variant"/>.
+    /// </returns>
+    internal Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
+
+    /// <summary>
+    /// Toggles the state of the button.
+    /// </summary>
+    public Task Toggle() => SetToggledAsync(!Toggled);
+
+    protected internal async Task SetToggledAsync(bool toggled)
     {
-        /// <summary>
-        /// Whether the icon is in the toggled state.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
-        public bool Toggled { get; set; }
-
-        /// <summary>
-        /// Occurs when <see cref="Toggled"/> is changed.
-        /// </summary>
-        [Parameter]
-        public EventCallback<bool> ToggledChanged { get; set; }
-
-        /// <summary>
-        /// The icon to use.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public string? Icon { get; set; }
-
-        /// <summary>
-        /// An alternative icon to use in the toggled state.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public string? ToggledIcon { get; set; }
-
-        /// <summary>
-        /// The color of the icon.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Color.Default"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Color Color { get; set; } = Color.Default;
-
-        /// <summary>
-        /// An alternative color to use in the toggled state.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Color? ToggledColor { get; set; }
-
-        /// <summary>
-        /// The size of the button.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Size.Medium"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
-
-        /// <summary>
-        /// An alternative size to use in the toggled state.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Size? ToggledSize { get; set; }
-
-        /// <summary>
-        /// The variant to use in the regular state.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Variant.Text"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
-
-        /// <summary>
-        /// An alternative variant to use in the toggled state.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Variant? ToggledVariant { get; set; }
-
-        /// <summary>
-        /// Applies a negative margin.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Edge.False"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public Edge Edge { get; set; }
-
-        /// <summary>
-        /// Shows a ripple effect when the user clicks the button.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>true</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public bool Ripple { get; set; } = true;
-
-        /// <summary>
-        /// Displays a shadow.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>true</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Appearance)]
-        public bool DropShadow { get; set; } = true;
-
-        /// <summary>
-        /// Disables interaction with the button.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
-        public bool Disabled { get; set; }
-
-        /// <summary>
-        /// Allows the click event to bubble up to the parent component.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Button.Behavior)]
-        public bool ClickPropagation { get; set; }
-
-        /// <summary>
-        /// Gets the icon to display based on the toggled state.
-        /// </summary>
-        /// <returns>
-        /// <see cref="ToggledIcon"/> if toggled and that property is set; otherwise, <see cref="Icon"/>.
-        /// </returns>
-        internal string? GetIcon() => Toggled ? (ToggledIcon ?? Icon) : Icon;
-
-        /// <summary>
-        /// Gets the size to use based on the toggled state.
-        /// </summary>
-        /// <returns>
-        /// <see cref="ToggledSize"/> if toggled and that property is set; otherwise, <see cref="Size"/>.
-        /// </returns>
-        internal Size GetSize() => Toggled ? (ToggledSize ?? Size) : Size;
-
-        /// <summary>
-        /// Gets the color to use based on the toggled state.
-        /// </summary>
-        /// <returns>
-        /// <see cref="ToggledColor"/> if toggled and that property is set; otherwise, <see cref="Color"/>.
-        /// </returns>
-        internal Color GetColor() => Toggled ? (ToggledColor ?? Color) : Color;
-
-        /// <summary>
-        /// Gets the variant to use based on the toggled state.
-        /// </summary>
-        /// <returns>
-        /// <see cref="ToggledVariant"/> if toggled and that property is set; otherwise, <see cref="Variant"/>.
-        /// </returns>
-        internal Variant GetVariant() => Toggled ? (ToggledVariant ?? Variant) : Variant;
-
-        /// <summary>
-        /// Toggles the state of the button.
-        /// </summary>
-        public Task Toggle() => SetToggledAsync(!Toggled);
-
-        protected internal async Task SetToggledAsync(bool toggled)
+        if (Disabled)
+            return;
+        if (Toggled != toggled)
         {
-            if (Disabled)
-                return;
-            if (Toggled != toggled)
-            {
-                Toggled = toggled;
-                await ToggledChanged.InvokeAsync(Toggled);
-            }
+            Toggled = toggled;
+            await ToggledChanged.InvokeAsync(Toggled);
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #5583 - The regular version of a property (`Color`) is now used in the case that the toggled version (`ToggledColor`) has not been set. This is in contrast to the current unexpected behaviour which will just use the default value of the type (`Color.Medium`).

Additionally:
- Improves XML docs
- Adds `ToggledVariant`
- Adds additional tests
- Makes `Icon` use `CategoryTypes.Button.Appearance` like others

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
