### PR TITLE
MudSwipeArea: Replace  ontouch with onpointer

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDatePickerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDatePickerExample.razor
@@ -2,22 +2,24 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudSwipeArea OnSwipeEnd="@OnSwipeEnd">
-    <MudDatePicker PickerVariant="PickerVariant.Static" Date="@(DateTime.Today.AddDays(1))" @bind-PickerMonth="@_pickerMonth" />
+    <div style="user-select: none;">
+        <MudDatePicker PickerVariant="PickerVariant.Static" Date="@(DateTime.Today.AddDays(1))" @bind-PickerMonth="@_pickerMonth"/>
+    </div>
 </MudSwipeArea>
 
 @code {
-    DateTime? _pickerMonth = DateTime.Now.StartOfMonth(CultureInfo.CurrentCulture);
+    private DateTime? _pickerMonth = DateTime.Now.StartOfMonth(CultureInfo.CurrentCulture);
 
     public void OnSwipeEnd(SwipeEventArgs e)
     {
         if (e.SwipeDirection == SwipeDirection.LeftToRight)
         {
-            _pickerMonth = _pickerMonth.Value.AddMonths(-1);
+            _pickerMonth = _pickerMonth?.AddMonths(-1);
             StateHasChanged();
         }
         else if (e.SwipeDirection == SwipeDirection.RightToLeft)
         {
-            _pickerMonth = _pickerMonth.Value.AddMonths(1);
+            _pickerMonth = _pickerMonth?.AddMonths(1);
             StateHasChanged();
         }
     }

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudSwipeArea OnSwipeEnd="@((e) => _swipeDirection = e.SwipeDirection)" Style="width: 100%; height: 300px">
-    <MudText Typo="@Typo.body1">@_swipeDirection</MudText>
+<MudSwipeArea OnSwipeEnd="@(e => _swipeDirection = e.SwipeDirection)" Style="width: 100%; height: 300px">
+    <MudText Style="user-select: none;" Typo="@Typo.body1">@_swipeDirection</MudText>
 </MudSwipeArea>
 
 @code {
-    SwipeDirection _swipeDirection;
+    private SwipeDirection _swipeDirection;
 }

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsPreventDefaultExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsPreventDefaultExample.razor
@@ -1,18 +1,17 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudSwipeArea @ref="_swipeArea" OnSwipeEnd="HandleSwipeEnd" Style="width: 100%; height: 300px" Sensitivity="_sensitivity" PreventDefault="@_preventDefault">
-    <MudText Typo="@Typo.body1">@($"{_swipeDirection} - Swiped: {_swipeDelta}px")</MudText>
+    <MudText Style="user-select: none;" Typo="@Typo.body1">@($"{_swipeDirection} - Swiped: {_swipeDelta}px")</MudText>
 </MudSwipeArea>
 <MudSwitch @bind-Value="_preventDefault" Color="Color.Primary">Prevent Default</MudSwitch>
 <MudNumericField @bind-Value="_sensitivity" Label="Sensitivity" Min="0" />
 
-@code
-    {
-    MudSwipeArea _swipeArea;
-    SwipeDirection _swipeDirection;
-    bool _preventDefault = true;
-    int _sensitivity = 100;
-    double? _swipeDelta;
+@code {
+    private MudSwipeArea _swipeArea;
+    private SwipeDirection _swipeDirection;
+    private bool _preventDefault = true;
+    private int _sensitivity = 100;
+    private double? _swipeDelta;
 
     private void HandleSwipeEnd(SwipeEventArgs args)
     {

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
@@ -16,7 +16,7 @@
 </MudSwipeArea>
 
 @code {
-    bool _drawerOpen;
+    private bool _drawerOpen;
 
     public void OnSwipeEnd(SwipeEventArgs e)
     {

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -111,10 +111,8 @@ namespace MudBlazor.UnitTests.Components
             ////Swipe from right to left
             last = carousel.SelectedContainer;
             var swipe = comp.Find("div.mud-carousel-swipe");
-            TouchPoint[] _startPoints = { new() { ClientY = 0, ClientX = 150 } };
-            swipe.TouchStart(0, _startPoints);
-            TouchPoint[] _endPoints = { new() { ClientY = 0, ClientX = 20 } };
-            swipe.TouchEnd(0, null, null, _endPoints);
+            await swipe.PointerDownAsync(new PointerEventArgs { ClientY = 0, ClientX = 150 });
+            await swipe.PointerUpAsync(new PointerEventArgs { ClientY = 0, ClientX = 20 });
             carousel.SelectedIndex.Should().Be(1);
             carousel.SelectedContainer.Should().Be(carousel.Items[1]);
             carousel.SelectedItem.Should().Be(carousel.Items[1]);
@@ -124,10 +122,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.fake-class-item3").Count.Should().Be(0);
             ////Swipe from left to right
             last = carousel.SelectedContainer;
-            _startPoints[0].ClientX = 20;
-            swipe.TouchStart(0, _startPoints);
-            _endPoints[0].ClientX = 150;
-            swipe.TouchEnd(0, null, null, _endPoints);
+            await swipe.PointerDownAsync(new PointerEventArgs { ClientY = 0, ClientX = 20 });
+            await swipe.PointerUpAsync(new PointerEventArgs { ClientY = 0, ClientX = 150 });
             carousel.SelectedIndex.Should().Be(0);
             carousel.SelectedContainer.Should().Be(carousel.Items[0]);
             carousel.SelectedItem.Should().Be(carousel.Items[0]);
@@ -241,33 +237,24 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudCarousel<object>>();
 
             //Add some pages
-            comp.Instance.Items.Add(new());
-            comp.Instance.Items.Add(new());
-            comp.Instance.Items.Add(new());
+            comp.Instance.Items.Add(new MudCarouselItem());
+            comp.Instance.Items.Add(new MudCarouselItem());
+            comp.Instance.Items.Add(new MudCarouselItem());
 
             //Move the SelectedIndex from -1 to 0
             await comp.InvokeAsync(() => comp.Instance.MoveTo(0));
 
             var mudSwipeArea = comp.FindComponent<MudSwipeArea>().Instance;
 
-            var initialTouchPoints = new TouchPoint[]
-            {
-                new() {ClientX = 200, ClientY = 0},
-            };
-            var touchPoints = new TouchPoint[]
-            {
-                new() {ClientX = 100, ClientY = 0},
-            };
-
 #pragma warning disable BL0005 // Component parameter should not be set outside of its component.
             comp.Instance.EnableSwipeGesture = false;
-            await comp.InvokeAsync(() => mudSwipeArea.OnTouchStart(new TouchEventArgs() { Touches = initialTouchPoints }));
-            await comp.InvokeAsync(async () => await mudSwipeArea.OnTouchEnd(new TouchEventArgs() { ChangedTouches = touchPoints }));
+            await comp.InvokeAsync(() => mudSwipeArea.OnPointerDown(new PointerEventArgs { ClientX = 200, ClientY = 0 }));
+            await comp.InvokeAsync(async () => await mudSwipeArea.OnPointerUp(new PointerEventArgs { ClientX = 100, ClientY = 0 }));
             comp.Instance.SelectedIndex.Should().Be(0);
 
             comp.Instance.EnableSwipeGesture = true;
-            await comp.InvokeAsync(() => mudSwipeArea.OnTouchStart(new TouchEventArgs() { Touches = initialTouchPoints }));
-            await comp.InvokeAsync(async () => await mudSwipeArea.OnTouchEnd(new TouchEventArgs() { ChangedTouches = touchPoints }));
+            await comp.InvokeAsync(() => mudSwipeArea.OnPointerDown(new PointerEventArgs { ClientX = 200, ClientY = 0 }));
+            await comp.InvokeAsync(async () => await mudSwipeArea.OnPointerUp(new PointerEventArgs { ClientX = 100, ClientY = 0 }));
             comp.Instance.SelectedIndex.Should().Be(1);
 #pragma warning restore BL0005 // Component parameter should not be set outside of its component.
         }

--- a/src/MudBlazor.UnitTests/Components/SwipeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwipeTests.cs
@@ -18,14 +18,13 @@ namespace MudBlazor.UnitTests.Components
             var swipe = comp.FindComponent<MudSwipeArea>();
 
             await comp.InvokeAsync(() => swipe.Instance._yDown = 50);
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchEnd(new TouchEventArgs()));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerUp(new PointerEventArgs()));
 
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchCancel(new TouchEventArgs()));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerCancel(new PointerEventArgs()));
             comp.WaitForAssertion(() => swipe.Instance._xDown.Should().Be(null));
 
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchEnd(new TouchEventArgs()));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerUp(new PointerEventArgs()));
             comp.WaitForAssertion(() => swipe.Instance._xDown.Should().Be(null));
