### PR TITLE
MudStepper: Fix step number alignment

### DIFF
--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -48,11 +48,16 @@
           width: 24px;
           align-items: center;
           justify-content: center;
+          text-align: center;
           font-size: 12px;
           letter-spacing: 0;
           line-height: 1;
           text-indent: 0;
           white-space: nowrap;
+
+          .mud-typography {
+            line-height: 24px;
+          }
         }
 
         .mud-step-label-content {

--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -48,15 +48,13 @@
           width: 24px;
           align-items: center;
           justify-content: center;
-          text-align: center;
           font-size: 12px;
           letter-spacing: 0;
-          line-height: 1;
           text-indent: 0;
           white-space: nowrap;
 
           .mud-typography {
-            line-height: 24px;
+            line-height: 1;
           }
         }
 


### PR DESCRIPTION
## Description
Part of #9928

Text alignment in the stepper was off, corrected by forcing the same lineheight as the parent width/height

### Before:
![image](https://github.com/user-attachments/assets/73eca430-2dff-4333-8302-b1437aae80af)
### After:
![image](https://github.com/user-attachments/assets/923b237b-d597-45a4-85c4-62cf5aa77c97)


## How Has This Been Tested?
visually 

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
