### PR TITLE
MudField, MudMask: Support typography customization

### DIFF
--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -22,6 +22,7 @@ namespace MudBlazor
                 .AddClass("mud-shrink", when: () => !string.IsNullOrWhiteSpace(ChildContent?.ToString()) || Adornment == Adornment.Start)
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", Error && !string.IsNullOrEmpty(ErrorText))
+                .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
                 .Build();
 
         protected string InnerClassname =>
@@ -61,6 +62,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Field.Appearance)]
         public Margin Margin { get; set; } = Margin.None;
+
+        /// <summary>
+        /// Typography for the field text.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Field.Appearance)]
+        public Typo Typo { get; set; } = Typo.input;
 
         /// <summary>
         /// Displays the error in <see cref="ErrorText"/>.

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -35,6 +35,7 @@ namespace MudBlazor
                 .AddClass("mud-disabled", GetDisabledState())
                 .AddClass("mud-input-error", HasErrors)
                 .AddClass("mud-ltr", GetInputType() == InputType.Email || GetInputType() == InputType.Telephone)
+                .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
                 .AddClass(Class)
                 .Build();
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Follows up on #8754 and Resolves #9412, also reported in https://github.com/MudBlazor/MudBlazor/pull/8754#issuecomment-2231442930.

MudField and MudMask are not using a standard inheritance so were missed in the original PR. This brings parity for the application of typography classes to them.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
