### PR TITLE
TreeItemData<T>: Add virtual to all properties as per request

### DIFF
--- a/src/MudBlazor/Components/TreeView/TreeItemData.cs
+++ b/src/MudBlazor/Components/TreeView/TreeItemData.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace MudBlazor;
 
 #nullable enable
+
 public class TreeItemData<T> : IEquatable<TreeItemData<T>>
 {
     public TreeItemData() : this(default) { }
@@ -17,17 +18,17 @@ public class TreeItemData<T> : IEquatable<TreeItemData<T>>
         Value = value;
     }
 
-    public string? Text { get; set; }
+    public virtual string? Text { get; set; }
 
-    public string? Icon { get; set; }
+    public virtual string? Icon { get; set; }
 
     public T? Value { get; init; }
 
-    public bool Expanded { get; set; }
+    public virtual bool Expanded { get; set; }
 
-    public bool Expandable { get; set; } = true;
+    public virtual bool Expandable { get; set; } = true;
 
-    public bool Selected { get; set; }
+    public virtual bool Selected { get; set; }
 
     public virtual List<TreeItemData<T>>? Children { get; set; }
 

--- a/src/MudBlazor/MudBlazor.csproj.DotSettings
+++ b/src/MudBlazor/MudBlazor.csproj.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=components_005Ctreeview/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=components_005Ctypography/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=components_005Cvirtualize/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=interfaces/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cresizelistener/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=utilities_005Cmaskalgorithms/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Users migrating to v7 requested that we make the `TreeItemData<T>` properties virtual so they could override them and place their custom logic in them which can simplify their razor and reduce necessity to cast. 
