### PR TITLE
MudSelect: Add nullable annotation.

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -10,13 +10,18 @@ using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor
 {
+#nullable enable
     public partial class MudSelect<T> : MudBaseInput<T>, IMudSelect, IMudShadowSelect
     {
-        private HashSet<T> _selectedValues = new HashSet<T>();
-        private IEqualityComparer<T> _comparer;
-        private bool _dense;
-        private string multiSelectionText;
+        private string? _activeItemId;
         private bool? _selectAllChecked;
+        private string? _multiSelectionText;
+        private IEqualityComparer<T?>? _comparer;
+        private TaskCompletionSource? _renderComplete;
+        private MudInput<string> _elementReference = null!;
+        private HashSet<T?> _selectedValues = new HashSet<T?>();
+        protected internal List<MudSelectItem<T>> _items = new();
+        private string _elementId = Identifier.Create("select");
 
         protected string OuterClassname =>
             new CssBuilder("mud-select")
@@ -37,9 +42,7 @@ namespace MudBlazor
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 
         [Inject]
-        private IScrollManager ScrollManager { get; set; }
-
-        private string _elementId = Identifier.Create("select");
+        private IScrollManager ScrollManager { get; set; } = null!;
 
         private Task SelectNextItem() => SelectAdjacentItem(+1);
 
@@ -47,12 +50,12 @@ namespace MudBlazor
 
         private async Task SelectAdjacentItem(int direction)
         {
-            if (_items == null || _items.Count == 0)
+            if (_items.Count == 0)
                 return;
-            var index = _items.FindIndex(x => x.ItemId == (string)_activeItemId);
+            var index = _items.FindIndex(x => x.ItemId == _activeItemId);
             if (direction < 0 && index < 0)
                 index = 0;
-            MudSelectItem<T> item = null;
+            MudSelectItem<T>? item = null;
             // the loop allows us to jump over disabled items until we reach the next non-disabled one
             for (var i = 0; i < _items.Count; i++)
             {
@@ -69,32 +72,30 @@ namespace MudBlazor
                     _selectedValues.Clear();
                     _selectedValues.Add(item.Value);
                     await SetValueAsync(item.Value, updateText: true);
-                    HilightItem(item);
+                    HighlightItem(item);
                     break;
                 }
-                else
-                {
-                    // in multiselect mode don't select anything, just hilight.
-                    // selecting is done by Enter
-                    HilightItem(item);
-                    break;
-                }
+
+                // in multiselect mode don't select anything, just highlight.
+                // selecting is done by Enter
+                HighlightItem(item);
+                break;
             }
             await _elementReference.SetText(Text);
             await ScrollToItemAsync(item);
         }
-        private ValueTask ScrollToItemAsync(MudSelectItem<T> item)
+        private ValueTask ScrollToItemAsync(MudSelectItem<T>? item)
             => item != null ? ScrollManager.ScrollToListItemAsync(item.ItemId) : ValueTask.CompletedTask;
-        private async Task SelectFirstItem(string startChar = null)
+
+        private async Task SelectFirstItem(string? startChar = null)
         {
-            if (_items == null || _items.Count == 0)
+            if (_items.Count == 0)
                 return;
             var items = _items.Where(x => !x.Disabled);
-            var firstItem = items.FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(startChar))
             {
                 // find first item that starts with the letter
-                var currentItem = items.FirstOrDefault(x => x.ItemId == (string)_activeItemId);
+                var currentItem = items.FirstOrDefault(x => x.ItemId == _activeItemId);
                 if (currentItem != null &&
                     Converter.Set(currentItem.Value)?.ToLowerInvariant().StartsWith(startChar) == true)
                 {
@@ -111,11 +112,11 @@ namespace MudBlazor
                 _selectedValues.Clear();
                 _selectedValues.Add(item.Value);
                 await SetValueAsync(item.Value, updateText: true);
-                HilightItem(item);
+                HighlightItem(item);
             }
             else
             {
-                HilightItem(item);
+                HighlightItem(item);
             }
             await _elementReference.SetText(Text);
             await ScrollToItemAsync(item);
@@ -123,7 +124,7 @@ namespace MudBlazor
 
         private async Task SelectLastItem()
         {
-            if (_items == null || _items.Count == 0)
+            if (_items.Count == 0)
                 return;
             var item = _items.LastOrDefault(x => !x.Disabled);
             if (item == null)
@@ -133,11 +134,11 @@ namespace MudBlazor
                 _selectedValues.Clear();
                 _selectedValues.Add(item.Value);
                 await SetValueAsync(item.Value, updateText: true);
-                HilightItem(item);
+                HighlightItem(item);
             }
             else
             {
-                HilightItem(item);
+                HighlightItem(item);
             }
             await _elementReference.SetText(Text);
             await ScrollToItemAsync(item);
@@ -147,57 +148,57 @@ namespace MudBlazor
         /// The outer div's classnames, seperated by space.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Appearance)]
-        [Parameter] public string OuterClass { get; set; }
+        [Parameter]
+        public string? OuterClass { get; set; }
 
         /// <summary>
         /// Input's classnames, seperated by space.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Appearance)]
-        [Parameter] public string InputClass { get; set; }
+        [Parameter]
+        public string? InputClass { get; set; }
 
         /// <summary>
         /// Fired when dropdown opens.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Behavior)]
-        [Parameter] public EventCallback OnOpen { get; set; }
+        [Parameter]
+        public EventCallback OnOpen { get; set; }
 
         /// <summary>
         /// Fired when dropdown closes.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Behavior)]
-        [Parameter] public EventCallback OnClose { get; set; }
+        [Parameter]
+        public EventCallback OnClose { get; set; }
 
         /// <summary>
         /// Add the MudSelectItems here
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// User class names for the popover, separated by space
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public string PopoverClass { get; set; }
+        public string? PopoverClass { get; set; }
 
         /// <summary>
         /// User class names for the internal list, separated by space
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public string ListClass { get; set; }
+        public string? ListClass { get; set; }
 
         /// <summary>
         /// If true, compact vertical padding will be applied to all Select items.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public bool Dense
-        {
-            get { return _dense; }
-            set { _dense = value; }
-        }
+        public bool Dense { get; set; }
 
         /// <summary>
         /// The Open Select Icon
@@ -230,14 +231,15 @@ namespace MudBlazor
         /// <summary>
         /// Fires when SelectedValues changes.
         /// </summary>
-        [Parameter] public EventCallback<IEnumerable<T>> SelectedValuesChanged { get; set; }
+        [Parameter]
+        public EventCallback<IEnumerable<T?>?> SelectedValuesChanged { get; set; }
 
         /// <summary>
         /// Function to define a customized multiselection text.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public Func<List<string>, string> MultiSelectionTextFunc { get; set; }
+        public Func<List<string?>?, string>? MultiSelectionTextFunc { get; set; }
 
         /// <summary>
         /// Parameter to define the delimited string separator.
@@ -251,20 +253,19 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
-        public IEnumerable<T> SelectedValues
+        public IEnumerable<T?>? SelectedValues
         {
             get
             {
-                if (_selectedValues == null)
-                    _selectedValues = new HashSet<T>(_comparer);
                 return _selectedValues;
             }
             set
             {
-                var set = value ?? new HashSet<T>(_comparer);
-                if (SelectedValues.Count() == set.Count() && _selectedValues.All(x => set.Contains(x)))
+                var set = value ?? new HashSet<T?>(_comparer);
+                var selectedValues = SelectedValues ?? new HashSet<T>(_comparer);
+                if (selectedValues.Count() == set.Count() && _selectedValues.All(x => set.Contains(x)))
                     return;
-                _selectedValues = new HashSet<T>(set, _comparer);
+                _selectedValues = new HashSet<T?>(set, _comparer);
                 SelectionChangedFromOutside?.Invoke(_selectedValues);
                 if (!MultiSelection)
                     SetValueAsync(_selectedValues.FirstOrDefault()).CatchAndLog();
@@ -273,18 +274,18 @@ namespace MudBlazor
                     //Warning. Here the Converter was not set yet
                     if (MultiSelectionTextFunc != null)
                     {
-                        SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))),
-                            selectedConvertedValues: SelectedValues.Select(x => Converter.Set(x)).ToList(),
+                        SetCustomizedTextAsync(string.Join(Delimiter, _selectedValues.Select(Converter.Set)),
+                            selectedConvertedValues: _selectedValues.Select(Converter.Set).ToList(),
                             multiSelectionTextFunc: MultiSelectionTextFunc).CatchAndLog();
                     }
                     else
                     {
-                        SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))), updateValue: false).CatchAndLog();
+                        SetTextAsync(string.Join(Delimiter, _selectedValues.Select(Converter.Set)), updateValue: false).CatchAndLog();
                     }
                 }
