### PR TITLE
Performance: Add Identifier helper class

### DIFF
--- a/src/MudBlazor.Docs/Components/SectionContent.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionContent.razor.cs
@@ -50,7 +50,7 @@ public partial class SectionContent
             .AddClass("show-code", _hasCode && ShowCode)
             .Build();
 
-    private string _snippetId = "_" + Guid.NewGuid().ToString()[..8];
+    private string _snippetId = Identifier.Create();
 
     [Parameter] public string Class { get; set; }
     [Parameter] public bool DarkenBackground { get; set; }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -36,7 +36,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<FormIsValidTest3>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("textFieldLabelTest");
-            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
+            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
         }
 
         /// <summary>
@@ -47,8 +47,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<FieldTest>();
             var label = comp.FindAll(".mud-input-label");
-            label[0].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
-            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput-");
+            label[0].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
+            label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
             label[2].Attributes.GetNamedItem("for")?.Value.Should().Be("fieldLabelTest");
         }
 

--- a/src/MudBlazor.UnitTests/Utilities/IdentifierTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/IdentifierTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities;
+
+[TestFixture]
+public class IdentifierTests
+{
+    [Test]
+    public void Create_WithPrefix_ShouldReturnIdentifierWithPrefix()
+    {
+        // Arrange
+        const string Prefix = "prefix";
+
+        // Act
+        var result = Identifier.Create(Prefix);
+
+        // Assert
+        result.Should().StartWith(Prefix);
+        result.Length.Should().Be(Prefix.Length + 8);
+    }
+
+    [Test]
+    public void Create_WithoutPrefix_ShouldReturnIdentifierWithDefaultPrefix()
+    {
+        // Act
+        var result = Identifier.Create();
+
+        // Assert
+        result.Should().StartWith("a");
+        result.Length.Should().Be(9);
+    }
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -32,8 +32,8 @@ namespace MudBlazor
         /// The resolved input element ID.
         /// </summary>
         protected string? InputElementId => _inputIdState.Value;
-        private string? _userAttributesId = $"mudinput-{Guid.NewGuid()}";
-        private readonly string _componentId = $"mudinput-{Guid.NewGuid()}";
+        private string? _userAttributesId = Identifier.Create("mudinput");
+        private readonly string _componentId = Identifier.Create("mudinput");
         private readonly ParameterState<string?> _inputIdState;
 
         protected MudBaseInput()

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -73,7 +73,7 @@ namespace MudBlazor
         /// </remarks>
         protected bool IsJSRuntimeAvailable { get; set; }
 
-        private readonly string _id = $"mudinput-{Guid.NewGuid()}";
+        private readonly string _id = Identifier.Create("mudinput");
         /// <summary>
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
         /// <summary>
         /// We need a random id for the year items in the year list so we can scroll to the item safely in every DatePicker.
         /// </summary>
-        private readonly string _componentId = Guid.NewGuid().ToString();
+        private readonly string _componentId = Identifier.Create();
 
         /// <summary>
         /// This boolean will keep track if the clear function is called too keep the set text function to be called.

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
     public partial class MudCheckBox<T> : MudBooleanInput<T>
     {
         private IKeyInterceptor? _keyInterceptor;
-        private string _elementId = "checkbox" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("checkbox");
 
         [Inject]
         private IKeyInterceptorFactory KeyInterceptorFactory { get; set; } = null!;

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
     public partial class MudDialogInstance : MudComponentBase, IDisposable
     {
         private DialogOptions? _options = new();
-        private readonly string _elementId = "dialog_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private readonly string _elementId = Identifier.Create("dialog");
         private IKeyInterceptor? _keyInterceptor;
 
         [Inject]

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -75,7 +75,7 @@ namespace MudBlazor
         [Inject] private IJsEventFactory _jsEventFactory { get; set; }
         [Inject] private IJsApiService _jsApiService { get; set; }
 
-        private string _elementId = "mask_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("mask");
 
         private IMask _mask = new PatternMask("** **-** **");
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -115,7 +115,7 @@ namespace MudBlazor
 
         [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
-        private string _elementId = "numericField_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("numericField");
 
         private MudInput<string> _elementReference;
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
         [Inject]
         private IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
 
-        private string _elementId = "picker" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("picker");
 
         protected string PickerClassname =>
             new CssBuilder("mud-picker")

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
     {
         private IMudRadioGroup? _parent;
         private IKeyInterceptor? _keyInterceptor;
-        private string _elementId = "radio" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("radio");
 
         protected string Classname =>
             new CssBuilder("mud-radio")

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
         [Inject] private IKeyInterceptorFactory KeyInterceptorFactory { get; set; }
         [Inject] IScrollManager ScrollManager { get; set; }
 
-        private string _elementId = "select_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("select");
 
         private Task SelectNextItem() => SelectAdjacentItem(+1);
 

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
             .Build();
 
         private IMudSelect _parent;
-        internal string ItemId { get; } = "_" + Guid.NewGuid().ToString().Substring(0, 8);
+        internal string ItemId { get; } = Identifier.Create();
 
         /// <summary>
         /// The parent select component

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 #nullable enable
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
-        private string _elementId = "switch_" + Guid.NewGuid().ToString().Substring(0, 8);
+        private string _elementId = Identifier.Create("switch");
         private IKeyInterceptor? _keyInterceptor;
 
         [Inject]

--- a/src/MudBlazor/Utilities/Identifier.cs
+++ b/src/MudBlazor/Utilities/Identifier.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Utilities/Identifier.cs
+++ b/src/MudBlazor/Utilities/Identifier.cs
@@ -11,8 +11,9 @@ namespace MudBlazor;
 /// </summary>
 internal static class Identifier
 {
-    private const int GuidLength = 32;
-    private const int GuidSubLength = 8;
+    private const string Chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+    private const int CharsLength = 35;
+    private const int RandomStringLength = 8;
 
     /// <summary>
     /// Creates a unique identifier with the specified prefix.
@@ -22,10 +23,15 @@ internal static class Identifier
     /// <example><code>prefixdb54bcd0</code></example>
     internal static string Create(ReadOnlySpan<char> prefix)
     {
-        Span<char> identifierSpan = stackalloc char[prefix.Length + GuidLength];
+        Span<char> identifierSpan = stackalloc char[prefix.Length + RandomStringLength];
         prefix.CopyTo(identifierSpan);
-        Guid.NewGuid().TryFormat(identifierSpan[prefix.Length..], out _, ['n']);
-        return identifierSpan[..(prefix.Length + GuidSubLength)].ToString();
+        for (var i = 0; i < RandomStringLength; i++)
+        {
+            var index = Random.Shared.Next(CharsLength);
+            identifierSpan[prefix.Length + i] = Chars[index];
+        }
+
+        return identifierSpan.ToString();
     }
 
     /// <summary>

--- a/src/MudBlazor/Utilities/Identifier.cs
+++ b/src/MudBlazor/Utilities/Identifier.cs
@@ -1,0 +1,37 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor;
+
+/// <summary>
+/// Provides methods to create unique identifiers with optional prefixes.
+/// </summary>
+internal static class Identifier
+{
+    private const int GuidLength = 32;
+    private const int GuidSubLength = 8;
+
+    /// <summary>
+    /// Creates a unique identifier with the specified prefix.
+    /// </summary>
+    /// <param name="prefix">The prefix to prepend to the unique identifier.</param>
+    /// <returns>A unique identifier string with the specified prefix.</returns>
+    /// <example><code>prefixdb54bcd0</code></example>
+    internal static string Create(ReadOnlySpan<char> prefix)
+    {
+        Span<char> identifierSpan = stackalloc char[prefix.Length + GuidLength];
+        prefix.CopyTo(identifierSpan);
+        Guid.NewGuid().TryFormat(identifierSpan[prefix.Length..], out _, ['n']);
+        return identifierSpan[..(prefix.Length + GuidSubLength)].ToString();
+    }
+
+    /// <summary>
+    /// Creates a unique identifier.
+    /// </summary>
+    /// <returns>A unique identifier string.</returns>
+    /// <example><code>adb54bcd0</code></example>
+    internal static string Create() => Create(['a']);
+}


### PR DESCRIPTION
Hey,

this PR adds a new helper class `Identifier` which provides a `Create` method to create a unique string with fewer allocations than the current approach.

```c#
// Current
private string _elementId = "checkbox" + Guid.NewGuid().ToString().Substring(0, 8);

// After
private string _elementId = Identifier.Create("checkbox");
```

Benchmark:

| Method            | Mean     | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
|------------------ |---------:|---------:|---------:|------:|----------:|------------:|
| Guid_SubString    | 85.88 ns | 0.717 ns | 0.635 ns |  1.00 |     192 B |        1.00 |
| Identifier_Create | 78.02 ns | 0.371 ns | 0.347 ns |  0.91 |      56 B |        0.29 |


Currently, I only updated the `MudCheckBox` component. Depending on your feedback, I would update all usages.

## How Has This Been Tested?
Added tests.


## Type of Changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