-
         }
 
         [Test]
@@ -35,33 +34,16 @@ namespace MudBlazor.UnitTests.Components
             var swipe = comp.FindComponent<MudSwipeArea>();
 
             // Swipe below the sensitivity should not make change.
-            var initialTouchPoints = new TouchPoint[]
-            {
-                new TouchPoint() {ClientX = 0, ClientY = 0},
-            };
-            var touchPoints = new TouchPoint[]
-            {
-                new TouchPoint() {ClientX = 20, ClientY = 20},
-            };
 
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchStart(new TouchEventArgs() { Touches = initialTouchPoints }));
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchEnd(new TouchEventArgs() { ChangedTouches = touchPoints }));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerDown(new PointerEventArgs { ClientX = 0, ClientY = 0 }));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerUp(new PointerEventArgs { ClientX = 20, ClientY = 20 }));
 
             comp.WaitForAssertion(() => comp.Instance.SwipeDirection.Should().Be(SwipeDirection.None));
             comp.WaitForAssertion(() => comp.Instance.SwipeDelta.Should().Be(null));
 
-            initialTouchPoints = new TouchPoint[]
-            {
-                new TouchPoint() {ClientX = 0, ClientY = 0},
-            };
-            touchPoints = new TouchPoint[]
-            {
-                new TouchPoint() {ClientX = 150, ClientY = 200},
-                new TouchPoint() {ClientX = 100, ClientY = 50},
-            };
-
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchStart(new TouchEventArgs() { Touches = initialTouchPoints }));
-            await comp.InvokeAsync(() => swipe.Instance.OnTouchEnd(new TouchEventArgs() { ChangedTouches = touchPoints }));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerDown(new PointerEventArgs { ClientX = 0, ClientY = 0 }));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerUp(new PointerEventArgs { ClientX = 150, ClientY = 200 }));
+            await comp.InvokeAsync(() => swipe.Instance.OnPointerUp(new PointerEventArgs { ClientX = 100, ClientY = 50 }));
 
             comp.WaitForAssertion(() => comp.Instance.SwipeDirection.Should().Be(SwipeDirection.TopToBottom));
             comp.WaitForAssertion(() => comp.Instance.SwipeDelta.Should().Be(-200));
