### PR TITLE
MudButton : Implement IDisposable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidth.razor
@@ -1,5 +1,0 @@
-﻿<MudButtonGroup FullWidth>
-    <MudButton>Button One</MudButton>
-    <MudButton>Button Two</MudButton>
-    <MudButton>Button Third</MudButton>
-</MudButtonGroup>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidthWithButtonFullWidth.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupFullWidthWithButtonFullWidth.razor
@@ -1,5 +1,0 @@
-﻿<MudButtonGroup FullWidth>
-    <MudButton FullWidth>Button One</MudButton>
-    <MudButton>Button Two</MudButton>
-    <MudButton>Button Third</MudButton>
-</MudButtonGroup>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupWithThreeButtons.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupWithThreeButtons.razor
@@ -1,0 +1,37 @@
+﻿<MudButtonGroup FullWidth="ButtonGroupFullWidth">
+    @if(Button1Displayed)
+    {
+        <MudButton FullWidth="Button1FullWidth">Button One</MudButton>
+    }
+    @if(Button2Displayed)
+    {
+        <MudButton FullWidth="Button2FullWidth">Button Two</MudButton>
+    }
+    @if(Button3Displayed)
+    {
+        <MudButton FullWidth="Button3FullWidth">Button Third</MudButton>
+    }
+</MudButtonGroup>
+
+@code {
+    [Parameter]
+    public bool ButtonGroupFullWidth { get; set; } = true;
+
+    [Parameter]
+    public bool Button1Displayed { get; set; } = true;
+
+    [Parameter]
+    public bool Button1FullWidth { get; set; }
+
+    [Parameter]
+    public bool Button2Displayed { get; set; } = true;
+
+    [Parameter]
+    public bool Button2FullWidth { get; set; }
+
+    [Parameter]
+    public bool Button3Displayed { get; set; } = true;
+
+    [Parameter]
+    public bool Button3FullWidth { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
@@ -10,11 +10,17 @@ namespace MudBlazor.UnitTests.Components
     public class ButtonGroupTests : BunitTest
     {
         [Test]
-        public void WithFullWidth_ThenAllButtonsStreched()
+        public void WithFullWidthAndNoneButtonIsStreched_ThenAllButtonsStreched()
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ButtonGroupFullWidth>();
+            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+                parameters => parameters
+                    .Add(c => c.ButtonGroupFullWidth, true)
+                    .Add(c => c.Button1FullWidth, false)
+                    .Add(c => c.Button2FullWidth, false)
+                    .Add(c => c.Button3FullWidth, false)
+            );
 
             // Assert
 
@@ -23,11 +29,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void WithFullWidthAndHasOneButtonFullWidth_ThenOtherButtonsNotStreched()
+        public void WithFullWidthAndOneButtonIsStreched_ThenOtherButtonsNotStreched()
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ButtonGroupFullWidthWithButtonFullWidth>();
+            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+                parameters => parameters
+                    .Add(c => c.ButtonGroupFullWidth, true)
+                    .Add(c => c.Button1FullWidth, true)
+                    .Add(c => c.Button2FullWidth, false)
+                    .Add(c => c.Button3FullWidth, false)
+            );
 
             // Assert
 
@@ -39,14 +51,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void WhenButtonWithFullWidthIsRemoved_ThenOtherButtonsAreStreched()
+        public void WithFullWidth_WhenButtonWithFullWidthIsRemoved_ThenOtherButtonsAreStreched()
         {
             // Arrange
 
             var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
                 parameters => parameters
-                .Add(c => c.ButtonGroupFullWidth, true)
-                .Add(c => c.Button1FullWidth, true)
+                    .Add(c => c.ButtonGroupFullWidth, true)
+                    .Add(c => c.Button1FullWidth, true)
+                    .Add(c => c.Button2FullWidth, false)
+                    .Add(c => c.Button3FullWidth, false)
             );
 
             // Act

--- a/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
@@ -37,5 +37,29 @@ namespace MudBlazor.UnitTests.Components
             buttonComps[1].ClassList.Should().NotContain("mud-width-full");
             buttonComps[2].ClassList.Should().NotContain("mud-width-full");
         }
+
+        [Test]
+        public void WhenButtonWithFullWidthIsRemoved_ThenOtherButtonsAreStreched()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+                parameters => parameters
+                .Add(c => c.ButtonGroupFullWidth, true)
+                .Add(c => c.Button1FullWidth, true)
+            );
+
+            // Act
+
+            comp.SetParam(c => c.Button1Displayed, false);
+
+            // Assert
+
+            comp.FindAll(".mud-button-group-root.mud-width-full").Count.Should().Be(1);
+            var buttonComps = comp.FindAll(".mud-button-root");
+            buttonComps.Count.Should().Be(2);
+            buttonComps[0].ClassList.Should().Contain("mud-width-full");
+            buttonComps[1].ClassList.Should().Contain("mud-width-full");
+        }
     }
 }

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -1,5 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudBaseButton
+@implements IDisposable
 
 <MudElement @bind-Ref="@_elementReference"
             HtmlTag="@HtmlTag"

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
     /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
     /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
     /// </remarks>
-    public partial class MudButton : MudBaseButton, IHandleEvent
+    public partial class MudButton : MudBaseButton, IHandleEvent, IDisposable
     {
         protected string Classname => new CssBuilder("mud-button-root mud-button")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}")


### PR DESCRIPTION
## Description

In the PR #9713, the method `MudButton.Dispose` was added. But `MudButton` don't implement `IDisposable`, so `MudButton.Dispose` isn't called.

## How Has This Been Tested?

I added unit test.

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