-                SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer));
+                SelectedValuesChanged.InvokeAsync(new HashSet<T?>(_selectedValues, _comparer));
                 if (MultiSelection && typeof(T) == typeof(string))
-                    SetValueAsync((T)(object)Text, updateText: false).CatchAndLog();
+                    SetValueAsync((T?)(object?)Text, updateText: false).CatchAndLog();
             }
         }
 
@@ -293,28 +294,26 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public IEqualityComparer<T> Comparer
+        public IEqualityComparer<T?>? Comparer
         {
             get => _comparer;
             set
             {
                 _comparer = value;
                 // Apply comparer and refresh selected values
-                _selectedValues = new HashSet<T>(_selectedValues, _comparer);
+                _selectedValues = new HashSet<T?>(_selectedValues, _comparer);
                 SelectedValues = _selectedValues;
             }
         }
 
-        private Func<T, string> _toStringFunc = x => x?.ToString();
-
-        private MudInput<string> _elementReference;
+        private Func<T?, string?>? _toStringFunc = x => x?.ToString();
 
         /// <summary>
         /// Defines how values are displayed in the drop-down list
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<T, string> ToStringFunc
+        public Func<T?, string?>? ToStringFunc
         {
             get => _toStringFunc;
             set
@@ -356,10 +355,9 @@ namespace MudBlazor
             }
         }
 
