### PR TITLE
MudDataGrid : Fix Resize column when neighboring is hidden

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHideAndResizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHideAndResizeTest.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPopoverProvider />
+
+<MudDataGrid T="Model" Items="@_items" Dense ColumnResizeMode="ResizeMode.Column" Hideable>
+    <Columns>
+        <PropertyColumn Property="x => x.Column1" />
+        <PropertyColumn Property="x => x.Column2" />
+        <PropertyColumn Property="x => x.Column3" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>();
+
+    public record Model(string Column1, string Column2, string Column3);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4337,6 +4337,44 @@ namespace MudBlazor.UnitTests.Components
             cells[28].TextContent.Should().Be("Calcium"); cells[29].TextContent.Should().Be("20");
         }
 
+        /// <summary>
+        /// Reproduce the bug from https://github.com/MudBlazor/MudBlazor/issues/9585
+        /// When a column is hiden by the menu and the precedent column is resized, then the app crash
+        /// </summary>
+        [Test]
+        public void DataGrid_ResizeColumn_WhenNeighboringColumnIsHidden()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<DataGridHideAndResizeTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHideAndResizeTest.Model>>();
+            var columns = dataGrid.FindComponents<Column<DataGridHideAndResizeTest.Model>>();
+
+            columns.Count.Should().Be(3);
+
+            var dg = dataGrid.Instance;
+
+            // Act
+
+            var columnMenu = comp.FindAll("th .mud-menu button").ElementAt(1);
+            columnMenu.Click();
+
+            comp.WaitForAssertion(() => comp.FindAll(".mud-list-item").ElementAt(1));
+            var hideMenuItem = comp.FindAll(".mud-list-item").ElementAt(1);
+            hideMenuItem.Click();
+
+            // Assert
+
+            var ddd = comp.Markup;
+            comp.FindAll("th").Count.Should().Be(2);
+
+            // Act
+
+            var resizer = comp.FindAll(".mud-resizer").ElementAt(0);
+            resizer.PointerDown();
+            resizer.MouseMove(10, 0);
+        }
+
         [Test]
         public void QueryFilterExtensionTest()
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4357,8 +4357,8 @@ namespace MudBlazor.UnitTests.Components
 
             // Mock mudElementRef.getBoundingClientRect for DataGrid and visible columns
             var gridElement = (ElementReference)dgComp.Instance.GetType()
