### PR TITLE
MudAutocomplete : CoerceValue only on Blur with Immediate=false

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -892,11 +892,12 @@ namespace MudBlazor.UnitTests.Components
                 await comp.InvokeAsync(() => autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());
-                autocompletecomp.Find("input").Input("abc");
+                await autocompletecomp.Find("input").InputAsync(new ChangeEventArgs() { Value = "abc" });
                 await comp.InvokeAsync(async () => await autocomplete.SelectAsync());
                 await comp.InvokeAsync(async () => await autocomplete.SelectRangeAsync(0, 1));
-                autocompletecomp.Find("input").Input("");
-                await comp.InvokeAsync(() => autocomplete.ToggleMenuAsync());
+                comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
+
+                await autocompletecomp.Find("input").InputAsync(new ChangeEventArgs() { Value = "" });
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -209,6 +209,82 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            {
+                parameters.Add(a => a.CoerceValue, true);
+                parameters.Add(a => a.CoerceText, false);
+                parameters.Add(a => a.Immediate, false);
+                parameters.Add(a => a.DebounceInterval, 0);
+            });
+            var ccc = comp.FindComponent<MudInput<string>>();
+
+            // Assert : Initial
+
+            comp.Instance.Text.Should().BeNull();
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Input("ABC");
+
+            // Assert : Immediate false, so value isn't set
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Blur();
+
+            // Assert : Focus lost, so value is set
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().Be("ABC");
+        }
+
+        [Test]
+        public async Task CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnEnter()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            {
+                parameters.Add(a => a.CoerceValue, true);
+                parameters.Add(a => a.CoerceText, false);
+                parameters.Add(a => a.Immediate, false);
+                parameters.Add(a => a.DebounceInterval, 0);
+            });
+            var ccc = comp.FindComponent<MudInput<string>>();
+
+            // Assert : Initial
+
+            comp.Instance.Text.Should().BeNull();
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Input("ABC");
+
+            // Assert : Immediate false, so value isn't set
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").KeyUp("Enter");
+
+            // Assert : Enter pressed, so value is set
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().Be("ABC");
+        }
+
+        [Test]
         public async Task AutocompleteCoercionOffTest()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -231,7 +231,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Input("ABC");
 
-            // Assert : Immediate false, so value isn't set
+            // Assert : Immediate false, so value is not set on text changed
 
             comp.Instance.Text.Should().Be("ABC");
             comp.Instance.Value.Should().BeNull();
@@ -240,10 +240,48 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Blur();
 
-            // Assert : Focus lost, so value is set
+            // Assert : CoercedValue disabled, so value is set on focus lost
 
             comp.Instance.Text.Should().Be("ABC");
             comp.Instance.Value.Should().Be("ABC");
+        }
+
+        [Test]
+        public async Task NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            {
+                parameters.Add(a => a.CoerceValue, false);
+                parameters.Add(a => a.CoerceText, false);
+                parameters.Add(a => a.Immediate, false);
+                parameters.Add(a => a.DebounceInterval, 0);
+            });
+            var ccc = comp.FindComponent<MudInput<string>>();
+
+            // Assert : Initial
+
+            comp.Instance.Text.Should().BeNull();
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Input("ABC");
+
+            // Assert : Immediate false, so value is not set on text changed
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Blur();
+
+            // Assert : CoercedValue disabled, so value is not set on focus lost
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
         }
 
         [Test]
@@ -269,7 +307,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Input("ABC");
 
-            // Assert : Immediate false, so value isn't set
+            // Assert : Immediate false, so value is not set
 
             comp.Instance.Text.Should().Be("ABC");
             comp.Instance.Value.Should().BeNull();
@@ -278,10 +316,48 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").KeyUp("Enter");
 
-            // Assert : Enter pressed, so value is set
+            // Assert : CoercedValue enabled, so value is set on key enter pressed
 
             comp.Instance.Text.Should().Be("ABC");
             comp.Instance.Value.Should().Be("ABC");
