### PR TITLE
MudDataGrid: Fix `RowsPerPage` firing ServerData twice

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerPaginationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerPaginationTest.razor
@@ -16,6 +16,8 @@
     private int _totalItems = 100;
     IEnumerable<Model> _data;
 
+    public int ServerReloadCallCount { get; private set; }
+
     protected override void OnInitialized()
     {
         List<Model> data = new List<Model>();
@@ -31,6 +33,7 @@
 
     private async Task<GridData<Model>> ServerReload(GridState<Model> state)
     {
+        ServerReloadCallCount++;
         var data = _data.OrderBySortDefinitions(state);
         data = data.Skip(state.Page * state.PageSize).Take(state.PageSize);
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2808,6 +2808,30 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await dataGrid.Instance.ReloadServerData());
         }
 
+        /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/8298
+        /// </summary>
+        [Test]
+        public async Task SetRowsPerPageAsync_CallOneTimeServerData()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<DataGridServerPaginationTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerPaginationTest.Model>>();
+            dataGrid.Instance.CurrentPage = 2;
+            var beforeCount = comp.Instance.ServerReloadCallCount;
+
+            // Act
+
+            await dataGrid.InvokeAsync(() => dataGrid.Instance.SetRowsPerPageAsync(25));
+
+            // Assert
+
+            var afterCount = comp.Instance.ServerReloadCallCount;
+            var reloadCount = afterCount - beforeCount;
+            reloadCount.Should().Be(1);
+        }
+
         [Test]
         public async Task DataGridCellTemplateTest()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1633,7 +1633,7 @@ namespace MudBlazor
             _rowsPerPage = size;
 
             if (resetPage)
-                CurrentPage = 0;
+                _currentPage = 0;
 
             await RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
 


### PR DESCRIPTION
## Description

Currently, when `DataGrid.RowsPerPage` is modified, `DataGrid.ServerData` is called two time.

First because `DataGrid.CurrentPage` is reset to 0.
Second because `DataGrid.RowsPerPage` is modified.

This PR modify this behavior to call only one time `DataGrid.ServerData` when `DataGrid.RowsPerPage` is modified.
The modification is `DataGrid.RowsPerPage` reset the field `DataGrid._currentPage` to 0 instead of the property.

Fixes #8298

## How Has This Been Tested?

I added a test to reproduce the bug.

## Type of Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
