### PR TITLE
Menu: Stay open after being clicked with `MouseOver`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -110,7 +110,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MenuPointerLeave_CheckClosed()
+        public async Task MouseOver_PointerLeave_ShouldClose()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();
             var pop = comp.FindComponent<MudPopover>();
@@ -126,26 +126,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MenuPointerClickAndLeave_CheckClosed()
-        {
-            var comp = Context.RenderComponent<MenuTestMouseOver>();
-            var pop = comp.FindComponent<MudPopover>();
-            comp.FindAll("button.mud-button-root")[0].Click();
-
-            IElement List() => comp.FindAll("div.mud-list")[0];
-
-            await List().TriggerEventAsync("onpointerenter", new PointerEventArgs());
-            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
-
-            // Click activator to keep the menu open.
-            comp.FindAll("button.mud-button-root")[0].Click();
-
-            await List().TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
-        }
-
-        [Test]
-        public async Task MenuPointerLeave_MenuPointerEnter_CheckOpen()
+        public async Task MouseOver_PointerLeaveAndEnter_ShouldOpen()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();
             IRenderedComponent<MudPopover> Popover() => comp.FindComponent<MudPopover>();
@@ -165,6 +146,25 @@ namespace MudBlazor.UnitTests.Components
             // Pointer moves to menu, still need to open
             await Menu().TriggerEventAsync("onpointerenter", new PointerEventArgs());
             comp.WaitForAssertion(() => Popover().Instance.Open.Should().BeTrue());
+        }
+
+        [Test]
+        public async Task MouseOver_ClickAndPointerLeave_ShouldStayOpen()
+        {
+            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var pop = comp.FindComponent<MudPopover>();
+            comp.FindAll("button.mud-button-root")[0].Click();
+
+            IElement List() => comp.FindAll("div.mud-list")[0];
+
+            await List().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
+
+            // Click activator to keep the menu open.
+            comp.FindAll("button.mud-button-root")[0].Click();
+
+            await List().TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -126,6 +126,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MenuPointerClickAndLeave_CheckClosed()
+        {
+            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var pop = comp.FindComponent<MudPopover>();
+            comp.FindAll("button.mud-button-root")[0].Click();
+
+            IElement List() => comp.FindAll("div.mud-list")[0];
+
+            await List().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
+
+            // Click activator to keep the menu open.
+            comp.FindAll("button.mud-button-root")[0].Click();
+
+            await List().TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
+        }
+
+        [Test]
         public async Task MenuPointerLeave_MenuPointerEnter_CheckOpen()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -160,8 +160,13 @@ namespace MudBlazor.UnitTests.Components
             // Enter opens the menu.
             comp.FindAll("div.mud-menu")[0].PointerEnter();
 
-            // Clicking the button should keep the menu open.
+            // Clicking the button should close the menu.
             comp.FindAll("button.mud-button-root")[0].Click();
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeFalse());
+
+            // Clicking the button again should open the menu permanently.
+            comp.FindAll("button.mud-button-root")[0].Click();
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
 
             // Leaving the menu should not close it.
             comp.FindAll("div.mud-menu")[0].PointerLeave();

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -4,9 +4,7 @@ using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -114,7 +114,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();
             var pop = comp.FindComponent<MudPopover>();
-            comp.FindAll("button.mud-button-root")[0].Click();
+
+            // Briefly hover over the button which will open the popover while leaving a small delay to allow the user to move the pointer to the menu.
+            comp.FindAll("div.mud-menu")[0].PointerEnter();
+            comp.FindAll("div.mud-menu")[0].PointerLeave();
 
             IElement List() => comp.FindAll("div.mud-list")[0];
 
@@ -126,7 +129,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MouseOver_PointerLeaveAndEnter_ShouldOpen()
+        public async Task MouseOver_Hover_ShouldOpenMenu()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();
             IRenderedComponent<MudPopover> Popover() => comp.FindComponent<MudPopover>();
