### PR TITLE
MudField: Text overflow ellipsis for labels

### DIFF
--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -91,6 +91,11 @@ label.mud-input-label.mud-input-label-inputcontrol {
     transform-origin: top right;
   }
 
+  .mud-input-label-inputcontrol {
+    left: unset;
+    right: 0;
+  }
+
   .mud-input-label-shrink {
     transform-origin: top right;
   }

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -1,6 +1,10 @@
 .mud-input-label {
   display: block;
   transform-origin: top left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .mud-input-label-inputcontrol {
@@ -26,6 +30,7 @@
 .mud-input-label-filled {
   z-index: 1;
   transform: translate(12px, 20px) scale(1);
+  max-width: calc(100% - 12px);
   pointer-events: none;
 
   &.mud-input-label-margin-dense {
@@ -36,6 +41,7 @@
 
 .mud-input-label-outlined {
   transform: translate(14px, 20px) scale(1);
+  max-width: calc(100% - 14px);
   pointer-events: none;
   background-color: var(--mud-palette-surface);
   padding: 0px 5px !important;
@@ -62,6 +68,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
     &.mud-input-label-filled {
       transform: translate(12px, 10px) scale(0.75);
+      max-width: calc(100% - 12px);
 
       &.mud-input-label-margin-dense {
         transform: translate(12px, 7px) scale(0.75);
@@ -70,6 +77,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
     &.mud-input-label-outlined {
       transform: translate(14px, -6px) scale(0.75);
+      max-width: calc(100% - 14px);
     }
   }
 
@@ -81,11 +89,6 @@ label.mud-input-label.mud-input-label-inputcontrol {
 .mud-application-layout-rtl {
   .mud-input-label {
     transform-origin: top right;
-  }
-
-  .mud-input-label-inputcontrol {
-    left: unset;
-    right: 0;
   }
 
   .mud-input-label-shrink {


### PR DESCRIPTION

## Description
Fixes: #9574
As proposed in #9574, field label styles to prevent text overflow and text wrap. instead does ellipsis. Tested locally and seems to work okay.

Before:
![image](https://github.com/user-attachments/assets/f9d4a6d7-f218-4875-a4c8-b175b0712f05)
![image](https://github.com/user-attachments/assets/418ed6bc-2401-44c5-84cb-83a60329d27e)


After:
![image](https://github.com/user-attachments/assets/19b36c11-6f9d-4aed-a8ec-5746c6ea630c)
![image](https://github.com/user-attachments/assets/c4987bff-7f18-4836-aabe-ce69157ffc05)
![image](https://github.com/user-attachments/assets/d84e2f5f-ee35-4820-93f3-40b1c100ef56)


## How Has This Been Tested?
Visually tested on different docs pages.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
