### PR TITLE
Performance: Reduce memory allocation in CssBuilder and StyleBuilder by using StringBuilderCache

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -42,6 +42,27 @@ namespace UtilityTests
         }
 
         [Test]
+        public void CssBuilder_And_StyleBuilder_Used_Together_Do_Not_Interfere()
+        {
+            // Arrange
+            var cssValue = "test-class";
+            var stylsProp = "color";
+            var styleValue = "red";
+
+            // Act
+            var cssBuilder = new CssBuilder();
+            var styleBuilder = new StyleBuilder();
+            cssBuilder.AddClass(cssValue);
+            styleBuilder.AddStyle(stylsProp, styleValue);
+            var css = cssBuilder.Build();
+            var style = styleBuilder.Build();
+
+            // Assert
+            style.Should().Be("color:red;");
+            css.Should().Be("test-class");
+        }
+
+        [Test]
         public void Empty_Returns_Instance_With_Empty_Value()
         {
             // Act

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.Utilities
     /// </summary>
     public struct CssBuilder
     {
-        private StringBuilder? _stringBuilder;
+        private StringBuilder _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of CssBuilder with the specified initial value.

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -2,8 +2,7 @@
 // License: MIT
 // See https://github.com/EdCharbeneau
 
-using System;
-using System.Collections.Generic;
+using System.Text;
 
 namespace MudBlazor.Utilities
 {
@@ -13,7 +12,7 @@ namespace MudBlazor.Utilities
     /// </summary>
     public struct CssBuilder
     {
-        private string? _stringBuffer;
+        private StringBuilder? _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of CssBuilder with the specified initial value.
@@ -35,6 +34,16 @@ namespace MudBlazor.Utilities
         public static CssBuilder Empty() => new();
 
         /// <summary>
+        /// Creates an empty instance of CssBuilder.
+        /// </summary>
+        /// <remarks>
+        /// Call <see cref="Build"/> to return the completed CSS classes as a string. 
+        /// </remarks>
+        /// <returns>The <see cref="CssBuilder"/> instance.</returns>
+        public CssBuilder() : this(null)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the CssBuilder class with the specified initial value.
         /// </summary>
         /// <remarks>
@@ -42,7 +51,14 @@ namespace MudBlazor.Utilities
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
-        public CssBuilder(string? value) => _stringBuffer = value;
+        public CssBuilder(string? value)
+        {
+            _stringBuilder = StringBuilderCache.Acquire();
+            if (value is not null)
+            {
+                _stringBuilder.Append(value);
+            }
+        }
 
         /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next class or value added to the builder.
@@ -51,7 +67,11 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddValue(string? value)
         {
-            _stringBuffer += value;
+            _stringBuilder ??= StringBuilderCache.Acquire();
+            if (value is not null)
+            {
+                _stringBuilder.Append(value);
+            }
             return this;
         }
 
@@ -60,7 +80,12 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="value">The CSS class to add.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
-        public CssBuilder AddClass(string? value) => AddValue(" " + value);
+        public CssBuilder AddClass(string? value)
+        {
+            AddValue(" ");
+            AddValue(value);
+            return this;
+        }
 
         /// <summary>
         /// Adds a conditional CSS class to the builder with a space separator.
@@ -137,11 +162,7 @@ namespace MudBlazor.Utilities
         /// Finalizes the completed CSS classes as a string.
         /// </summary>
         /// <returns>The string representation of the CSS classes.</returns>
-        public string Build()
-        {
-            // String buffer finalization code
-            return _stringBuffer is not null ? _stringBuffer.Trim() : string.Empty;
-        }
+        public string Build() => StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
 
         // ToString should only and always call Build to finalize the rendered string.
         /// <inheritdoc />

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -40,8 +40,10 @@ namespace MudBlazor.Utilities
         /// Call <see cref="Build"/> to return the completed CSS classes as a string. 
         /// </remarks>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
-        public CssBuilder() : this(null)
-        { }
+        public CssBuilder()
+        {
+            _stringBuilder = StringBuilderCache.Acquire();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CssBuilder class with the specified initial value.
@@ -51,9 +53,8 @@ namespace MudBlazor.Utilities
         /// </remarks>
         /// <param name="value">The initial CSS class value.</param>
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
-        public CssBuilder(string? value)
+        public CssBuilder(string? value) : this()
         {
-            _stringBuilder = StringBuilderCache.Acquire();
             if (value is not null)
             {
                 _stringBuilder.Append(value);
@@ -67,7 +68,6 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddValue(string? value)
         {
-            _stringBuilder ??= StringBuilderCache.Acquire();
             if (value is not null)
             {
                 _stringBuilder.Append(value);

--- a/src/MudBlazor/Utilities/StringBuilderCache.cs
+++ b/src/MudBlazor/Utilities/StringBuilderCache.cs
@@ -31,36 +31,6 @@
 **            cache and return the resulting string
 **
 ===========================================================*/
-/*============================================================
-**
-** Class:  StringBuilderCache
-**
-** Purpose: provide a cached reusable instance of stringbuilder
-**          per thread  it's an optimisation that reduces the 
-**          number of instances constructed and collected.
-**
-**  Acquire - is used to get a string builder to use of a 
-**            particular size.  It can be called any number of 
-**            times, if a stringbuilder is in the cache then
-**            it will be returned and the cache emptied.
-**            subsequent calls will return a new stringbuilder.
-**
-**            A StringBuilder instance is cached in 
-**            Thread Local Storage and so there is one per thread
-**
-**  Release - Place the specified builder in the cache if it is 
-**            not too big.
-**            The stringbuilder should not be used after it has 
-**            been released.
-**            Unbalanced Releases are perfectly acceptable.  It
-**            will merely cause the runtime to create a new 
-**            stringbuilder next time Acquire is called.
-**
-**  GetStringAndRelease
-**          - ToString() the stringbuilder, Release it to the 
-**            cache and return the resulting string
-**
-===========================================================*/
 
 namespace System.Text
 {

--- a/src/MudBlazor/Utilities/StringBuilderCache.cs
+++ b/src/MudBlazor/Utilities/StringBuilderCache.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// License: MIT
+// See https://github.com/microsoft/referencesource/blob/master/mscorlib/system/text/stringbuildercache.cs
+/*============================================================
+**
+** Class:  StringBuilderCache
+**
+** Purpose: provide a cached reusable instance of stringbuilder
+**          per thread  it's an optimisation that reduces the 
+**          number of instances constructed and collected.
+**
+**  Acquire - is used to get a string builder to use of a 
+**            particular size.  It can be called any number of 
+**            times, if a stringbuilder is in the cache then
+**            it will be returned and the cache emptied.
+**            subsequent calls will return a new stringbuilder.
+**
+**            A StringBuilder instance is cached in 
+**            Thread Local Storage and so there is one per thread
+**
+**  Release - Place the specified builder in the cache if it is 
+**            not too big.
+**            The stringbuilder should not be used after it has 
+**            been released.
+**            Unbalanced Releases are perfectly acceptable.  It
+**            will merely cause the runtime to create a new 
+**            stringbuilder next time Acquire is called.
+**
+**  GetStringAndRelease
+**          - ToString() the stringbuilder, Release it to the 
+**            cache and return the resulting string
+**
+===========================================================*/
+/*============================================================
+**
+** Class:  StringBuilderCache
+**
+** Purpose: provide a cached reusable instance of stringbuilder
+**          per thread  it's an optimisation that reduces the 
+**          number of instances constructed and collected.
+**
+**  Acquire - is used to get a string builder to use of a 
+**            particular size.  It can be called any number of 
+**            times, if a stringbuilder is in the cache then
+**            it will be returned and the cache emptied.
+**            subsequent calls will return a new stringbuilder.
+**
+**            A StringBuilder instance is cached in 
+**            Thread Local Storage and so there is one per thread
+**
+**  Release - Place the specified builder in the cache if it is 
+**            not too big.
+**            The stringbuilder should not be used after it has 
+**            been released.
+**            Unbalanced Releases are perfectly acceptable.  It
+**            will merely cause the runtime to create a new 
+**            stringbuilder next time Acquire is called.
+**
+**  GetStringAndRelease
+**          - ToString() the stringbuilder, Release it to the 
+**            cache and return the resulting string
+**
+===========================================================*/
+
+namespace System.Text
+{
+    internal static class StringBuilderCache
+    {
+        // The value 360 was chosen in discussion with performance experts as a compromise between using
+        // as litle memory (per thread) as possible and still covering a large part of short-lived
+        // StringBuilder creations on the startup path of VS designers.
+        private const int MaxBuilderSize = 360;
+
+        [ThreadStatic]
+        private static StringBuilder _cachedInstance;
+
+        public static StringBuilder Acquire(int capacity = MaxBuilderSize)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                var sb = _cachedInstance;
+                if (sb is not null)
+                {
+                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // when the requested size is larger than the current capacity
+                    if (capacity <= sb.Capacity)
+                    {
+                        _cachedInstance = null;
+                        sb.Clear();
+                        return sb;
+                    }
+                }
+            }
+            return new StringBuilder(capacity);
+        }
+
+        public static void Release(StringBuilder sb)
+        {
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                _cachedInstance = sb;
+            }
+        }
+
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            var result = sb.ToString();
+            Release(sb);
+            return result;
+        }
+    }
+}

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace MudBlazor.Utilities
 {
@@ -13,7 +14,7 @@ namespace MudBlazor.Utilities
     /// </summary>
     public struct StyleBuilder
     {
-        private string? _stringBuffer;
+        private StringBuilder _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of StyleBuilder with the specified property and value.
@@ -46,6 +47,18 @@ namespace MudBlazor.Utilities
         public static StyleBuilder Empty() => new();
 
         /// <summary>
+        /// Creates an empty instance of StyleBuilder.
+        /// </summary>
+        /// <remarks>
+        /// Call <see cref="Build"/>> to return the completed style as a string.
+        /// </remarks>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder()
+        {
+            _stringBuilder = StringBuilderCache.Acquire();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the StyleBuilder class with the specified property and value.
         /// </summary>
         /// <remarks>
@@ -54,7 +67,11 @@ namespace MudBlazor.Utilities
         /// <param name="prop">The CSS property.</param>
         /// <param name="value">The value of the property.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder(string prop, string value) => _stringBuffer = $"{prop}:{value};";
+        public StyleBuilder(string prop, string value) : this() =>
+            _stringBuilder
+                .Append(prop)
+                .Append(':')
+                .Append(value);
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
@@ -86,7 +103,21 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         private StyleBuilder AddRaw(string? style)
         {
-            _stringBuffer += style;
+            if (style is not null)
+            {
+                _stringBuilder.Append(style);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a raw char to the builder to the builder.
+        /// </summary>
+        /// <param name="c">The character to add.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        private StyleBuilder AddRaw(char c)
+        {
+            _stringBuilder.Append(c);
             return this;
         }
 
@@ -96,7 +127,10 @@ namespace MudBlazor.Utilities
         /// <param name="prop">The CSS property.</param>
         /// <param name="value">The value of the property.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string prop, string? value) => AddRaw($"{prop}:{value};");
+        public StyleBuilder AddStyle(string prop, string? value) =>
+            AddRaw(prop)
+            .AddRaw(':')
+            .AddRaw(value);
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
@@ -195,7 +229,7 @@ namespace MudBlazor.Utilities
         public string Build()
         {
             // String buffer finalization code
-            return _stringBuffer is not null ? _stringBuffer.Trim() : string.Empty;
+            return StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
         }
 
         // ToString should only and always call Build to finalize the rendered string.

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -71,7 +71,8 @@ namespace MudBlazor.Utilities
             _stringBuilder
                 .Append(prop)
                 .Append(':')
-                .Append(value);
+                .Append(value)
+                .Append(';');
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -79,7 +79,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         /// <param name="style">The style to add.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw($"{style};") : this;
+        public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw(style).AddRaw(';') : this;
 
         /// <summary>
         /// Adds a conditional style to the builder with a space separator and closing semicolon.

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -131,7 +131,8 @@ namespace MudBlazor.Utilities
         public StyleBuilder AddStyle(string prop, string? value) =>
             AddRaw(prop)
             .AddRaw(':')
-            .AddRaw(value);
+            .AddRaw(value)
+            .AddRaw(';');
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.


### PR DESCRIPTION
## Description
As memory allocation by building strings without a StringBuilder and the CssBuilder and StyleBuilder is heavy used, using a StringBuilder in those classes seems to be good for the performance. And to even improve the performance, the StringBuilderCache as also used by Microsoft (https://github.com/microsoft/referencesource/blob/master/mscorlib/system/text/stringbuildercache.cs) adds even more performance as the StringBuilder is reused if the capacity does not increase above the default capacity.

## How Has This Been Tested?
There are already CssBuilderTests which cover the StyleBuilder and CssBuilder.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
