### PR TITLE
MudTable: Rename MudBlazorFix namespace to MudBlazor

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Localization/ManualMarkdown/CrowdsourcedTranslationsInstallExampleCode.html
+++ b/src/MudBlazor.Docs/Pages/Features/Localization/ManualMarkdown/CrowdsourcedTranslationsInstallExampleCode.html
@@ -1,5 +1,0 @@
-<div class="mud-codeblock">
-<div class="html"><pre>
-dotnet add package MudBlazor.Translations
-</pre></div>
-</div>

--- a/src/MudBlazor/Components/Table/EditButtonContext.cs
+++ b/src/MudBlazor/Components/Table/EditButtonContext.cs
@@ -2,43 +2,39 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace MudBlazor; // A bug in Blazor requires a different namespace in some scenarios, see: https://github.com/dotnet/aspnetcore/issues/36326 (fixed in .NET 7)
 
-namespace MudBlazorFix // A bug in Blazor requires a different namespace in some scenarios, see: https://github.com/dotnet/aspnetcore/issues/36326 (fixed in .NET 7)
-{
 #nullable enable
+/// <summary>
+/// Information about the Edit button of a <see cref="MudBlazor.MudTable{T}"/> row.
+/// </summary>
+public class EditButtonContext
+{
+    /// <summary>
+    /// The action which occurs when the edit button is clicked.
+    /// </summary>
+    public Action ButtonAction { get; }
 
     /// <summary>
-    /// Information about the Edit button of a <see cref="MudBlazor.MudTable{T}"/> row.
+    /// Prevents the user from clicking the button.
     /// </summary>
-    public class EditButtonContext
+    public bool ButtonDisabled { get; }
+
+    /// <summary>
+    /// The item being edited.
+    /// </summary>
+    public object? Item { get; }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    /// <param name="buttonAction">The action which occurs when the edit button is clicked.</param>
+    /// <param name="buttonDisabled">Prevents the user from clicking the button.</param>
+    /// <param name="item">The item being edited.</param>
+    public EditButtonContext(Action buttonAction, bool buttonDisabled, object? item)
     {
-        /// <summary>
-        /// The action which occurs when the edit button is clicked.
-        /// </summary>
-        public Action ButtonAction { get; }
-
-        /// <summary>
-        /// Prevents the user from clicking the button.
-        /// </summary>
-        public bool ButtonDisabled { get; }
-
-        /// <summary>
-        /// The item being edited.
-        /// </summary>
-        public object? Item { get; }
-
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        /// <param name="buttonAction">The action which occurs when the edit button is clicked.</param>
-        /// <param name="buttonDisabled">Prevents the user from clicking the button.</param>
-        /// <param name="item">The item being edited.</param>
-        public EditButtonContext(Action buttonAction, bool buttonDisabled, object? item)
-        {
-            ButtonAction = buttonAction;
-            ButtonDisabled = buttonDisabled;
-            Item = item;
-        }
+        ButtonAction = buttonAction;
+        ButtonDisabled = buttonDisabled;
+        Item = item;
     }
 }

--- a/src/MudBlazor/Components/Table/EditButtonContext.cs
+++ b/src/MudBlazor/Components/Table/EditButtonContext.cs
@@ -2,7 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MudBlazor; // A bug in Blazor requires a different namespace in some scenarios, see: https://github.com/dotnet/aspnetcore/issues/36326 (fixed in .NET 7)
+namespace MudBlazor;
 
 #nullable enable
 /// <summary>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -523,7 +523,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
-        public RenderFragment<MudBlazorFix.EditButtonContext>? EditButtonContent { get; set; }
+        public RenderFragment<EditButtonContext>? EditButtonContent { get; set; }
 
         /// <summary>
         /// Occurs before inline editing begins for a row.

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -11,7 +11,7 @@
             {
                 @if (Context?.Table.EditButtonContent != null)
                 {
-                    @Context?.Table.EditButtonContent(new MudBlazorFix.EditButtonContext(StartEditingItem, Context.EditButtonDisabled(Item), Item))
+                    @Context?.Table.EditButtonContent(new EditButtonContext(StartEditingItem, Context.EditButtonDisabled(Item), Item))
                 }
                 else
                 {
@@ -54,7 +54,7 @@
             {
                 @if (Context?.Table.EditButtonContent != null)
                 {
-                    @Context?.Table.EditButtonContent(new MudBlazorFix.EditButtonContext(StartEditingItem, Context.EditButtonDisabled(Item), Item))
+                    @Context?.Table.EditButtonContent(new EditButtonContext(StartEditingItem, Context.EditButtonDisabled(Item), Item))
                 }
                 else
                 {


### PR DESCRIPTION
## Description
This was an old bug in blazor. It's not needed anymore

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
