### PR TITLE
MudDialog: Improve max height and alignment of dialog container on mobile

### DIFF
--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -2,6 +2,7 @@
   display: flex;
   position: fixed;
   top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   z-index: var(--mud-zindex-dialog);
@@ -70,7 +71,8 @@
   -webkit-animation: mud-open-dialog-center 0.1s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;
   animation: mud-open-dialog-center 0.1s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;
   box-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2), 0px 24px 38px 3px rgba(0,0,0,0.14), 0px 9px 46px 8px rgba(0,0,0,0.12);
-  max-height: calc(100vh - var(--mud-appbar-height));
+  max-height: calc(100vh - var(--mud-appbar-height)); // keep as fallback
+  max-height: calc(100dvh - var(--mud-appbar-height));
   overflow-y: auto;
 
   &.mud-dialog-rtl .mud-dialog-title .mud-button-close {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

1. Change the position of the `.mud-dialog-container` to be aligned to the left side of the nearest ancestor which has position relative. The dialog container can be at the containers start position, which does not take margin into consideration, left: 0; will attach it explicitly to the most left part. 

2. Change the `max-height` property of the `.mud-dialog` to be responsive regarding mobile phone adress/navigation bars. `100vh` does not take them into consideration, but `dvh` (smallest viewport height) will respect these. this is an additional feature to `vh`, so it will not break things.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
2. I have tested this on an iphone on a dev site, if you want to test that yourself you can put 200 lines of text in the `<DialogContent>` in the `MudBlazor/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogUsageExample_Dialog.razor` file, which is the first example in the dialog page.

To access this on your smartphone/iphone, change launchsettings>profiles>https>applicationUrl to `https://0.0.0.0:6666`, then just access your pc/mac from your phone using 192.168.x.x:6666 (disable any vpn!)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
1. Dialog container position:
Position is at the left of the `<main>` which has auto margin left & right
![image](https://github.com/user-attachments/assets/6f20b71c-43c3-48fb-910b-dcc27fafd64b)
Not noticeable when the `<main>` is full width
![image](https://github.com/user-attachments/assets/12125a1c-f1b7-4336-8286-f3039d23bf8e)
Dialog container now explicitly attached to the left using `left: 0;`
![image](https://github.com/user-attachments/assets/cef7af09-498b-429f-b3cd-3ce4dfc89abe)

2. Here is what i mean with `vh` & `dvh`:
![image](https://github.com/user-attachments/assets/f5820c4c-8ee7-48ec-aea0-3ca8d69344e2)



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
