### PR TITLE
MudNumericField: Change default InputMode to decimal

### DIFF
--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -86,6 +86,7 @@ namespace MudBlazor
                 _minDefault = (T)(object)float.MinValue;
                 _maxDefault = (T)(object)float.MaxValue;
                 _stepDefault = (T)(object)1.0f;
+                InputMode = InputMode.@decimal;
             }
             // double
             else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
@@ -93,6 +94,7 @@ namespace MudBlazor
                 _minDefault = (T)(object)double.MinValue;
                 _maxDefault = (T)(object)double.MaxValue;
                 _stepDefault = (T)(object)1.0;
+                InputMode = InputMode.@decimal;
             }
             // decimal
             else if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
@@ -100,6 +102,7 @@ namespace MudBlazor
                 _minDefault = (T)(object)decimal.MinValue;
                 _maxDefault = (T)(object)decimal.MaxValue;
                 _stepDefault = (T)(object)1M;
+                InputMode = InputMode.@decimal;
             }
 
             #endregion parameters default depending on T


### PR DESCRIPTION
MudNumericField: Change default InputMode for numeric types that require decimals. (#4198)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Fixes #4198 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Ran MudBlazor.Docs.Server with a devtunnel to connect an iPhone using Safari browser and checked MudNumericField, MudDataGrid, and MudColorPicker for appropriate updates. Did the same with a Windows machine using Chrome and an Android device using Chrome to make sure there were no other breaking changes.

Also modified the NumericFieldBasicExample.razor to ensure that a user can override the default back to InputMode numeric if they so desired. (Not included in PR, just for testing purposes.)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
