### PR TITLE
Snackbar: Revert ReaderWriterLockSlim  dispose in SnackbarService

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -316,6 +316,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DisposeTest1()
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
+            _service.Clear();
             _service.Dispose();
 
             _service.ShownSnackbars.Count().Should().Be(0);

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -313,6 +313,15 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DisposeTest1()
+        {
+            await _provider.InvokeAsync(() =>  _service.Add("Boom, big reveal. Im a pickle!"));
+            _service.Dispose();
+
+            _service.ShownSnackbars.Count().Should().Be(0);
+        }
+
+        [Test]
         public async Task TestSnackBarRemoveByKey()
         {
             const string TestText = "Boom, big reveal. Im a pickle!";

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -315,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DisposeTest1()
         {
-            await _provider.InvokeAsync(() =>  _service.Add("Boom, big reveal. Im a pickle!"));
+            await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
             _service.Dispose();
 
             _service.ShownSnackbars.Count().Should().Be(0);

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -240,7 +240,6 @@ namespace MudBlazor
         {
             if (disposing)
             {
-                _snackBarLock.Dispose();
                 Configuration.OnUpdate -= ConfigurationUpdated;
                 _navigationManager.LocationChanged -= NavigationManager_LocationChanged;
                 RemoveAllSnackbars(_snackBarList);


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/9762

If the snackbar is disposed, and you will access any snackbar API it will throw exception. This is a problem in some scenarios, because the whole API is using that `ReaderWriterLockSlim`. Ideally the API shouldn't do anything when the service is disposed, just like it's done for popover.

## How Has This Been Tested?
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
