### PR TITLE
MudTreeViewItem: Add property Visible for conditionally hiding sub-trees without reloading

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
@@ -1,0 +1,69 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px" Elevation="0">
+    <MudStack Spacing="5" AlignItems="AlignItems.Center">
+        <MudTextField T="string" Label="Search" AdornmentIcon="@Icons.Material.Filled.Search" TextChanged="OnTextChanged" Immediate />
+        <MudTreeView Items="@_treeItemData">
+            <ItemTemplate>
+                <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children" Value="@context.Value"
+                                 Icon="@context.Icon" Text="@context.Text" Visible="@context.Visible" />
+            </ItemTemplate>
+        </MudTreeView>
+    </MudStack>
+</MudPaper>
+
+@code {
+    private List<TreeItemData<string>> _treeItemData = [];
+
+    public class TreeItemPresenter : TreeItemData<string>
+    {
+        public TreeItemPresenter(string text, string icon) : base(text)
+        {
+            Text = text;
+            Icon = icon;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        _treeItemData.Add(new TreeItemPresenter("All Mail", Icons.Material.Filled.Email));
+        _treeItemData.Add(new TreeItemPresenter("Trash", Icons.Material.Filled.Delete));
+        _treeItemData.Add(new TreeItemPresenter("Categories", Icons.Material.Filled.Label)
+            {
+                Expanded = true,
+                Children = 
+                [
+                    new TreeItemPresenter("Social", Icons.Material.Filled.Group),
+                    new TreeItemPresenter("Updates", Icons.Material.Filled.Info),
+                    new TreeItemPresenter("Forums", Icons.Material.Filled.QuestionAnswer),
+                    new TreeItemPresenter("Promotions", Icons.Material.Filled.LocalOffer)
+                ]
+            });
+        _treeItemData.Add(new TreeItemPresenter("History", Icons.Material.Filled.Label));
+    }
+
+    private void OnTextChanged(string searchTerm) => Filter(_treeItemData, searchTerm);
+
+    private void Filter(IEnumerable<TreeItemData<string>> treeItemData, string text)
+    {
+        foreach (TreeItemData<string> itemData in treeItemData)
+        {
+            if (itemData.HasChildren)
+            {
+                Filter(itemData.Children, text);
+            }
+
+            itemData.Visible = IsVisible(itemData, text);
+        }
+    }
+
+    private bool IsVisible(TreeItemData<string> treeItemData, string searchTerm)
+    {
+        if (!treeItemData.HasChildren)
+        {
+            return treeItemData.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return treeItemData.Children.Any(i => i.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="300px" Elevation="0">
-    <MudStack Spacing="5" AlignItems="AlignItems.Center">
+    <MudStack AlignItems="AlignItems.Center">
         <MudTextField T="string" Label="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" TextChanged="OnTextChanged" Immediate="true" Clearable="true" />
         <MudTreeView Items="@_treeItemData">
             <ItemTemplate>

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Width="300px" Elevation="0">
     <MudStack Spacing="5" AlignItems="AlignItems.Center">
-        <MudTextField T="string" Label="Search" AdornmentIcon="@Icons.Material.Filled.Search" TextChanged="OnTextChanged" Immediate />
+        <MudTextField T="string" Label="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" TextChanged="OnTextChanged" Immediate="true" Clearable="true" />
         <MudTreeView Items="@_treeItemData">
             <ItemTemplate>
                 <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children" Value="@context.Value"
@@ -64,6 +64,6 @@
             return treeItemData.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
         }
 
-        return treeItemData.Children.Any(i => i.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+        return treeItemData.Children.Any(i => i.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) || treeItemData.Text.Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -133,6 +133,18 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Filtering">
+                <Description>
+                    The tree nodes can be filtered using the property <CodeInline>Visible</CodeInline>. Implementing a function to determine whether a node is displayed according the filter options you can set the
+                    filtered nodes to invisible without having to reload the entire tree.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TreeViewFilteringExample)" ShowCode="false">
+                <TreeViewFilteringExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Custom Look and Behavior">
                 <Description>
                     When the <CodeInline>Content</CodeInline> property is used, it will completely replace the default rendering of the <CodeInline>MudTreeViewItem</CodeInline> to use your own. 

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/TreeViewPage.razor
@@ -135,8 +135,8 @@
         <DocsPageSection>
             <SectionHeader Title="Filtering">
                 <Description>
-                    The tree nodes can be filtered using the property <CodeInline>Visible</CodeInline>. Implementing a function to determine whether a node is displayed according the filter options you can set the
-                    filtered nodes to invisible without having to reload the entire tree.
+                    The tree nodes can be shown or hidden by setting the <CodeInline>Visible</CodeInline> property. This way a filtering mechanism can be implemented on the tree, 
+                    hiding the subtrees that do not match the filtering logic.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TreeViewFilteringExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/ItemVisibleTreeViewTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/ItemVisibleTreeViewTest.razor
@@ -1,0 +1,10 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string">
+    <MudTreeViewItem T="string" Value="@("World")" Visible="@IsElementVisible"/>
+</MudTreeView>
+
+@code {
+    [Parameter]
+    public bool IsElementVisible { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -260,9 +255,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItemVisible_RendersWhenVisibleIsTrue()
         {
-            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element => 
-            { 
-                element.Add(x => x.IsElementVisible, true); 
+            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element =>
+            {
+                element.Add(x => x.IsElementVisible, true);
             });
 
             comp.FindAll("li").Should().HaveCount(1);

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -258,6 +258,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TreeViewItemVisible_RendersWhenVisibleIsTrue()
+        {
+            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element => 
+            { 
+                element.Add(x => x.IsElementVisible, true); 
+            });
+
+            comp.FindAll("li").Should().HaveCount(1);
+        }
+
+        [Test]
+        public void TreeViewItemVisible_RendersNotWhenVisibleIsFalse()
+        {
+            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element =>
+            {
+                element.Add(x => x.IsElementVisible, false);
+            });
+
+            comp.FindAll("li").Should().HaveCount(0);
+        }
+
+        [Test]
         public void InitialValueOfTreeViewItemSelected_Should_InfluenceSelectedValue_MultiSelection()
         {
             var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -547,6 +547,7 @@ namespace MudBlazor.UnitTests.Components
             new TreeItemData<int>().Expanded.Should().Be(false);
             new TreeItemData<int>().Selected.Should().Be(false);
             new TreeItemData<int>().Expandable.Should().Be(true);
+            new TreeItemData<int>().Visible.Should().Be(true);
             new TreeItemData<int>().Text.Should().Be(null);
             new TreeItemData<int>().Icon.Should().Be(null);
             new TreeItemData<int>().HasChildren.Should().Be(false);
@@ -559,6 +560,7 @@ namespace MudBlazor.UnitTests.Components
                 Text = "t",
                 Expandable = false,
                 Expanded = true,
+                Visible = true,
                 Selected = true,
                 Children = [new TreeItemData<string>()]
             };
@@ -567,6 +569,7 @@ namespace MudBlazor.UnitTests.Components
             data.Text.Should().Be("t");
             data.Expandable.Should().Be(false);
             data.Expanded.Should().Be(true);
+            data.Visible.Should().Be(true);
             data.Selected.Should().Be(true);
             data.HasChildren.Should().Be(true);
             data.Children.Count.Should().Be(1);

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -12,7 +12,7 @@
             }
             else
             {
-                <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@HasChildren()" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
+                <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@(HasChildren() && AreChildrenVisible())" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
 
                 @if (MultiSelection)
                 {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -2,65 +2,68 @@
 @inherits MudComponentBase
 @typeparam T
 
-<li @attributes="UserAttributes" class="@Classname" style="@Style">
-    <div class="@ContentClassname" @onclick="OnItemClickedAsync" @onclick:stopPropagation="true" @ondblclick="OnItemDoubleClickedAsync" @ondblclick:stopPropagation="true">
-        @if (Content != null)
-        {
-            @Content
-        }
-        else
-        {
-            <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@HasChildren()" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
-
-            @if (MultiSelection)
+@if (Visible)
+{
+    <li @attributes="UserAttributes" class="@Classname" style="@Style">
+        <div class="@ContentClassname" @onclick="OnItemClickedAsync" @onclick:stopPropagation="true" @ondblclick="OnItemDoubleClickedAsync" @ondblclick:stopPropagation="true">
+            @if (Content != null)
             {
-                <MudCheckBox T="bool?" TriState Class="mud-treeview-item-checkbox" CheckedIcon="@CheckedIcon" UncheckedIcon="@UncheckedIcon" IndeterminateIcon="@GetIndeterminateIcon()" 
-                        @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x=>OnCheckboxChangedAsync())" Disabled="@Disabled"></MudCheckBox>
-            }
-
-            @if (HasIcon)
-            {
-                <div class="mud-treeview-item-icon">
-                    <MudIcon Disabled="@GetDisabled()" Icon="@GetIcon()" Color="@IconColor" />
-                </div>
-            }
-
-            @if (BodyContent != null)
-            {
-                @BodyContent(this)
+                @Content
             }
             else
             {
-                <MudText Typo="@TextTypo" Class="@TextClassname">
-                    @GetText()
-                </MudText>
+                <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@HasChildren()" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
 
-                @if (!string.IsNullOrEmpty(EndText))
+                @if (MultiSelection)
                 {
-                    <MudText Typo="@EndTextTypo" Class="@EndTextClass">
-                        @EndText
-                    </MudText>
+                    <MudCheckBox T="bool?" TriState Class="mud-treeview-item-checkbox" CheckedIcon="@CheckedIcon" UncheckedIcon="@UncheckedIcon" IndeterminateIcon="@GetIndeterminateIcon()"
+                                 @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x=>OnCheckboxChangedAsync())" Disabled="@Disabled"></MudCheckBox>
                 }
 
-                @if (!string.IsNullOrEmpty(EndIcon))
+                @if (HasIcon)
                 {
                     <div class="mud-treeview-item-icon">
-                        <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@EndIconColor" />
+                        <MudIcon Disabled="@GetDisabled()" Icon="@GetIcon()" Color="@IconColor" />
                     </div>
                 }
+
+                @if (BodyContent != null)
+                {
+                    @BodyContent(this)
+                }
+                else
+                {
+                    <MudText Typo="@TextTypo" Class="@TextClassname">
+                        @GetText()
+                    </MudText>
+
+                    @if (!string.IsNullOrEmpty(EndText))
+                    {
+                        <MudText Typo="@EndTextTypo" Class="@EndTextClass">
+                            @EndText
+                        </MudText>
+                    }
+
+                    @if (!string.IsNullOrEmpty(EndIcon))
+                    {
+                        <div class="mud-treeview-item-icon">
+                            <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@EndIconColor" />
+                        </div>
+                    }
+                }
             }
-        }
-    </div>
-    @if (HasChildren())
-    {
-        <MudCollapse Expanded="@_expandedState.Value">
-            <CascadingValue Value="@MudTreeRoot" IsFixed="true">
-                <CascadingValue Value="this" IsFixed="true">
-                    <MudTreeView Items="Items" ItemTemplate="MudTreeRoot?.ItemTemplate" Class="mud-treeview-group">
-                        @ChildContent
-                    </MudTreeView>
+        </div>
+        @if (HasChildren())
+        {
+            <MudCollapse Expanded="@_expandedState.Value">
+                <CascadingValue Value="@MudTreeRoot" IsFixed="true">
+                    <CascadingValue Value="this" IsFixed="true">
+                        <MudTreeView Items="Items" ItemTemplate="MudTreeRoot?.ItemTemplate" Class="mud-treeview-group">
+                            @ChildContent
+                        </MudTreeView>
+                    </CascadingValue>
                 </CascadingValue>
-            </CascadingValue>
-        </MudCollapse>
-    }
-</li>
+            </MudCollapse>
+        }
+    </li>
+}

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -278,11 +278,10 @@ namespace MudBlazor
         {
             return ChildContent != null
                 || (MudTreeRoot != null && Items != null && Items.Count != 0)
-                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null
-                || Items.Count == 0));
+                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null || Items.Count == 0));
         }
 
