### PR TITLE
MudTreeView: Don't select on expand button double click

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4126,11 +4126,11 @@ namespace MudBlazor.UnitTests.Components
             clickablePopover.Click();
             cells = dataGrid.FindAll("td");
             // We do not need check all 10 rows as it's clear that it's ungrouped if first row pass
-            cells[0].TextContent.Should().Be("1"); 
-            cells[1].TextContent.Should().Be("H"); 
-            cells[2].TextContent.Should().Be("Hydrogen"); 
-            cells[3].TextContent.Should().Be("0"); 
-            cells[4].TextContent.Should().Be("1.00794"); 
+            cells[0].TextContent.Should().Be("1");
+            cells[1].TextContent.Should().Be("H");
+            cells[2].TextContent.Should().Be("Hydrogen");
+            cells[3].TextContent.Should().Be("0");
+            cells[4].TextContent.Should().Be("1.00794");
             cells[5].TextContent.Should().Be("Other");
             dataGrid.Instance.GroupedColumn.Should().BeNull();
         }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -4087,6 +4088,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [SetCulture("en-US")]
         public async Task DataGridServerGroupUngroupingTest()
         {
             var comp = Context.RenderComponent<DataGridServerDataColumnGroupingTest>();
@@ -4124,7 +4126,12 @@ namespace MudBlazor.UnitTests.Components
             clickablePopover.Click();
             cells = dataGrid.FindAll("td");
             // We do not need check all 10 rows as it's clear that it's ungrouped if first row pass
-            cells[0].TextContent.Should().Be("1"); cells[1].TextContent.Should().Be("H"); cells[2].TextContent.Should().Be("Hydrogen"); cells[3].TextContent.Should().Be("0"); cells[4].TextContent.Should().Be("1.00794"); cells[5].TextContent.Should().Be("Other");
+            cells[0].TextContent.Should().Be("1"); 
+            cells[1].TextContent.Should().Be("H"); 
+            cells[2].TextContent.Should().Be("Hydrogen"); 
+            cells[3].TextContent.Should().Be("0"); 
+            cells[4].TextContent.Should().Be("1.00794"); 
+            cells[5].TextContent.Should().Be("Other");
             dataGrid.Instance.GroupedColumn.Should().BeNull();
         }
 

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -409,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
-            comp.Find("mud-treeview-item-expand-button").Click();
+            comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.FindAll("input.mud-checkbox-input").Count.Should().Be(10);
             comp.Find("input.mud-checkbox-input").Change(true);

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -359,12 +359,34 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TreeViewTest1>();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
-            comp.Find("button").Click();
+            comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
-            comp.Find("button").Click();
+            comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void DoubleClickOnArrowButton_ShouldNotSelectItem()
+        {
+            var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
+            comp.Find("button.mud-treeview-item-expand-button").Click();
+            comp.FindAll("input.mud-checkbox-input").Count.Should().Be(10);
+            comp.Instance.SubItemSelected.Should().BeFalse();
+            comp.Instance.Item1Selected.Should().BeFalse();
+            // double-click on expand button should not influence selection
+            comp.Find("button.mud-treeview-item-expand-button").DoubleClick();
+            comp.Instance.SubItemSelected.Should().BeFalse();
+            comp.Instance.Item1Selected.Should().BeFalse();
+            comp.Find("input.mud-checkbox-input").Change(true);
+            comp.Instance.SubItemSelected.Should().BeTrue();
+            comp.Instance.Item1Selected.Should().BeTrue();
+            // double-click on expand button should not influence selection
+            comp.Find("button.mud-treeview-item-expand-button").DoubleClick();
+            comp.Instance.SubItemSelected.Should().BeTrue();
+            comp.Instance.Item1Selected.Should().BeTrue();
         }
 
         [Test]
