### PR TITLE
MudTreeView: Allow for parent auto selection configuration

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewMultiSelectionExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px" Elevation="0">
-    <MudTreeView Hover ReadOnly="@ReadOnly" TriState="@TriState" @bind-SelectedValues="SelectedValues" SelectionMode="SelectionMode.MultiSelection"
+    <MudTreeView Hover ReadOnly="@ReadOnly" TriState="@TriState" AutoSelectParent="@AutoSelectParent" @bind-SelectedValues="SelectedValues" SelectionMode="SelectionMode.MultiSelection"
                  CheckBoxColor="Color.Info">
         <MudTreeViewItem Text="bundle.zip" Expanded Icon="@Icons.Material.Filled.FolderZip">
             <MudTreeViewItem Text="config" Expanded Icon="@Icons.Custom.Uncategorized.Folder" IconExpanded="@Icons.Custom.Uncategorized.FolderOpen">
@@ -25,6 +25,7 @@
         <MudChip Text="logo.png"/>
     </MudChipSet>
     <MudSwitch @bind-Value="TriState" Color="Color.Info">TriState</MudSwitch>
+    <MudSwitch @bind-Value="AutoSelectParent" Color="Color.Info">AutoSelectParent</MudSwitch>
     <MudSwitch @bind-Value="ReadOnly" Color="Color.Info">ReadOnly</MudSwitch>    
 </MudStack>
 
@@ -32,4 +33,5 @@
     public IReadOnlyCollection<string> SelectedValues = ["tasks.json", "launch.json"];
     public bool ReadOnly = false;
     public bool TriState = true;
+    public bool AutoSelectParent = true;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewAutoSelectParentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewAutoSelectParentTest.razor
@@ -1,0 +1,18 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView Class="tree1" T="string" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValue="SelectedValue" @bind-SelectedValues="SelectedValues" AutoSelectParent="@AutoSelectParent">
+    <MudTreeViewItem Class="item-1" Value='"item1"'>
+        <MudTreeViewItem Class="item-1-1" Value='"item1.1"' />
+        <MudTreeViewItem Class="item-1-2" Value='"item1.2"' />
+    </MudTreeViewItem>
+</MudTreeView>
+
+<p class="selected-values">
+    @(string.Join( ", ", (SelectedValues ?? Array.Empty<string>()).OrderBy(x=>x)))
+</p>
+
+@code {
+    [Parameter] public string SelectedValue { get; set; }
+    [Parameter] public IReadOnlyCollection<string> SelectedValues { get; set; }
+    [Parameter] public bool AutoSelectParent { get; set; } = true;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewSelectionBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewSelectionBindingTest.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTreeView Class="tree1" T="string" SelectionMode="@SelectionMode" @bind-SelectedValue="SelectedValue" @bind-SelectedValues="SelectedValues">
+<MudTreeView Class="tree1" T="string" SelectionMode="@SelectionMode" @bind-SelectedValue="SelectedValue" @bind-SelectedValues="SelectedValues" AutoSelectParent="@AutoSelectParent">
     <MudTreeViewItem Class="item-1" Value='"item1"'>
         <MudTreeViewItem Class="item-1-1" Value='"item1.1"' />
         <MudTreeViewItem Class="item-1-2" Value='"item1.2"' />
     </MudTreeViewItem>
 </MudTreeView>
 
-<MudTreeView Class="tree2" T="string" SelectionMode="@SelectionMode" @bind-SelectedValue="SelectedValue" @bind-SelectedValues="SelectedValues">
+<MudTreeView Class="tree2" T="string" SelectionMode="@SelectionMode" @bind-SelectedValue="SelectedValue" @bind-SelectedValues="SelectedValues" AutoSelectParent="@AutoSelectParent">
     <MudTreeViewItem Class="item-1" Value='"item1"'>
         <MudTreeViewItem Class="item-1-1" Value='"item1.1"' />
         <MudTreeViewItem Class="item-1-2" Value='"item1.2"' />
@@ -25,4 +25,5 @@
     [Parameter] public SelectionMode SelectionMode { get; set; }
     [Parameter] public string SelectedValue { get; set; }
     [Parameter] public IReadOnlyCollection<string> SelectedValues { get; set; }
+    [Parameter] public bool AutoSelectParent { get; set; } = true;
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -190,6 +190,40 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TreeViewWith_MultiSelection_ShouldNotAutoSelectParent()
+        {
+            var comp = Context.RenderComponent<TreeViewAutoSelectParentTest>(self => self
+                .Add(x => x.SelectedValues, ["item1.2"])
+                .Add(x => x.AutoSelectParent, false));
+            // check initial selection
+            comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
+            comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-false");
+            comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("item1.2");
+
+            // select another value on tree1 and check parent is not selected
+            comp.Find(".tree1 .item-1-1 .mud-treeview-item-content").Click();
+            comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
+            comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("item1.1, item1.2");
+            
+            // manually selecting a parent should still work
+            comp.Find(".tree1 .item-1 .mud-treeview-item-content").Click();
+            comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("item1, item1.1, item1.2");
+            
+            // removing selection of a child should still unselect the parent
+            comp.Find(".tree1 .item-1-1 .mud-treeview-item-content").Click();
+            comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
+            comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-false");
+            comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("item1.2");
+        }
+
+        [Test]
         public void TreeViewItemSelected_ShouldBeInitializedCorrectly_SingleSelection()
         {
             var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -215,12 +215,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find("p.selected-values").TrimmedText().Should().Be("item1, item1.1, item1.2");
 
-            // removing selection of a child should still unselect the parent
+            // removing selection of a child will keep the parent selected
             comp.Find(".tree1 .item-1-1 .mud-treeview-item-content").Click();
             comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
             comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-false");
             comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
-            comp.Find("p.selected-values").TrimmedText().Should().Be("item1.2");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("item1, item1.2");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -207,14 +207,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find("p.selected-values").TrimmedText().Should().Be("item1.1, item1.2");
-            
+
             // manually selecting a parent should still work
             comp.Find(".tree1 .item-1 .mud-treeview-item-content").Click();
             comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find(".tree1 .item-1-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find(".tree1 .item-1-2 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
             comp.Find("p.selected-values").TrimmedText().Should().Be("item1, item1.1, item1.2");
-            
+
             // removing selection of a child should still unselect the parent
             comp.Find(".tree1 .item-1-1 .mud-treeview-item-content").Click();
             comp.Find(".tree1 .item-1 .mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -106,6 +106,14 @@ namespace MudBlazor
         public bool TriState { get; set; } = true;
 
         /// <summary>
+        /// If true, selecting all children will result in the parent being automatically selected.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.TreeView.Selecting)]
+        public bool AutoSelectParent { get; set; } = true;
+
+        /// <summary>
+        /// <summary>
         /// If true, clicking anywhere on the item will expand it, if it has children.
         /// </summary>
         [Parameter]
@@ -358,7 +366,10 @@ namespace MudBlazor
                         _selection.Add(item.GetValue()!);
                     }
                 }
-                UpdateParentItem(clickedItem.Parent);
+                if (AutoSelectParent)
+                {
+                    UpdateParentItem(clickedItem.Parent);
+                }
                 await _selectedValuesState.SetValueAsync(_selection.ToList()); // note: .ToList() is essential here!
                 await UpdateItemsAsync();
                 return;

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -108,6 +108,7 @@ namespace MudBlazor
         /// <summary>
         /// If true, selecting all children will result in the parent being automatically selected.
         /// Unselecting a children will still unselect the parent.
+        /// Note: This only has an effect in SelectionMode.MultiSelection.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Selecting)]

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -366,9 +366,7 @@ namespace MudBlazor
                         _selection.Add(item.GetValue()!);
                     }
                 }
