### PR TITLE
MudAutocomplete: Cancel SearchFunc on Dispose

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteContainer.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteContainer.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+<MudPopoverProvider></MudPopoverProvider>
+
+ <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1"
+    SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
+@code {
+    [Parameter] public bool HasBeenDisposed  { get; set; }
+    [Parameter] public EventCallback<bool> HasBeenDisposedChanged { get; set; }
+    private string value1 = "Alabama";
+
+    private List<string> states = new List<string>
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(2000, token);
+        }
+        catch (TaskCanceledException)
+        {
+            await HasBeenDisposedChanged.InvokeAsync(true);
+        }
+
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest8.razor
@@ -2,48 +2,11 @@
 @using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudForm>
-    <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1"
-        SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
-</MudForm>
+@if (mustBeShown)
+{
+    <AutoCompleteContainer @bind-HasBeenDisposed="@HasBeenDisposed"></AutoCompleteContainer>
+}
 @code {
-    public bool completed;
-    public CancellationTokenSource cancellationTokenSource = new();
-    public static string __description__ = "The data loading should be canceled when the Autocomplete is disposed..";
-    private string value1 = "Alabama";
-
-    private List<string> states = new List<string>
-    {
-        "Alabama", "Alaska", "American Samoa", "Arizona",
-        "Arkansas", "California", "Colorado", "Connecticut",
-        "Delaware", "District of Columbia", "Federated States of Micronesia",
-        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
-        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
-        "Louisiana", "Maine", "Marshall Islands", "Maryland",
-        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
-        "Missouri", "Montana", "Nebraska", "Nevada",
-        "New Hampshire", "New Jersey", "New Mexico", "New York",
-        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
-        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
-        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
-        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
-        "Washington", "West Virginia", "Wisconsin", "Wyoming",
-    };
-
-    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
-    {
-        try
-        {
-            token = cancellationTokenSource.Token;
-            await Task.Delay(1000, token);
-        }
-        catch (TaskCanceledException)
-        {
-            states.Clear();
-        }
-
-        if (string.IsNullOrEmpty(value))
-            return states;
-        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
-    }
+    public bool mustBeShown = true;
+    public bool HasBeenDisposed;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest8.razor
@@ -1,0 +1,49 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudForm>
+    <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1"
+        SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
+</MudForm>
+@code {
+    public bool completed;
+    public CancellationTokenSource cancellationTokenSource = new();
+    public static string __description__ = "The data loading should be canceled when the Autocomplete is disposed..";
+    private string value1 = "Alabama";
+
+    private List<string> states = new List<string>
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        try
+        {
+            token = cancellationTokenSource.Token;
+            await Task.Delay(1000, token);
+        }
+        catch (TaskCanceledException)
+        {
+            states.Clear();
+        }
+
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -15,6 +15,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
@@ -103,14 +104,15 @@ namespace MudBlazor.UnitTests.Components
         public async Task AutocompleteCancelDisposeTest()
         {
             var comp = Context.RenderComponent<AutocompleteTest8>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
-            autocompletecomp.SetParam(a => a.Text, "Alabama");
+            var autocompleteContainerComp = comp.FindComponent<AutoCompleteContainer>();
+            var autocompleteComp = autocompleteContainerComp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComp.SetParam(a => a.Text, "Alabama");
             await Task.Delay(500);
-            comp.Instance.cancellationTokenSource.Cancel();
-            await Task.Delay(1000);
-            var items = comp.FindAll(".mud-list-item-text");
-            items.Count.Should().Be(0);
+            comp.Instance.mustBeShown = false;
+            await Task.Delay(500);
+            comp.Render();
+            await Task.Delay(500);
+            comp.Instance.HasBeenDisposed.Should().Be(true);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -97,6 +97,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The autocomplete should stop loading data when it is disposed
+        /// </summary>
+        [Test]
+        public async Task AutocompleteCancelDisposeTest()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest8>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
+            autocompletecomp.SetParam(a => a.Text, "Alabama");
+            await Task.Delay(500);
+            comp.Instance.cancellationTokenSource.Cancel();
+            await Task.Delay(1000);
+            var items = comp.FindAll(".mud-list-item-text");
+            items.Count.Should().Be(0);
+        }
+
+        /// <summary>
         /// Autocomplete id should propagate to label for attribute
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -992,6 +992,11 @@ namespace MudBlazor
             {
                 try
                 {
+                    _cancellationTokenSrc?.Cancel();
+                }
+                catch { /*ignored*/ }
+                try
+                {
                     _cancellationTokenSrc.Dispose();
                 }
                 catch { /*ignored*/ }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -992,7 +992,7 @@ namespace MudBlazor
             {
                 try
                 {
-                    _cancellationTokenSrc?.Cancel();
+                    _cancellationTokenSrc.Cancel();
                 }
                 catch { /*ignored*/ }
                 try


### PR DESCRIPTION
## Description
The aim is to implement Microsoft's recommendation : [Cancel early and avoid use-after-dispose](https://learn.microsoft.com/en-us/aspnet/core/blazor/security/server/interactive-server-side-rendering?view=aspnetcore-8.0#cancel-early-and-avoid-use-after-dispose). This logic is totally internal, and the user need not be aware of it.

## How Has This Been Tested?
No requirement, as the method/logic remains the same .

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.