### PR TITLE
Tests: Disable `CS1998` less

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectValidationDataAttrTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectValidationDataAttrTest.razor
@@ -17,7 +17,6 @@
     </MudItem>
 </MudGrid>
 @code {
-    #pragma warning disable CS1998 // async without await
     public static string __description__ = "Test use of data attributes accessible using `For` bound expression.";
 
     class TestModel

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.UnitTests.TestComponents
 {
-#pragma warning disable CS1998 // async without await
     public partial class TableMultiSelectionItemsTest1
     {
         [Parameter]

--- a/src/MudBlazor.UnitTests/Components/BadgeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BadgeTests.cs
@@ -1,7 +1,4 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
@@ -23,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Badge_Renders_When_VisibleIsTrue()
+        public void Badge_Renders_When_VisibleIsTrue()
         {
             var comp = Context.RenderComponent<MudBadge>();
             comp.SetParam("Visible", true);
@@ -31,7 +28,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Badge_Does_Not_Render_When_VisibleIsFalse()
+        public void Badge_Does_Not_Render_When_VisibleIsFalse()
         {
             var comp = Context.RenderComponent<MudBadge>();
             comp.SetParam("Visible", false);
@@ -50,7 +47,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Badge_AccessibilityAttributes()
+        public void Badge_AccessibilityAttributes()
         {
             // Arrange
             const string BadgeAriaLabel = "New notifications";

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -1,7 +1,4 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -606,7 +603,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [Obsolete]
-        public async Task MudPopoverService_CallInitializeOnlyOnce()
+        public void MudPopoverService_CallInitializeOnlyOnce()
         {
             var mock = new Mock<IJSRuntime>();
 

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1,7 +1,4 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -27,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task AddingAndRemovingTabPanels()
+        public void AddingAndRemovingTabPanels()
         {
             var comp = Context.RenderComponent<TabsAddingRemovingTabsTest>();
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().BeEmpty();
@@ -80,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         /// a callback that is fired only when OnRenderAsync of the tab panel happens the first time (which outputs a message at the bottom).
         /// </summary>
         [Test]
-        public async Task KeepTabsAliveTest()
+        public void KeepTabsAliveTest()
         {
             var comp = Context.RenderComponent<TabsKeepAliveTest>();
             // all panels should be evident in the markup:
@@ -137,7 +134,7 @@ namespace MudBlazor.UnitTests.Components
         /// a callback that is fired only when OnRenderAsync of the tab panel happens the first time (which outputs a message at the bottom).
         /// </summary>
         [Test]
-        public async Task KeepTabs_Not_AliveTest()
+        public void KeepTabs_Not_AliveTest()
         {
             var comp = Context.RenderComponent<TabsKeepAliveTest>(ComponentParameter.CreateParameter("KeepPanelsAlive", false));
             // only one panel should be evident in the markup:
@@ -315,7 +312,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Scroll_NotEnabled_EnoughSpace()
+        public void Scroll_NotEnabled_EnoughSpace()
         {
             var comp = Context.RenderComponent<ScrollableTabsTest>();
 
@@ -385,7 +382,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ScrollNext()
+        public void ScrollNext()
         {
             var observer = new MockResizeObserver
             {
@@ -854,7 +851,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ActivatePanels()
+        public void ActivatePanels()
         {
             var activator = new Action<IRenderedComponent<ActivateDisabledTabsTest>, ActivateDisabledTabsTest.TabBindingHelper>[] {
                (x,y) => x.Instance.ActivateTab(y.Index),
@@ -912,7 +909,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ActivatePanels_EvenWhenDisabled()
+        public void ActivatePanels_EvenWhenDisabled()
         {
             var activator = new Action<IRenderedComponent<ActivateDisabledTabsTest>, ActivateDisabledTabsTest.TabBindingHelper>[] {
                (x,y) => x.Instance.ActivateTab(y.Index, true),
@@ -948,7 +945,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task SelectedIndex_Binding()
+        public void SelectedIndex_Binding()
         {
             //starting with index 1:
             var comp = Context.RenderComponent<SelectedIndexTabsTest>();
@@ -997,7 +994,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         [TestCase(TabHeaderPosition.After)]
         [TestCase(TabHeaderPosition.Before)]
-        public async Task RenderHeaderBasedOnPosition(TabHeaderPosition position)
+        public void RenderHeaderBasedOnPosition(TabHeaderPosition position)
         {
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, position));
@@ -1027,7 +1024,7 @@ namespace MudBlazor.UnitTests.Components
         /// If the header template is set, but the position is none, no header should be rendered
         /// </summary>
         [Test]
-        public async Task RenderHeaderBasedOnPosition_None()
+        public void RenderHeaderBasedOnPosition_None()
         {
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
@@ -1043,7 +1040,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         [TestCase(TabHeaderPosition.After)]
         [TestCase(TabHeaderPosition.Before)]
-        public async Task RenderHeaderPanelBasedOnPosition(TabHeaderPosition position)
+        public void RenderHeaderPanelBasedOnPosition(TabHeaderPosition position)
         {
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
@@ -1078,7 +1075,7 @@ namespace MudBlazor.UnitTests.Components
         /// If the header template is set, but the position is none, no header should be rendered
         /// </summary>
         [Test]
-        public async Task RenderHeaderPanelBasedOnPosition_None()
+        public void RenderHeaderPanelBasedOnPosition_None()
         {
             var comp = Context.RenderComponent<TabsWithHeaderTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
@@ -1089,7 +1086,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TabPanelIconColorOverridesTabIconColor()
+        public void TabPanelIconColorOverridesTabIconColor()
         {
             var comp = Context.RenderComponent<TabPanelIconColorTest>();
             comp.SetParametersAndRender(x => x.Add(y => y.MudTabPanelIconColor, Color.Success));
@@ -1099,7 +1096,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TabPanelIconColorOverridesTabIconColorExceptWhenDisabled()
+        public void TabPanelIconColorOverridesTabIconColorExceptWhenDisabled()
         {
             var comp = Context.RenderComponent<TabPanelIconColorTest>();
             comp.SetParam("DisableTab", true);
@@ -1110,7 +1107,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task HtmlTextTabs()
+        public void HtmlTextTabs()
         {
             // get the tab panels, we must have 2 tabs, one with html text and one without
             var comp = Context.RenderComponent<HtmlTextTabsTest>();
@@ -1130,7 +1127,7 @@ namespace MudBlazor.UnitTests.Components
         ///  Depending on the SliderAnimation parameter, it should toggle the transition style attribute
         /// </summary>
         [Test]
-        public async Task ToggleTabsSliderAnimation()
+        public void ToggleTabsSliderAnimation()
         {
             //The first tab should be active because for the rest the slider position is calculated by JS
             //and before the calculation the slider is hidden to avoid movement on first load
@@ -1154,7 +1151,7 @@ namespace MudBlazor.UnitTests.Components
         ///  Specifying a custom minimum width should add a min-width style to each tab
         /// </summary>
         [Test]
-        public async Task MinimumTabWidth()
+        public void MinimumTabWidth()
         {
             var comp = Context.RenderComponent<MinimumWidthTabs>();
 
@@ -1168,7 +1165,7 @@ namespace MudBlazor.UnitTests.Components
         /// See: https://github.com/MudBlazor/MudBlazor/issues/2976
         /// </summary>
         [Test]
-        public async Task MenuInHeaderPanelCloseOnClickOutside()
+        public void MenuInHeaderPanelCloseOnClickOutside()
         {
             var comp = Context.RenderComponent<TabsWithMenuInHeader>();
 
@@ -1186,7 +1183,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task PrePanelContent()
+        public void PrePanelContent()
         {
             var comp = Context.RenderComponent<TabsWithPrePanelContent>(p => p.Add(x => x.SelectedIndex, 0));
 
@@ -1208,7 +1205,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task CancelPanelActivation()
+        public void CancelPanelActivation()
         {
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
@@ -1239,7 +1236,7 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public async Task DynamicTabs_CollectionRenderSyncTest()
+        public void DynamicTabs_CollectionRenderSyncTest()
         {
             var comp = Context.RenderComponent<DynamicTabsSimpleExample>();
 
@@ -1280,7 +1277,7 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public async Task TabPanel_ShowCloseIconTest()
+        public void TabPanel_ShowCloseIconTest()
         {
             var comp = Context.RenderComponent<DynamicTabsSimpleExample>();
             var tabs = comp.FindAll("div.mud-tab");

--- a/src/MudBlazor.UnitTests/Components/VirtualizeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/VirtualizeTests.cs
@@ -1,14 +1,7 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {

--- a/src/MudBlazor.UnitTests/Services/JsEventTests.cs
+++ b/src/MudBlazor.UnitTests/Services/JsEventTests.cs
@@ -10,8 +10,6 @@ using Moq;
 using MudBlazor.Services;
 using NUnit.Framework;
 
-#pragma warning disable CS1998 // async without await
-
 namespace MudBlazor.UnitTests.Services
 {
     [TestFixture]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

>Async method lacks 'await' operators and will run synchronously

Reduces the dependence on CS1998 to promote healthier test code.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
