### PR TITLE
MudBaseButton: Stop activation of `IActivatable` components when `ClickPropagation` is disabled

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonActivationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonActivationTest.razor
@@ -1,0 +1,13 @@
+<DummyActivatable>
+    <MudFab id="fab-button"
+            ClickPropagation="@ClickPropagation" />
+    <MudButton id="button-button"
+               ClickPropagation="@ClickPropagation" />
+    <MudIconButton id="icon-button"
+                   Icon="Icon.Material.Filled.Add" ClickPropagation="@ClickPropagation" />
+</DummyActivatable>
+
+@code {
+    [Parameter]
+    public bool ClickPropagation { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor
@@ -1,0 +1,7 @@
+@using MudBlazor.Interfaces
+@namespace MudBlazor.UnitTests
+
+<CascadingValue Value="@((IActivatable)this)"
+                IsFixed="true">
+    @ChildContent
+</CascadingValue>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/DummyActivatable.razor.cs
@@ -1,0 +1,19 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Interfaces;
+
+namespace MudBlazor.UnitTests;
+
+public partial class DummyActivatable : ComponentBase, IActivatable
+{
+#nullable enable
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    public int ActivationCount { get; private set; }
+
+    public void Activate(object activator, MouseEventArgs args) => ActivationCount++;
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -58,7 +58,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup
                 .Should()
                 .Contain("rel=\"noopener\"");
-            //it is an anchor and not contains stopPropagation 
+            //it is an anchor and not contains stopPropagation
             comp.Markup
                 .Replace(" ", string.Empty)
                 .Should()
@@ -479,6 +479,40 @@ namespace MudBlazor.UnitTests.Components
             alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
             await comp.InvokeAsync(comp.Instance.Recover);
             alertTextFunc.Should().Throw<ComponentNotFoundException>();
+        }
+
+        [Test]
+        public void Buttons_should_activate_parent_activatables_when_click_propagation_is_enabled()
+        {
+            var comp = Context.RenderComponent<ButtonActivationTest>(parameters => parameters
+                .Add(param => param.ClickPropagation, true));
+            var dummyActivatable = comp.FindComponent<DummyActivatable>();
+
+            comp.Find("#fab-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(1);
+
+            comp.Find("#button-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(2);
+
+            comp.Find("#icon-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(3);
+        }
+
+        [Test]
+        public void Buttons_should_not_activate_parent_activatables_when_click_propagation_is_disabled()
+        {
+            var comp = Context.RenderComponent<ButtonActivationTest>(parameters => parameters
+                .Add(param => param.ClickPropagation, false));
+            var dummyActivatable = comp.FindComponent<DummyActivatable>();
+
+            comp.Find("#fab-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(0);
+
+            comp.Find("#button-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(0);
+
+            comp.Find("#icon-button").Click();
+            dummyActivatable.Instance.ActivationCount.Should().Be(0);
         }
     }
 }

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -128,7 +128,12 @@ namespace MudBlazor
             if (GetDisabledState())
                 return;
             await OnClick.InvokeAsync(ev);
-            Activatable?.Activate(this, ev);
+
+            // Don't activate activatable parents if click propagation is disabled
+            if (ClickPropagation)
+            {
+                Activatable?.Activate(this, ev);
+            }
         }
 
         protected override void OnInitialized()


### PR DESCRIPTION
## Description

Thanks to the discussion in #9596 I found out that `MudBaseButton` triggers `IActivatable` cascading values when it is clicked. While the use case for `MudFileUpload` described in the mentioned issue isn't necessarily valid, I still think buttons should only trigger activation if `ClickPropagation` is enabled.

Note that by default `ClickPropagation` is false when the `MudBaseButton` inheritor uses the `HtmlTag`, implying it already has a custom action associated with it.

## How Has This Been Tested?
Visually + bunit tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
