### PR TITLE
MudTable: Cancel ServerLoad func on Dispose

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest7.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest7.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+
+<MudTable ServerData="ServerReload">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    #pragma warning disable CS1998 // async without await
+    public static string __description__ = "The server loading should be canceled when the Table is disposed.";
+    private IEnumerable<int> pagedData;
+    private int totalItems;
+
+    private async Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
+    {
+        IEnumerable<int> data = [];
+        try
+        {
+            await Task.Delay(1000, token);
+            data = new List<int>() { 1, 2, 3 };
+        }
+        catch (TaskCanceledException)
+        {
+            // ignored
+        }
+        totalItems = data.Count();
+        pagedData = data.ToArray();
+        return new TableData<int>() { TotalItems = totalItems, Items = pagedData };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1362,6 +1362,20 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The table should stop loading data when it is disposed
+        /// </summary>
+        [Test]
+        public async Task StopLoadingDataWhenDisposedTest()
+        {
+            var comp = Context.RenderComponent<TableServerSideDataTest7>();
+            var table = comp.FindComponent<MudTable<int>>();
+            table.Instance.Dispose();
+            await Task.Delay(2000);
+            var tds = comp.FindAll("td");
+            tds.Count.Should().Be(0);
+        }
+
+        /// <summary>
         /// The table should not render its NoContent fragment prior to loading server data
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -616,7 +616,11 @@ namespace MudBlazor
         [Category(CategoryTypes.Table.Data)]
         public Func<TableState, CancellationToken, Task<TableData<T>>>? ServerData { get; set; }
 
-        private void CancelToken()
+        /// <summary>
+        /// Cancel the token used by the table.
+        /// </summary>
+        /// <param name="cancellationTokenRecreated">By default, the cancellation token is recreated after it has been cancelled.</param>
+        public void CancelToken(bool cancellationTokenRecreated = true)
         {
             try
             {
@@ -625,7 +629,10 @@ namespace MudBlazor
             catch { /*ignored*/ }
             finally
             {
-                _cancellationTokenSrc = new CancellationTokenSource();
+                if (cancellationTokenRecreated)
+                {
+                    _cancellationTokenSrc = new CancellationTokenSource();
+                }
             }
         }
 

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -435,6 +435,13 @@ namespace MudBlazor
         public RenderFragment<TableGroupData<object, T>>? GroupFooterTemplate { get; set; }
 
         /// <summary>
+        /// Gives the possibility to define an external CancellationTokenSource reference. 
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Behavior)]
+        public CancellationTokenSource CancellationTokenSrc { get; set; } = new();
+
+        /// <summary>
         /// For unit testing the filtering cache mechanism.
         /// </summary>
         internal uint FilteringRunCount { get; private set; } = 0;
@@ -616,23 +623,16 @@ namespace MudBlazor
         [Category(CategoryTypes.Table.Data)]
         public Func<TableState, CancellationToken, Task<TableData<T>>>? ServerData { get; set; }
 
-        /// <summary>
-        /// Cancel the token used by the table.
-        /// </summary>
-        /// <param name="cancellationTokenRecreated">By default, the cancellation token is recreated after it has been cancelled.</param>
-        public void CancelToken(bool cancellationTokenRecreated = true)
+        private void CancelToken()
         {
             try
             {
                 _cancellationTokenSrc?.Cancel();
             }
-            catch { /*ignored*/ }
+            catch { /* ignored */ }
             finally
             {
-                if (cancellationTokenRecreated)
-                {
-                    _cancellationTokenSrc = new CancellationTokenSource();
-                }
+                _cancellationTokenSrc = CancellationTokenSource.CreateLinkedTokenSource(CancellationTokenSrc.Token);
             }
         }
 

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -435,13 +435,6 @@ namespace MudBlazor
         public RenderFragment<TableGroupData<object, T>>? GroupFooterTemplate { get; set; }
 
         /// <summary>
-        /// Gives the possibility to define an external CancellationTokenSource reference. 
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.Table.Behavior)]
-        public CancellationTokenSource CancellationTokenSrc { get; set; } = new();
-
-        /// <summary>
         /// For unit testing the filtering cache mechanism.
         /// </summary>
         internal uint FilteringRunCount { get; private set; } = 0;
@@ -629,10 +622,10 @@ namespace MudBlazor
             {
                 _cancellationTokenSrc?.Cancel();
             }
-            catch { /* ignored */ }
+            catch { /*ignored*/ }
             finally
             {
-                _cancellationTokenSrc = CancellationTokenSource.CreateLinkedTokenSource(CancellationTokenSrc.Token);
+                _cancellationTokenSrc = new CancellationTokenSource();
             }
         }
 
@@ -780,6 +773,11 @@ namespace MudBlazor
 
         protected virtual void Dispose(bool disposing)
         {
+            try
+            {
+                _cancellationTokenSrc?.Cancel();
+            }
+            catch { /*ignored*/ }
             _cancellationTokenSrc?.Dispose();
         }
     }


### PR DESCRIPTION
## Description
The aim is to implement Microsoft's recommendation : [Cancel early and avoid use-after-dispose](https://learn.microsoft.com/en-us/aspnet/core/blazor/security/server/interactive-server-side-rendering?view=aspnetcore-8.0#cancel-early-and-avoid-use-after-dispose). With this PR, it will be possible to implement the following :

```C#
@implements IDisposable

...

@code {
    private MudTable<Element> _mudTable = null!;

    private async Task<TableData<Element>> ServerReload(TableState state, CancellationToken token)
    {
        try
        {
             ...
             data = await DataService.GetDataAsync(DateTime.Now, token);
             ...
        }
        catch (TaskCanceledException)
        {
           // ignored
        }
    }

    public void Dispose()
    {
        _mudTable.Cancel(false);
    }
}
```

## How Has This Been Tested?
No requirement, as the method remains the same except that it is public and the parameter supplied defaults to the same behavior.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
