### PR TITLE
TreeViewItem: ReloadAsync() now also reloads in collapsed state

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -17,13 +17,4 @@
     <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Update="TestComponents\RadioGroup\RadioGroupExceptionTest.razor">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-    <Content Update="TestComponents\TreeView\TreeViewServerTest2.razor">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-
 </Project>

--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -21,6 +21,9 @@
     <Content Update="TestComponents\RadioGroup\RadioGroupExceptionTest.razor">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
+    <Content Update="TestComponents\TreeView\TreeViewServerTest2.razor">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest2.razor
@@ -1,0 +1,77 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPaper Width="300px" Elevation="0">
+    <MudTreeView ServerData="@LoadServerData" Items="@InitialTreeItems">
+        <ItemTemplate>
+            <MudTreeViewItem Value="@context.Value" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.Expandable">
+                <BodyContent Context="viewItem">
+                    <MudButton OnClick="() => OnClickAsync(viewItem)">Reload</MudButton>
+                </BodyContent>
+            </MudTreeViewItem>
+        </ItemTemplate>
+    </MudTreeView>
+</MudPaper>
+
+@code {
+    private List<TreeItemData<string>> InitialTreeItems { get; set; } = new();
+    private List<TreeItemData<string>> ServerTreeItems { get; set; } = new();
+
+    private Task OnClickAsync(MudTreeViewItem<string> viewItem)
+    {
+        return viewItem.ReloadAsync();
+    }
+
+    protected override void OnInitialized()
+    {
+        // MudTreeView initially only gets these top-level items
+        InitialTreeItems.Add(new TreeItemData<string> { Value = "All Mail", Icon = Icons.Material.Filled.Label, });
+        InitialTreeItems.Add(new TreeItemData<string> { Value = "Trash", Icon = Icons.Material.Filled.Delete });
+
+        // LoadServerData will load from this hierarchy
+        ServerTreeItems.Add(new TreeItemData<string> {
+                Value = "All Mail",
+                Icon = Icons.Material.Filled.Label,
+                Children = [
+                            new TreeItemData<string> { Value = "Promotions", Icon = Icons.Material.Filled.Group,
+                                Children = [
+                                    new TreeItemData<string> { Value = "L.E.D Door Mats", Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
+                                    new TreeItemData<string> { Value = "Car Beauty Salon", Icon = Icons.Material.Filled.CarRepair, Expandable = false },
+                                    new TreeItemData<string> { Value = "Fakedoors.com", Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
+                                    new TreeItemData<string> { Value = "Bluetooth Toilet", Icon = Icons.Material.Filled.Wc, Expandable = false }
+                                ]},
+                    new TreeItemData<string> { Value = "Updates", Icon = Icons.Material.Filled.Info, Expandable = false },
+                    new TreeItemData<string> { Value = "Forums", Icon = Icons.Material.Filled.QuestionAnswer, Expandable = false },
+                    new TreeItemData<string> { Value = "Social", Icon = Icons.Material.Filled.LocalOffer, Expandable = false }
+                    ]
+            });
+    }
+
+    public Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)
+    {
+        foreach (var item in ServerTreeItems) {
+            if (item.Value == parentValue)
+                return Task.FromResult<IReadOnlyCollection<TreeItemData<string>>>(item.Children);
+            if (!item.HasChildren)
+                continue;
+            var descendentItem = FindTreeItemData(parentValue, item);
+            if (descendentItem != null)
+                return Task.FromResult<IReadOnlyCollection<TreeItemData<string>>>(descendentItem.Children);
+        }
+        return null;
+    }
+
+    private TreeItemData<string> FindTreeItemData(string value, TreeItemData<string> parent)
+    {
+        foreach (var child in parent.Children) {
+            if (child.Value == value)
+                return child;
+            if (!child.HasChildren)
+                continue;
+            var descendentItem = FindTreeItemData(value, child);
+            if (descendentItem != null)
+                return descendentItem;
+        }
+        return null;
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -487,6 +487,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TreeViewItem_ShouldBeAbleTo_ReloadInCollapsedState()
+        {
+            var comp = Context.RenderComponent<TreeViewServerTest2>();
+            var treeviewItem = comp.FindComponents<MudTreeViewItem<string>>().FirstOrDefault();
+            treeviewItem!.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded)).Should().Be(false);
+            comp.FindAll("div.mud-treeview-item-arrow button").Count.Should().Be(2);
+            // expand first tree
+            comp.Find("div.mud-treeview-item-arrow button").Click();
+            comp.FindAll("div.mud-treeview-item-arrow button").Count.Should().Be(3);
+            // collapse first tree again
+            comp.Find("div.mud-treeview-item-arrow button").Click();
+            treeviewItem.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded)).Should().Be(false);
+            // reload first tree in collapsed state
+            var reloadTask = Task.CompletedTask;
+            await comp.InvokeAsync(() => reloadTask = treeviewItem.Instance.ReloadAsync());
+            await reloadTask;
+            comp.FindAll("div.mud-treeview-item-arrow button").Count.Should().Be(3);
+        }
+
+        [Test]
         public void TreeViewTreeItemDataTest()
         {
             // test default values

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -491,7 +491,7 @@ namespace MudBlazor
 
         internal async Task TryInvokeServerLoadFunc()
         {
-            if (!_expandedState || (Items != null && Items.Count != 0) || !CanExpand || MudTreeRoot?.ServerData == null)
+            if ((Items != null && Items.Count != 0) || !CanExpand || MudTreeRoot?.ServerData == null)
                 return;
             _loading = true;
             StateHasChanged();


### PR DESCRIPTION
## Description

Fixes #9464

Turns out the problem was that `TryReloadServerLoadFunc()` was early exiting if the item was collapsed. Removing that check did not influence the tests and the server loading behavior is still the same. 

A test has been added to enforce this fix.

<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
 unit | visually 

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
