### PR TITLE
Docs: Removal of all language preferences in URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ For example:
 - Your Pull Request should not include any unnecessary refactoring
 - If there are visual changes, you should include a screenshot, gif or video
 - If there are any corresponding issues, link them to the Pull Request. Include `Fixes #<issue nr>` for bug fixes and `Closes #<issue nr>` for other issues in the description ([Link issues guide](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) 
-- Your code should be formatted correctly ([Format documentation](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules))
+- Your code should be formatted correctly ([Format documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules))
 
 
 
@@ -88,7 +88,7 @@ For example:
 in your component and apply styles at component level.
 - You must add tests if your component contains any logic (CSS styling requires no testing)
 - Use our `css variables` if possible. For instance, you should not hard code any colors etc.
-- Include a summary comment for every public property ([Summary documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags))
+- Include a summary comment for every public property ([Summary documentation](https://learn.microsoft.com/dotnet/csharp/language-reference/xmldoc/recommended-tags))
 - Use the `CssBuilder` for classes and styles
 - Add a doc page and examples which should be ordered from easy to more complex
 - Examples with more than 15 lines should be collapsed by default
@@ -229,7 +229,7 @@ We are slowly but surely refactoring all of those, you can help if you like.
 
 ## Avoid overwriting parameters in Blazor Components
 
-The `ParameterState` framework offers a solution to prevent parameter overwriting issues. For a detailed explanation of this problem, refer to the [article](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/overwriting-parameters?view=aspnetcore-8.0#overwritten-parameters).
+The `ParameterState` framework offers a solution to prevent parameter overwriting issues. For a detailed explanation of this problem, refer to the [article](https://learn.microsoft.com/aspnet/core/blazor/components/overwriting-parameters?view=aspnetcore-8.0#overwritten-parameters).
 
 ### Example of a bad code
 
@@ -304,7 +304,7 @@ public class CalendarComponent : ComponentBase
 }
 ```
 
-This code would result in a [BL0005](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0005?view=aspnetcore-8.0) warning.
+This code would result in a [BL0005](https://learn.microsoft.com/aspnet/core/diagnostics/bl0005?view=aspnetcore-8.0) warning.
 
 ### Example of a good code
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MudBlazor is an ambitious Material Design component framework for Blazor with an
 
 :information_source: Currently only interactive rendering modes are supported - [Learn more](https://learn.microsoft.com/aspnet/core/blazor/components/render-modes).
 
-:warning: Blazor only supports [current browser versions](https://learn.microsoft.com/en-us/aspnet/core/blazor/supported-platforms).
+:warning: Blazor only supports [current browser versions](https://learn.microsoft.com/aspnet/core/blazor/supported-platforms).
 To ensure a seamless experience with MudBlazor, please use an up-to-date web browser.
 If a browser version is no longer maintained by its publisher, we cannot guarantee compatibility with MudBlazor.
 

--- a/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
+++ b/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.Analyzers.Internal
                 {
                     if (member is IPropertySymbol property)
                     {
-                        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.parameterattribute?view=aspnetcore-6.0&WT.mc_id=DT-MVP-5003978
+                        // https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.components.parameterattribute?view=aspnetcore-6.0&WT.mc_id=DT-MVP-5003978
                         var parameterAttribute = property.GetAttribute(parameterSymbol, inherits: false); // the attribute is sealed
                         if (parameterAttribute is null)
                             continue;

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -267,7 +267,7 @@ public partial class ApiDocumentationBuilder()
     /// <returns>The member key for looking up documentation.</returns>
     public static string GetXmlKey(string typeFullName, string memberName = null)
     {
-        // See: https://learn.microsoft.com/en-us/archive/msdn-magazine/2019/october/csharp-accessing-xml-documentation-via-reflection
+        // See: https://learn.microsoft.com/archive/msdn-magazine/2019/october/csharp-accessing-xml-documentation-via-reflection
 
         // Get the key for the type
         var key = TypeFullNameRegEx().Replace(typeFullName, string.Empty).Replace('+', '.');

--- a/src/MudBlazor.Docs/Components/ApiText.cs
+++ b/src/MudBlazor.Docs/Components/ApiText.cs
@@ -76,7 +76,7 @@ public partial class ApiText : ComponentBase
                                         }
                                         else if (linkRef != null && (linkRef.StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase) || linkRef.StartsWith("System", StringComparison.OrdinalIgnoreCase)))
                                         {
-                                            builder.AddMudLink(0, $"https://learn.microsoft.com/en-us/dotnet/api/{linkRef}", linkRef, "docs-link docs-code docs-code-primary", "_external");
+                                            builder.AddMudLink(0, $"https://learn.microsoft.com/dotnet/api/{linkRef}", linkRef, "docs-link docs-code docs-code-primary", "_external");
                                         }
                                         else
                                         {

--- a/src/MudBlazor.Docs/Components/ApiTypeLink.cs
+++ b/src/MudBlazor.Docs/Components/ApiTypeLink.cs
@@ -85,7 +85,7 @@ public class ApiTypeLink : ComponentBase
                     // Is this a linkable type?
                     if (!TypeName.Contains("[["))
                     {
-                        builder.AddMudLink(0, $"https://learn.microsoft.com/en-us/dotnet/api/{TypeName}", TypeFriendlyName, "docs-link docs-code docs-code-primary", "_external");
+                        builder.AddMudLink(0, $"https://learn.microsoft.com/dotnet/api/{TypeName}", TypeFriendlyName, "docs-link docs-code docs-code-primary", "_external");
                     }
                     else
                     {

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -73,7 +73,7 @@ namespace MudBlazor.Docs.Extensions
                         new CookieCategoryService
                         {
                             Identifier = "necessary",
-                            PolicyUrl = "https://privacy.microsoft.com/en-us/privacystatementy",
+                            PolicyUrl = "https://privacy.microsoft.com/privacystatementy", //This is unavailable
                             TitleText = new()
                             {
                                 ["en"] = "Azure App Service",

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -73,7 +73,7 @@ namespace MudBlazor.Docs.Extensions
                         new CookieCategoryService
                         {
                             Identifier = "necessary",
-                            PolicyUrl = "https://privacy.microsoft.com/privacystatementy", //This is unavailable
+                            PolicyUrl = "https://privacy.microsoft.com/privacystatement",
                             TitleText = new()
                             {
                                 ["en"] = "Azure App Service",

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -1,4 +1,4 @@
-﻿<!--https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reference -->
+﻿<!--https://docs.microsoft.com/visualstudio/msbuild/msbuild-reference -->
 <!--Use: dotnet msbuild -preprocess:<fileName>.xml to evaluate this project-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -51,7 +51,7 @@
                         <br>
                         In MAUI using an Android device for example, you should use <CodeInline>Accept="image/png, image/jpg"</CodeInline> rather than <CodeInline>Accept=".png, .jpg"</CodeInline>.
                         <br>
-                        Refer to the <a href="https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/file-picker?view=net-maui-8.0&tabs=android#platform-differences">MAUI docs</a> for more information.
+                        Refer to the <a href="https://learn.microsoft.com/dotnet/maui/platform-integration/storage/file-picker?view=net-maui-8.0&tabs=android#platform-differences">MAUI docs</a> for more information.
                     </MudAlert>
                 </Description>
 

--- a/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
@@ -32,9 +32,9 @@
         <DocsPageSection>
             <SectionHeader Title="EditForm Support">
                 <Description>
-                    In Blazor, form validation is usually done with EditForm in conjunction with a form model class that is decorated with <MudLink Href="https://docs.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-3.1">data annotations</MudLink>. MudBlazor's input components support
+                    In Blazor, form validation is usually done with EditForm in conjunction with a form model class that is decorated with <MudLink Href="https://docs.microsoft.com/aspnet/core/mvc/models/validation?view=aspnetcore-3.1">data annotations</MudLink>. MudBlazor's input components support
                     Blazor's form validation if you put them into a <CodeInline>&lt;EditForm&gt;</CodeInline>. The following example shows a very simple use case. If you want to learn more, please check out
-                    <MudLink Href="https://docs.microsoft.com/en-us/aspnet/core/blazor/forms-validation?view=aspnetcore-3.1">ASP.NET Core Blazor forms and validation</MudLink> on the official Blazor documentation.
+                    <MudLink Href="https://docs.microsoft.com/aspnet/core/blazor/forms-validation?view=aspnetcore-3.1">ASP.NET Core Blazor forms and validation</MudLink> on the official Blazor documentation.
                     <br /><br />
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         Note: for EditForm validation to work make sure to set <CodeInline>ButtonType="ButtonType.Submit"</CodeInline> and do not use a MudForm.

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -224,13 +224,13 @@
     <SectionHeader Title="Input Types">
         <Description>
             You can change the InputType of MudTextField to use the native browser implementation of the
-            <MudLink Href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input">HTML input element</MudLink>.
+            <MudLink Href="https://developer.mozilla.org/docs/Web/HTML/Element/input">HTML input element</MudLink>.
             Note that any Placeholder will be ignored where the browser provides a default placeholder.
             <br/>
             <br/>
             All inputs can be bound to <CodeInline>string</CodeInline> types; alternatively, input types <CodeInline>Date</CodeInline> and <CodeInline>DateTimeLocal</CodeInline>
             can be bound to a nullable <CodeInline>DateTime?</CodeInline>. When binding to a <CodeInline>DateTime?</CodeInline> you <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>yyyy-MM-dd</CodeInline> for input type <CodeInline>Date</CodeInline>, and you
-            <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
+            <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
 
         </Description>
     </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Consent/CookiePolicy.razor
+++ b/src/MudBlazor.Docs/Pages/Consent/CookiePolicy.razor
@@ -152,27 +152,27 @@
                             </MudBadge>
                             <MudBadge Class="mt-1" Color="Color.Primary" Dot="true" Origin="Origin.CenterLeft">
                                 <div class="pl-4 docs-line-height-normal">
-                                    <MudLink Href="https://support.microsoft.com/en-us/windows/microsoft-edge-browsing-data-and-privacy-bb8174ba-9d73-dcf2-9b4a-c582b4e640dd" Target="_blank">Microsoft Edge</MudLink>
+                                    <MudLink Href="https://support.microsoft.com/windows/microsoft-edge-browsing-data-and-privacy-bb8174ba-9d73-dcf2-9b4a-c582b4e640dd" Target="_blank">Microsoft Edge</MudLink>
                                 </div>
                             </MudBadge>
                             <MudBadge Class="mt-1" Color="Color.Primary" Dot="true" Origin="Origin.CenterLeft">
                                 <div class="pl-4 docs-line-height-normal">
-                                    <MudLink Href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop?redirectslug=enable-and-disable-cookies-website-preferences&redirectlocale=en-US" Target="_blank">Mozilla Firefox</MudLink>
+                                    <MudLink Href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?redirectslug=enable-and-disable-cookies-website-preferences" Target="_blank">Mozilla Firefox</MudLink>
                                 </div>
                             </MudBadge>
                             <MudBadge Class="mt-1" Color="Color.Primary" Dot="true" Origin="Origin.CenterLeft">
                                 <div class="pl-4 docs-line-height-normal">
-                                    <MudLink Href="https://support.microsoft.com/en-gb/windows/delete-and-manage-cookies-168dab11-0753-043d-7c16-ede5947fc64d" Target="_blank">Microsoft Internet Explorer</MudLink>
+                                    <MudLink Href="https://support.microsoft.com/windows/delete-and-manage-cookies-168dab11-0753-043d-7c16-ede5947fc64d" Target="_blank">Microsoft Internet Explorer</MudLink>
                                 </div>
                             </MudBadge>
                             <MudBadge Class="mt-1" Color="Color.Primary" Dot="true" Origin="Origin.CenterLeft">
                                 <div class="pl-4 docs-line-height-normal">
-                                    <MudLink Href="https://help.opera.com/en/latest/web-preferences/" Target="_blank">Opera</MudLink>
+                                    <MudLink Href="https://help.opera.com/latest/web-preferences/" Target="_blank">Opera</MudLink>
                                 </div>
                             </MudBadge>
                             <MudBadge Class="mt-1" Color="Color.Primary" Dot="true" Origin="Origin.CenterLeft">
                                 <div class="pl-4 docs-line-height-normal">
-                                    <MudLink Href="https://support.apple.com/en-gb/safari" Target="_blank">Apple Safari</MudLink>
+                                    <MudLink Href="https://support.apple.com/safari" Target="_blank">Apple Safari</MudLink>
                                 </div>
                             </MudBadge>
                         </div>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/EventUtil1Test.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/EventUtil1Test.razor
@@ -1,6 +1,6 @@
 ﻿<h3>EventUtil1Test</h3>
 <p>
-    Inspired from https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#avoid-rerendering-after-handling-events-without-state-changes
+    Inspired from https://learn.microsoft.com/aspnet/core/blazor/performance?view=aspnetcore-6.0#avoid-rerendering-after-handling-events-without-state-changes
 </p>
 <p id="clicks">
     Clicks: @NumClicks1/@NumClicks2/@NumClicks3

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -28,8 +28,8 @@ namespace MudBlazor
         /// The HTML tag rendered for this component.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button"><c>button</c></see>,
-        /// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a"><c>a</c></see> if <see cref="Href"/> is set.
+        /// Defaults to <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button"><c>button</c></see>,
+        /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a"><c>a</c></see> if <see cref="Href"/> is set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.ClickAction)]

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -9,8 +9,8 @@ namespace MudBlazor
     /// Represents a button for actions, links, and commands.
     /// </summary>
     /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
+    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
     /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
     /// </remarks>
     public partial class MudButton : MudBaseButton, IHandleEvent

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -9,8 +9,8 @@ namespace MudBlazor
     /// Represents a floating action button.
     /// </summary>
     /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
+    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
     /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
     /// </remarks>
     public partial class MudFab : MudBaseButton, IHandleEvent

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -9,8 +9,8 @@ namespace MudBlazor
     /// Represents a button consisting of an icon.
     /// </summary>
     /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
+    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
     /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
     /// </remarks>
     public partial class MudIconButton : MudBaseButton, IHandleEvent

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -8,8 +8,8 @@ namespace MudBlazor;
 /// Represents a button consisting of an icon that can be toggled between two distinct states.
 /// </summary>
 /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+/// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
+/// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
 /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
 /// </remarks>
 public partial class MudToggleIconButton : MudComponentBase

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -8,8 +8,8 @@ namespace MudBlazor;
 /// Represents a button consisting of an icon that can be toggled between two distinct states.
 /// </summary>
 /// <remarks>
-/// Creates a <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Button">button</see> element,
-/// or <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
+    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
+    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
 /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
 /// </remarks>
 public partial class MudToggleIconButton : MudComponentBase

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
         /// The format applied to numbers on the vertical axis.
         /// </summary>
         /// <remarks>
-        /// Values in this property are standard .NET format strings, such as those passed into the <c>ToString()</c> method.  For a list of common formats, see: <see href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/formatting-types" />
+        /// Values in this property are standard .NET format strings, such as those passed into the <c>ToString()</c> method.  For a list of common formats, see: <see href="https://learn.microsoft.com/dotnet/standard/base-types/formatting-types" />
         /// </remarks>
         public string YAxisFormat { get; set; }
 

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -190,7 +190,7 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>ddd, dd MMM</c>.<br />
-        /// Supported date formats can be found here: <see href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings"/>.
+        /// Supported date formats can be found here: <see href="https://learn.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
             base.BuildRenderTree(builder);
 
             // Initialize the sequence number.
-            // https://learn.microsoft.com/en-us/aspnet/core/blazor/advanced-scenarios.
+            // https://learn.microsoft.com/aspnet/core/blazor/advanced-scenarios.
             var seq = 0;
 
             // Open element.

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
@@ -64,7 +64,7 @@ public partial class MudInputAdornment
     /// The accessible name for this adornment.
     /// </summary>
     /// <remarks>
-    /// More information on accessible names can be found <see href="https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name">here</see>.
+    /// More information on accessible names can be found <see href="https://developer.mozilla.org/docs/Glossary/Accessible_name">here</see>.
     /// </remarks>
     [Parameter]
     public string AriaLabel { get; set; }

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -88,7 +88,7 @@ public partial class MudText : MudComponentBase
     /// <remarks>
     /// <para>
     /// This can be used to
-    /// <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element#text_content">
+    /// <see href="https://developer.mozilla.org/docs/Web/HTML/Element#text_content">
     /// specify the type of content for accessibility and SEO more accurately
     /// </see>.
     /// </para>

--- a/src/MudBlazor/Enums/InputMode.cs
+++ b/src/MudBlazor/Enums/InputMode.cs
@@ -9,62 +9,62 @@ namespace MudBlazor;
 /// <summary>
 /// The inputmode global attribute is an enumerated attribute that hints at the type of data that might be entered by the user while editing the element or its contents.
 /// Not supported by safari. Use Pattern to achieve special mobile keyboards in safari.
-/// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+/// https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode
 /// </summary>
 public enum InputMode
 {
     /// <summary>
     /// No virtual keyboard. For when the page implements its own keyboard input control.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#none">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#none">Reference</a>
     /// </summary>
     [Description("none")]
     none,
 
     /// <summary>
     /// Default. Standard input keyboard for the user's current locale.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#text">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#text">Reference</a>
     /// </summary>
     [Description("text")]
     text,
 
     /// <summary>
     /// Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically . or ,). Devices may or may not show a minus key (-).
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#decimal">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#decimal">Reference</a>
     /// </summary>
     [Description("decimal")]
     @decimal,
 
     /// <summary>
     /// Numeric input keyboard, but only requires the digits 0–9. Devices may or may not show a minus key.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#numeric">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#numeric">Reference</a>
     /// </summary>
     [Description("numeric")]
     numeric,
 
     /// <summary>
     /// A telephone keypad input, including the digits 0–9, the asterisk (*), and the pound (#) key. Inputs that require a telephone number should typically use &lt;input type="tel"&gt;instead.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#tel">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#tel">Reference</a>
     /// </summary>
     [Description("tel")]
     tel,
 
     /// <summary>
     /// A virtual keyboard optimized for search input. For instance, the return/submit key may be labeled “Search”, along with possible other optimizations. Inputs that require a search query should typically use &lt;input type="search"&gt; instead.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#search">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#search">Reference</a>
     /// </summary>
     [Description("search")]
     search,
 
     /// <summary>
     /// A virtual keyboard optimized for entering email addresses. Typically includes the @ character as well as other optimizations. Inputs that require email addresses should typically use &lt;input type="email"&gt; instead.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#email">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#email">Reference</a>
     /// </summary>
     [Description("email")]
     email,
 
     /// <summary>
     /// A keypad optimized for entering URLs. This may have the / key more prominent, for example. Enhanced features could include history access and so on. Inputs that require a URL should typically use &lt;input type="url"&gt; instead.
-    /// <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#url">Reference</a>
+    /// <a href="https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode#url">Reference</a>
     /// </summary>
     [Description("url")]
     url

--- a/src/MudBlazor/Themes/Models/PseudoCss.cs
+++ b/src/MudBlazor/Themes/Models/PseudoCss.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
         /// Set different scopes for the generated Theme
         /// </summary>
         /// <remarks>
-        /// Ensure you use a valid CSS scope <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/:root">Pseudo-classes Mozilla</see> for a list of valid ones
+        /// Ensure you use a valid CSS scope <see href="https://developer.mozilla.org/docs/Web/CSS/:root">Pseudo-classes Mozilla</see> for a list of valid ones
         /// Defaults to :root
         /// </remarks>
         public string Scope

--- a/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.Utilities.Clone;
 /// </summary>
 /// <remarks>
 /// This implementation is <b>not</b> trim safe.
-/// Use different strategy or use System Text Json with <see href="https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-7-0">source generator</see> and pass <see cref="JsonSerializerContext"/> of your object.
+/// Use different strategy or use System Text Json with <see href="https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-7-0">source generator</see> and pass <see cref="JsonSerializerContext"/> of your object.
 /// </remarks>
 /// <typeparam name="T">The type of the object to be deep-copied.</typeparam>
 public sealed class SystemTextJsonDeepCloneStrategy<T> : ICloneStrategy<T>

--- a/src/MudBlazor/Utilities/EventUtil.cs
+++ b/src/MudBlazor/Utilities/EventUtil.cs
@@ -11,7 +11,7 @@ namespace MudBlazor
     /// after the component's event handlers are invoked. In some cases, it might be unnecessary or
     /// undesirable to trigger a rerender after an event handler is invoked. For example, an event
     /// handler might not modify the component state.
-    /// https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#avoid-rerendering-after-handling-events-without-state-changes
+    /// https://learn.microsoft.com/aspnet/core/blazor/performance?view=aspnetcore-6.0#avoid-rerendering-after-handling-events-without-state-changes
     /// </summary>
     public static class EventUtil
     {


### PR DESCRIPTION

## Description
After a discussion in #9564 with @danielchalmers about the links redirecting to different languages, I decided to create a PR here with them all removed to see whether it would be in the best interest.

## How Has This Been Tested?
Every link has been opened after changing it to ensure no dead hits

## Type of Changes
The language preferences has been removed for all links with a "en-US", "en-GB" etc.
Fixed extra "y" in https://privacy.microsoft.com/privacystatementy