### PR TITLE
Make object-fit and object-position styles important

### DIFF
--- a/src/MudBlazor/Styles/utilities/layout/_object-fit.scss
+++ b/src/MudBlazor/Styles/utilities/layout/_object-fit.scss
@@ -1,19 +1,19 @@
-﻿.object-none {
-  object-fit: none;
+.object-none {
+  object-fit: none !important;
 }
 
 .object-cover {
-  object-fit: cover;
+  object-fit: cover !important;
 }
 
 .object-contain {
-  object-fit: contain;
+  object-fit: contain !important;
 }
 
 .object-fill {
-  object-fit: fill;
+  object-fit: fill !important;
 }
 
 .object-scale-down {
-  object-fit: scale-down;
+  object-fit: scale-down !important;
 }

--- a/src/MudBlazor/Styles/utilities/layout/_object-position.scss
+++ b/src/MudBlazor/Styles/utilities/layout/_object-position.scss
@@ -1,35 +1,35 @@
-﻿.object-center {
-  object-position: center;
+.object-center {
+  object-position: center !important;
 }
 
 .object-top {
-  object-position: top;
+  object-position: top !important;
 }
 
 .object-bottom {
-  object-position: bottom;
+  object-position: bottom !important;
 }
 
 .object-left {
-  object-position: left;
+  object-position: left !important;
 }
 
 .object-left-top {
-  object-position: left top;
+  object-position: left top !important;
 }
 
 .object-left-bottom {
-  object-position: left bottom;
+  object-position: left bottom !important;
 }
 
 .object-right {
-  object-position: right;
+  object-position: right !important;
 }
 
 .object-right-top {
-  object-position: right top;
+  object-position: right top !important;
 }
 
 .object-right-bottom {
-  object-position: right bottom;
+  object-position: right bottom !important;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

This adds the `!important` override to the `object-fit` and `object-position` utility classes, much like other utility classes. I suspect those were added later and these two were left behind or forgotten.

Technically a breaking change but I don't think many people if any are using this utility and I believe it's only used in the MudAvatar in MudBlazor. This should be the expected behavior anyway.

Closes #9218

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
