### PR TITLE
Build: Disable warnings about files being in the wrong namespace

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -287,14 +287,14 @@ csharp_style_var_elsewhere = true:warning
 dotnet_diagnostic.CA1822.severity = suggestion
 
 # MudBlazor Team Overrides
-# Settings in editorconfig are last in wins so add overides here
+# Settings in editorconfig are last in wins so add overrides here
 
 [*.cs]
 # CS1591 Missing XML comment for publicly visible type or member
 # We should try and finish the documentation and remove this
 # For now its too noisy
 dotnet_diagnostic.CS1591.severity = none
-# IDE0071 Require file header 
+# IDE0071 Require file header
 dotnet_diagnostic.IDE0073.severity = none
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = suggestion
@@ -310,6 +310,10 @@ dotnet_diagnostic.IDE0057.severity = none
 dotnet_diagnostic.BL0007.severity = suggestion
 # IDE0290 Use primary constructor
 dotnet_diagnostic.IDE0290.severity = none
+
+[*.{cs,razor}]
+dotnet_style_namespace_match_folder = false
+resharper_check_namespace_highlighting = none
 
 [*]
 end_of_line = lf

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -311,7 +311,7 @@ dotnet_diagnostic.BL0007.severity = suggestion
 # IDE0290 Use primary constructor
 dotnet_diagnostic.IDE0290.severity = none
 
-[*.{cs,razor}]
+[src/MudBlazor/**/*.{cs,razor}]
 dotnet_style_namespace_match_folder = false
 resharper_check_namespace_highlighting = none
 


### PR DESCRIPTION
## Description

Disables warnings about files being in the wrong namespace. I recently added this to our work codebase but only for our `.Components` assembly because that's the only one that merges all files into the same namespace. I could also add sub-`.editorconfig`s for the assemblies where namespaces are merged in MudBlazor if that's preferred.

## How Has This Been Tested?

Rider doesn't show me squiggly lines on the namespace declaration :')

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