-
         private Task WaitForRender()
         {
-            Task t = null;
+            Task? t;
             lock (this)
             {
                 if (_renderComplete != null)
@@ -370,8 +368,6 @@ namespace MudBlazor
             StateHasChanged();
             return t;
         }
-
-        private TaskCompletionSource _renderComplete;
 
         /// <summary>
         /// Returns whether or not the Value can be found in items. If not, the Select will display it as a string.
@@ -394,11 +390,11 @@ namespace MudBlazor
             {
                 if (Value == null)
                     return false;
-                return _shadowLookup.TryGetValue(Value, out var _);
+                return _shadowLookup.TryGetValue(Value, out _);
             }
         }
 
-        protected RenderFragment GetSelectedValuePresenter()
+        protected RenderFragment? GetSelectedValuePresenter()
         {
             if (Value == null)
                 return null;
@@ -422,20 +418,18 @@ namespace MudBlazor
             if (MultiSelectionTextFunc != null)
             {
                 return MultiSelection
-                    ? SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))),
-                        selectedConvertedValues: SelectedValues.Select(x => Converter.Set(x)).ToList(),
+                    ? SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)),
+                        selectedConvertedValues: SelectedValues!.Select(Converter.Set).ToList(),
                         multiSelectionTextFunc: MultiSelectionTextFunc)
                     : base.UpdateTextPropertyAsync(updateValue);
             }
-            else
-            {
-                return MultiSelection
-                    ? SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))))
-                    : base.UpdateTextPropertyAsync(updateValue);
-            }
+
+            return MultiSelection
+                ? SetTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)))
+                : base.UpdateTextPropertyAsync(updateValue);
         }
 
-        internal event Action<ICollection<T>> SelectionChangedFromOutside;
+        internal event Action<ICollection<T?>>? SelectionChangedFromOutside;
 
         private bool _multiSelection;
         /// <summary>
