### PR TITLE
MudAutocomplete: Fix search not being triggered when the text is cleared

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetValueOnEmptyText.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteResetValueOnEmptyText.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" ResetValueOnEmptyText />
+
+@code {
+    public static string __description__ = "Initial value should be shown and popup should not open.";
+
+    public int SearchCount { get; private set; }
+
+    private string value1 = "California";
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        SearchCount++;
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(50, token);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1586,7 +1586,7 @@ namespace MudBlazor.UnitTests.Components
         /// https://github.com/MudBlazor/MudBlazor/issues/9495
         /// With `ResetValueOnEmptyText`,
         /// when the input text is cleared,
-        /// then the value is setted with null and the search is called
+        /// then the value is set to null and the search func is called
         /// </summary>
         [Test]
         public void ResetValueOnEmptyText_WhenTextCleared_ThenSetNullAndTriggerSearch()

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1581,5 +1581,30 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("on");
         }
+
+        /// <summary>
+        /// https://github.com/MudBlazor/MudBlazor/issues/9495
+        /// With `ResetValueOnEmptyText`,
+        /// when the input text is cleared,
+        /// then the value is setted with null and the search is called
+        /// </summary>
+        [Test]
+        public void ResetValueOnEmptyText_WhenTextCleared_ThenSetNullAndTriggerSearch()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<AutocompleteResetValueOnEmptyText>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // Act
+
+            autocompletecomp.Find("input").Input("");
+
+            // Assert
+
+            autocomplete.Value.Should().Be(null);
+            comp.WaitForAssertion(() => comp.Instance.SearchCount.Should().Be(1));
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -680,7 +680,7 @@ namespace MudBlazor
                     // This is a fix for #1012
                     if (RuntimeLocation.IsServerSide && TextUpdateSuppression)
                     {
-                        updateText = false;
+                        //updateText = false;
                     }
                 }
                 if (updateText)

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -680,7 +680,7 @@ namespace MudBlazor
                     // This is a fix for #1012
                     if (RuntimeLocation.IsServerSide && TextUpdateSuppression)
                     {
-                        //updateText = false;
+                        updateText = false;
                     }
                 }
                 if (updateText)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -569,8 +569,6 @@ namespace MudBlazor
 
         protected override Task UpdateTextPropertyAsync(bool updateValue)
         {
-            _debounceTimer?.Dispose();
-
             // This keeps the text from being set when ClearAsync() was called
             if (_isCleared)
                 return Task.CompletedTask;


### PR DESCRIPTION
## Description

This PR fixes #9495 :
> When `ResetValueOnEmptyText` is enable and the text cleared, the search isn't called to refresh the drop down list.

## How Has This Been Tested?

I added a test to simulate the case.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
