### PR TITLE
MudTreeView: Improve templating example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
@@ -94,7 +94,14 @@
             Value = new Product("Tea Pots", Icons.Material.Filled.Label),
             Expanded = true,
             Children = [
-                new TreeItemData<Product> { Value = new Product("Glass Teapot with Infuser", Icons.Material.Filled.LocalOffer, 7.99m) },
+                new TreeItemData<Product> {
+                    Value=new Product("Glass Teapot", Icons.Material.Filled.LocalOffer, 36.99m),
+                    Expanded = true,
+                    Children = [ 
+                        new TreeItemData<Product> { Value = new Product("Glass Infuser", Icons.Material.Filled.LocalOffer, 2.99m) }, 
+                        new TreeItemData<Product> { Value = new Product("Stainless Steel Infuser", Icons.Material.Filled.LocalOffer, 5.99m) }
+                    ]
+                },
                 new TreeItemData<Product> { Value = new Product("Stainless Steel Teapot", Icons.Material.Filled.LocalOffer, 14.15m) },
                 new TreeItemData<Product> { Value = new Product("Japanese Cast Iron Teapot", Icons.Material.Filled.LocalOffer, 26.39m) },
                 new TreeItemData<Product> { Value = new Product("Porcelain Teapot", Icons.Material.Filled.LocalOffer, 38.00m) },

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
@@ -78,15 +78,14 @@
             Value=new Product("Coffee Makers", Icons.Material.Filled.Label), 
             Expanded = true,
             Children = [
-                new TreeItemData<Product> { 
-                    Value=new Product("Moka pot", Icons.Material.Filled.LocalOffer, 36.99m),  
-                    Expanded = true,
-                    Children = [ new TreeItemData<Product> { Value = new Product("Cleaning Kit", Icons.Material.Filled.LocalOffer, 17.59m) } ]
-                },
+                new TreeItemData<Product> { Value=new Product("Moka Pot", Icons.Material.Filled.LocalOffer, 36.99m),  },
                 new TreeItemData<Product> { 
                     Value=new Product("French Press", Icons.Material.Filled.LocalOffer, 19.99m),
                     Expanded = true,
-                    Children = [ new TreeItemData<Product> { Value = new Product("Spare Sieve", Icons.Material.Filled.LocalOffer, 6.00m) } ]
+                    Children = [ 
+                        new TreeItemData<Product> { Value = new Product("Spare Sieve", Icons.Material.Filled.LocalOffer, 6.00m) },
+                        new TreeItemData<Product> { Value = new Product("Cleaning Kit", Icons.Material.Filled.LocalOffer, 17.59m) }
+                    ]
                 }
             ]
         });
@@ -104,7 +103,7 @@
                 },
                 new TreeItemData<Product> { Value = new Product("Stainless Steel Teapot", Icons.Material.Filled.LocalOffer, 14.15m) },
                 new TreeItemData<Product> { Value = new Product("Japanese Cast Iron Teapot", Icons.Material.Filled.LocalOffer, 26.39m) },
-                new TreeItemData<Product> { Value = new Product("Porcelain Teapot", Icons.Material.Filled.LocalOffer, 38.00m) },
+                new TreeItemData<Product> { Value = new Product("Porcelain Teapot", Icons.Material.Filled.LocalOffer, 38.00m) }
             ]
         });
     }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewCustomExample.razor
