### PR TITLE
Performance: Add faster Any(...) Extensions for Array and List

### DIFF
--- a/src/MudBlazor/Extensions/CollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,7 +20,7 @@ internal static class CollectionExtensions
     {
         return Array.Exists(array, predicate);
     }
-    
+
     /// <summary>
     /// Determines whether any element of a list satisfies a condition.
     /// </summary>

--- a/src/MudBlazor/Extensions/CollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/CollectionExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace MudBlazor;
+
+internal static class CollectionExtensions
+{
+    /// <summary>
+    /// Determines whether any element of an array satisfies a condition.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of the array.</typeparam>
+    /// <param name="array">The array to apply the predicate to.</param>
+    /// <param name="predicate">The predicate to apply to each element.</param>
+    /// <returns>true if any elements match the predicate; otherwise, false.</returns>
+    internal static bool Any<T>(this T[] array, Predicate<T> predicate)
+    {
+        return Array.Exists(array, predicate);
+    }
+    
+    /// <summary>
+    /// Determines whether any element of a list satisfies a condition.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of the list.</typeparam>
+    /// <param name="list">The list to apply the predicate to.</param>
+    /// <param name="predicate">The predicate to apply to each element.</param>
+    /// <returns>true if any elements match the predicate; otherwise, false.</returns>
+    internal static bool Any<T>(this List<T> list, Predicate<T> predicate)
+    {
+        return list.FindIndex(predicate) != -1;
+    }
+}


### PR DESCRIPTION
Hey,

what do you think about this approach to gain some performance improvements? We are using Linq in some cases where it's not the best option regarding performance. With this little trick, we get a performance improvement as these `Any` methods will be used instead of the default Linq method. I think there are some more methods that we could add. We don't have to change existing code to make use of this.

| Method         | Mean       | Error    | StdDev   | Allocated |
|--------------- |-----------:|---------:|---------:|----------:|
| Array_Any      | 1,165.1 ns | 351.8 ns | 19.28 ns |      32 B |
| Array_Exists   |   508.8 ns | 249.2 ns | 13.66 ns |         - |
| List_Any       | 1,020.8 ns | 342.4 ns | 18.77 ns |      40 B |
| List_FindIndex |   518.8 ns | 201.7 ns | 11.06 ns |         - |

## Type of Changes
- [x] New feature (non-breaking change which adds functionality)


<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