@@ -448,7 +442,7 @@ namespace MudBlazor
             get => _multiSelection;
             set
             {
-                if (value != _multiSelection)
+                if (_multiSelection != value)
                 {
                     _multiSelection = value;
                     UpdateTextPropertyAsync(false).CatchAndLog();
@@ -461,13 +455,12 @@ namespace MudBlazor
         /// </summary>
         public IReadOnlyList<MudSelectItem<T>> Items => _items;
 
-        protected internal List<MudSelectItem<T>> _items = new();
+#nullable disable
         protected Dictionary<T, MudSelectItem<T>> _valueLookup = new();
         protected Dictionary<T, MudSelectItem<T>> _shadowLookup = new();
+#nullable enable
 
-        private string _activeItemId;
-
-        internal bool Add(MudSelectItem<T> item)
+        internal bool Add(MudSelectItem<T>? item)
         {
             if (item == null)
                 return false;
@@ -552,11 +545,12 @@ namespace MudBlazor
         /// <summary>
         /// Button click event for clear button. Called after text and value has been cleared.
         /// </summary>
-        [Parameter] public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         internal bool _open;
 
-        public string _currentIcon { get; set; }
+        public string? _currentIcon { get; set; }
 
         public async Task SelectOption(int index)
         {
@@ -569,26 +563,24 @@ namespace MudBlazor
             await SelectOption(_items[index].Value);
         }
 
-        public async Task SelectOption(object obj)
+        public async Task SelectOption(object? obj)
         {
-            var value = (T)obj;
+            var value = (T?)obj;
             if (MultiSelection)
             {
                 // multi-selection: menu stays open
-                if (!_selectedValues.Contains(value))
-                    _selectedValues.Add(value);
-                else
+                if (!_selectedValues.Add(value))
                     _selectedValues.Remove(value);
 
                 if (MultiSelectionTextFunc != null)
                 {
-                    await SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))),
-                        selectedConvertedValues: SelectedValues.Select(x => Converter.Set(x)).ToList(),
+                    await SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)),
+                        selectedConvertedValues: SelectedValues!.Select(Converter.Set).ToList(),
                         multiSelectionTextFunc: MultiSelectionTextFunc);
                 }
                 else
                 {
-                    await SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))), updateValue: false);
+                    await SetTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)), updateValue: false);
                 }
 
                 UpdateSelectAllChecked();
@@ -612,51 +604,50 @@ namespace MudBlazor
                 _selectedValues.Add(value);
             }
 
-            HilightItemForValueAsync(value);
+            HighlightItemForValueAsync(value);
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
-                await SetValueAsync((T)(object)Text, updateText: false);
+                await SetValueAsync((T?)(object?)Text, updateText: false);
             await InvokeAsync(StateHasChanged);
         }
 
-        private async void HilightItemForValueAsync(T value)
+        private async void HighlightItemForValueAsync(T? value)
         {
             if (value == null)
             {
-                HilightItem(null);
+                HighlightItem(null);
                 return;
             }
             await WaitForRender();
             _valueLookup.TryGetValue(value, out var item);
-            HilightItem(item);
+            HighlightItem(item);
         }
 
-        private async void HilightItem(MudSelectItem<T> item)
+        private async void HighlightItem(MudSelectItem<T>? item)
         {
             _activeItemId = item?.ItemId;
             // we need to make sure we are just after a render here or else there will be race conditions
             await WaitForRender();
-            // Note: this is a hack but I found no other way to make the list hilight the currently hilighted item
-            // without the delay it always shows the previously hilighted item because the popup items don't exist yet
+            // Note: this is a hack, but I found no other way to make the list highlight the currently highlighted item
+            // without the delay it always shows the previously highlighted item because the popup items don't exist yet
             // they are only registered after they are rendered, so we need to render again!
             await Task.Delay(1);
             StateHasChanged();
         }
 