-        private bool AreChildrenVisible() => Items is null || Items?.Any(i => i.Visible) is true;
+        private bool AreChildrenVisible() => Items is null || Items.Any(i => i.Visible);
 
         internal T? GetValue()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -110,6 +110,13 @@ namespace MudBlazor
         public string? EndTextClass { get; set; }
 
         /// <summary>
+        /// Indicates whether the tree view item and its children are visible.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.TreeView.Appearance)]
+        public bool Visible { get; set; } = true;
+
+        /// <summary>
         /// If true, TreeViewItem will be disabled.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
@@ -282,11 +278,11 @@ namespace MudBlazor
         {
             return ChildContent != null
                 || (MudTreeRoot != null && Items != null && Items.Count != 0)
-                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null 
+                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null
                 || Items.Count == 0));
         }
 
-        private bool AreChildrenVisible() => Items?.Any(i => i.Visible) is true;
+        private bool AreChildrenVisible() => Items is null || Items?.Any(i => i.Visible) is true;
 
         internal T? GetValue()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -280,10 +280,13 @@ namespace MudBlazor
 
         private bool HasChildren()
         {
-            return ChildContent != null ||
-                   (MudTreeRoot != null && Items != null && Items.Count != 0) ||
-                   (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null || Items.Count == 0));
+            return ChildContent != null
+                || (MudTreeRoot != null && Items != null && Items.Count != 0)
+                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null 
+                || Items.Count == 0));
         }