@@ -149,22 +152,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MouseOver_ClickAndPointerLeave_ShouldStayOpen()
+        public async Task MouseOver_Click_ShouldKeepOpen()
         {
             var comp = Context.RenderComponent<MenuTestMouseOver>();
             var pop = comp.FindComponent<MudPopover>();
+
+            // Enter opens the menu.
+            comp.FindAll("div.mud-menu")[0].PointerEnter();
+
+            // Clicking the button should keep the menu open.
             comp.FindAll("button.mud-button-root")[0].Click();
+
+            // Leaving the menu should not close it.
+            comp.FindAll("div.mud-menu")[0].PointerLeave();
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
 
             IElement List() => comp.FindAll("div.mud-list")[0];
 
+            // Hover over the list shouldn't change anything.
             await List().TriggerEventAsync("onpointerenter", new PointerEventArgs());
             comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
 
-            // Click activator to keep the menu open.
-            comp.FindAll("button.mud-button-root")[0].Click();
-
+            // Leave the list shouldn't change anything.
             await List().TriggerEventAsync("onpointerleave", new PointerEventArgs());
             comp.WaitForAssertion(() => pop.Instance.Open.Should().BeTrue());
+
+            // Clicking the button should now close the menu.
+            comp.FindAll("button.mud-button-root")[0].Click();
+            comp.WaitForAssertion(() => pop.Instance.Open.Should().BeFalse());
         }
 
         [Test]

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -7,13 +7,13 @@
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
+     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? OpenMenuAsync : null)"
      @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)">
 
     @if (ActivatorContent != null)
     {
         <CascadingValue Value="@((IActivatable)this)" IsFixed="true">
-            <div @onclick="ToggleMenuAsync" disabled="@Disabled" class="@ActivatorClassname">
+            <div @onclick="OpenMenuAsync" disabled="@Disabled" class="@ActivatorClassname">
                 @ActivatorContent
             </div>
         </CascadingValue>
@@ -29,7 +29,7 @@
                    Disabled="@Disabled"
                    Ripple="@Ripple"
                    DropShadow="@DropShadow"
-                   OnClick="@ToggleMenuAsync"
+                   OnClick="@OpenMenuAsync"
                    aria-label="@AriaLabel">
             @Label
         </MudButton>
@@ -43,7 +43,7 @@
                        Disabled="@Disabled"
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
-                       @onclick="@ToggleMenuAsync"
+                       @onclick="@OpenMenuAsync"
                        aria-label="@AriaLabel" />
     }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -7,13 +7,13 @@
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? OpenMenuAsync : null)"
+     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
      @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)">
 
     @if (ActivatorContent != null)
     {
         <CascadingValue Value="@((IActivatable)this)" IsFixed="true">
-            <div @onclick="OpenMenuAsync" disabled="@Disabled" class="@ActivatorClassname">
+            <div @onclick="ToggleMenuAsync" disabled="@Disabled" class="@ActivatorClassname">
                 @ActivatorContent
             </div>
         </CascadingValue>
@@ -29,7 +29,7 @@
                    Disabled="@Disabled"
                    Ripple="@Ripple"
                    DropShadow="@DropShadow"
-                   OnClick="@OpenMenuAsync"
+                   OnClick="@ToggleMenuAsync"
                    aria-label="@AriaLabel">
             @Label
         </MudButton>
@@ -43,7 +43,7 @@
                        Disabled="@Disabled"
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
-                       OnClick="@OpenMenuAsync"
+                       OnClick="@ToggleMenuAsync"
                        aria-label="@AriaLabel" />
     }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -43,7 +43,7 @@
                        Disabled="@Disabled"
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
-                       @onclick="@OpenMenuAsync"
+                       OnClick="@OpenMenuAsync"
                        aria-label="@AriaLabel" />
     }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -48,7 +48,7 @@
     }
 
     @* The portal has to include the cascading values inside, because it's not able to teletransport the cascade *@
-    <MudPopover Open="@_open"
+    <MudPopover Open="@Open"
                 Class="@PopoverClass"
                 MaxHeight="@MaxHeight"
                 AnchorOrigin="@AnchorOrigin"
@@ -67,5 +67,5 @@
         </CascadingValue>
     </MudPopover>
 
-    <MudOverlay Visible="@(_open && ActivationEvent != MouseEvent.MouseOver)" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
+    <MudOverlay @bind-Visible="_overlayVisible" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -67,5 +67,5 @@
         </CascadingValue>
     </MudPopover>
 
