### PR TITLE
MudMenu: Fix nested menu to support multiple levels. (#7376)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestNestWithMouseOver.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestNestWithMouseOver.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudMenu AnchorOrigin="Origin.BottomCenter" Label="Full Menu Width" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenuItem Class="test-class">1</MudMenuItem>
+    <MudMenuItem Href="https://www.test.com">2</MudMenuItem>
+    <MudMenu Variant="Variant.Filled" AnchorOrigin="Origin.TopRight" Color="Color.Primary" FullWidth="true" ActivationEvent="@MouseEvent.MouseOver">
+        <ActivatorContent>
+            <MudMenuItem>Open Sub Menu</MudMenuItem>
+        </ActivatorContent>
+        <ChildContent>
+            <MudMenuItem>Sub Menu Item 1</MudMenuItem>
+            <MudMenuItem>Sub Menu Item 2</MudMenuItem>
+            <MudMenu AnchorOrigin="Origin.TopRight" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" ActivationEvent="@MouseEvent.MouseOver">
+                <ActivatorContent>
+                    <MudMenuItem>Open Level2 Sub Menu</MudMenuItem>
+                </ActivatorContent>
+                <ChildContent>
+                    <MudMenuItem>Level2 Sub Menu Item 1</MudMenuItem>
+                    <MudMenuItem>Level2 Sub Menu Item 2</MudMenuItem>
+                </ChildContent>
+            </MudMenu>
+        </ChildContent>
+    </MudMenu>
+</MudMenu>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -428,5 +428,52 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("button").GetAttribute("aria-label").Should().Be(expectedAriaLabel);
         }
+
+        [Test]
+        public async Task MultiNest_MenuPointerLeave_MenuPointerEnter_CheckOpenClose()
+        {
+            var comp = Context.RenderComponent<MenuTestNestWithMouseOver>();
+            // open all sub menus
+            var mudMenus = comp.FindComponents<MudMenu>();
+            var menu = mudMenus[0].WaitForElement(".mud-menu");
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(1));
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeTrue());
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(2));
+            menu = mudMenus[0].WaitForElement(".mud-menu");
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeTrue());
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(3));
+            menu = mudMenus[1].WaitForElement(".mud-menu");
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[1].Instance.Open.Should().BeTrue());
+
+            mudMenus = comp.FindComponents<MudMenu>();
+
+            // keep the first menu open
+            var cancellationTokenSource = new CancellationTokenSource();
+            var token = cancellationTokenSource.Token;
+            _ = Task.Run(async () =>
+            {
+                var menuItem = mudMenus[2].Find(".mud-menu");
+                while (!token.IsCancellationRequested)
+                {
+                    await menuItem.TriggerEventAsync("onpointermove", new PointerEventArgs());
+                    await Task.Delay(10, token);
+                }
+            }, token);
+            // leave last sub menu , and then parent menu open will be false
+            // but the first menu should still be open
+            menu = mudMenus[1].WaitForElement(".mud-menu");
+            await menu.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await Task.Delay(100, CancellationToken.None);
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(2));
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeFalse());
+            comp.WaitForAssertion(() => mudMenus[1].Instance.Open.Should().BeTrue());
+            await cancellationTokenSource.CancelAsync();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -173,20 +173,9 @@ namespace MudBlazor.UnitTests.Components
             menus = comp.FindAll(".mud-menu");
             comp.WaitForAssertion(() => menus.Count.Should().Be(3));
 
-            menus = comp.FindAll(".mud-menu");
-
+            // parent menu will close when pointer leaves
             await menus[1].TriggerEventAsync("onpointerleave", new PointerEventArgs());
             comp.WaitForAssertion(() => menus[1].IsVisible().Should().BeFalse());
