### PR TITLE
IDialogService: Forward event DialogInstanceAddedAsync to OnDialogInstanceAdded for compatibility

### DIFF
--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -12,8 +12,6 @@ using Microsoft.AspNetCore.Components;
 #nullable enable
 namespace MudBlazor
 {
-    public delegate Task DialogInstanceAddedEventHandler(IDialogReference reference);
-
     /// <summary>
     /// A service for managing <see cref="MudDialog"/> components.
     /// </summary>

--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Components;
 #nullable enable
 namespace MudBlazor
 {
+    public delegate Task DialogInstanceAddedEventHandler(IDialogReference reference);
+
     /// <summary>
     /// A service for managing <see cref="MudDialog"/> components.
     /// </summary>
@@ -24,17 +26,31 @@ namespace MudBlazor
         /// Occurs when a new dialog instance is created.
         /// </summary>
         [Obsolete($"Please use {nameof(DialogInstanceAddedAsync)} instead!")]
-        public event Action<IDialogReference>? OnDialogInstanceAdded;
+        event Action<IDialogReference>? OnDialogInstanceAdded;
 
         /// <summary>
         /// Occurs when a new dialog instance is created.
         /// </summary>
-        public event Func<IDialogReference, Task>? DialogInstanceAddedAsync;
-
+        public event Func<IDialogReference, Task> DialogInstanceAddedAsync
+        {
+            add
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                OnDialogInstanceAdded += dialogReference => value(dialogReference);
+            }
+            // ReSharper disable ValueParameterNotUsed
+            remove
+            // ReSharper restore ValueParameterNotUsed
+            {
+                // Removing the event handler requires keeping track of the added handlers
+                // which is complex. Hence, this part is left out.
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+        }
         /// <summary>
         /// Occurs when a request is made to close a dialog.
         /// </summary>
-        public event Action<IDialogReference, DialogResult?>? OnDialogCloseRequested;
+        event Action<IDialogReference, DialogResult?>? OnDialogCloseRequested;
 
         /// <summary>
         /// Displays a dialog.

--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -33,6 +33,7 @@ namespace MudBlazor
         /// </summary>
         public event Func<IDialogReference, Task> DialogInstanceAddedAsync
         {
+            // TODO: Remove default implementation in next major
             add
             {
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
## Description
Fixes: https://github.com/fgilde/MudBlazor.Extensions/issues/98

It's ugly, but there is nothing much I can do, and it's `event`, if it was a delegate or just typical `Func` it would be better.

## How Has This Been Tested?
Manually by making sure the `DialogInstanceAddedAsync` is not mandatory to be implemented when implementing the `IDialogService`.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
