### PR TITLE
Docs: Update CSS utils for spacing description

### DIFF
--- a/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/SpacingPage.razor
+++ b/src/MudBlazor.Docs/Pages/CSS Utilities/Spacing/SpacingPage.razor
@@ -8,7 +8,7 @@
         <DocsPageSection>
             <SectionHeader Title="How it works">
                 <Description>
-                    Use the <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> <b>property</b> and choose a <b>direction</b>. Then add <b>size</b>, ranging from 0 to 16.
+                    Use the <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> <b>property</b> and choose a <b>direction</b>. Then add <b>size</b>, ranging from 0 to 20.
                 </Description>
             </SectionHeader>
             <MudText Class="pt-6 pb-2">The <b>properties</b>:</MudText>
@@ -57,6 +57,10 @@
                         <li><CodeInline>14</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>56px</CodeInline></li>
                         <li><CodeInline>15</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>60px</CodeInline></li>
                         <li><CodeInline>16</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>64px</CodeInline></li>
+                        <li><CodeInline>17</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>68px</CodeInline></li>
+                        <li><CodeInline>18</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>72px</CodeInline></li>
+                        <li><CodeInline>19</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>76px</CodeInline></li>
+                        <li><CodeInline>20</CodeInline> sets <CodeInline>margin</CodeInline> or <CodeInline>padding</CodeInline> to <CodeInline>80px</CodeInline></li>
                         <li><CodeInline>auto</CodeInline> sets the spacing to <CodeInline>auto</CodeInline></li>
                     </ul>
                 </MudItem>
@@ -79,6 +83,10 @@
                         <li><CodeInline SecondaryColor="true">n14</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-56px</CodeInline></li>
                         <li><CodeInline SecondaryColor="true">n15</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-60px</CodeInline></li>
                         <li><CodeInline SecondaryColor="true">n16</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-64px</CodeInline></li>
+                        <li><CodeInline SecondaryColor="true">n17</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-68px</CodeInline></li>
+                        <li><CodeInline SecondaryColor="true">n18</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-72px</CodeInline></li>
+                        <li><CodeInline SecondaryColor="true">n19</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-76px</CodeInline></li>
+                        <li><CodeInline SecondaryColor="true">n20</CodeInline> sets <CodeInline SecondaryColor="true">margin</CodeInline> to <CodeInline SecondaryColor="true">-80px</CodeInline></li>
                     </ul>
                 </MudItem>
             </MudGrid>


### PR DESCRIPTION
## Description
The spacing CSS utils have been extended in #8943 beyond 16 options, but the documentation has not been updated so far. The PR fixes this.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