-
-            await Task.Delay(100);
-
-            await menus[0].TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            comp.WaitForAssertion(() => menus[0].IsVisible().Should().BeFalse());
-
-            await Task.Delay(100);
-
-            await menus[2].TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            comp.WaitForAssertion(() => menus[2].IsVisible().Should().BeFalse());
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -430,6 +430,50 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MultiNest_MenuPointerLeave_MenuPointerEnter_Closing()
+        {
+            var comp = Context.RenderComponent<MenuTestNestWithMouseOver>();
+            // open all sub menus
+            var mudMenus = comp.FindComponents<MudMenu>();
+            var menu = mudMenus[0].WaitForElement(".mud-menu");
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(1));
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeTrue());
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(2));
+            menu = mudMenus[0].WaitForElement(".mud-menu");
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeTrue());
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(3));
+            menu = mudMenus[1].WaitForElement(".mud-menu");
+            await menu.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.WaitForAssertion(() => mudMenus[1].Instance.Open.Should().BeTrue());
+
+            // try to keep mouse enter
+            var cancellationTokenSource = new CancellationTokenSource();
+            var token = cancellationTokenSource.Token;
+            _ = Task.Run(async () =>
+            {
+                var menuItem = mudMenus[2].Find(".mud-menu");
+                while (!token.IsCancellationRequested)
+                {
+                    await menuItem.TriggerEventAsync("onpointermove", new PointerEventArgs());
+                    await Task.Delay(35, token);
+                }
+            }, token);
+            await Task.Delay(10, CancellationToken.None);
+            // click menu item
+            // all opened menu should be close
+            _ = mudMenus[1].InvokeAsync(() => mudMenus[1].Instance.CloseMenuAsync());
+            _ = cancellationTokenSource.CancelAsync();
+            await Task.Delay(200, CancellationToken.None);
+            mudMenus = comp.FindComponents<MudMenu>();
+            comp.WaitForAssertion(() => mudMenus.Count.Should().Be(1));
+            comp.WaitForAssertion(() => mudMenus[0].Instance.Open.Should().BeFalse());
+        }
+
+        [Test]
         public async Task MultiNest_MenuPointerLeave_MenuPointerEnter_CheckOpenClose()
         {
             var comp = Context.RenderComponent<MenuTestNestWithMouseOver>();

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -151,6 +151,45 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MultiNest_MenuPointerLeave_MenuPointerEnter_CheckOpenClose()
+        {
+            var comp = Context.RenderComponent<MenuTestNestWithMouseOver>();
+            IRenderedComponent<MudPopover> Popover() => comp.FindComponent<MudPopover>();
+
+            var menus = comp.FindAll(".mud-menu");
+
+            comp.WaitForAssertion(() => Popover().Instance.Open.Should().BeFalse());
+
+            // Pointer over to menu to open popover
+            await menus[0].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            menus = comp.FindAll(".mud-menu");
+            comp.WaitForAssertion(() => menus.Count.Should().Be(2));
+
+            await menus[0].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            menus = comp.FindAll(".mud-menu");
+            comp.WaitForAssertion(() => menus.Count.Should().Be(3));
+
+            await menus[1].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            menus = comp.FindAll(".mud-menu");
+            comp.WaitForAssertion(() => menus.Count.Should().Be(3));
+
+            menus = comp.FindAll(".mud-menu");
+
+            await menus[1].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.WaitForAssertion(() => menus[1].IsVisible().Should().BeFalse());
+
+            await Task.Delay(100);
+
+            await menus[0].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.WaitForAssertion(() => menus[0].IsVisible().Should().BeFalse());
+
+            await Task.Delay(100);
+
+            await menus[2].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.WaitForAssertion(() => menus[2].IsVisible().Should().BeFalse());
+        }
+
+        [Test]
         public void ActivatorContent_Disabled_CheckDisabled()
         {
             var comp = Context.RenderComponent<MenuTestDisabledCustomActivator>();

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -5,7 +5,7 @@
 <div @attributes="UserAttributes"
      class="@Classname"
      style="@Style"
-     @onpointermove="@OnPointerMoveAsync"
+     @onpointermove="@PointerMoveAsync"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
      @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
@@ -61,7 +61,7 @@
             <MudList T="object"
                      Class="@ListClass"
                      Dense="@Dense"
-                     @onpointermove="@OnPointerMoveAsync"
+                     @onpointermove="@PointerMoveAsync"
                      @onpointerenter="@PointerEnterAsync"
                      @onpointerleave="@PointerLeaveAsync">
                 @ChildContent

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -5,6 +5,7 @@
 <div @attributes="UserAttributes"
      class="@Classname"
      style="@Style"
+     @onpointermove="@OnPointerMoveAsync"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
      @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
@@ -60,6 +61,7 @@
             <MudList T="object"
                      Class="@ListClass"
                      Dense="@Dense"
+                     @onpointermove="@OnPointerMoveAsync"
                      @onpointerenter="@PointerEnterAsync"
                      @onpointerleave="@PointerLeaveAsync">
                 @ChildContent

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -5,7 +5,7 @@
 <div @attributes="UserAttributes"
      class="@Classname"
      style="@Style"
-     @onpointermove="@PointerMoveAsync"
+     @onpointermove="@PointerMove"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
      @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)"
@@ -61,7 +61,7 @@
             <MudList T="object"
                      Class="@ListClass"
                      Dense="@Dense"
-                     @onpointermove="@PointerMoveAsync"
+                     @onpointermove="@PointerMove"
                      @onpointerenter="@PointerEnterAsync"
                      @onpointerleave="@PointerLeaveAsync">
                 @ChildContent

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -308,15 +308,27 @@ namespace MudBlazor
             }
         }
 
+        private void OnPointerMoveAsync()
+        {
+            _isPointerOver = true;
+        }
+
         private async Task PointerLeaveAsync()
         {
-            _isPointerOver = false;
+            var menu = this;
+            while (menu is { ActivationEvent: MouseEvent.MouseOver })
+            {
+                menu._isPointerOver = false;
+                menu = menu.ParentMenu;
+            }
 
             await Task.Delay(100);
 
-            if (ActivationEvent == MouseEvent.MouseOver && !_isPointerOver)
+            menu = this;
+            while (menu is { ActivationEvent: MouseEvent.MouseOver, _isPointerOver: false, _open: true })
             {
-                await CloseMenuAsync();
+                await menu.CloseMenuAsync();
+                menu = menu.ParentMenu;
             }
         }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -201,6 +201,9 @@ namespace MudBlazor
         [Category(CategoryTypes.Menu.PopupBehavior)]
         public EventCallback<bool> OpenChanged { get; set; }
 
+        [CascadingParameter]
+        private MudMenu? ParentMenu { get; set; }
+
         /// <summary>
         /// Gets a value indicating whether the menu is currently open or not.
         /// </summary>
@@ -296,6 +299,8 @@ namespace MudBlazor
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
             _isPointerOver = true;
+            if (ParentMenu is { ActivationEvent: MouseEvent.MouseOver })
+                ParentMenu._isPointerOver = true;
 
             if (ActivationEvent == MouseEvent.MouseOver)
             {


### PR DESCRIPTION
## Description

When nesting menus more than one level deep with mouse over, the parent menu cannot stay displayed when the mouse moves to the nested menu.

close #7376

## How Has This Been Tested?

I add a test page in MudBlazor.UnitTests.Viewer

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

before:
![before](https://github.com/user-attachments/assets/f55b5a17-c488-428e-b272-5c2093303f58)

after:
![after](https://github.com/user-attachments/assets/146460db-67a0-4560-b4cf-50e76638569d)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
