### PR TITLE
Fix GitHub button for appbar drawer

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -83,9 +83,6 @@
         </MudTooltip>
     }
     <AppbarButtons />
-    <MudTooltip Delay="1000" Text="GitHub">
-        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" aria-label="Open GitHub repository" />
-    </MudTooltip>
 </div>
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -33,3 +33,6 @@
 <MudTooltip Delay="1000" Text="@(DarkLightModeButtonText)">
     <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@LayoutService.CycleDarkLightModeAsync" aria-label="@(DarkLightModeButtonText)" />
 </MudTooltip>
+<MudTooltip Delay="1000" Text="Open GitHub repository">
+    <MudIconButton Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" />
+</MudTooltip>


### PR DESCRIPTION
## Description
When in a smaller window the github button would not appear because the drawer used appbarbuttons (and github was not in that component). This PR just moves the github button to the appbarbuttons component so it shows on large window app bar and small window drawer.
![image](https://github.com/user-attachments/assets/b178d364-6a03-4af9-b8cc-a317aaeb9dfe)

## How Has This Been Tested?
Visually tested docs project 

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

**Before:**
![image](https://github.com/user-attachments/assets/75efe63b-9c54-447d-a94a-06de20d64994)

**After:**
![image](https://github.com/user-attachments/assets/f396813a-42e8-4b2c-960a-7103a3b34430)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
