### PR TITLE
MudSkeleton: add dark mode support

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -109,6 +109,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-palette-table-hover: rgba(0,0,0,0.0392156862745098);",
                 "--mud-palette-divider: rgba(224,224,224,1);",
                 "--mud-palette-divider-light: rgba(0,0,0,0.8);",
+                "--mud-palette-skeleton: rgba(0,0,0,0.10980392156862745);",
                 "--mud-palette-gray-default: #9E9E9E;",
                 "--mud-palette-gray-light: #BDBDBD;",
                 "--mud-palette-gray-lighter: #E0E0E0;",

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -277,6 +277,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         theme.AppendLine($"--{Palette}-divider: {palette.Divider};");
         theme.AppendLine($"--{Palette}-divider-light: {palette.DividerLight};");
 
+        theme.AppendLine($"--{Palette}-skeleton: {palette.Skeleton};");
+
         theme.AppendLine($"--{Palette}-gray-default: {palette.GrayDefault};");
         theme.AppendLine($"--{Palette}-gray-light: {palette.GrayLight};");
         theme.AppendLine($"--{Palette}-gray-lighter: {palette.GrayLighter};");

--- a/src/MudBlazor/Styles/components/_skeleton.scss
+++ b/src/MudBlazor/Styles/components/_skeleton.scss
@@ -1,8 +1,8 @@
-﻿
+
 .mud-skeleton {
   height: 1.2em;
   display: block;
-  background-color: rgba(0, 0, 0, 0.11);
+  background-color: var(--mud-palette-skeleton);
 }
 
 .mud-skeleton-text {

--- a/src/MudBlazor/Themes/Models/Palette.cs
+++ b/src/MudBlazor/Themes/Models/Palette.cs
@@ -224,6 +224,12 @@ namespace MudBlazor
         /// </summary>
         public virtual MudColor DividerLight { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.8).ToString(MudColorOutputFormats.RGBA);
 
+
+        /// <summary>
+        /// The color for skeletons.
+        /// </summary>
+        public virtual MudColor Skeleton { get; set; } = new MudColor("rgba(0, 0, 0, 0.11)").ToString(MudColorOutputFormats.RGBA);
+
         /// <summary>
         /// The darkened value of the primary color.<br/>
         /// This is calculated using <see cref="MudColor.ColorRgbDarken"/> if not set.

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -92,5 +92,8 @@ namespace MudBlazor
 
         /// <inheritdoc />
         public override MudColor DividerLight { get; set; } = "rgba(255,255,255, 0.06)";
+
+        /// <inheritdoc />
+        public override MudColor Skeleton { get; set; } = "rgba(255,255,255, 0.11)";
     }
 }


### PR DESCRIPTION
## Description
MudSkeletons did not had a dark mode color and they were harder to see in dark mode.
fixes #9803

## How Has This Been Tested?
Visually, ran/fixed current tests

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

**Before:**
![skeletonbefore](https://github.com/user-attachments/assets/e933e9d7-5eb7-4042-a6c4-386f556015e1)
**After:**
![skeletonafter](https://github.com/user-attachments/assets/604f38c2-0fff-4d4b-ba5e-9c3d3a2b6901)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
