### PR TITLE
MudButtonGroup: Stretch child buttons

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
@@ -1,0 +1,5 @@
+﻿<MudButtonGroup FullWidth="true">
+    <MudButton>Button One</MudButton>
+    <MudButton>Button Two</MudButton>
+    <MudButton>Button Third</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
@@ -1,4 +1,4 @@
-﻿<MudButtonGroup FullWidth="true">
+﻿<MudButtonGroup FullWidth>
     <MudButton>Button One</MudButton>
     <MudButton>Button Two</MudButton>
     <MudButton>Button Third</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidthWithButtonFullWidth.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidthWithButtonFullWidth.razor
@@ -1,0 +1,5 @@
+﻿<MudButtonGroup FullWidth>
+    <MudButton FullWidth>Button One</MudButton>
+    <MudButton>Button Two</MudButton>
+    <MudButton>Button Third</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
@@ -1,0 +1,38 @@
+﻿using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents.ButtonGroup;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ButtonGroupTests : BunitTest
+    {
+        [Test]
+        public void WithFullWidth_ThenAllButtonsStreched()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<ButtonGroupFullWidth>();
+
+            // Assert
+
+            comp.FindAll(".mud-button-group-root.mud-width-full").Count.Should().Be(1);
+            comp.FindAll(".mud-button-root.mud-width-full").Count.Should().Be(3);
+        }
+
+        [Test]
+        public void WithFullWidthAndHasOneButtonFullWidth_ThenOtherButtonsNotStreched()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<ButtonGroupFullWidthWithButtonFullWidth>();
+
+            // Assert
+
+            comp.FindAll(".mud-button-group-root.mud-width-full").Count.Should().Be(1);
+            comp.FindAll(".mud-button-root.mud-width-full").Count.Should().Be(1);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
@@ -32,7 +32,10 @@ namespace MudBlazor.UnitTests.Components
             // Assert
 
             comp.FindAll(".mud-button-group-root.mud-width-full").Count.Should().Be(1);
-            comp.FindAll(".mud-button-root.mud-width-full").Count.Should().Be(1);
+            var buttonComps = comp.FindAll(".mud-button-root");
+            buttonComps[0].ClassList.Should().Contain("mud-width-full");
+            buttonComps[1].ClassList.Should().NotContain("mud-width-full");
+            buttonComps[2].ClassList.Should().NotContain("mud-width-full");
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         /// The buton group which owns this button.
         /// </summary>
         [CascadingParameter]
-        public MudButtonGroup? ButtonGroup { get; set; }
+        private MudButtonGroup? ButtonGroup { get; set; }
 
         /// <summary>
         /// The icon displayed before the text.

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -19,7 +18,7 @@ namespace MudBlazor
             .AddClass($"mud-button-{Variant.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
-            .AddClass($"mud-width-full", FullWidth)
+            .AddClass($"mud-width-full", GetRealFullWith())
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-button-disable-elevation", !DropShadow)
             .AddClass(Class)
@@ -34,6 +33,12 @@ namespace MudBlazor
             .AddClass($"mud-button-icon-size-{(IconSize ?? Size).ToDescriptionString()}")
             .AddClass(IconClass)
             .Build();
+
+        /// <summary>
+        /// The buton group which owns this button.
+        /// </summary>
+        [CascadingParameter]
+        public MudButtonGroup? ButtonGroup { get; set; }
 
         /// <summary>
         /// The icon displayed before the text.
@@ -59,7 +64,7 @@ namespace MudBlazor
         /// The color of icons.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Inherit"/>.  
+        /// Defaults to <see cref="Color.Inherit"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
@@ -131,6 +136,38 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Behavior)]
         public RenderFragment? ChildContent { get; set; }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            if (ButtonGroup != null)
