### PR TITLE
MudDataGrid: properly clear the filter values

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnFilterRowPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnFilterRowPropertyTest.razor
@@ -1,6 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterRow">
+<MudDataGrid @ref="@_dataGrid" T="Model" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterRow">
+    <ToolBarContent>
+        <MudButton Class="clear-all-filters" OnClick="@(() => _dataGrid.ClearFiltersAsync())">Clear All Filters</MudButton>
+    </ToolBarContent>
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -12,6 +15,31 @@
 
 @code {
     public record Model (string Name, int? Age, Severity? Status, bool? Hired, DateTime? HiredOn);
+
+    private MudDataGrid<Model> _dataGrid;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var item = _items.Skip(2).First();
+
+            AddFilter(0, item.Name);
+            AddFilter(1, Convert.ToDouble(item.Age));
+            AddFilter(2, item.Status);
+            AddFilter(3, item.Hired);
+            AddFilter(4, item.HiredOn);
+
+            StateHasChanged();
+        }
+    }
+
+    private void AddFilter(int columnIndex, object value)
+    {
+        var filter = _dataGrid.RenderedColumns[columnIndex].FilterContext.FilterDefinition;
+        filter!.Value = value;
+        _dataGrid.FilterDefinitions.Add(filter);
+    }
 
     private readonly IEnumerable<Model> _items = new List<Model>()
     {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -609,6 +609,8 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("input")[0].IsChecked().Should().BeFalse(because: "select all checkbox should reflect 'not all selected' state");
             dataGrid.FindAll("tfoot input")[0].IsChecked().Should().BeFalse(because: "select all checkbox should reflect 'not all selected' state");
 
+            // ClearFiltersAsync() has cleared the value, so it needs to be set again
+            twoBFilter.Value = "B";
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(twoBFilter));
             dataGrid.FindAll("input[type=checkbox]")[0].IsChecked().Should().BeTrue(because: "select all checkbox should reflect 'all selected' state");
             dataGrid.FindAll("tfoot input[type=checkbox]")[0].IsChecked().Should().BeTrue(because: "select all checkbox should reflect 'all selected' state");

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1,9 +1,11 @@
 ﻿#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
+using System.Globalization;
 using System.Reflection;
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -3242,6 +3244,43 @@ namespace MudBlazor.UnitTests.Components
             Assert.DoesNotThrow(() => comp.FindComponent<MudSelect<Enum>>());
             Assert.DoesNotThrow(() => comp.FindComponent<MudSelect<bool?>>());
             Assert.DoesNotThrow(() => comp.FindComponent<MudDatePicker>());
+        }
+
+        [Test]
+        public async Task DataGridColumnFilterRowPropertyClearTest()
+        {
+            var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
+
+            var inputsBefore = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
+            var hireDate = new DateTime(2011, 1, 2).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, CultureInfo.CurrentCulture);
+            inputsBefore.Should().BeEquivalentTo("Ira", "27", "Success", "True", hireDate, "00:00");
+
+            var clearButtons = dataGrid.FindAll(".align-self-center");
+            clearButtons.Should().HaveCount(5);
+            foreach (var clearButton in clearButtons)
+            {
+                clearButton.Click();
+            }
+
+            var inputsAfter = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
+            inputsAfter.Should().HaveCount(6).And.AllBe("", because: "clicking the clear buttons should reset all filters");
+        }
+
+        [Test]
+        public async Task DataGridColumnFilterRowPropertyClearAllTest()
+        {
+            var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
+
+            var inputsBefore = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
+            var hireDate = new DateTime(2011, 1, 2).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, CultureInfo.CurrentCulture);
+            inputsBefore.Should().BeEquivalentTo("Ira", "27", "Success", "True", hireDate, "00:00");
+
+            dataGrid.Find(".clear-all-filters").Click();
+
+            var inputsAfter = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
+            inputsAfter.Should().HaveCount(6).And.AllBe("", because: "clicking the clear button should reset all filters");
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -1447,7 +1446,6 @@ namespace MudBlazor
         internal async Task RemoveFilterAsync(Guid id)
         {
             var index = FilterDefinitions.FindIndex(x => x.Id == id);
-            Debug.Assert(index != -1);
             FilterDefinitions[index].Value = null;
             FilterDefinitions.RemoveAt(index);
             await InvokeServerLoadFunc();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -1426,6 +1427,7 @@ namespace MudBlazor
         /// </summary>
         public Task ClearFiltersAsync()
         {
+            FilterDefinitions.ForEach(x => x.Value = null);
             FilterDefinitions.Clear();
             return InvokeServerLoadFunc();
         }
@@ -1444,6 +1446,9 @@ namespace MudBlazor
 
         internal async Task RemoveFilterAsync(Guid id)
         {
+            var filterDefinition = FilterDefinitions.Find(x => x.Id == id);
+            Debug.Assert(filterDefinition != null);
+            filterDefinition.Value = null;
             FilterDefinitions.RemoveAll(x => x.Id == id);
             await InvokeServerLoadFunc();
             GroupItems();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1446,10 +1446,10 @@ namespace MudBlazor
 
         internal async Task RemoveFilterAsync(Guid id)
         {
-            var filterDefinition = FilterDefinitions.Find(x => x.Id == id);
-            Debug.Assert(filterDefinition != null);
-            filterDefinition.Value = null;
-            FilterDefinitions.RemoveAll(x => x.Id == id);
+            var index = FilterDefinitions.FindIndex(x => x.Id == id);
+            Debug.Assert(index != -1);
+            FilterDefinitions[index].Value = null;
+            FilterDefinitions.RemoveAt(index);
             await InvokeServerLoadFunc();
             GroupItems();
         }


### PR DESCRIPTION
## Description

Clicking the clear filter buttons or calling the `dataGrid.ClearFiltersAsync()` method would not actually clear the filter values. 

Fixes #6951
Fixes #8318
Closes #9532

## How Has This Been Tested?

Two unit tests have been added.

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Before (❌ filter values don't clear):

https://github.com/user-attachments/assets/62f5b569-63e6-45b5-a03c-ac6eaab08039


After (✅ filter values are properly cleared):

https://github.com/user-attachments/assets/c0fd6abd-3762-4c66-a3ed-86a7d263e3f3


## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
