### PR TITLE
Build: Prevent Sonar workflow in forks

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,8 +3,8 @@ name: sonar
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - dev
+    branches:
+      - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,8 +3,8 @@ name: sonar
 on:
   workflow_dispatch:
   push:
-    branches:
-      - dev
+    # branches:
+    #   - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event.repository.fork == false
     name: Analyze solution
     uses: MudBlazor/Workflows/.github/workflows/template-sonar.yml@main
     secrets: inherit

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: github.event.repository.fork == false
+    if: ${{ github.repository_owner == 'MudBlazor' }}
     name: Analyze solution
     uses: MudBlazor/Workflows/.github/workflows/template-sonar.yml@main
     secrets: inherit


### PR DESCRIPTION
This small change prevents that the `sonar.yml` workflow will run in forks. Once we have PR decoration, we _may_ have to update the if condition again. I'm not 100% sure how it behaves with PRs from a fork to the main repository.