+        }
+
+        [Test]
+        public async Task NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueNotSetOnEnter()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            {
+                parameters.Add(a => a.CoerceValue, false);
+                parameters.Add(a => a.CoerceText, false);
+                parameters.Add(a => a.Immediate, false);
+                parameters.Add(a => a.DebounceInterval, 0);
+            });
+            var ccc = comp.FindComponent<MudInput<string>>();
+
+            // Assert : Initial
+
+            comp.Instance.Text.Should().BeNull();
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").Input("ABC");
+
+            // Assert : Immediate false, so value is not set
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
+
+            // Act
+
+            comp.Find("input").KeyUp("Enter");
+
+            // Assert : CoercedValue disabled, so value is not set on key enter pressed
+
+            comp.Instance.Text.Should().Be("ABC");
+            comp.Instance.Value.Should().BeNull();
         }
 
         [Test]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -712,14 +712,14 @@ namespace MudBlazor
                 Open = true;
             }
 
-            if (_items?.Length == 0)
+            if (Immediate && _items?.Length == 0)
             {
                 await CoerceValueToTextAsync();
                 StateHasChanged();
                 return;
             }
 
-            if (!CoerceText && CoerceValue)
+            if (Immediate && !CoerceText)
             {
                 await CoerceValueToTextAsync();
             }
@@ -883,12 +883,9 @@ namespace MudBlazor
             {
                 // When Immediate is enabled, then the CoerceValue is set by TextChanged
                 // So only coerce the value on enter when Immediate is disabled
-                if (CoerceValue && !Immediate)
+                if (!Immediate)
                 {
-                    _debounceTimer?.Dispose();
-
-                    var value = Converter.Get(Text);
-                    await SetValueAsync(value, updateText: false);
+                    await CoerceValueToTextAsync();
                 }
                 return;
             }
@@ -942,12 +939,9 @@ namespace MudBlazor
 
             // When Immediate is enabled, then the CoerceValue is set by TextChanged
             // So only coerce the value on blur when Immediate is disabled
-            if (CoerceValue && !Immediate)
+            if (!Immediate)
             {
-                _debounceTimer?.Dispose();
-
-                var value = Converter.Get(Text);
-                return SetValueAsync(value, updateText: false);
+                return CoerceValueToTextAsync();
             }
 
             return OnBlur.InvokeAsync(args);
@@ -984,7 +978,7 @@ namespace MudBlazor
 
         private Task CoerceValueToTextAsync()
         {
-            if (Immediate && CoerceValue)
+            if (CoerceValue)
             {
                 _debounceTimer?.Dispose();
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -978,15 +978,13 @@ namespace MudBlazor
 
         private Task CoerceValueToTextAsync()
         {
-            if (CoerceValue)
-            {
-                _debounceTimer?.Dispose();
+            if (!CoerceValue)
+                return Task.CompletedTask;
 
-                var value = Converter.Get(Text);
-                return SetValueAsync(value, updateText: false);
-            }
+            _debounceTimer?.Dispose();
 
-            return Task.CompletedTask;
+            var value = Converter.Get(Text);
+            return SetValueAsync(value, updateText: false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -881,7 +881,9 @@ namespace MudBlazor
         {
             if (!Open || _items == null || _items.Length == 0)
             {
-                if (!Immediate)
+                // When Immediate is enabled, then the CoerceValue is set by TextChanged
+                // So only coerce the value on enter when Immediate is disabled
+                if (CoerceValue && !Immediate)
                 {
                     _debounceTimer?.Dispose();
 
@@ -938,7 +940,9 @@ namespace MudBlazor
         {
             _isFocused = false;
 
-            if (!Immediate)
+            // When Immediate is enabled, then the CoerceValue is set by TextChanged
+            // So only coerce the value on blur when Immediate is disabled
+            if (CoerceValue && !Immediate)
             {
                 _debounceTimer?.Dispose();
 


### PR DESCRIPTION
## Description

Currently, `MudAutocomplete` with the parameters `CoerceValue=true` and `Immediate=false` set immediately the value :
![371849987-e06ce9b9-1c7d-47f4-9b73-e38497e41777](https://github.com/user-attachments/assets/839784e6-4b7c-4f12-beba-4164089849d0)

This PR modify the behavior to set the value only on blur or enter is pressed.

Resolve #9874

## How Has This Been Tested?

I added unit tests.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