-        private async Task HilightSelectedValue()
+        private async Task HighlightSelectedValue()
         {
             await WaitForRender();
             if (MultiSelection)
-                HilightItem(_items.FirstOrDefault(x => !x.Disabled));
+                HighlightItem(_items.FirstOrDefault(x => !x.Disabled));
             else
-                HilightItemForValueAsync(Value);
+                HighlightItemForValueAsync(Value);
         }
 
         private void UpdateSelectAllChecked()
         {
             if (MultiSelection && SelectAll)
             {
-                var oldState = _selectAllChecked;
                 if (_selectedValues.Count == 0)
                 {
                     _selectAllChecked = false;
@@ -689,11 +680,11 @@ namespace MudBlazor
             _open = true;
             UpdateIcon();
             StateHasChanged();
-            await HilightSelectedValue();
+            await HighlightSelectedValue();
             //Scroll the active item on each opening
             if (_activeItemId != null)
             {
-                var index = _items.FindIndex(x => x.ItemId == (string)_activeItemId);
+                var index = _items.FindIndex(x => x.ItemId == _activeItemId);
                 if (index > 0)
                 {
                     var item = _items[index];
@@ -774,9 +765,9 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        public void CheckGenericTypeMatch(object select_item)
+        public void CheckGenericTypeMatch(object selectItem)
         {
-            var itemT = select_item.GetType().GenericTypeArguments[0];
+            var itemT = selectItem.GetType().GenericTypeArguments[0];
             if (itemT != typeof(T))
                 throw new GenericTypeMismatchException("MudSelect", "MudSelectItem", typeof(T), itemT);
         }
@@ -816,21 +807,21 @@ namespace MudBlazor
         }
 
         protected async Task SetCustomizedTextAsync(string text, bool updateValue = true,
-            List<string> selectedConvertedValues = null,
-            Func<List<string>, string> multiSelectionTextFunc = null)
+            List<string?>? selectedConvertedValues = null,
+            Func<List<string?>?, string>? multiSelectionTextFunc = null)
         {
             // The Text property of the control is updated
             Text = multiSelectionTextFunc?.Invoke(selectedConvertedValues);
 
             // The comparison is made on the multiSelectionText variable
-            if (multiSelectionText != text)
+            if (_multiSelectionText != text)
             {
-                multiSelectionText = text;
-                if (!string.IsNullOrWhiteSpace(multiSelectionText))
+                _multiSelectionText = text;
+                if (!string.IsNullOrWhiteSpace(_multiSelectionText))
                     Touched = true;
                 if (updateValue)
                     await UpdateValuePropertyAsync(false);
-                await TextChanged.InvokeAsync(multiSelectionText);
+                await TextChanged.InvokeAsync(_multiSelectionText);
             }
         }
 
@@ -860,10 +851,7 @@ namespace MudBlazor
         /// </summary>
         protected string SelectAllCheckBoxIcon
         {
-            get
-            {
-                return _selectAllChecked.HasValue ? _selectAllChecked.Value ? CheckedIcon : UncheckedIcon : IndeterminateIcon;
-            }
+            get => _selectAllChecked.HasValue ? _selectAllChecked.Value ? CheckedIcon : UncheckedIcon : IndeterminateIcon;
         }
 
         internal async Task HandleKeyDownAsync(KeyboardEventArgs obj)
@@ -887,32 +875,30 @@ namespace MudBlazor
                         await CloseMenu();
                         break;
                     }
-                    else if (_open == false)
+
+                    if (_open == false)
                     {
                         await OpenMenu();
                         break;
                     }
-                    else
-                    {
-                        await SelectPreviousItem();
-                        break;
-                    }
+
+                    await SelectPreviousItem();
+                    break;
                 case "ArrowDown":
                     if (obj.AltKey)
                     {
                         await OpenMenu();
                         break;
                     }
-                    else if (_open == false)
+
+                    if (_open == false)
                     {
                         await OpenMenu();
                         break;
                     }
-                    else
-                    {
-                        await SelectNextItem();
-                        break;
-                    }
+
+                    await SelectNextItem();
+                    break;
                 case " ":
                     await ToggleMenu();
                     break;
@@ -927,7 +913,7 @@ namespace MudBlazor
                     break;
                 case "Enter":
                 case "NumpadEnter":
-                    var index = _items.FindIndex(x => x.ItemId == (string)_activeItemId);
+                    var index = _items.FindIndex(x => x.ItemId == _activeItemId);
                     if (!MultiSelection)
                     {
                         if (!_open)
@@ -935,27 +921,21 @@ namespace MudBlazor
                             await OpenMenu();
                             break;
                         }
-                        else
-                        {
-                            // this also closes the menu
-                            await SelectOption(index);
-                            break;
-                        }
+
+                        // this also closes the menu
+                        await SelectOption(index);
+                        break;
                     }
-                    else
+
+                    if (!_open)
                     {
-                        if (!_open)
-                        {
-                            await OpenMenu();
-                            break;
-                        }
-                        else
-                        {
-                            await SelectOption(index);
-                            await _elementReference.SetText(Text);
-                            break;
-                        }
+                        await OpenMenu();
+                        break;
                     }
+
+                    await SelectOption(index);
+                    await _elementReference.SetText(Text);
+                    break;
                 case "a":
                 case "A":
                     if (obj.CtrlKey)
@@ -1015,34 +995,34 @@ namespace MudBlazor
         {
             if (!MultiSelection)
                 return;
-            var selectedValues = new HashSet<T>(_items.Where(x => !x.Disabled && x.Value != null).Select(x => x.Value), _comparer);
-            _selectedValues = new HashSet<T>(selectedValues, _comparer);
+            var selectedValues = new HashSet<T?>(_items.Where(x => !x.Disabled && x.Value != null).Select(x => x.Value), _comparer);
+            _selectedValues = new HashSet<T?>(selectedValues, _comparer);
             if (MultiSelectionTextFunc != null)
             {
-                await SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))),
-                    selectedConvertedValues: SelectedValues.Select(x => Converter.Set(x)).ToList(),
+                await SetCustomizedTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)),
+                    selectedConvertedValues: SelectedValues!.Select(Converter.Set).ToList(),
                     multiSelectionTextFunc: MultiSelectionTextFunc);
             }
             else
             {
-                await SetTextAsync(string.Join(Delimiter, SelectedValues.Select(x => Converter.Set(x))), updateValue: false);
+                await SetTextAsync(string.Join(Delimiter, SelectedValues!.Select(Converter.Set)), updateValue: false);
             }
             UpdateSelectAllChecked();
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
             await BeginValidateAsync();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
