### PR TITLE
MudDataGrid: Improve the doc about `ServerData`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -251,13 +251,16 @@
                 <Description>
                     Set <CodeInline>ServerData</CodeInline> to load data from the backend that is filtered, sorted and paginated.
                     DataGrid will call this async function whenever the user navigates the pager or changes sorting by clicking on the sort header icons.
-                    In this example, we also show how to force the table to update when the search textfield blurs, so that the table reloads server-filtered data.
+                    In this example, we also show how to force the datagrid to update when the search textfield blurs, so that the datagrid reloads server-filtered data.
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-3">
+                        The parameter <CodeInline>ServerData</CodeInline> is incompatible with the parameters <CodeInline>Items</CodeInline> and <CodeInline>QuickFilter</CodeInline>. If <CodeInline>ServerData</CodeInline> is mixed with <CodeInline>Items</CodeInline> and <CodeInline>QuickFilter</CodeInline>, a <CodeInline>InvalidOperationException</CodeInline> is throw at runtime.
+                    </MudAlert>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                        Note: with a <CodeInline>ServerData</CodeInline> func you don't need <CodeInline>Items</CodeInline> and <CodeInline>Filter</CodeInline>.
+                        The example show a solution to replace <CodeInline>QuickFilter</CodeInline> when <CodeInline>ServerData</CodeInline> is used.
                     </MudAlert>
                 </Description>
             </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="@nameof(TableServerSidePaginateExample)" ShowCode="false" Block="true" FullWidth="true">
+            <SectionContent DarkenBackground="true" Code="@nameof(DataGridServerSideExample)" ShowCode="false" Block="true" FullWidth="true">
                 <DataGridServerSideExample />
             </SectionContent>
         </DocsPageSection>


### PR DESCRIPTION
## Description

Improve/fix the PR #9469

* Fix to replace a Table example by the DataGrid example
* Notice what mixed `ServerData` with `Items` or `QuickFilter` throw a error at runtime.
* Emphasize on the example show how replace `QuickFilter`


## How Has This Been Tested?

I debug the doc in ServerMode and checked the modified section.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