+
+        private bool AreChildrenVisible() => Items?.Any(i => i.Visible) is true;
 
         internal T? GetValue()
         {

--- a/src/MudBlazor/Components/TreeView/TreeItemData.cs
+++ b/src/MudBlazor/Components/TreeView/TreeItemData.cs
@@ -30,6 +30,8 @@ public class TreeItemData<T> : IEquatable<TreeItemData<T>>
 
     public virtual bool Selected { get; set; }
 
+    public virtual bool Visible { get; set; } = true;
+
     public virtual List<TreeItemData<T>>? Children { get; set; }
 
     public virtual bool HasChildren => Children is not null && Children.Count > 0;


### PR DESCRIPTION
## Description

This pull request adds a non-breaking change to the `MudTreeViewItem` component. It allows users to control the visibilty on every `MudTreeViewItem` by setting a new flag `Visible`. By default this is set to 'true' so it won't affect any existing implementation. The new property can be used to implement filtering on the `MudTreeView` without having to manipulate the data structure underlying. Additional to that, the visibility property has also been added to the `TreeItemData` to control the visibility from the data structure directly (e.g. to implement filtering). Since a flag to control the visibility has been added to many input controls in MudBlazor, I would like to add this to the `MudTreeView` as well to achieve a greater functional range of this component. This pull request resolves #9797.

## How Has This Been Tested?

This feature has been tested visually. A unit test has been modified to test the visibility property on the `TreeItemData<T>`

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Screenshots

Based on the basic example of the `MudTreeView` the entire tree can be seen without any visibility constraints.
![image](https://github.com/user-attachments/assets/4d358e6e-c6f1-4213-80c6-b9acf1ef384d)

By setting the `Visible` flag on the node the corresponding node and its children are not displayed anymore.
![image](https://github.com/user-attachments/assets/047001e0-b008-405c-8f5d-626b68521b65)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
