### PR TITLE
Build: potentially fix invalid JS in the minified scripts file

### DIFF
--- a/src/MudBlazor/TScripts/mudInputAutoGrow.js
+++ b/src/MudBlazor/TScripts/mudInputAutoGrow.js
@@ -101,4 +101,4 @@ window.mudInputAutoGrow = {
             elem.restoreToInitialState();
         }
     }
-}
+};


### PR DESCRIPTION
## Description
Docs on `dev.mudblazor.com` don't load because of invalid JS in the generated `MudBlazor.min.js`, this is potentially caused by incompatible JS files being merged during the minification process. Adding the trailing `;` in this specific file should fix it for the time being.

Likely related to #9481 

## How Has This Been Tested?
Checked the generated JS locally, needs to be verified on `dev.mudblazor.com` though.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
