### PR TITLE
Alert: Fix vertical icon position on alerts

### DIFF
--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -105,7 +105,7 @@
 .mud-alert-position {
   flex: 1;
   display: flex;
-  align-items:center;
+  align-items: start;
 }
 
 .mud-alert-close {


### PR DESCRIPTION
Simple CSS tweak to fix a regression from MudBlazor v6. Severity icon for alerts with two or more lines of wrapped text is positioned in the center of the alert (in v7) instead of the top of the alert (as in v6).

Fix (like v6)
![image](https://github.com/user-attachments/assets/9413bef3-4c8f-483d-9471-9c1bde0482d0)

Pre-fix (v7)
![image](https://github.com/user-attachments/assets/d2bc4025-64e5-48b3-9ec7-7901f3490556)
