### PR TITLE
MudColor: Remove [JsonInclude] from public properties

### DIFF
--- a/src/MudBlazor.UnitTests/Dummy/MudColorSerializerContext.cs
+++ b/src/MudBlazor.UnitTests/Dummy/MudColorSerializerContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace MudBlazor.UnitTests.Dummy;
+
+[JsonSerializable(typeof(PaletteLight))]
+internal sealed partial class MudColorSerializerContext : JsonSerializerContext;

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -4,9 +4,9 @@
 
 using System.Buffers.Binary;
 using System.Globalization;
-using System.IO;
 using System.Text;
 using FluentAssertions;
+using MudBlazor.UnitTests.Dummy;
 using MudBlazor.Utilities;
 using NUnit.Framework;
 
@@ -15,6 +15,21 @@ namespace MudBlazor.UnitTests.Utilities
     [TestFixture]
     public class MudColorTests
     {
+        [Test]
+        public void MudColor_STJ_SourceGen_Serialization()
+        {
+            var originalMudColor = new MudColor("#f6f9fb");
+
+            var mudColorType = typeof(MudColor);
+            var context = new MudColorSerializerContext();
+
+            var jsonString = System.Text.Json.JsonSerializer.Serialize(originalMudColor, mudColorType, context);
+            var deserializeMudColor = System.Text.Json.JsonSerializer.Deserialize(jsonString, mudColorType, context);
+
+            jsonString.Should().Be("{\"R\":246,\"G\":249,\"B\":251,\"A\":255}");
+            deserializeMudColor.Should().Be(originalMudColor);
+        }
+
         [Test]
         public void MudColor_STJ_Serialization()
         {

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -62,25 +62,21 @@ namespace MudBlazor.Utilities
         /// <summary>
         /// Gets the red component value of the color.
         /// </summary>
-        [JsonInclude]
         public byte R => _valuesAsByte[0];
 
         /// <summary>
         /// Gets the green component value of the color.
         /// </summary>
-        [JsonInclude]
         public byte G => _valuesAsByte[1];
 
         /// <summary>
         /// Gets the blue component value of the color.
         /// </summary>
-        [JsonInclude]
         public byte B => _valuesAsByte[2];
 
         /// <summary>
         /// Gets the alpha component value of the color.
         /// </summary>
-        [JsonInclude]
         public byte A => _valuesAsByte[3];
 
         /// <summary>
@@ -351,10 +347,10 @@ namespace MudBlazor.Utilities
 
                 _valuesAsByte = new[]
                 {
-                    GetByteFromValuePart(value,0),
-                    GetByteFromValuePart(value,2),
-                    GetByteFromValuePart(value,4),
-                    GetByteFromValuePart(value,6),
+                    MudColor.GetByteFromValuePart(value,0),
+                    MudColor.GetByteFromValuePart(value,2),
+                    MudColor.GetByteFromValuePart(value,4),
+                    MudColor.GetByteFromValuePart(value,6),
                 };
             }
 
@@ -563,7 +559,7 @@ namespace MudBlazor.Utilities
         /// <returns>The 32-bit unsigned integer representation of the color.</returns>
         public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
 
-        private byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
+        private static byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 
         private static string[] SplitInputIntoParts(string value)
         {

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -347,10 +347,10 @@ namespace MudBlazor.Utilities
 
                 _valuesAsByte = new[]
                 {
-                    MudColor.GetByteFromValuePart(value,0),
-                    MudColor.GetByteFromValuePart(value,2),
-                    MudColor.GetByteFromValuePart(value,4),
-                    MudColor.GetByteFromValuePart(value,6),
+                    GetByteFromValuePart(value,0),
+                    GetByteFromValuePart(value,2),
+                    GetByteFromValuePart(value,4),
+                    GetByteFromValuePart(value,6),
                 };
             }
 


### PR DESCRIPTION
## Description
Apparently the `JsonIncludeAttribute` is only meant for private / internal modifiers, you don't need it for public properties.
This produced a false positive warring when `MudColor` is used with source-generator.

## How Has This Been Tested?
Manual, unit test.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