@@ -372,9 +394,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TreeViewTest2>();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
-            comp.Find("button").Click();
+            comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
-            comp.Find("button").Click();
+            comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
@@ -387,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
-            comp.Find("button").Click();
+            comp.Find("mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.FindAll("input.mud-checkbox-input").Count.Should().Be(10);
             comp.Find("input.mud-checkbox-input").Change(true);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -1,6 +1,5 @@
 @namespace MudBlazor
 @inherits MudComponentBase
-@using Microsoft.VisualBasic
 @typeparam T
 
 <li @attributes="UserAttributes" class="@Classname" style="@Style">

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+#nullable enable
+
+namespace MudBlazor;
+
+public partial class MudTreeViewItemToggleButton : MudComponentBase
+{
+
+    protected string Classname =>
+        new CssBuilder(Class)
+            .AddClass("mud-treeview-item-arrow-expand", !Loading)
+            .AddClass("mud-transform", Expanded && !Loading)
+            .AddClass("mud-treeview-item-arrow-load", Loading)
+            .Build();
+
+    /// <summary>
+    /// If true, displays the button.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Behavior)]
+    public bool Visible { get; set; }
+
+    /// <summary>
+    /// Propagate disabled state to icon.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Behavior)]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Determines when to flip the expanded icon.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Behavior)]
+    public bool Expanded { get; set; }
+
+    /// <summary>
+    /// If true, displays the loading icon.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Behavior)]
+    public bool Loading { get; set; }
+
+    /// <summary>
+    /// Called whenever expanded changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    /// <summary>
+    /// The loading icon.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Appearance)]
+    public string LoadingIcon { get; set; } = Icons.Material.Filled.Loop;
+
+    /// <summary>
+    /// The color of the loading. It supports the theme colors.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Appearance)]
+    public Color LoadingIconColor { get; set; } = Color.Default;
+
+    /// <summary>
+    /// The expand/collapse icon.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Appearance)]
+    public string ExpandedIcon { get; set; } = Icons.Material.Filled.ChevronRight;
+
+    /// <summary>
+    /// The color of the expand/collapse. It supports the theme colors.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.TreeView.Appearance)]
+    public Color ExpandedIconColor { get; set; } = Color.Default;
+
+    private Task ToggleAsync()
+    {
+        Expanded = !Expanded;
+        return ExpandedChanged.InvokeAsync(Expanded);
+    }
+
+    private void OnDoubleClick()
+    {
+        /* Don't do anything on purpose. Fixes #9419 */
+    }
+}

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.cs
@@ -19,6 +19,7 @@ public partial class MudTreeViewItemToggleButton : MudComponentBase
 
     protected string Classname =>
         new CssBuilder(Class)
+            .AddClass("mud-treeview-item-expand-button")
             .AddClass("mud-treeview-item-arrow-expand", !Loading)
             .AddClass("mud-transform", Expanded && !Loading)
             .AddClass("mud-treeview-item-arrow-load", Loading)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
@@ -2,9 +2,9 @@
 @namespace MudBlazor
 @inherits MudComponentBase
 
-<div class="mud-treeview-item-arrow" @ondblclick="OnDoubleClick" @ondblclick:stopPropagation="true">
+<div @attributes="UserAttributes" class="mud-treeview-item-arrow" @ondblclick="OnDoubleClick" @ondblclick:stopPropagation="true">
     @if (Visible) {
-        <MudIconButton UserAttributes="@UserAttributes"
+        <MudIconButton
                        Disabled="@Disabled"
                        OnClick="@ToggleAsync"
                        Icon="@(Loading ? LoadingIcon : ExpandedIcon)"

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor.Utilities
-@namespace MudBlazor
+﻿@namespace MudBlazor
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="mud-treeview-item-arrow" @ondblclick="OnDoubleClick" @ondblclick:stopPropagation="true">

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
@@ -1,87 +1,17 @@
-﻿@using MudBlazor.Utilities 
+﻿@using MudBlazor.Utilities
 @namespace MudBlazor
+@inherits MudComponentBase
 
-<div class="mud-treeview-item-arrow">
-    @if (Visible)
-    {
-        <MudIconButton Disabled="@Disabled" OnClick="@ToggleAsync" Icon="@(Loading ? LoadingIcon : ExpandedIcon)" Color="@(Loading ? LoadingIconColor : ExpandedIconColor)" Class="@Classname"></MudIconButton>
+<div class="mud-treeview-item-arrow" @ondblclick="OnDoubleClick" @ondblclick:stopPropagation="true">
+    @if (Visible) {
+        <MudIconButton UserAttributes="@UserAttributes"
+                       Disabled="@Disabled"
+                       OnClick="@ToggleAsync"
+                       Icon="@(Loading ? LoadingIcon : ExpandedIcon)"
+                       Color="@(Loading ? LoadingIconColor : ExpandedIconColor)"
+                       Class="@Classname"
+                       Style="@Style" 
+                       />
     }
 </div>
- 
-@code {
-#nullable enable
-    protected string Classname =>
-        new CssBuilder()
-            .AddClass("mud-treeview-item-arrow-expand", !Loading)
-            .AddClass("mud-transform", Expanded && !Loading)
-            .AddClass("mud-treeview-item-arrow-load", Loading)
-            .Build();
 
-    /// <summary>
-    /// If true, displays the button.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Behavior)]
-    public bool Visible { get; set; }
-    
-    /// <summary>
-    /// Propagate disabled state to icon.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Behavior)]
-    public bool Disabled { get; set; }
-
-    /// <summary>
-    /// Determines when to flip the expanded icon.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Behavior)]
-    public bool Expanded { get; set; }
-
-    /// <summary>
-    /// If true, displays the loading icon.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Behavior)]
-    public bool Loading { get; set; }
-
-    /// <summary>
-    /// Called whenever expanded changed.
-    /// </summary>
-    [Parameter]
-    public EventCallback<bool> ExpandedChanged { get; set; }
-
-    /// <summary>
-    /// The loading icon.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Appearance)]
-    public string LoadingIcon { get; set; } = Icons.Material.Filled.Loop;
-
-    /// <summary>
-    /// The color of the loading. It supports the theme colors.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Appearance)]
-    public Color LoadingIconColor { get; set; } = Color.Default;
-
-    /// <summary>
-    /// The expand/collapse icon.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Appearance)]
-    public string ExpandedIcon { get; set; } = Icons.Material.Filled.ChevronRight;
-
-    /// <summary>
-    /// The color of the expand/collapse. It supports the theme colors.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.TreeView.Appearance)]
-    public Color ExpandedIconColor { get; set; } = Color.Default;
-
-    private Task ToggleAsync()
-    {
-        Expanded = !Expanded;
-        return ExpandedChanged.InvokeAsync(Expanded);
-    }
-}

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor.cs
@@ -2,26 +2,31 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 #nullable enable
-
 namespace MudBlazor;
 
 public partial class MudTreeViewItemToggleButton : MudComponentBase
 {
+    private readonly ParameterState<bool> _expandedState;
+
+    public MudTreeViewItemToggleButton()
+    {
+        using var registerScope = CreateRegisterScope();
+        _expandedState = registerScope.RegisterParameter<bool>(nameof(Expanded))
+            .WithParameter(() => Expanded)
+            .WithEventCallback(() => ExpandedChanged);
+    }
 
     protected string Classname =>
         new CssBuilder(Class)
             .AddClass("mud-treeview-item-expand-button")
             .AddClass("mud-treeview-item-arrow-expand", !Loading)
-            .AddClass("mud-transform", Expanded && !Loading)
+            .AddClass("mud-transform", _expandedState.Value && !Loading)
             .AddClass("mud-treeview-item-arrow-load", Loading)
             .Build();
 
@@ -89,8 +94,7 @@ public partial class MudTreeViewItemToggleButton : MudComponentBase
 
     private Task ToggleAsync()
     {
-        Expanded = !Expanded;
-        return ExpandedChanged.InvokeAsync(Expanded);
+        return _expandedState.SetValueAsync(!_expandedState.Value);
     }
 
     private void OnDoubleClick()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #9419

- When expanding/collapsing via the expand button don't select on double click by preventing its propagation
- Split `MudTreeViewItemToggleButton` into code and razor files
- `MudTreeViewItemToggleButton` inherits MudComponentBase now
- `MudTreeViewItemToggleButton` forwards Class and Style as well as UserAttributes to inner icon button

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