-    <MudOverlay @bind-Visible="_overlayVisible" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
+    <MudOverlay Visible="Open && !_isTemporary" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -259,6 +259,11 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Opens the menu.
+        /// </summary>
+        public Task OpenMenuAsync() => OpenMenuAsync(EventArgs.Empty);
+
+        /// <summary>
         /// Sets the popover style ONLY when there is an activator.
         /// </summary>
         private void SetPopoverStyle(MouseEventArgs args)
@@ -303,10 +308,10 @@ namespace MudBlazor
 
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
+            // We only do this for mice because other pointers should toggle instead.
             if (ActivationEvent == MouseEvent.MouseOver && args.PointerType == "mouse")
             {
                 // Only set if conditions are met to avoid triggering unnecessary code in the Leave event.
-                // We only do this for mice because other pointers should toggle instead.
                 _isPointerOver = true;
 
                 await OpenMenuAsync(args, true);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -311,10 +311,12 @@ namespace MudBlazor
 
             _isPointerOver = true;
 
-            if (_isTemporary && ActivationEvent == MouseEvent.MouseOver)
+            if (Open || ActivationEvent != MouseEvent.MouseOver)
             {
-                await OpenMenuAsync(args, true);
+                return;
             }
+
+            await OpenMenuAsync(args, true);
         }
 
         private async Task PointerLeaveAsync()

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -243,10 +243,12 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            // Don't open if already open, but we can change from a temporary overlay to a permanent one.
+            // Update from a temporary overlay to a permanent one or vice versa.
+            _overlayVisible = !temporary;
+
+            // Don't open if already open.
             if (Open)
             {
-                _overlayVisible = !temporary;
                 return Task.CompletedTask;
             }
 
@@ -302,6 +304,12 @@ namespace MudBlazor
 
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
+            // Don't open again.
+            if (Open)
+            {
+                return;
+            }
+
             // We only do this for mice because other pointers should toggle instead.
             if (ActivationEvent == MouseEvent.MouseOver && args.PointerType == "mouse")
             {
@@ -315,7 +323,8 @@ namespace MudBlazor
         private async Task PointerLeaveAsync(PointerEventArgs args)
         {
             // Don't do anything if the Enter event wasn't triggered first (rare) to avoid unnecessary execution.
-            if (!_isPointerOver)
+            // And if an overlay is visible then the menu isn't temporary and shouldn't close when the pointer leaves.
+            if (!_isPointerOver || _overlayVisible)
             {
                 return;
             }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -283,6 +283,15 @@ namespace MudBlazor
         public Task OpenMenuAsync(EventArgs args) => OpenMenuAsync(args, false);
 
         /// <summary>
+        /// Sets the popover style ONLY when there is an activator.
+        /// </summary>
+        private void SetPopoverStyle(MouseEventArgs args)
+        {
+            AnchorOrigin = Origin.TopLeft;
+            _popoverStyle = $"margin-top: {args?.OffsetY.ToPx()}; margin-left: {args?.OffsetX.ToPx()};";
+        }
+
+        /// <summary>
         /// Toggle the visibility of the menu.
         /// </summary>
         /// <param name="args">The arguments from the event that called this.</param>
@@ -315,7 +324,7 @@ namespace MudBlazor
             }
         }
 