-                bool itemSelected = clickedItem.GetValue() is { } value && _selection.Contains(value);
-                // ignore the AutoSelectParent configuration if the item got unselected
-                if (AutoSelectParent || !itemSelected)
+                if (AutoSelectParent)
                 {
                     UpdateParentItem(clickedItem.Parent);
                 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -368,7 +368,7 @@ namespace MudBlazor
                 }
                 bool itemSelected = clickedItem.GetValue() is { } value && _selection.Contains(value);
                 // ignore the AutoSelectParent configuration if the item got unselected
-                if (AutoSelectParent || !itemSelected) 
+                if (AutoSelectParent || !itemSelected)
                 {
                     UpdateParentItem(clickedItem.Parent);
                 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -107,6 +107,7 @@ namespace MudBlazor
 
         /// <summary>
         /// If true, selecting all children will result in the parent being automatically selected.
+        /// Unselecting a children will still unselect the parent.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Selecting)]
@@ -365,7 +366,9 @@ namespace MudBlazor
                         _selection.Add(item.GetValue()!);
                     }
                 }
-                if (AutoSelectParent)
+                bool itemSelected = clickedItem.GetValue() is { } value && _selection.Contains(value);
+                // ignore the AutoSelectParent configuration if the item got unselected
+                if (AutoSelectParent || !itemSelected) 
                 {
                     UpdateParentItem(clickedItem.Parent);
                 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -106,6 +106,14 @@ namespace MudBlazor
         public bool TriState { get; set; } = true;
 
         /// <summary>
+        /// If true, selecting all children will result in the parent being automatically selected.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.TreeView.Selecting)]
+        public bool AutoSelectParent { get; set; } = true;
+
+        /// <summary>
+        /// <summary>
         /// If true, clicking anywhere on the item will expand it, if it has children.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -113,7 +113,6 @@ namespace MudBlazor
         public bool AutoSelectParent { get; set; } = true;
 
         /// <summary>
-        /// <summary>
         /// If true, clicking anywhere on the item will expand it, if it has children.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
## Description
Resolves #9411

This change makes it possible to configure the auto selection of a parent when all childs are selected.
In some case selecting all child, or selecting the parent, can means different thing.
(Think about a treeview to display a directory with it's file. You could choose to delete all the files withing a directory, without deleting the directory itself)

## How Has This Been Tested?
visually, unittest

I'm not sure which kind of test I should add for this feature. First time making a PR on this project. I would be glad to update my PR based on your input.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
