### PR TITLE
Obsolete unused field `EnableIllegalRazorParameterDetection`

### DIFF
--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -102,7 +102,7 @@ public static class MudGlobal
     /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
     /// to help our users find old parameters they missed by throwing a runtime exception.
     /// </remarks>
-    [Obsolete("This field is obsolete and has no function. It will be removed in a future version.", true)]
+    [Obsolete("This field is obsolete and has no function due to the new Analyzer. It will be removed in a future version.", true)]
     public static bool EnableIllegalRazorParameterDetection = true;
 
     /// <summary>

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -101,10 +101,8 @@ public static class MudGlobal
     /// <remarks>
     /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
     /// to help our users find old parameters they missed by throwing a runtime exception.
-    ///
-    /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
-    /// Sometime when the v7 version has stabilized.
     /// </remarks>
+    [Obsolete("This field is obsolete and has no function. It will be removed in a future version.", true)]
     public static bool EnableIllegalRazorParameterDetection = true;
 
     /// <summary>

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -96,6 +96,18 @@ public static class MudGlobal
     public static Action<Exception> UnhandledExceptionHandler { get; set; } = OnDefaultExceptionHandler;
 
     /// <summary>
+    /// Gets or sets whether old parameters that were renamed in v7.0.0 should cause a runtime exception.
+    /// </summary>
+    /// <remarks>
+    /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
+    /// to help our users find old parameters they missed by throwing a runtime exception.
+    ///
+    /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
+    /// Sometime when the v7 version has stabilized.
+    /// </remarks>
+    public static bool EnableIllegalRazorParameterDetection = true;
+
+    /// <summary>
     /// Note: the user can overwrite this default handler with their own implementation. The default implementation
     /// makes sure that the unhandled exceptions don't go unnoticed
     /// </summary>

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -96,18 +96,6 @@ public static class MudGlobal
     public static Action<Exception> UnhandledExceptionHandler { get; set; } = OnDefaultExceptionHandler;
 
     /// <summary>
-    /// Gets or sets whether old parameters that were renamed in v7.0.0 should cause a runtime exception.
-    /// </summary>
-    /// <remarks>
-    /// Razor silently ignores parameters which don't exist. Since v7.0.0 renamed so many parameters we want
-    /// to help our users find old parameters they missed by throwing a runtime exception.
-    ///
-    /// TODO: Remove this later. At the moment, we don't know yet when will be the best time to remove it.
-    /// Sometime when the v7 version has stabilized.
-    /// </remarks>
-    public static bool EnableIllegalRazorParameterDetection = true;
-
-    /// <summary>
     /// Note: the user can overwrite this default handler with their own implementation. The default implementation
     /// makes sure that the unhandled exceptions don't go unnoticed
     /// </summary>


### PR DESCRIPTION
I guess it's a leftover of the runtime IllegalRazorParameterDetection. It's now marked as obsolete.