### PR TITLE
CsssBuilder/StyleBuilder: Fix for initialized as default

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -338,5 +338,18 @@ namespace UtilityTests
             // Assert
             classToRender.Should().Be("item-one");
         }
+
+        [Test]
+        public void DefaultCssBuilder_ShouldNotCrashHavingNoStringBuilder()
+        {
+            // Arrange
+            var styleBuilder = default(CssBuilder);
+
+            // Act
+            styleBuilder.AddClass("test-class");
+
+            // Assert
+            styleBuilder.Build().Should().Be("test-class");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -343,13 +343,14 @@ namespace UtilityTests
         public void DefaultCssBuilder_ShouldNotCrashHavingNoStringBuilder()
         {
             // Arrange
-            var styleBuilder = default(CssBuilder);
+            var cssBuilder = default(CssBuilder);
 
             // Act
-            styleBuilder.AddClass("test-class");
+            cssBuilder.AddClass("test-class");
+            cssBuilder.AddClass("test-class-2");
 
             // Assert
-            styleBuilder.Build().Should().Be("test-class");
+            cssBuilder.Build().Should().Be("test-class test-class-2");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -340,7 +340,7 @@ namespace UtilityTests
         }
 
         [Test]
-        public void DefaultCssBuilder_ShouldNotCrashHavingNoStringBuilder()
+        public void AddClass_ShouldNotBeNullWithDefaultStruct()
         {
             // Arrange
             var cssBuilder = default(CssBuilder);
@@ -351,6 +351,16 @@ namespace UtilityTests
 
             // Assert
             cssBuilder.Build().Should().Be("test-class test-class-2");
+        }
+
+        [Test]
+        public void Build_ShouldNotBeNullWithDefaultStruct()
+        {
+            // Arrange
+            var cssBuilder = default(CssBuilder);
+
+            // Assert
+            cssBuilder.Build().Should().Be("");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -316,5 +316,18 @@ namespace UtilityTests
             // Assert
             styleBuilder.Should().Be(string.Empty);
         }
+
+        [Test]
+        public void DefaultStyleBuilder_ShouldNotCrashHavingNoStringBuilder()
+        {
+            // Arrange
+            var styleBuilder = default(StyleBuilder);
+
+            // Act
+            styleBuilder.AddStyle("background-color", "green");
+
+            // Assert
+            styleBuilder.Build().Should().Be("background-color:green;");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -318,7 +318,7 @@ namespace UtilityTests
         }
 
         [Test]
-        public void DefaultStyleBuilder_ShouldNotCrashHavingNoStringBuilder()
+        public void AddStyle_ShouldNotBeNullWithDefaultStruct()
         {
             // Arrange
             var styleBuilder = default(StyleBuilder);
@@ -329,6 +329,16 @@ namespace UtilityTests
 
             // Assert
             styleBuilder.Build().Should().Be("background-color:green;color:red;");
+        }
+
+        [Test]
+        public void Build_ShouldNotBeNullWithDefaultStruct()
+        {
+            // Arrange
+            var styleBuilder = default(StyleBuilder);
+
+            // Assert
+            styleBuilder.Build().Should().Be("");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -325,9 +325,10 @@ namespace UtilityTests
 
             // Act
             styleBuilder.AddStyle("background-color", "green");
+            styleBuilder.AddStyle("color", "red");
 
             // Assert
-            styleBuilder.Build().Should().Be("background-color:green;");
+            styleBuilder.Build().Should().Be("background-color:green;color:red;");
         }
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -168,6 +168,7 @@ namespace MudBlazor.Utilities
         /// <inheritdoc />
         public override string ToString() => Build();
 
+        // TODO: v8, remove that and declare CssBuilder as readonly struct, improve documentation to avoid default(StringBuilder), add Breaking Change notes.
         private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.Utilities
     /// </summary>
     public struct CssBuilder
     {
-        private StringBuilder _stringBuilder;
+        private StringBuilder? _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of CssBuilder with the specified initial value.
@@ -42,7 +42,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder()
         {
-            _stringBuilder = StringBuilderCache.Acquire();
+            _stringBuilder = EnsureCreated();
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace MudBlazor.Utilities
         {
             if (value is not null)
             {
-                _stringBuilder.Append(value);
+                EnsureCreated().Append(value);
             }
         }
 
@@ -70,8 +70,7 @@ namespace MudBlazor.Utilities
         {
             if (value is not null)
             {
-                _stringBuilder ??= StringBuilderCache.Acquire();
-                _stringBuilder.Append(value);
+                EnsureCreated().Append(value);
             }
             return this;
         }
@@ -163,10 +162,12 @@ namespace MudBlazor.Utilities
         /// Finalizes the completed CSS classes as a string.
         /// </summary>
         /// <returns>The string representation of the CSS classes.</returns>
-        public string Build() => StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
+        public string Build() => StringBuilderCache.GetStringAndRelease(EnsureCreated()).Trim();
 
         // ToString should only and always call Build to finalize the rendered string.
         /// <inheritdoc />
         public override string ToString() => Build();
+
+        private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -70,6 +70,7 @@ namespace MudBlazor.Utilities
         {
             if (value is not null)
             {
+                _stringBuilder ??= StringBuilderCache.Acquire();
                 _stringBuilder.Append(value);
             }
             return this;

--- a/src/MudBlazor/Utilities/StringBuilderCache.cs
+++ b/src/MudBlazor/Utilities/StringBuilderCache.cs
@@ -5,29 +5,29 @@
 **
 ** Class:  StringBuilderCache
 **
-** Purpose: provide a cached reusable instance of stringbuilder
+** Purpose: provide a cached reusable instance of StringBuilder
 **          per thread  it's an optimisation that reduces the 
 **          number of instances constructed and collected.
 **
 **  Acquire - is used to get a string builder to use of a 
 **            particular size.  It can be called any number of 
-**            times, if a stringbuilder is in the cache then
+**            times, if a StringBuilder is in the cache then
 **            it will be returned and the cache emptied.
-**            subsequent calls will return a new stringbuilder.
+**            subsequent calls will return a new StringBuilder.
 **
 **            A StringBuilder instance is cached in 
 **            Thread Local Storage and so there is one per thread
 **
 **  Release - Place the specified builder in the cache if it is 
 **            not too big.
-**            The stringbuilder should not be used after it has 
+**            The StringBuilder should not be used after it has 
 **            been released.
 **            Unbalanced Releases are perfectly acceptable.  It
 **            will merely cause the runtime to create a new 
-**            stringbuilder next time Acquire is called.
+**            StringBuilder next time Acquire is called.
 **
 **  GetStringAndRelease
-**          - ToString() the stringbuilder, Release it to the 
+**          - ToString() the StringBuilder, Release it to the 
 **            cache and return the resulting string
 **
 ===========================================================*/
@@ -38,7 +38,7 @@ namespace System.Text
     internal static class StringBuilderCache
     {
         // The value 360 was chosen in discussion with performance experts as a compromise between using
-        // as litle memory (per thread) as possible and still covering a large part of short-lived
+        // as little memory (per thread) as possible and still covering a large part of short-lived
         // StringBuilder creations on the startup path of VS designers.
         private const int MaxBuilderSize = 360;
 
@@ -52,7 +52,7 @@ namespace System.Text
                 var sb = _cachedInstance;
                 if (sb is not null)
                 {
-                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // Avoid StringBuilder block fragmentation by getting a new StringBuilder
                     // when the requested size is larger than the current capacity
                     if (capacity <= sb.Capacity)
                     {

--- a/src/MudBlazor/Utilities/StringBuilderCache.cs
+++ b/src/MudBlazor/Utilities/StringBuilderCache.cs
@@ -34,6 +34,7 @@
 
 namespace System.Text
 {
+#nullable enable
     internal static class StringBuilderCache
     {
         // The value 360 was chosen in discussion with performance experts as a compromise between using
@@ -42,7 +43,7 @@ namespace System.Text
         private const int MaxBuilderSize = 360;
 
         [ThreadStatic]
-        private static StringBuilder _cachedInstance;
+        private static StringBuilder? _cachedInstance;
 
         public static StringBuilder Acquire(int capacity = MaxBuilderSize)
         {

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -2,8 +2,6 @@
 // License: MIT
 // See https://github.com/EdCharbeneau
 
-using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace MudBlazor.Utilities
@@ -14,7 +12,7 @@ namespace MudBlazor.Utilities
     /// </summary>
     public struct StyleBuilder
     {
-        private StringBuilder _stringBuilder;
+        private StringBuilder? _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of StyleBuilder with the specified property and value.
@@ -55,7 +53,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder()
         {
-            _stringBuilder = StringBuilderCache.Acquire();
+            _stringBuilder = EnsureCreated();
         }
 
         /// <summary>
@@ -67,8 +65,8 @@ namespace MudBlazor.Utilities
         /// <param name="prop">The CSS property.</param>
         /// <param name="value">The value of the property.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder(string prop, string value) : this() =>
-            _stringBuilder
+        public StyleBuilder(string prop, string value) =>
+            EnsureCreated()
                 .Append(prop)
                 .Append(':')
                 .Append(value)
@@ -106,8 +104,7 @@ namespace MudBlazor.Utilities
         {
             if (style is not null)
             {
-                _stringBuilder ??= StringBuilderCache.Acquire();
-                _stringBuilder.Append(style);
+                EnsureCreated().Append(style);
             }
             return this;
         }
@@ -119,8 +116,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         private StyleBuilder AddRaw(char c)
         {
-            _stringBuilder ??= StringBuilderCache.Acquire();
-            _stringBuilder.Append(c);
+            EnsureCreated().Append(c);
             return this;
         }
 
@@ -130,11 +126,10 @@ namespace MudBlazor.Utilities
         /// <param name="prop">The CSS property.</param>
         /// <param name="value">The value of the property.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string prop, string? value) =>
-            AddRaw(prop)
-            .AddRaw(':')
-            .AddRaw(value)
-            .AddRaw(';');
+        public StyleBuilder AddStyle(string prop, string? value) => AddRaw(prop)
+                .AddRaw(':')
+                .AddRaw(value)
+                .AddRaw(';');
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
@@ -144,7 +139,6 @@ namespace MudBlazor.Utilities
         /// <param name="when">The condition in which the style is added.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyle(string prop, string? value, bool when) => when ? AddStyle(prop, value) : this;
-
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
@@ -230,14 +224,12 @@ namespace MudBlazor.Utilities
         /// Finalizes the completed style as a string.
         /// </summary>
         /// <returns>The string representation of the style.</returns>
-        public string Build()
-        {
-            // String buffer finalization code
-            return StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
-        }
+        public string Build() => StringBuilderCache.GetStringAndRelease(EnsureCreated()).Trim();
 
         // ToString should only and always call Build to finalize the rendered string.
         /// <inheritdoc />
         public override string ToString() => Build();
+
+        private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -106,6 +106,7 @@ namespace MudBlazor.Utilities
         {
             if (style is not null)
             {
+                _stringBuilder ??= StringBuilderCache.Acquire();
                 _stringBuilder.Append(style);
             }
             return this;
@@ -118,6 +119,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         private StyleBuilder AddRaw(char c)
         {
+            _stringBuilder ??= StringBuilderCache.Acquire();
             _stringBuilder.Append(c);
             return this;
         }

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -230,6 +230,7 @@ namespace MudBlazor.Utilities
         /// <inheritdoc />
         public override string ToString() => Build();
 
+        // TODO: v8, remove that and declare StyleBuilder as readonly struct, improve documentation to avoid default(StyleBuilder), add Breaking Change notes.
         private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }


### PR DESCRIPTION
## Description
Fix for null reference exception in StyleBuilder and CssBuilder when initializing it as default(StyleBuilder) or default(CssBuilder) mentioned in https://github.com/MudBlazor/MudBlazor/pull/9635#issuecomment-2332009217

## How Has This Been Tested?
I tested it adding two tests for those cases.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
