### PR TITLE
MudIconButton : Add the parameter FullWidth (#9811)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/IconButtonTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconButtonTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using ColorCode.Styling;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components;
+
+[TestFixture]
+public class IconButtonTests : BunitTest
+{
+    [Test]
+    public void WithFullWidth_ThenStretched_AfterwardsWithoutFullWidth_ThenNotStretched()
+    {
+        // Arrange
+
+        var comp = Context.RenderComponent<MudIconButton>(parameters => parameters.Add(c => c.FullWidth, true));
+
+        // Assert
+
+        comp.Find("button").ClassList.Should().Contain("mud-width-full");
+
+        // Act
+
+        comp.SetParametersAndRender(parameters => parameters.Add(c => c.FullWidth, false));
+
+        // Assert
+
+        comp.Find("button").ClassList.Should().NotContain("mud-width-full");
+    }
+
+    [Test]
+    public void WithoutFullWidth_ThenNotStretched_AfterwardsWithFullWidth_ThenStretched()
+    {
+        // Arrange
+
+        var comp = Context.RenderComponent<MudIconButton>(parameters => parameters.Add(c => c.FullWidth, false));
+
+        // Assert
+
+        comp.Find("button").ClassList.Should().NotContain("mud-width-full");
+
+        // Act
+
+        comp.SetParametersAndRender(parameters => parameters.Add(c => c.FullWidth, true));
+
+        // Assert
+
+        comp.Find("button").ClassList.Should().Contain("mud-width-full");
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -26,6 +26,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.DropShadow.Should().BeTrue();
             comp.Instance.Disabled.Should().BeFalse();
             comp.Instance.ClickPropagation.Should().BeFalse();
+            comp.Instance.FullWidth.Should().BeFalse();
         }
 
         [Test]
@@ -170,6 +171,46 @@ namespace MudBlazor.UnitTests.Components
 
             // Check toggled state
             comp.Instance.GetVariant().Should().Be(expectedToggledVariant);
+        }
+
+        [Test]
+        public void WithFullWidth_ThenStretched_AfterwardsWithoutFullWidth_ThenNotStretched()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters.Add(c => c.FullWidth, true));
+
+            // Assert
+
+            comp.Find("button").ClassList.Should().Contain("mud-width-full");
+
+            // Act
+
+            comp.SetParametersAndRender(parameters => parameters.Add(c => c.FullWidth, false));
+
+            // Assert
+
+            comp.Find("button").ClassList.Should().NotContain("mud-width-full");
+        }
+
+        [Test]
+        public void WithoutFullWidth_ThenNotStretched_AfterwardsWithFullWidth_ThenStretched()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters.Add(c => c.FullWidth, false));
+
+            // Assert
+
+            comp.Find("button").ClassList.Should().NotContain("mud-width-full");
+
+            // Act
+
+            comp.SetParametersAndRender(parameters => parameters.Add(c => c.FullWidth, true));
+
+            // Assert
+
+            comp.Find("button").ClassList.Should().Contain("mud-width-full");
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
             .AddClass($"mud-button-{Variant.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}", AsButton)
+            .AddClass($"mud-width-full", FullWidth)
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-ripple-icon", Ripple && !AsButton)
             .AddClass($"mud-icon-button-size-{Size.ToDescriptionString()}", when: () => Size != Size.Medium)
@@ -80,6 +81,16 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Expands the button to 100% of the container width.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public bool FullWidth { get; set; }
 
         /// <summary>
         /// The custom content within this button.

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor
@@ -13,5 +13,6 @@
                Style="@Style"
                DropShadow="@DropShadow"
                ClickPropagation="ClickPropagation"
+               FullWidth="@FullWidth"
                aria-pressed="@Toggled.ToString().ToLowerInvariant()"
                @attributes="UserAttributes" />

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -143,6 +143,16 @@ public partial class MudToggleIconButton : MudComponentBase
     public bool ClickPropagation { get; set; }
 
     /// <summary>
+    /// Expands the button to 100% of the container width.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public bool FullWidth { get; set; }
+
+    /// <summary>
     /// Gets the icon to display based on the toggled state.
     /// </summary>
     /// <returns>

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -1,5 +1,4 @@
 .mud-icon-button {
-  flex: 0 0 auto;
   padding: 12px;
   overflow: visible;
   font-size: 1.5rem;


### PR DESCRIPTION
## Description

This PR add the parameter `FullWidth` in `MudIconButton` and `MudToggleIconButton`.
`FullWidth` add the class `mud-width-full` on the button to stretch it.

Visual example :
```razor
<p>MudToggleIconButton without FullWidth</p>
<div style="background-color: rgba(51, 170, 51, .05)">
    <MudToggleIconButton Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
                         ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" />
</div>

<br />

<p>MudToggleIconButton with FullWidth</p>
<div style="background-color: rgba(51, 170, 51, .05)">
    <MudToggleIconButton Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
                         ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success"
                         FullWidth />
</div>
```
![image](https://github.com/user-attachments/assets/e89cf0d8-8df0-40db-a2ee-fe67e6951f2b)

From the issue #9811.

I will do a second PR to manage the case with `MudButtonGroup`.

## How Has This Been Tested?

I added new tests.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