@@ -82,7 +64,7 @@ namespace MudBlazor.UnitTests.Components
 
             var invocation = handler.VerifyInvoke("mudElementRef.addDefaultPreventingHandlers");
             invocation.Arguments.Count.Should().Be(2);
-            invocation.Arguments[1].Should().BeEquivalentTo(new[] { "touchstart", "touchend", "touchcancel" });
+            invocation.Arguments[1].Should().BeEquivalentTo(new[] { "onpointerdown", "onpointerup", "onpointercancel" });
         }
 
         [Test]
@@ -105,7 +87,7 @@ namespace MudBlazor.UnitTests.Components
 
             var invocation = handler.VerifyInvoke("mudElementRef.removeDefaultPreventingHandlers");
             invocation.Arguments.Count.Should().Be(3);
-            invocation.Arguments[1].Should().BeEquivalentTo(new[] { "touchstart", "touchend", "touchcancel" });
+            invocation.Arguments[1].Should().BeEquivalentTo(new[] { "onpointerdown", "onpointerup", "onpointercancel" });
             invocation.Arguments[2].Should().BeEquivalentTo(listenerIds);
         }
     }

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor
@@ -2,8 +2,8 @@
 @inherits MudComponentBase
 
 <div @ref="_componentRef" @attributes="UserAttributes" class="@Class" style="@Style" 