-                SetValueAsync((T)(object)Text, updateText: false).CatchAndLog();
+                SetValueAsync((T?)(object?)Text, updateText: false).CatchAndLog();
         }
 
-        public void RegisterShadowItem(MudSelectItem<T> item)
+        public void RegisterShadowItem(MudSelectItem<T>? item)
         {
             if (item == null || item.Value == null)
                 return;
             _shadowLookup[item.Value] = item;
         }
 
-        public void UnregisterShadowItem(MudSelectItem<T> item)
+        public void UnregisterShadowItem(MudSelectItem<T>? item)
         {
             if (item == null || item.Value == null)
                 return;
@@ -1084,12 +1064,11 @@ namespace MudBlazor
         /// </summary>
         /// <param name="value"></param>
         /// <returns>True when component has a value</returns>
-        protected override bool HasValue(T value)
+        protected override bool HasValue(T? value)
         {
             if (MultiSelection)
                 return SelectedValues?.Any() ?? false;
-            else
-                return base.HasValue(value);
+            return base.HasValue(value);
         }
 
         public override async Task ForceUpdate()
@@ -1097,13 +1076,12 @@ namespace MudBlazor
             await base.ForceUpdate();
             if (MultiSelection == false)
             {
-                SelectedValues = new HashSet<T>(_comparer) { Value };
+                SelectedValues = new HashSet<T?>(_comparer) { Value };
             }
             else
             {
-                await SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer));
+                await SelectedValuesChanged.InvokeAsync(new HashSet<T?>(SelectedValues!, _comparer));
             }
         }
-
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor
@@ -2,7 +2,7 @@
 @typeparam T
 @inherits MudBaseSelectItem
 
-@if (HideContent == false)
+@if (!HideContent)
 {
 	<MudListItem @attributes="UserAttributes" Value="@ItemId" id="@ItemId" OnClick="@OnClicked" OnClickPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
 		@if (ChildContent != null)
@@ -15,5 +15,3 @@
 		}
 	</MudListItem>
 }
