### PR TITLE
MudDrawer: Add OverlayAutoClose, use OnClosed instead of OnClick

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -29,7 +29,7 @@
                 <DocsPageSection>
                     <SectionHeader Title="Temporary">
                         <Description>
-                            Temporary Drawers can be opened temporarily above all other content until a section is selected or clicked on an overlay.
+                            Temporary Drawers can be opened temporarily above all other content until a section is selected, or until the overlay is clicked if <CodeInline>OverlayAutoClose</CodeInline> is set to true.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(DrawerTemporaryExample)" ShowCode="false">
@@ -40,7 +40,7 @@
                 <DocsPageSection>
                     <SectionHeader Title="Persistent">
                         <Description>
-                            Persistent Drawer is outside of its container. When opened, it forces other contents to change their size.
+                            Persistent Drawer is outside its container. When opened, it forces other contents to change their size.
                             Persistent Drawer will stay open until the <CodeInline>Open</CodeInline> parameter is set to false again.
                         </Description>
                     </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/Examples/DrawerTemporaryExample.razor
@@ -4,8 +4,8 @@
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.End))">End</MudButton>
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Top))">Top</MudButton>
 <MudButton Variant="Variant.Text" OnClick="@(() => OpenDrawer(Anchor.Bottom))">Bottom</MudButton>
-
-<MudDrawer @bind-Open="@_open" Anchor="@_anchor" Elevation="1" Variant="@DrawerVariant.Temporary">
+<MudSwitch @bind-Value="_overlayAutoClose" Label="Overlay Autoclose" Color="Color.Secondary" />
+<MudDrawer @bind-Open="@_open" Anchor="@_anchor" Elevation="1" Variant="@DrawerVariant.Temporary" OverlayAutoClose="@_overlayAutoClose">
     <MudDrawerHeader>
         <MudText Typo="Typo.h6">My App</MudText>
     </MudDrawerHeader>
@@ -13,12 +13,14 @@
         <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>
         <MudNavLink Match="NavLinkMatch.All">Library</MudNavLink>
         <MudNavLink Match="NavLinkMatch.All">Community</MudNavLink>
+        <MudNavLink OnClick="_ => _open = false">Close Drawer</MudNavLink>
     </MudNavMenu>
 </MudDrawer>
 
 @code{ 
     private bool _open;
     private Anchor _anchor;
+    private bool _overlayAutoClose = true;
 
     private void OpenDrawer(Anchor anchor)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Overlay="@Overlay" ClipMode="@ClipMode"></MudDrawer>
+<MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Overlay="@Overlay" OverlayAutoClose="@OverlayAutoClose" ClipMode="@ClipMode"></MudDrawer>
 <button @onclick="@HandleButtonClick" />
 
 @code {
@@ -16,6 +16,9 @@
 
     [Parameter]
     public DrawerClipMode ClipMode { get; set; }
+
+    [Parameter]
+    public bool OverlayAutoClose { get; set; } = true;
 
     public void HandleButtonClick() => _open = !_open;
 }

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.JSInterop;
@@ -41,7 +42,7 @@ namespace MudBlazor.UnitTests.Components
 
         private BrowserViewportService AddBrowserViewportService(int height = 640, int width = 960) => AddBrowserViewportService(new BrowserWindowSize { Height = height, Width = width });
 
-        private BrowserWindowSize BreakpointBrowserAssociatedSize(Breakpoint breakpoint)
+        private static BrowserWindowSize BreakpointBrowserAssociatedSize(Breakpoint breakpoint)
         {
             return breakpoint switch
             {
@@ -68,6 +69,44 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Temporary_OverlayAutoClose(bool overlayAutoClose)
+        {
+            _ = AddBrowserViewportService();
+            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+                .Add(parameter => parameter.Variant, DrawerVariant.Temporary)
+                .Add(parameter => parameter.OverlayAutoClose, overlayAutoClose));
+
+            // Open the drawer
+            comp.Find("button").Click();
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
+            comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            // Clicking on the overlay
+            await comp.Find("div.mud-overlay").ClickAsync(new MouseEventArgs());
+
+            if (overlayAutoClose)
+            {
+                // Drawer should close
+                comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(0);
+                comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
+                comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(0);
+                comp.Instance.Drawer.Open.Should().BeFalse();
+            }
+            else
+            {
+                // Drawer should stay open
+                comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
+                comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(0);
+                comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
+                comp.Instance.Drawer.Open.Should().BeTrue();
+            }
         }
 
         [Test]

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor
@@ -8,4 +8,4 @@
         </CascadingValue>
     </div>
 </aside>
-<MudOverlay Visible="@OverlayVisible" @onclick="@CloseDrawerAsync" Class="@OverlayClass" DarkBackground="true" LockScroll="false" />
+<MudOverlay Visible="@OverlayVisible" AutoClose="@OverlayAutoClose" OnClosed="CloseDrawerAsync" Class="@OverlayClass" DarkBackground="true" LockScroll="false" />

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -163,6 +163,19 @@ namespace MudBlazor
         public bool Overlay { get; set; } = true;
 
         /// <summary>
+        /// Sets a value indicating whether the overlay should automatically close when clicked.
+        /// </summary>
+        /// <remarks>
+        /// If the <see cref="Variant"/> is set to <see cref="DrawerVariant.Temporary"/>, an overlay will be displayed. 
+        /// When this property is <c>true</c>, clicking on the overlay will close it automatically. 
+        /// When this property is <c>false</c>, the overlay will not close automatically.
+        /// Defaults to <c>true</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Drawer.Behavior)]
+        public bool OverlayAutoClose { get; set; } = true;
+
+        /// <summary>
         /// For mini drawers, opens this drawer when the pointer hovers over it.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Description
Makes corresponding changes after: https://github.com/MudBlazor/MudBlazor/pull/9458
Addresses: https://github.com/MudBlazor/MudBlazor/discussions/9491
 
## How Has This Been Tested?
Visually, bUnit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