@@ -1,60 +1,111 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudPaper Width="350px" MaxHeight="500px" Class="overflow-y-auto" Elevation="2">
-    <MudTreeView Items="@TreeItems">
-        <ItemTemplate>
-            <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children">
-                <Content>
-                    <MudTreeViewItemToggleButton @bind-Expanded="@context.Expanded" Visible="@context.HasChildren" />
-                    <MudIcon Icon="@context.Icon" Class="ml-0 mr-2" Color="@Color.Default" />
-                    <MudText>@context.Text</MudText>
-                </Content>
-            </MudTreeViewItem>
-        </ItemTemplate>
-    </MudTreeView>
-</MudPaper>
+<MudStack>
+    <MudPaper Width="400px" MaxHeight="400px" Class="overflow-y-auto" Elevation="2">
+        <MudTreeView Items="@TreeItems" ReadOnly>
+            <ItemTemplate>
+                @{                
+                    var product = context.Value; // for convenient usage in the template
+                }
+                <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children" Value="@context.Value">
+                    <Content>
+                        <MudTreeViewItemToggleButton @bind-Expanded="@context.Expanded" Visible="@context.HasChildren" />
+                        @if (product?.Price is not null) {
+                            <MudCheckBox T="bool" Size="Size.Small" Value="@context.Selected" ValueChanged="@((v)=> OnCheckboxChanged(v, context))" />
+                        }
+                        <MudIcon Icon="@product?.Icon" Class="ml-0 mr-2" Color="@Color.Default" />
+                        <MudText>@product?.Name</MudText>
+                        @if (product?.Price is not null) {
+                            <MudChip Class="ml-1">@product.Price.Value.ToString("C")</MudChip>
+                        }
+                    </Content>
+                </MudTreeViewItem>
+            </ItemTemplate>
+        </MudTreeView>
+    </MudPaper>
+    <MudStack Class="mt-3" Style="width: 400px">
+        <MudText Typo="@Typo.subtitle1" Inline>Selected items: @(string.Join(", ", (SelectedValues ?? []).Select(x => x.Name)))</MudText>
+        <MudStack>
+            <MudText Typo="@Typo.subtitle1">Sum: <MudChip T="string">@GetSelectedSum().ToString("C")</MudChip></MudText>
+        </MudStack>
+    </MudStack>
+</MudStack>
 
 @code {
-
-    private HashSet<TreeItemData<string>> TreeItems { get; set; } = new();
-
-    public class TreeItemData : TreeItemData<string>
+    public void OnCheckboxChanged(bool selected, TreeItemData<Product> context)
     {
-        public TreeItemData(string text, string icon) : base(text)
+        context.Selected = selected;
+        if (context.Value?.Price is null)
+            return;
+        if (context.Selected)
+            SelectedValues.Add(context.Value);
+        else
+            SelectedValues.Remove(context.Value);
+    }
+
+    public HashSet<Product> SelectedValues { get; set; } = new();
+
+    public List<TreeItemData<Product>> TreeItems { get; set; } = new();
+
+    public class Product : IEquatable<Product>
+    {
+        public decimal? Price { get; set; }
+        public string Name { get; init; }
+        public string Icon { get; set; }
+
+        public Product(string name, string icon, decimal? price = null)
         {
-            Text = text;
+            Name = name;
             Icon = icon;
+            Price = price;
         }
+
+        public bool Equals(Product other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Product other && Equals(other);
+
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
     }
 
     protected override void OnInitialized()
     {
-        TreeItems.Add(new TreeItemData(".azure", Icons.Custom.Brands.MicrosoftAzure));
-        TreeItems.Add(new TreeItemData(".github", Icons.Custom.Brands.GitHub));
-        TreeItems.Add(new TreeItemData(".vscode", Icons.Custom.Brands.MicrosoftVisualStudio));
-        TreeItems.Add(new TreeItemData("content", Icons.Custom.FileFormats.FileDocument));
-        TreeItems.Add(new TreeItemData("src", Icons.Custom.FileFormats.FileCode)
-        {
+        TreeItems.Add(new TreeItemData<Product> { 
+            Value=new Product("Coffee Makers", Icons.Material.Filled.Label), 
+            Expanded = true,
             Children = [
-                new TreeItemData("MudBlazor", Icons.Custom.Brands.MudBlazor),
-                new TreeItemData("MudBlazor.Docs", Icons.Custom.FileFormats.FileDocument)
-                {
-                    Children = [                    
-                        new TreeItemData("_Imports.razor", Icons.Material.Filled.AlternateEmail),
-                        new TreeItemData( "compilerconfig.json", Icons.Custom.FileFormats.FileImage),
-                        new TreeItemData( "MudBlazor.Docs.csproj", Icons.Custom.Brands.MicrosoftVisualStudio),
-                        new TreeItemData("NewFilesToBuild.txt" , Icons.Custom.FileFormats.FileDocument),
-                    ]
+                new TreeItemData<Product> { 
+                    Value=new Product("Moka pot", Icons.Material.Filled.LocalOffer, 36.99m),  
+                    Expanded = true,
+                    Children = [ new TreeItemData<Product> { Value = new Product("Cleaning Kit", Icons.Material.Filled.LocalOffer, 17.59m) } ]
                 },
-                new TreeItemData("MudBlazor.Docs.Client", Icons.Material.Filled.Folder),
-                new TreeItemData("MudBlazor.Docs.Compiler", Icons.Material.Filled.Folder),
-                new TreeItemData("MudBlazor.Docs.Server", Icons.Material.Filled.Folder),
-                new TreeItemData("MudBlazor.UnitTests", Icons.Material.Filled.Folder),
-                new TreeItemData("MudBlazor.UnitTests.Viewer", Icons.Material.Filled.Folder),
-                new TreeItemData(".editorconfig", Icons.Custom.FileFormats.FileCode),
-                new TreeItemData("MudBlazor.sln", Icons.Custom.Brands.MicrosoftVisualStudio)
+                new TreeItemData<Product> { 
+                    Value=new Product("French Press", Icons.Material.Filled.LocalOffer, 19.99m),
+                    Expanded = true,
+                    Children = [ new TreeItemData<Product> { Value = new Product("Spare Sieve", Icons.Material.Filled.LocalOffer, 6.00m) } ]
+                }
             ]
         });
-        TreeItems.Add(new TreeItemData("History", Icons.Material.Filled.Folder));
+        TreeItems.Add(new TreeItemData<Product> {
+            Value = new Product("Tea Pots", Icons.Material.Filled.Label),
+            Expanded = true,
+            Children = [
+                new TreeItemData<Product> { Value = new Product("Glass Teapot with Infuser", Icons.Material.Filled.LocalOffer, 7.99m) },
+                new TreeItemData<Product> { Value = new Product("Stainless Steel Teapot", Icons.Material.Filled.LocalOffer, 14.15m) },
+                new TreeItemData<Product> { Value = new Product("Japanese Cast Iron Teapot", Icons.Material.Filled.LocalOffer, 26.39m) },
+                new TreeItemData<Product> { Value = new Product("Porcelain Teapot", Icons.Material.Filled.LocalOffer, 38.00m) },
+            ]
+        });
+    }
+
+    public decimal GetSelectedSum()
+    {
+        if (SelectedValues is null)
+            return 0;
+        return SelectedValues.Sum(p => p.Price ?? 0);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -133,11 +133,14 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Custom Tree">
+            <SectionHeader Title="Custom Look and Behavior">
                 <Description>
-                    When the <CodeInline>Content</CodeInline> property is used, it will completely replace the default rendering of the MudTreeViewItem to use your own.
-                    You must constrain the container's <CodeInline>height</CodeInline> or <CodeInline>max-height</CodeInline> and set the container's <CodeInline>overflow-y</CodeInline>
-                    accordingly to scroll the <CodeInline Tag>MudTreeView</CodeInline>.
+                    When the <CodeInline>Content</CodeInline> property is used, it will completely replace the default rendering of the <CodeInline>MudTreeViewItem</CodeInline> to use your own. 
+                    This gives you every opportunity to change the behavior of <CodeInline>MudTreeView</CodeInline> to anything you want. In this example we build our own non-standard multi selection behavior where
+                    selecting the parent node does not automatically select the children and vice-versa. Also, note how only certain items can be selected.
+                    <br /><br />
+                    By the way, to get nice scrolling behavior like in this example, you must constrain the container's <CodeInline>height</CodeInline> or <CodeInline>max-height</CodeInline> and set the container's 
+                    <CodeInline>overflow-y</CodeInline> accordingly.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TreeViewCustomExample)" ShowCode="false">


### PR DESCRIPTION
The current example does little to demonstrate how you can change the treeview's selection behavior which is crucial for many users who do not want the default multi-selection behavior. The new example shows not only how to make your own selection behavior but also how to use a POCO for data and that the look of tree items can be individually customized.

Resolves #9411

Before:
![image](https://github.com/user-attachments/assets/e85fb6f3-044e-4c3c-a8dc-d629829767be)


After:
![image](https://github.com/user-attachments/assets/1389449b-26a3-4a8b-8262-a4716444069e)