+            {
+                ButtonGroup.AddButton(this);
+            }
+        }
+
+        /// <summary>
+        /// Releases resources used by this button.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            if (ButtonGroup != null)
+            {
+                ButtonGroup.RemoveButton(this);
+            }
+        }
+
+        internal bool GetRealFullWith()
+        {
+            if (FullWidth)
+            {
+                return true;
+            }
+            // If the button is in a group, the group is stretched and none button is stretched,
+            // then the button need to be streched
+            return ButtonGroup != null && ButtonGroup.FullWidth &&
+                !ButtonGroup.RenderedButtons.Any(b => b.FullWidth);
+        }
 
         /// <inheritdoc/>
         /// <remarks>

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -140,10 +140,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            if (ButtonGroup != null)
-            {
-                ButtonGroup.AddButton(this);
-            }
+            ButtonGroup?.AddButton(this);
         }
 
         /// <summary>
@@ -151,10 +148,7 @@ namespace MudBlazor
         /// </summary>
         public virtual void Dispose()
         {
-            if (ButtonGroup != null)
-            {
-                ButtonGroup.RemoveButton(this);
-            }
+            ButtonGroup?.RemoveButton(this);
         }
 
         internal bool GetRealFullWith()
@@ -163,10 +157,10 @@ namespace MudBlazor
             {
                 return true;
             }
-            // If the button is in a group, the group is stretched and none button is stretched,
+            // If the button is in a group, the group is stretched and none button is explicitly stretched,
             // then the button need to be streched
-            return ButtonGroup != null && ButtonGroup.FullWidth &&
-                !ButtonGroup.RenderedButtons.Any(b => b.FullWidth);
+            // See https://github.com/MudBlazor/MudBlazor/issues/9710
+            return ButtonGroup != null && ButtonGroup.FullWidth && ButtonGroup.NoneButtonIsStreched();
         }
 
         /// <inheritdoc/>

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
@@ -2,7 +2,9 @@
 @inherits MudComponentBase
 
 <MudElement HtmlTag="div" Class="@Classname" Style="@Style" Tag="@Tag" UserAttributes="@UserAttributes">
-    @ChildContent
+    <CascadingValue IsFixed="true" Value="this">
+        @ChildContent
+    </CascadingValue>
 </MudElement>
 
 @{

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -101,5 +101,19 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
         public bool FullWidth { get; set; }
+
+        private readonly List<MudButton> renderedButtons = new List<MudButton>();
+
+        internal IEnumerable<MudButton> RenderedButtons => renderedButtons.AsEnumerable();
+
+        internal void AddButton(MudButton button)
+        {
+            renderedButtons.Add(button);
+        }
+
+        internal void RemoveButton(MudButton button)
+        {
+            renderedButtons.Remove(button);
+        }
     }
 }

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -102,18 +102,21 @@ namespace MudBlazor
         [Category(CategoryTypes.ButtonGroup.Appearance)]
         public bool FullWidth { get; set; }
 
-        private readonly List<MudButton> renderedButtons = new List<MudButton>();
-
-        internal IEnumerable<MudButton> RenderedButtons => renderedButtons.AsEnumerable();
+        private readonly List<MudButton> _renderedButtons = [];
 
         internal void AddButton(MudButton button)
         {
-            renderedButtons.Add(button);
+            _renderedButtons.Add(button);
         }
 
         internal void RemoveButton(MudButton button)
         {
-            renderedButtons.Remove(button);
+            _renderedButtons.Remove(button);
+        }
+
+        internal bool NoneButtonIsStreched()
+        {
+            return !_renderedButtons.Any(b => b.FullWidth);
         }
     }
 }


### PR DESCRIPTION
## Description

`MudButtonGroup.FullWidth` stretch the container, but not child buttons, so the available space isn't filled :
![361464105-90b4cccb-4540-4492-a8d6-e4ac98188e80](https://github.com/user-attachments/assets/e02ea798-4c77-4b6b-8857-7a52ff021947)

The modification stretch child buttons to fill the available space :
![361465361-2a76aa8c-f9e0-4301-a037-637dab5f8cef](https://github.com/user-attachments/assets/5cb474af-c826-482a-949e-43589f061836)

If one (or many) child `MudButton` has `FullWidth`, then other child buttons aren't stretched :
![361465900-5e974626-79e1-42cf-b5e0-d3612fb96c97](https://github.com/user-attachments/assets/cbfb8f4c-1bac-4010-adfa-06bef8f5d856)

Resolves #9710


## How Has This Been Tested?

I added tests.


## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)


## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
