### PR TITLE
MudInput: Revert left and right margins added in #9517

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -24,7 +24,7 @@
   }
 
   &.mud-input-control-margin-dense {
-    margin: 4px;
+    margin: 4px 0px;
 
     &.mud-input-outlined-with-label {
       margin-top: 8px;
@@ -33,7 +33,7 @@
   }
 
   &.mud-input-control-margin-normal {
-    margin: 8px;
+    margin: 8px 0px;
 
     &.mud-input-outlined-with-label {
       margin-top: 16px;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Reverted left and right margins added on #9517 to follow standards

![image](https://github.com/user-attachments/assets/63742313-5d5a-43ee-9da0-5cedf00f5480)
![image](https://github.com/user-attachments/assets/f8afe4e1-3a09-482e-9b8c-9496890dfe59)
![image](https://github.com/user-attachments/assets/96cbe418-784d-4552-96b5-bbca4e67acf3)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visual tested on AllInputsTest, with all margin variants

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
