### PR TITLE
Docs: Use spaces for indententation in the examples

### DIFF
--- a/src/MudBlazor.Docs/Components/SectionContent.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionContent.razor.cs
@@ -121,6 +121,9 @@ public partial class SectionContent
             {
                 var read = reader.ReadToEnd();
 
+                // Ensure the code uses spaces for identation regardless of the formatting within the source code.
+                read = read.Replace("\t", "    ");
+
                 if (!string.IsNullOrEmpty(HighLight))
                 {
                     if (HighLight.Contains(','))


### PR DESCRIPTION
## Description
The code examples are formatted very differently at the moment. Besides the differences in line spaces, the use of visibility modifiers and other things which are not touched, this PR at least fixes the indentation. Tabs are now converted to spaces when displaying the code, reducing the line length and making the code easier to read.

An alternative to this solution would be to fix the affected example files (currently 19 files). However, this does not prevent new exampels from being added with wrong styling.

So this PR fixes #9535, at least partially. Fixing all the code examples (currently 700+) by hand is too much manual labor for me at the moment and not practical at all. My attempts to use VS Code or Visual Studio to format the code failed painfully, the formatting simply doesn't work as one would expect (e.g. random newlines are inserted).
However, I think it would make sense to go over all examples and try to apply the same code style to all of them in some sort of coordinated effort (e.g. component per PR or maybe a hand full of components per PR).

## How Has This Been Tested?
Visually, e.g. using the Cancellation Token example of the Autocomplete component.

**Before:**
![image](https://github.com/user-attachments/assets/aab44b98-d879-414a-8e73-4bbc7fd3f168)

**After:**
![image](https://github.com/user-attachments/assets/0769e39e-1411-4dd0-ba71-90eed8a43803)

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