-                .GetField("_gridElement", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(dgComp.Instance);
+                .GetField("_gridElement", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(dgComp.Instance)!;
             Context.JSInterop
               .Setup<Interop.BoundingClientRect>("mudElementRef.getBoundingClientRect", gridElement)
               .SetResult(new Interop.BoundingClientRect { Width = 50 });
@@ -4369,8 +4369,8 @@ namespace MudBlazor.UnitTests.Components
                 if (!col.Column.HiddenState.Value)
                 {
                     var headerElement = (ElementReference)col.GetType()
-                        .GetField("_headerElement", BindingFlags.NonPublic | BindingFlags.Instance)
-                        .GetValue(col);
+                        .GetField("_headerElement", BindingFlags.NonPublic | BindingFlags.Instance)!
+                        .GetValue(col)!;
                     Context.JSInterop
                         .Setup<Interop.BoundingClientRect>("mudElementRef.getBoundingClientRect", headerElement)
                         .SetResult(new Interop.BoundingClientRect { Width = 50 });
@@ -4385,12 +4385,12 @@ namespace MudBlazor.UnitTests.Components
             var resizeService = dgComp.Instance.ResizeService;
             var resizeServiceType = resizeService.GetType();
             var eventListener = (EventListener)resizeServiceType
-                .GetField("_eventListener", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetField("_eventListener", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .GetValue(resizeService);
             var upEventId = (Guid)resizeServiceType
-                .GetField("_pointerUpSubscriptionId", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(resizeService);
-            await comp.InvokeAsync(async () => await eventListener.OnEventOccur(upEventId, """{"ClientX":-10}"""));
+                .GetField("_pointerUpSubscriptionId", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(resizeService)!;
+            await comp.InvokeAsync(async () => await eventListener!.OnEventOccur(upEventId, """{"ClientX":-10}"""));
 
             // Assert
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4344,31 +4344,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DataGrid_HideColumn()
-        {
-            // Arrange : Init a datagrid with 3 columns
-
-            var comp = Context.RenderComponent<DataGridHideAndResizeTest>();
-            comp.FindAll("th").Count.Should().Be(3);
-
-            // Act : Hide 1 column
-
-            // Open column menu
-            var columnMenu = comp.FindAll("th .mud-menu button").ElementAt(1);
-            columnMenu.Click();
-            // Wait the context menu is opened
-            comp.WaitForAssertion(() => comp.FindAll(".mud-list-item").Should().NotBeNullOrEmpty());
-            // Click on 'Hide' menu item
-            var hideMenuItem = comp.FindAll(".mud-list-item").ElementAt(1);
-            hideMenuItem.InnerHtml.Contains("Hidde");
-            hideMenuItem.Click();
-
-            // Assert : Check only 2 columns are displayed
-
-            comp.FindAll("th").Count.Should().Be(2);
-        }
-
-        [Test]
         public async Task DataGrid_ResizeColumn()
         {
             // Arrange : Init a datagrid with 3 columns
@@ -4378,19 +4353,24 @@ namespace MudBlazor.UnitTests.Components
                 .SetResult(new Interop.BoundingClientRect { Width = 50 });
             var comp = Context.RenderComponent<DataGridHideAndResizeTest>();
             var dgComp = comp.FindComponent<MudDataGrid<DataGridHideAndResizeTest.Model>>();
+
+            // Assert
+
             {
-                // At init, <th> elements haven't width
                 var thElements = comp.FindAll("th");
-                thElements.Should().NotContain(e => e.GetStyle().Any(cssProp => cssProp.Name == "width"));
+                thElements.Should().NotContain(
+                    e => e.GetStyle().Any(cssProp => cssProp.Name == "width"),
+                    "At init, <th> elements haven't width"
+                );
             }
 
             // Act : Resize the column
 
-            // Mouse click down
+            // Press mouse bouton over resizer
             var resizer = comp.FindAll(".mud-resizer").ElementAt(0);
             await comp.InvokeAsync(async () => resizer.PointerDown());
 
-            // Mouse move and release
+            // Move the mouse and release button
             var resizeService = dgComp.Instance.ResizeService;
             var resizeServiceType = resizeService.GetType();
             var eventListener = (EventListener)resizeServiceType
@@ -4402,10 +4382,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await eventListener.OnEventOccur(upEventId, """{"ClientX":-10}"""));
 
             // Assert
+
             {
-                // Check the first column is resized (50 - 10 = 40)
                 var thElement = comp.Find("th");
-                thElement.GetStyle().Should().Contain(cssProp => cssProp.Name == "width" && cssProp.Value == "40px");
+                thElement.GetStyle().Should().Contain(
+                    cssProp => cssProp.Name == "width" && cssProp.Value == "40px",
+                    "First column is resized to 40 (50-10)"
+                );
             }
         }
 
@@ -4426,14 +4409,13 @@ namespace MudBlazor.UnitTests.Components
 
             // Act : Hide the middle column and resize the first column
 
-            // Open column menu
+            // Open column the second column header menu
             var columnMenu = comp.FindAll("th .mud-menu button").ElementAt(1);
             columnMenu.Click();
 
-            // Click on 'Hide' menu item
+            // Click on the menu item 'Hide'
             comp.WaitForAssertion(() => comp.FindAll(".mud-list-item").ElementAt(1));
             var hideMenuItem = comp.FindAll(".mud-list-item").ElementAt(1);
-            hideMenuItem.InnerHtml.Contains("Hidde");
             hideMenuItem.Click();
 
             // Mouse click down
@@ -4453,11 +4435,8 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert
 
-            // Two columns are displayed
-            comp.FindAll("th").Count.Should().Be(2);
-            // The first column is resized
-            var thElement = comp.Find("th");
-            thElement.GetStyle().Should().Contain(cssProp => cssProp.Name == "width");
+            comp.FindAll("th").Count.Should().Be(2, "Two columns are displayed");
+            comp.Find("th").GetStyle().Should().Contain(cssProp => cssProp.Name == "width", "The first column is resized");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4363,10 +4363,10 @@ namespace MudBlazor.UnitTests.Components
               .Setup<Interop.BoundingClientRect>("mudElementRef.getBoundingClientRect", gridElement)
               .SetResult(new Interop.BoundingClientRect { Width = 50 });
             var colComps = comp.FindComponents<HeaderCell<DataGridHideAndResizeTest.Model>>();
-            foreach(var colComp in colComps)
+            foreach (var colComp in colComps)
             {
                 var col = colComp.Instance;
-                if(!col.Column.HiddenState.Value)
+                if (!col.Column.HiddenState.Value)
                 {
                     var headerElement = (ElementReference)col.GetType()
                         .GetField("_headerElement", BindingFlags.NonPublic | BindingFlags.Instance)

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -14,7 +14,9 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Interfaces;
+using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.Utilities.Clone;
 using NUnit.Framework;
@@ -4346,33 +4348,35 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
+            Context.JSInterop
+                .Setup<Interop.BoundingClientRect>()
+                .SetResult(new Interop.BoundingClientRect());
             var comp = Context.RenderComponent<DataGridHideAndResizeTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHideAndResizeTest.Model>>();
-            var columns = dataGrid.FindComponents<Column<DataGridHideAndResizeTest.Model>>();
-
-            columns.Count.Should().Be(3);
-
-            var dg = dataGrid.Instance;
+            comp.FindAll("th").Count.Should().Be(3);
 
             // Act
 
+            // Open column menu
             var columnMenu = comp.FindAll("th .mud-menu button").ElementAt(1);
             columnMenu.Click();
 
+            // Click on 'Hide' menu item
             comp.WaitForAssertion(() => comp.FindAll(".mud-list-item").ElementAt(1));
             var hideMenuItem = comp.FindAll(".mud-list-item").ElementAt(1);
+            hideMenuItem.InnerHtml.Contains("Hidde");
             hideMenuItem.Click();
+
 
             // Assert
 
-            var ddd = comp.Markup;
             comp.FindAll("th").Count.Should().Be(2);
 
             // Act
 
             var resizer = comp.FindAll(".mud-resizer").ElementAt(0);
             resizer.PointerDown();
-            resizer.MouseMove(10, 0);
+            // TODO : Move move
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -54,7 +54,7 @@ namespace MudBlazor
                 if (headerCell.Column is not null)
                 {
                     var nextResizableColumn = columns.Skip(columns.IndexOf(headerCell.Column) + (rightToLeft ? -1 : 1))
-                        .FirstOrDefault(c => (c.Resizable ?? true) && !c.Hidden);
+                        .FirstOrDefault(c => (c.Resizable ?? true) && !c.HiddenState.Value);
                     if (nextResizableColumn == null)
                         return false;
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1202,7 +1202,7 @@ namespace MudBlazor
         {
             get
             {
-                return RenderedColumns.Any(x => !x.Hidden && (x.FooterTemplate != null || x.AggregateDefinition != null));
+                return RenderedColumns.Any(x => !x.HiddenState.Value && (x.FooterTemplate != null || x.AggregateDefinition != null));
             }
         }
 


### PR DESCRIPTION
## Description

When a column is resized and the neighboring column is hidden, then the application crash.

Fixes #9585 

## How Has This Been Tested?

I added a test case that reproduce the bug.

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.