### PR TITLE
Docs: Fix "Size" xml docs for MudSlider

### DIFF
--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -147,7 +147,7 @@ namespace MudBlazor
         public string[]? TickMarkLabels { get; set; }
 
         /// <summary>
-        /// Labels for tick marks, will attempt to map the labels to each step in index order.
+        /// Size of the slider.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]


### PR DESCRIPTION
Fixed "Size" docs for MudSlider<T> Component

## Description

A copy-paste error occurred.

![image](https://github.com/user-attachments/assets/1c91881c-40ce-436b-b540-b2ea1e92ddf9)

## How Has This Been Tested?
no test needed

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