-        private async Task PointerLeaveAsync(PointerEventArgs args)
+        private async Task PointerLeaveAsync()
         {
             // If an overlay is visible then the menu isn't temporary and shouldn't close when the pointer leaves.
             if (_overlayVisible)
@@ -344,15 +353,6 @@ namespace MudBlazor
         void IActivatable.Activate(object activator, MouseEventArgs args)
         {
             _ = ToggleMenuAsync(args);
-        }
-
-        /// <summary>
-        /// Sets the popover style ONLY when there is an activator.
-        /// </summary>
-        private void SetPopoverStyle(MouseEventArgs args)
-        {
-            AnchorOrigin = Origin.TopLeft;
-            _popoverStyle = $"margin-top: {args?.OffsetY.ToPx()}; margin-left: {args?.OffsetX.ToPx()};";
         }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -11,8 +11,8 @@ namespace MudBlazor
     public partial class MudMenu : MudComponentBase, IActivatable
     {
         private bool _overlayVisible;
-        private bool _isPointerOver;
         private string? _popoverStyle;
+        private bool _isPointerOver;
 
         protected string Classname =>
             new CssBuilder("mud-menu")
@@ -202,7 +202,7 @@ namespace MudBlazor
         public EventCallback<bool> OpenChanged { get; set; }
 
         /// <summary>
-        /// Indicates whether the menu is currently open or not.
+        /// Gets a value indicating whether the menu is currently open or not.
         /// </summary>
         public bool Open { get; private set; }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -238,8 +238,15 @@ namespace MudBlazor
         /// </param>
         public Task OpenMenuAsync(EventArgs args, bool temporary = false)
         {
-            if (Disabled || Open)
+            if (Disabled)
             {
+                return Task.CompletedTask;
+            }
+
+            // Don't open if already open, but we can change from a temporary overlay to a permanent one.
+            if (Open)
+            {
+                _overlayVisible = !temporary;
                 return Task.CompletedTask;
             }
 
@@ -262,7 +269,6 @@ namespace MudBlazor
             }
 
             Open = true;
-            _overlayVisible = !temporary;
             StateHasChanged();
 
             return OpenChanged.InvokeAsync(Open);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -303,7 +303,7 @@ namespace MudBlazor
 
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
-            if (ActivationEvent == MouseEvent.MouseOver && args.Type == "mouse")
+            if (ActivationEvent == MouseEvent.MouseOver && args.PointerType == "mouse")
             {
                 // Only set if conditions are met to avoid triggering unnecessary code in the Leave event.
                 // We only do this for mice because other pointers should toggle instead.
@@ -315,7 +315,7 @@ namespace MudBlazor
 
         private async Task PointerLeaveAsync(PointerEventArgs args)
         {
-            // Don't do anything unless Enter event was triggered first to avoid unnecessary execution.
+            // Don't do anything if the Enter event wasn't triggered first (rare) to avoid unnecessary execution.
             if (!_isPointerOver)
             {
                 return;

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -236,38 +236,27 @@ namespace MudBlazor
         /// If the menu is temporary, an overlay won't be applied.
         /// This is relevant for a menu that is only open while the cursor is over it.
         /// </param>
-        public Task OpenMenuAsync(EventArgs args, bool temporary)
+        public Task OpenMenuAsync(EventArgs args, bool temporary = false)
         {
             if (Disabled)
             {
                 return Task.CompletedTask;
             }
 
-            // Update from a temporary overlay to a permanent one or vice versa.
             _overlayVisible = !temporary;
 
-            // Don't open if already open.
-            if (Open)
-            {
-                return Task.CompletedTask;
-            }
-
-            // Validate the mouse event conditions. This is a consideration for regular event args or the MouseOver activation.
             if (args is MouseEventArgs mouseEventArgs)
             {
-                var leftClick = ActivationEvent == MouseEvent.LeftClick && mouseEventArgs.Button == 0;
-                var rightClick = ActivationEvent == MouseEvent.RightClick && (mouseEventArgs.Button is -1 or 2); // oncontextmenu button is -1, right click is 2.
-
-                // Only allow valid left or right conditions, except MouseOver activation should always be allowed to toggle.
-                if (!leftClick && !rightClick && ActivationEvent != MouseEvent.MouseOver)
-                {
-                    return Task.CompletedTask;
-                }
-
                 if (PositionAtCursor)
                 {
                     SetPopoverStyle(mouseEventArgs);
                 }
+            }
+
+            // Don't open if already open, but let the stuff above get updated.
+            if (Open)
+            {
+                return Task.CompletedTask;
             }
 
             Open = true;
@@ -275,12 +264,6 @@ namespace MudBlazor
 
             return OpenChanged.InvokeAsync(Open);
         }
-
-        /// <summary>
-        /// Opens the menu and it remains open until the spawned overlay is clicked.
-        /// </summary>
-        /// <param name="args">The arguments from the event that called this.</param>
-        public Task OpenMenuAsync(EventArgs args) => OpenMenuAsync(args, false);
 
         /// <summary>
         /// Sets the popover style ONLY when there is an activator.
@@ -300,6 +283,19 @@ namespace MudBlazor
             if (Disabled)
             {
                 return Task.CompletedTask;
+            }
+
+            // Validate the mouse event conditions. This is a consideration for regular event args or the MouseOver activation.
+            if (args is MouseEventArgs mouseEventArgs)
+            {
+                var leftClick = ActivationEvent == MouseEvent.LeftClick && mouseEventArgs.Button == 0;
+                var rightClick = ActivationEvent == MouseEvent.RightClick && (mouseEventArgs.Button is -1 or 2); // oncontextmenu button is -1, right click is 2.
+
+                // Only allow valid left or right conditions, except MouseOver activation should always be allowed to toggle.
+                if (!leftClick && !rightClick && ActivationEvent != MouseEvent.MouseOver)
+                {
+                    return Task.CompletedTask;
+                }
             }
 
             if (Open)

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -309,7 +309,7 @@ namespace MudBlazor
                 // We only do this for mice because other pointers should toggle instead.
                 _isPointerOver = true;
 
-                await OpenMenuAsync(args);
+                await OpenMenuAsync(args, true);
             }
         }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -211,11 +211,6 @@ namespace MudBlazor
         /// </summary>
         public Task CloseMenuAsync()
         {
-            if (Disabled || !Open)
-            {
-                return Task.CompletedTask;
-            }
-
             Open = false;
             _overlayVisible = false;
             _isPointerOver = false;
@@ -245,9 +240,9 @@ namespace MudBlazor
 
             _overlayVisible = !temporary;
 
-            if (args is MouseEventArgs mouseEventArgs)
+            if (PositionAtCursor)
             {
-                if (PositionAtCursor)
+                if (args is MouseEventArgs mouseEventArgs)
                 {
                     SetPopoverStyle(mouseEventArgs);
                 }
@@ -298,7 +293,8 @@ namespace MudBlazor
                 }
             }
 
-            if (Open)
+            // The overlay being visible means we close it, otherwise we upgrade it to a permanent menu.
+            if (Open && _overlayVisible)
             {
                 return CloseMenuAsync();
             }
@@ -314,7 +310,7 @@ namespace MudBlazor
 
             // If an overlay is visible then the menu is open and not temporary.
             // The pointer Enter event occurs before Click on a device that can't hover which causes a conflict.
-            if (!_overlayVisible && ActivationEvent == MouseEvent.MouseOver && args.PointerType == "mouse")
+            if (!_overlayVisible && ActivationEvent == MouseEvent.MouseOver)
             {
                 await OpenMenuAsync(args, true);
             }
@@ -335,8 +331,8 @@ namespace MudBlazor
                 // Wait a bit to allow the cursor to move from the activator to the items popover.
                 await Task.Delay(100);
 
-                // Close the menu if the pointer hasn't re-entered the menu.
-                if (!_isPointerOver)
+                // Close the menu if the pointer hasn't re-entered the menu or the overlay made permanent because it was clicked.
+                if (!_isPointerOver && !_overlayVisible)
                 {
                     await CloseMenuAsync();
                 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -293,8 +293,7 @@ namespace MudBlazor
                 }
             }
 
-            // The overlay being visible means we close it, otherwise we upgrade it to a permanent menu.
-            if (Open && _overlayVisible)
+            if (Open)
             {
                 return CloseMenuAsync();
             }
@@ -306,6 +305,12 @@ namespace MudBlazor
 
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
+            // The device can't hover then this event will be called with the Click event and interfere.
+            if (args.PointerType is "touch" or "pen")
+            {
+                return;
+            }
+
             _isPointerOver = true;
 
             // If an overlay is visible then the menu is open and not temporary.
@@ -319,7 +324,8 @@ namespace MudBlazor
         private async Task PointerLeaveAsync()
         {
             // If an overlay is visible then the menu isn't temporary and shouldn't close when the pointer leaves.
-            if (_overlayVisible)
+            // There's also no reason to handle the leave event if the pointer never entered the menu.
+            if (_overlayVisible || !_isPointerOver)
             {
                 return;
             }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Closes #9470 by refactoring some of the menu code and allowing you to click the activator to keep the menu open while using MouseOver. This is relevant on touch devices where you can't hover, so the menu would only stay open as long as you held a tap.

Tried to avoid any breaking changes.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Clicking the button will toggle the overlay, allowing you to hide the menu. If it's already closed (like if touched) then it will stay open until you click the overlay.

Touch:



https://github.com/user-attachments/assets/c2628be6-0dec-42fc-a69d-b82b269414c4


Mouse:




https://github.com/user-attachments/assets/662ebc53-eedc-4bd8-9cc6-c536449da7d3



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
