### PR TITLE
Add dark mode to native html input controls

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -247,6 +247,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-zindex-popover: 1200;",
                 "--mud-zindex-snackbar: 1500;",
                 "--mud-zindex-tooltip: 1600;",
+                "--mud-native-html-color-scheme: light;",
                 "}"
             };
 

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -481,6 +481,9 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         theme.AppendLine($"--{Zindex}-popover: {_theme.ZIndex.Popover};");
         theme.AppendLine($"--{Zindex}-snackbar: {_theme.ZIndex.Snackbar};");
         theme.AppendLine($"--{Zindex}-tooltip: {_theme.ZIndex.Tooltip};");
+
+        // Native HTML control light/dark mode
+        theme.AppendLine("--mud-native-html-color-scheme: " + (IsDarkMode ? "dark" : "light") + ";");
     }
 
     public void Dispose()

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -483,7 +483,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         theme.AppendLine($"--{Zindex}-tooltip: {_theme.ZIndex.Tooltip};");
 
         // Native HTML control light/dark mode
-        theme.AppendLine("--mud-native-html-color-scheme: " + (IsDarkMode ? "dark" : "light") + ";");
+        theme.AppendLine($"--mud-native-html-color-scheme: {(IsDarkMode ? "dark" : "light")};");
     }
 
     public void Dispose()

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -5,6 +5,7 @@
   display: inline-flex;
   box-sizing: border-box;
   align-items: center;
+  color-scheme: var(--mud-native-html-color-scheme);
 
   &.mud-input-full-width {
     width: 100%;


### PR DESCRIPTION
## Description
When in dark mode, native html controls would always be displayed in light. Now follows the mud theme dark/light mode. 
fixes #9796

## How Has This Been Tested?
Visually tested, and ran/fixed current tests

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

**Before:**
![image](https://github.com/user-attachments/assets/79be4564-aac3-4e52-8cff-6871f130140e)
**After:**
![image](https://github.com/user-attachments/assets/14c630a6-0096-42bd-a068-83393422eec0)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
