### PR TITLE
DataGrid: Document that GridState has a zero-based page index

### DIFF
--- a/src/MudBlazor/Components/DataGrid/GridState.cs
+++ b/src/MudBlazor/Components/DataGrid/GridState.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
     public class GridState<T>
     {
         /// <summary>
-        /// The current page being displayed.
+        /// The current page being displayed. The page index is zero-based.
         /// </summary>
         public int Page { get; set; }
 


### PR DESCRIPTION
## Description
This is just a minor addition in the code documentation to mention that the pages start at `0` when `ServerData` with `GridState<T>` is being used. For the `GridStateVirtualize<T>`, this information is already present:
https://github.com/MudBlazor/MudBlazor/blob/4f65a765a9dda184b4902cebb923bb51cd9910cf/src/MudBlazor/Components/DataGrid/GridState.cs#L39-L44

The information that the page is zero-based is taken from `MudDataGrid.razor.cs`:
https://github.com/MudBlazor/MudBlazor/blob/4f65a765a9dda184b4902cebb923bb51cd9910cf/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs#L1596-L1618

## How Has This Been Tested?
None

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
