### PR TITLE
ToggleItem: Add `Color` property independent from parent group

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleCustomColorExample.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudToggleGroup T="string" SelectionMode="SelectionMode.MultiSelection" Color="Color.Primary">
+    <MudToggleItem Value="@("One")"/>
+    <MudToggleItem Value="@("Two")" Color="Color.Warning" />
+    <MudToggleItem Value="@("Three")" Color="Color.Secondary" />
+    <MudToggleItem Value="@("Four")" Color="Color.Tertiary" />
+</MudToggleGroup>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
@@ -65,6 +65,17 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Custom Color">
+                <Description>
+                    You can change the color for individual items.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(ToggleCustomColorExample)" ShowCode="false">
+                <ToggleCustomColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Custom Selection Style">
                 <Description>
                     You can customize the look of selected items with <CodeInline>SelectedClass</CodeInline>.

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -13,6 +13,8 @@ namespace MudBlazor
 #nullable enable
     public partial class MudToggleGroup<T> : MudComponentBase
     {
+        private Color? _overrideColor;
+
         public MudToggleGroup()
         {
             using var registerScope = CreateRegisterScope();
@@ -77,7 +79,7 @@ namespace MudBlazor
             .AddClass("rounded", !Rounded)
             .AddClass("rounded-xl", Rounded)
             .AddClass("mud-toggle-group-rtl", RightToLeft)
-            .AddClass($"border mud-border-{Color.ToDescriptionString()} border-solid", Outlined)
+            .AddClass($"border mud-border-{(_overrideColor ?? Color).ToDescriptionString()} border-solid", Outlined)
             .AddClass("mud-disabled", Disabled)
             .AddClass(Class)
             .Build();
@@ -335,6 +337,7 @@ namespace MudBlazor
         protected internal async Task ToggleItemAsync(MudToggleItem<T> item)
         {
             var itemValue = item.Value;
+
             if (SelectionMode == SelectionMode.MultiSelection)
             {
                 var selectedValues = new HashSet<T?>(_values.Value ?? Array.Empty<T?>());
@@ -370,6 +373,22 @@ namespace MudBlazor
                 DeselectAllItems();
                 item.SetSelected(true);
                 await _value.SetValueAsync(itemValue);
+            }
+
+            // Override the set color if the item has its own color and was the last one selected.
+            if (item.Color is not null && item.Selected)
+            {
+                _overrideColor = item.Color;
+                StateHasChanged();
+            }
+            else
+            {
+                // Reset the override color if the item was deselected.
+                if (_overrideColor != null)
+                {
+                    _overrideColor = null;
+                    StateHasChanged();
+                }
             }
         }
 

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor
@@ -9,7 +9,7 @@
            Style="@Style"
            OnClick="HandleOnClickAsync"
            Size="@(Parent?.Size ?? Size.Medium)"
-           Color="@(Parent?.Color ?? Color.Default)"
+           Color="@(Color ?? Parent?.Color ?? MudBlazor.Color.Default)"
            Variant="@(Selected ? Variant.Filled : Variant.Outlined)"
            Disabled="Disabled || (Parent?.Disabled ?? false)"
            Ripple="Parent?.Ripple == true"

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -57,6 +57,13 @@ namespace MudBlazor
         public string? SelectedIcon { get; set; } = Icons.Material.Filled.Check;
 
         /// <summary>
+        /// The color of the toggle item. Affects borders and selection color. Default is to inherit from the parent.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Appearance)]
+        public Color? Color { get; set; }
+
+        /// <summary>
         /// The text to show. You need to set this only if you want a text that differs from the Value. If null,
         /// show Value?.ToString().
         /// Note: the Text is only shown if you haven't defined your own child content.


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #9326 by adding the ability to set a color on a toggle item that's different from the parent. This is like the sister MudButtonGroup but with a twist that the border changes based on the selection.

Todo:
- Tests
- Delimiters should use the right color

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Existing button group behavior (for reference):

https://github.com/user-attachments/assets/47eb1072-7ff8-4b62-90ad-59e37103a2a4

New toggle group behavior:


https://github.com/user-attachments/assets/228338e2-b335-43c7-aeef-c7ed4d93a0c8



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
