### PR TITLE
Build: Fix typo in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
         ":ignoreModulesAndTests"
     ],
     "labels": [
-        "depdendency"
+        "dependency"
     ],
     "packageRules": [
         {


### PR DESCRIPTION
Fixes a typo in the renovate configuration