### PR TITLE
MudSelect: Fix OnKeyDown not triggered correctly for the Enter key

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -937,7 +937,7 @@ namespace MudBlazor
                             // this also closes the menu
                             await SelectOption(index);
                             break;
-                        }                     
+                        }
                     }
                     else
                     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -930,15 +930,18 @@ namespace MudBlazor
                         if (!_open)
                         {
                             await OpenMenu();
-                            return;
+                            break;
                         }
-                        // this also closes the menu
-                        await SelectOption(index);
-                        break;
+                        else
+                        {
+                            // this also closes the menu
+                            await SelectOption(index);
+                            break;
+                        }                     
                     }
                     else
                     {
-                        if (_open == false)
+                        if (!_open)
                         {
                             await OpenMenu();
                             break;


### PR DESCRIPTION
## Description
Replaced `return` with `break` to ensure method continues after opening the menu. Moved logic for selecting an option when the menu is already open into an `else` block for better readability. Made minor formatting changes for consistency.

Fixes #9594

## How Has This Been Tested?
- Created a simple component using MudSelect
- Subscribed to the "OnKeyDown" event of the MudSelect with a handler that writes a console log whenever it is triggered
- Pressed "Enter" key to verify that every "KeyDown" is logged to console

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
