### PR TITLE
MudDateRangePicker: Add parameter to allow capture of disabled dates (#9452)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
@@ -11,7 +11,8 @@
                         @bind-PickerMonth="PickerMonth"
                         OpenTo="@OpenTo"
                         StartMonth="@StartMonth"
-                        AdditionalDateClassesFunc="@AdditionalDateClassesFunc" />
+                        AdditionalDateClassesFunc="@AdditionalDateClassesFunc" 
+                        StrictCaptureRange="@StrictCaptureRange"/>
 }
 else
 {
@@ -31,6 +32,7 @@ else
     [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
     [Parameter] public DateTime? StartMonth { get; set; }
     [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
+    [Parameter] public bool StrictCaptureRange { get; set; }
 
     public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
     public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
@@ -26,15 +26,29 @@ else
 @code {
     private MudDateRangePicker _picker;
 
-    [Parameter] public DateRange DateRange { get; set; }
-    [Parameter] public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
-    [Parameter] public DateTime? PickerMonth { get; set; }
-    [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
-    [Parameter] public DateTime? StartMonth { get; set; }
-    [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
-    [Parameter] public bool AllowDisabledDatesInRange { get; set; }
+    [Parameter]
+    public DateRange DateRange { get; set; }
+
+    [Parameter]
+    public Func<DateTime, bool> IsDateDisabledFunc { get; set; }
+
+    [Parameter]
+    public DateTime? PickerMonth { get; set; }
+
+    [Parameter]
+    public OpenTo OpenTo { get; set; } = OpenTo.Date;
+
+    [Parameter]
+    public DateTime? StartMonth { get; set; }
+
+    [Parameter]
+    public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
+
+    [Parameter]
+    public bool AllowDisabledDatesInRange { get; set; }
 
     public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
+
     public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());
 
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudMudDateRangePickerTest.razor
@@ -12,7 +12,7 @@
                         OpenTo="@OpenTo"
                         StartMonth="@StartMonth"
                         AdditionalDateClassesFunc="@AdditionalDateClassesFunc" 
-                        StrictCaptureRange="@StrictCaptureRange"/>
+                        AllowDisabledDatesInRange="@AllowDisabledDatesInRange"/>
 }
 else
 {
@@ -32,7 +32,7 @@ else
     [Parameter] public OpenTo OpenTo { get; set; } = OpenTo.Date;
     [Parameter] public DateTime? StartMonth { get; set; }
     [Parameter] public Func<DateTime, string> AdditionalDateClassesFunc { get; set; }
-    [Parameter] public bool StrictCaptureRange { get; set; }
+    [Parameter] public bool AllowDisabledDatesInRange { get; set; }
 
     public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
     public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -886,5 +886,27 @@ namespace MudBlazor.UnitTests.Components
             underlinedComp.FindAll(".mud-input-underline").Should().HaveCount(1);
             notUnderlinedComp.FindAll(".mud-input-underline").Should().HaveCount(0);
         }
+
+        [Test]
+        public void StrictCaptureRange_ShouldCaptureDisabledDates_WhenFalse()
+        {
+            var today = DateTime.Today;
+            var yesterday = DateTime.Today.Subtract(TimeSpan.FromDays(1));
+            var twoDaysAgo = DateTime.Today.Subtract(TimeSpan.FromDays(2));
+            var wasEventCallbackCalled = false;
+
+            var range = new DateRange(twoDaysAgo, today);
+            Func<DateTime, bool> isDisabledFunc = date => date == yesterday;
+            var comp = Context.RenderComponent<MudDateRangePicker>(
+                Parameter(nameof(MudDateRangePicker.StrictCaptureRange), false),
+                Parameter(nameof(MudDateRangePicker.IsDateDisabledFunc), isDisabledFunc),
+                EventCallback("DateRangeChanged", (DateRange _) => wasEventCallbackCalled = true)
+            );
+
+            comp.SetParam(picker => picker.DateRange, new DateRange(twoDaysAgo, today));
+
+            comp.Instance.DateRange.Should().Be(range);
+            wasEventCallbackCalled.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -898,7 +898,7 @@ namespace MudBlazor.UnitTests.Components
             var range = new DateRange(twoDaysAgo, today);
             Func<DateTime, bool> isDisabledFunc = date => date == yesterday;
             var comp = Context.RenderComponent<MudDateRangePicker>(
-                Parameter(nameof(MudDateRangePicker.StrictCaptureRange), false),
+                Parameter(nameof(MudDateRangePicker.AllowDisabledDatesInRange), true),
                 Parameter(nameof(MudDateRangePicker.IsDateDisabledFunc), isDisabledFunc),
                 EventCallback("DateRangeChanged", (DateRange _) => wasEventCallbackCalled = true)
             );

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -73,6 +73,16 @@ namespace MudBlazor
             set => SetDateRangeAsync(value, true).CatchAndLog();
         }
 
+        /// <summary>
+        /// Enables capture for disabled dates within the selected date range.
+        /// </summary>
+        /// <remarks>
+        /// By default, it will always ignore disabled dates. This parameter will take effect when <see cref="MudBaseDatePicker.IsDateDisabledFunc"/> is set.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Validation)]
+        public bool StrictCaptureRange { get; set; } = true;
+
         protected async Task SetDateRangeAsync(DateRange range, bool updateValue)
         {
             if (_dateRange != range)
@@ -83,7 +93,7 @@ namespace MudBlazor
                     .TakeWhile(date => date <= range.End.Value)
                     .Any(date => IsDateDisabledFunc(date.Date));
 
-                if (doesRangeContainDisabledDates)
+                if (doesRangeContainDisabledDates && StrictCaptureRange)
                 {
                     _rangeText = null;
                     await SetTextAsync(null, false);

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -60,7 +60,8 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when <see cref="DateRange"/> has changed.
         /// </summary>
-        [Parameter] public EventCallback<DateRange> DateRangeChanged { get; set; }
+        [Parameter]
+        public EventCallback<DateRange> DateRangeChanged { get; set; }
 
         /// <summary>
         /// The currently selected date range.
@@ -87,13 +88,13 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                var doesRangeContainDisabledDates = range?.Start != null && range?.End != null && Enumerable
+                var doesRangeContainDisabledDates = StrictCaptureRange && range?.Start != null && range?.End != null && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)
                     .Any(date => IsDateDisabledFunc(date.Date));
 
-                if (doesRangeContainDisabledDates && StrictCaptureRange)
+                if (doesRangeContainDisabledDates)
                 {
                     _rangeText = null;
                     await SetTextAsync(null, false);

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -88,7 +88,7 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                var doesRangeContainDisabledDates = StrictCaptureRange && range?.Start != null && range?.End != null && Enumerable
+                var doesRangeContainDisabledDates = StrictCaptureRange && range is { Start: not null, End: not null } && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -82,13 +82,13 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
-        public bool StrictCaptureRange { get; set; } = true;
+        public bool AllowDisabledDatesInRange { get; set; } = false;
 
         protected async Task SetDateRangeAsync(DateRange range, bool updateValue)
         {
             if (_dateRange != range)
             {
-                var doesRangeContainDisabledDates = StrictCaptureRange && range is { Start: not null, End: not null } && Enumerable
+                var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)


### PR DESCRIPTION
## Description

Resolves #9452

This PR adds the ability to capture disabled dates within the selected date range while maintaining previous strict capture behaviour by default. This can be toggled by setting the `AllowDisabledDatesInRange` parameter to true.
Certain use cases might require to prevent selection of certain dates, but still allow the end user to capture them (i.e. weekends). Previous behaviour forced the user to have strict capture and no external workaround.

## How Has This Been Tested?
I made an unit test to check if the range is being set to prevent any future regressions.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
