### PR TITLE
FileUpload: Fix code documentation of IReadOnlyCollection to supported IReadOnlyList

### DIFF
--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -20,9 +20,9 @@ namespace MudBlazor
 #nullable enable
 
     /// <summary>
-    /// A form component for uploading one or more files.  For <c>T</c>, use either <c>IBrowserFile</c> for a single file or <c>IReadOnlyCollection&lt;IBrowserFile&gt;</c> for multiple files.
+    /// A form component for uploading one or more files.  For <c>T</c>, use either <c>IBrowserFile</c> for a single file or <c>IReadOnlyList&lt;IBrowserFile&gt;</c> for multiple files.
     /// </summary>
-    /// <typeparam name="T">Either <see cref="IBrowserFile"/> for a single file or <see cref="IReadOnlyCollection{IBrowserFile}">IReadOnlyCollection&lt;IBrowserFile&gt;</see> for multiple files.</typeparam>
+    /// <typeparam name="T">Either <see cref="IBrowserFile"/> for a single file or <see cref="IReadOnlyList{IBrowserFile}">IReadOnlyList&lt;IBrowserFile&gt;</see> for multiple files.</typeparam>
     public partial class MudFileUpload<T> : MudFormComponent<T, string>, IActivatable
     {
         private readonly ParameterState<T?> _filesState;
@@ -53,7 +53,7 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// When <c>T</c> is <see cref="IBrowserFile" />, a single file is returned.<br />
-        /// When <c>T</c> is <see cref="IReadOnlyCollection{IBrowserFile}">IReadOnlyCollection&lt;IBrowserFile&gt;</see>, multiple files are returned.
+        /// When <c>T</c> is <see cref="IReadOnlyList{IBrowserFile}">IReadOnlyList&lt;IBrowserFile&gt;</see>, multiple files are returned.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]
@@ -77,7 +77,7 @@ namespace MudBlazor
         /// Appends additional files to the existing list.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>. This applies when <c>T</c> is <see cref="IReadOnlyCollection{IBrowserFile}">IReadOnlyCollection&lt;IBrowserFile&gt;</see>.
+        /// Defaults to <c>false</c>. This applies when <c>T</c> is <see cref="IReadOnlyList{IBrowserFile}">IReadOnlyList&lt;IBrowserFile&gt;</see>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FileUpload.Behavior)]


### PR DESCRIPTION
## Description
The `MudFileUpload` component mentions the use of `IBrowserFile` and `IReadOnlyCollection<IBrowserFile>` as supported generic types in multiple places, although [there is a type check that only allows `IBrowserFile` and `IReadOnlyList<IBrowserFile>` in the component](https://github.com/MudBlazor/MudBlazor/blob/025cb4439b073512a38b201736c105c155e75316/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs#L236-L244). The code documentation has therefore been changed to also use `IReadOnlyList<IBrowserFile>`.

## How Has This Been Tested?
None

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.