### PR TITLE
Build: Downgrade Microsoft.CodeAnalysis.CSharp

### DIFF
--- a/src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj
+++ b/src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj
@@ -8,7 +8,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
+++ b/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
@@ -32,7 +32,9 @@ namespace MudBlazor.Analyzers
         public static readonly DiagnosticDescriptor ParameterDescriptor = new(DiagnosticId1, _title, _parameterMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _description, helpLinkUri: _url.ToString());
         public static readonly DiagnosticDescriptor AttributeDescriptor = new(DiagnosticId2, _title, _attributeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _description, helpLinkUri: _url.ToString());
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get => [ParameterDescriptor, AttributeDescriptor]; }
+        private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = new[] { ParameterDescriptor, AttributeDescriptor }.ToImmutableArray();
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj
+++ b/src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Downgrade `Microsoft.CodeAnalysis.CSharp` to `4.7.0`. This is the lowest possible version. We are using some APIs which are only available since `4.7.0`.
See comment: https://github.com/MudBlazor/MudBlazor/pull/9243#issuecomment-2284476358
