### PR TITLE
Typography: Fix cannot resolve symbol in the xmldoc

### DIFF
--- a/src/MudBlazor/Themes/Models/Typography.cs
+++ b/src/MudBlazor/Themes/Models/Typography.cs
@@ -10,7 +10,7 @@
         /// Gets or sets the typography settings for the default typo.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Default.Default()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Default"/> constructor.
         /// </remarks>
         public Default Default { get; set; } = new();
 
@@ -18,7 +18,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h1"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H1.H1()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H1"/> constructor.
         /// </remarks>
         public H1 H1 { get; set; } = new();
 
@@ -26,7 +26,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h2"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H2.H2()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H2"/> constructor.
         /// </remarks>
         public H2 H2 { get; set; } = new();
 
@@ -34,7 +34,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h3"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H3.H3()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H3"/> constructor.
         /// </remarks>
         public H3 H3 { get; set; } = new();
 
@@ -42,7 +42,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h4"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H4.H4()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H4"/> constructor.
         /// </remarks>
         public H4 H4 { get; set; } = new();
 
@@ -50,7 +50,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h5"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H5.H5()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H5"/> constructor.
         /// </remarks>
         public H5 H5 { get; set; } = new();
 
@@ -58,7 +58,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.h6"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="H6.H6()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.H6"/> constructor.
         /// </remarks>
         public H6 H6 { get; set; } = new();
 
@@ -66,7 +66,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.subtitle1"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Subtitle1.Subtitle1()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Subtitle1"/> constructor.
         /// </remarks>
         public Subtitle1 Subtitle1 { get; set; } = new();
 
@@ -74,7 +74,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.subtitle2"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Subtitle2.Subtitle2()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Subtitle2"/> constructor.
         /// </remarks>
         public Subtitle2 Subtitle2 { get; set; } = new();
 
@@ -82,7 +82,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.body1"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Body1.Body1()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Body1"/> constructor.
         /// </remarks>
         public Body1 Body1 { get; set; } = new();
 
@@ -90,7 +90,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.body2"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Body2.Body2()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Body2"/> constructor.
         /// </remarks>
         public Body2 Body2 { get; set; } = new();
 
@@ -98,7 +98,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.input"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Input.Input()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Input"/> constructor.
         /// </remarks>
         public Input Input { get; set; } = new();
 
@@ -106,7 +106,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.button"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Button.Button()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Button"/> constructor.
         /// </remarks>
         public Button Button { get; set; } = new();
 
@@ -114,7 +114,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.caption"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Caption.Caption()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Caption"/> constructor.
         /// </remarks>
         public Caption Caption { get; set; } = new();
 
@@ -122,7 +122,7 @@
         /// Gets or sets the typography settings for <see cref="Typo.overline"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to the values from the <see cref="Overline.Overline()"/> constructor.
+        /// Defaults to the values from the <see cref="MudBlazor.Overline"/> constructor.
         /// </remarks>
         public Overline Overline { get; set; } = new();
     }


### PR DESCRIPTION
## Description
The `see cref` was used incorrectly and produced an error:
![Save](https://github.com/user-attachments/assets/2dde796a-4591-4d0f-8405-5cf63bc76a76)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
