### PR TITLE
DataGrid: Make FilterContext.FilterDefinition public to support custom filters

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomPropertyFilterTemplateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCustomPropertyFilterTemplateTest.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudDataGrid Items="@_items" Filterable FilterMode="DataGridFilterMode.ColumnFilterMenu">
+    <Columns>
+        <PropertyColumn Property="x => x.Name">
+            <FilterTemplate>
+                <DataGridStringContainsFilter FilterContext="context" />
+            </FilterTemplate>
+        </PropertyColumn>
+        <PropertyColumn Property="x => x.Age" Filterable="false" />
+        <PropertyColumn Property="x => x.Status" Filterable="false" />
+        <PropertyColumn Property="x => x.Hired" Filterable="false" />
+        <PropertyColumn Property="x => x.HiredOn" Filterable="false" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public record Model (string Name, int? Age, Severity? Status, bool? Hired, DateTime? HiredOn);
+
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam", 56, Severity.Normal, false, null), 
+        new Model("Alicia", 54, Severity.Info, null, null), 
+        new Model("Ira", 27, Severity.Success, true, new DateTime(2011, 1, 2)),
+        new Model("John", 32, Severity.Warning, false, null)
+    };
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStringContainsFilter.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStringContainsFilter.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@typeparam T
+
+<MudStack>
+    <MudTextField @bind-Value="_filterValue" Placeholder="Search" />
+    <MudStack Row>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ApplyAsync" Class="apply-filter-button">Apply</MudButton>
+        <MudButton Color="Color.Default" Variant="Variant.Filled" OnClick="@ResetAsync" Class="reset-filter-button">Reset</MudButton>
+    </MudStack>
+</MudStack>
+
+@code {
+    [Parameter]
+    public FilterContext<T> FilterContext { get; set; }
+
+    private string _filterValue;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        FilterContext.FilterDefinition.Operator = FilterOperator.String.Contains;
+
+        if (FilterContext.FilterDefinition.Value is string stringValue)
+        {
+            _filterValue = stringValue;
+        }
+    }
+
+    private async Task ApplyAsync()
+    {
+        FilterContext.FilterDefinition.Value = _filterValue;
+
+        await FilterContext.Actions.ApplyFilterAsync(FilterContext.FilterDefinition);
+    }
+
+    private async Task ResetAsync()
+    {
+        FilterContext.FilterDefinition.Value = null;
+
+        await FilterContext.Actions.ClearFilterAsync(FilterContext.FilterDefinition);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3153,6 +3153,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridCustomPropertyFilterTemplateTest()
+        {
+            var comp = Context.RenderComponent<DataGridCustomPropertyFilterTemplateTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomPropertyFilterTemplateTest.Model>>();
+
+            dataGrid.FindAll("tbody tr").Count.Should().Be(4);
+
+            comp.Find(".filter-button").Click();
+            var input = comp.FindComponent<MudTextField<string>>();
+            await comp.InvokeAsync(async () => await input.Instance.ValueChanged.InvokeAsync("Ira"));
+            comp.Find(".apply-filter-button").Click();
+
+            dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+
+            comp.Find(".filter-button").Click();
+            comp.Find(".reset-filter-button").Click();
+
+            dataGrid.FindAll("tbody tr").Count.Should().Be(4);
+        }
+
+        [Test]
         public async Task DataGridShowFilterIconTest()
         {
             var comp = Context.RenderComponent<DataGridCustomFilteringTest>();

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -17,9 +17,12 @@ namespace MudBlazor
     {
         private readonly MudDataGrid<T> _dataGrid;
 
-        internal IFilterDefinition<T>? FilterDefinition { get; set; }
-
         internal HeaderCell<T>? HeaderCell { get; set; }
+
+        /// <summary>
+        /// The definition of this filter.
+        /// </summary>
+        public IFilterDefinition<T>? FilterDefinition { get; set; }
 
         /// <summary>
         /// The items to filter.


### PR DESCRIPTION
## Description

This pull request resolves #6984.

The DataGrid currently supports multiple different filter modes: Simple, ColumnFilterMenu and ColumnFilterRow. In the latter two, the `FilterContext<T>` provided to the `FilterTemplate` is currently not very helpful. It allows to add and remove `IFilterDefinition<T>` from the grid, however, there is no link to the column the filtered column available which makes writing custom filters difficult and sometimes even impossible.

The `FilterContext<T>.FilterDefinition` solves this issue as it contains all the information regarding the column that it operates on. It also stays the same for the lifetime of the DataGrid, which is very helpful as it removes the need to retrieve the potentially applied `IFilterDefinition<T>` from the `FilterContext<T>.FilterDefinitions` each time the filter menu is opened.

Besides the above, the documentation currently already states that the `FilterDefinition` is available for custom filters:

https://github.com/MudBlazor/MudBlazor/blob/0761ff18ea8ab602772259bd7b80a125131a515f/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor#L166-L178

## How Has This Been Tested?

The change comes with a new unit tests for a DataGrid with a custom filter component on one property. The component provides a basic _string contains_ filter, although the actual need for this feature mostly comes from more complex filters (or styling requirements).

There are other existing tests using `FilterContext<T>.FilterDefinition` already. They seem to have worked so far due to the `InternalsVisibleTo` in the `MudBlazor.csproj`.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

From an OOP perspective, the change would be a breaking change. However, I don't think it currently makes sense to extend the `FilterContext<T>` class in user-land code as it is instantiated in the framework only.

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