-     @ontouchstart="OnTouchStart" @ontouchstart:stopPropagation="true"
-     @ontouchend="OnTouchEnd" @ontouchend:stopPropagation="true"
-     @ontouchcancel="OnTouchCancel" @ontouchcancel:stopPropagation="true">
+     @onpointerdown="OnPointerDown" @onpointerdown:stopPropagation="true"
+     @onpointerup="OnPointerUp" @onpointerup:stopPropagation="true"
+     @onpointercancel="OnPointerCancel" @onpointercancel:stopPropagation="true">
     @ChildContent
 </div>

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 #nullable enable
     public partial class MudSwipeArea : MudComponentBase
     {
-        private static readonly string[] _preventDefaultEventNames = { "touchstart", "touchend", "touchcancel" };
+        private static readonly string[] _preventDefaultEventNames = ["onpointerdown", "onpointerup", "onpointercancel"];
 
         private double? _swipeDelta;
         internal int[]? _listenerIds;
@@ -77,21 +77,21 @@ namespace MudBlazor
             }
         }
 
-        internal void OnTouchStart(TouchEventArgs arg)
+        internal void OnPointerDown(PointerEventArgs arg)
         {
-            _xDown = arg.Touches[0].ClientX;
-            _yDown = arg.Touches[0].ClientY;
+            _xDown = arg.ClientX;
+            _yDown = arg.ClientY;
         }
 
-        internal async Task OnTouchEnd(TouchEventArgs arg)
+        internal async Task OnPointerUp(PointerEventArgs arg)
         {
             if (_xDown is null || _yDown is null)
             {
                 return;
             }
 
-            var xDiff = _xDown.Value - arg.ChangedTouches[0].ClientX;
-            var yDiff = _yDown.Value - arg.ChangedTouches[0].ClientY;
+            var xDiff = _xDown.Value - arg.ClientX;
+            var yDiff = _yDown.Value - arg.ClientY;
 
             if (Math.Abs(xDiff) < Sensitivity && Math.Abs(yDiff) < Sensitivity)
             {
@@ -116,7 +116,7 @@ namespace MudBlazor
             _xDown = _yDown = null;
         }
 
-        internal void OnTouchCancel(TouchEventArgs arg)
+        internal void OnPointerCancel(PointerEventArgs arg)
         {
             _xDown = _yDown = null;
         }

--- a/src/MudBlazor/Components/SwipeArea/SwipeEventArgs.cs
+++ b/src/MudBlazor/Components/SwipeArea/SwipeEventArgs.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         /// <summary>
         /// Gets information about a touch event that is being raised.
         /// </summary>
-        public TouchEventArgs TouchEventArgs { get; }
+        public PointerEventArgs TouchEventArgs { get; }
 
         /// <summary>
         /// Gets the swipe delta value indicating the distance of the swipe movement.
@@ -39,7 +39,7 @@ namespace MudBlazor
         /// <param name="swipeDirection">The direction of the swipe.</param>
         /// <param name="swipeDelta">The swipe delta value indicating the distance of the swipe movement.</param>
         /// <param name="sender">The sender of the swipe event.</param>
-        public SwipeEventArgs(TouchEventArgs touchEventArgs, SwipeDirection swipeDirection, double? swipeDelta, MudSwipeArea sender)
+        public SwipeEventArgs(PointerEventArgs touchEventArgs, SwipeDirection swipeDirection, double? swipeDelta, MudSwipeArea sender)
         {
             TouchEventArgs = touchEventArgs;
             SwipeDirection = swipeDirection;

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -112,9 +112,13 @@ class MudElementReference {
     }
 
     addDefaultPreventingHandler(element, eventName) {
-        let listener = function(e) {
-            e.preventDefault();
-        }
+        let listener = function (e) {
+            // Only prevent default if not already prevented
+            if (!e.defaultPrevented) {
+                e.preventDefault();
+            }
+        };
+
         element.addEventListener(eventName, listener, { passive: false });
         this.eventListeners[++this.listenerId] = listener;
         return this.listenerId;


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/9288

I don’t know why, but somehow these:

```razor
@ontouchstart="OnTouchStart"
@ontouchend="OnTouchEnd"
@ontouchcancel="OnTouchCancel"
```

were affecting the behavior. It wasn’t due to the JS `mudElementRef.addDefaultPreventingHandlers` or the `stopPropagation="true"`.

Replacing them with `onpointerdown`, `onpointerup`, and `onpointercancel` fixed the issue for some reason.

Pointer events are a superset of mouse, touch, and pen events. This is an improvement because I always thought swipe gestures should work with both touch and mouse devices, but it didn’t before.

## How Has This Been Tested?
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