-
-

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -1,28 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+#nullable enable
     /// <summary>
     /// Represents an option of a select or multi-select. To be used inside MudSelect.
     /// </summary>
     public partial class MudSelectItem<T> : MudBaseSelectItem, IDisposable
     {
+        private IMudSelect? _parent;
+        private IMudShadowSelect? _shadowParent;
+
         private string GetCssClasses() => new CssBuilder()
             .AddClass(Class)
             .Build();
 
-        private IMudSelect _parent;
         internal string ItemId { get; } = Identifier.Create();
 
         /// <summary>
         /// The parent select component
         /// </summary>
         [CascadingParameter]
-        internal IMudSelect IMudSelect
+        internal IMudSelect? IMudSelect
         {
             get => _parent;
             set
@@ -46,17 +46,14 @@ namespace MudBlazor
             }
         }
 
-        private IMudShadowSelect _shadowParent;
-        private bool _selected;
-
         [CascadingParameter]
-        internal IMudShadowSelect IMudShadowSelect
+        internal IMudShadowSelect? IMudShadowSelect
         {
             get => _shadowParent;
             set
             {
                 _shadowParent = value;
-                ((MudSelect<T>)_shadowParent)?.RegisterShadowItem(this);
+                ((MudSelect<T>?)_shadowParent)?.RegisterShadowItem(this);
             }
         }
 
@@ -67,15 +64,15 @@ namespace MudBlazor
         [CascadingParameter(Name = "HideContent")]
         internal bool HideContent { get; set; }
 
-        internal MudSelect<T> MudSelect => (MudSelect<T>)IMudSelect;
+        internal MudSelect<T>? MudSelect => (MudSelect<T>?)IMudSelect;
 
-        private void OnUpdateSelectionStateFromOutside(IEnumerable<T> selection)
+        private void OnUpdateSelectionStateFromOutside(IEnumerable<T?>? selection)
         {
             if (selection == null)
                 return;
-            var old_selected = Selected;
+            var oldSelected = Selected;
             Selected = selection.Contains(Value);
-            if (old_selected != Selected)
+            if (oldSelected != Selected)
                 InvokeAsync(StateHasChanged);
         }
 
@@ -84,7 +81,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public T Value { get; set; }
+        public T? Value { get; set; }
 
         /// <summary>
         /// Mirrors the MultiSelection status of the parent select
@@ -102,19 +99,12 @@ namespace MudBlazor
         /// <summary>
         /// Selected state of the option. Only works if the parent is a mulit-select
         /// </summary>
-        internal bool Selected
-        {
-            get => _selected;
-            set
-            {
-                _selected = value;
-            }
-        }
+        internal bool Selected { get; set; }
 
         /// <summary>
         /// The checkbox icon reflects the multi-select option's state
         /// </summary>
-        protected string CheckBoxIcon
+        protected string? CheckBoxIcon
         {
             get
             {
@@ -124,7 +114,7 @@ namespace MudBlazor
             }
         }
 
-        protected string DisplayString
+        protected string? DisplayString
         {
             get
             {
@@ -149,9 +139,12 @@ namespace MudBlazor
             try
             {
                 MudSelect?.Remove(this);
-                ((MudSelect<T>)_shadowParent)?.UnregisterShadowItem(this);
+                ((MudSelect<T>?)_shadowParent)?.UnregisterShadowItem(this);
             }
-            catch (Exception) { }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Part of this issue https://github.com/MudBlazor/MudBlazor/issues/6535

There is an ugly thing:
https://github.com/MudBlazor/MudBlazor/blob/1f7f031848a476f31d46743ed3258fd6a1b8b5d4/src/MudBlazor/Components/Select/MudSelect.razor.cs#L458-L461

The `T` of the component can be null, but the key dictionary actually cannot be, so I had to disable the nullable check as it requires the `notnull` constrain on the `T` which I cannot do. This is a overall design problem of the component.

## How Has This Been Tested?
No tests required.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature  (non-breaking change, improve null diagnostic warnings)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
