### PR TITLE
MudListItem: Allow overriding `tabindex` via UserAttributes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListItemTabIndexTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListItemTabIndexTest.razor
@@ -1,0 +1,7 @@
+﻿<MudList T="string">
+    <MudListItem tabindex="-1" Text="You cannot tab to this"/>
+</MudList>
+
+@code {
+    public static string __description__ = "tabindex should be able to override the default behavior";
+}

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -245,5 +245,12 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.Ripple, false));
             comp.FindAll("div.mud-ripple").Count.Should().Be(0);
         }
+
+        [Test]
+        public void ListItemTabIndexTest()
+        {
+            var comp = Context.RenderComponent<ListItemTabIndexTest>();
+            comp.FindAll("div")[1].GetAttribute("tabindex").Should().Be("-1");
+        }
     }
 }

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -5,10 +5,10 @@
 <MudElement HtmlTag="@HtmlTag"
             Class="@Classname"
             Style="@Style"
+            tabindex="0"
             @attributes="UserAttributes"
             @onclick="OnClickHandlerAsync"
             href="@Href"
-            tabindex="0"
             target="@Target"
             PreventDefault="@GetPreventDefault()"
             ClickPropagation="@GetClickPropagation()">


### PR DESCRIPTION
## Description

The problem was that the following code used to work in v6 but in v7 it no longer works. The reason is because the tabIndex="0" in MudListItem was placed after the UserAttributes which made it impossible to override. This PR fixes the issue, so the following code should now work again.
`
            <MudListItem tabindex="-1">
                 text
            </MudListItem>
`

## How Has This Been Tested?
Tested visually and with unit test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)


## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests. (NOT APPLICABLE)
