### PR TITLE
Build: Disable renovate for SassCompiler

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
             "matchPackageNames": [
                 "AspNetCore.SassCompiler"
             ],
-            "allowedVersions": "1.72.0"
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
This change prevents PRs like https://github.com/MudBlazor/MudBlazor/pull/9725