### PR TITLE
MudDialog: Don't override `Class` param and convert BackgroundClass to getter

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -105,7 +105,6 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            ConfigureInstance();
             base.OnInitialized();
         }
 
@@ -162,7 +161,6 @@ namespace MudBlazor
         public void SetOptions(DialogOptions options)
         {
             Options = options;
-            ConfigureInstance();
             StateHasChanged();
         }
 
@@ -213,12 +211,6 @@ namespace MudBlazor
         public void Cancel()
         {
             Close(DialogResult.Cancel());
-        }
-
-        private void ConfigureInstance()
-        {
-            Class = Classname;
-            BackgroundClassname = new CssBuilder("mud-overlay-dialog").AddClass(Options.BackgroundClass).Build();
         }
 
         private string GetPosition()
@@ -295,7 +287,7 @@ namespace MudBlazor
                 .AddClass(_dialog?.Class)
             .Build();
 
-        protected string BackgroundClassname { get; set; } = "mud-overlay-dialog";
+        protected string BackgroundClassname => new CssBuilder("mud-overlay-dialog").AddClass(Options.BackgroundClass).Build();
 
         private bool GetHideHeader()
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

This PR removes `ConfigureInstance()` from `MudDialogInstance` to complete my refactoring towards only using getters instead of caching state in private and protected fields as a followup to #9906 where some fields were already eliminated.

The protected property `BackgroundClass` is now only used as a getter instead of using it as storage. I am not sure if this is even a breaking change as it is quite unlikely that someone would have derived from MudDialogInstance. But we'll not take any risks and merge it only with v8.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

No additional tests needed.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
