### PR TITLE
MudRadioGroup: Bind after should not trigger when value is modified externally

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudRadioGroup @bind-Value="@option">
+<MudRadioGroup @bind-Value="@option" @bind-Value:after="BindAfter">
     <MudRadio Value="@("1")" />
     <MudRadio Value="@("2")" />
     <MudRadio Value="@("3")" />
@@ -17,4 +17,7 @@
     {
         option = null;
     }
+
+    private void BindAfter() => BindAfterCount++;
+    public int BindAfterCount { get; private set; }
 }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -212,12 +212,12 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             var inputs = comp.FindAll("input").ToArray();
-            
+
             //Value should change on radio click and bind after should fire
             inputs[1].Click();
             group.Instance.Value.Should().Be("2");
             comp.Instance.BindAfterCount.Should().Be(1);
-            
+
             //Value should change when reset via the button, but bind after should NOT fire
             comp.Find("button").Click();
             group.Instance.Value.Should().Be(null);

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -206,6 +206,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void RadioTest_BindAfter()
+        {
+            var comp = Context.RenderComponent<RadioGroupTest5>();
+            // select elements needed for the test
+            var group = comp.FindComponent<MudRadioGroup<string>>();
+            var inputs = comp.FindAll("input").ToArray();
+            
+            //Value should change on radio click and bind after should fire
+            inputs[1].Click();
+            group.Instance.Value.Should().Be("2");
+            comp.Instance.BindAfterCount.Should().Be(1);
+            
+            //Value should change when reset via the button, but bind after should NOT fire
+            comp.Find("button").Click();
+            group.Instance.Value.Should().Be(null);
+            comp.Instance.BindAfterCount.Should().Be(1);
+        }
+
+        [Test]
         public void RadioTest_KeyboardInput()
         {
             var comp = Context.RenderComponent<RadioGroupTest1>();

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -74,7 +74,7 @@ namespace MudBlazor
         public T? Value
         {
             get => _value;
-            set => SetSelectedOptionAsync(value, true).CatchAndLog();
+            set => SetSelectedOptionAsync(value, true, updateValue: false).CatchAndLog();
         }
 
         [Parameter]
@@ -84,7 +84,7 @@ namespace MudBlazor
 
         internal bool GetReadOnlyState() => ReadOnly || ParentReadOnly; //internal because the MudRadio reads this value directly
 
-        protected async Task SetSelectedOptionAsync(T? option, bool updateRadio)
+        protected async Task SetSelectedOptionAsync(T? option, bool updateRadio, bool updateValue = true)
         {
             if (!OptionEquals(_value, option))
             {
@@ -96,7 +96,8 @@ namespace MudBlazor
                     await SetSelectedRadioAsync(radio, false);
                 }
 
-                await ValueChanged.InvokeAsync(_value);
+                if (updateValue)
+                    await ValueChanged.InvokeAsync(_value);
 
                 await BeginValidateAsync();
                 FieldChanged(_value);


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

When a `RadioGroup`'s value is set outside of the component, it will trigger its `ValueChanged` callback, which in turn will trigger `bind-after`, even though the value was not modified by the component. This is undesired and leads to odd looping behavior.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
