### PR TITLE
refactor: Switch from FrozenSet to HashSet

### DIFF
--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -89,7 +89,7 @@ internal class ParameterContainer : IParameterContainer
 
         var parametersHandlerShouldFire = _parameterScopeContainers.SelectMany(parameter => parameter)
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
-            .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
+            .ToHashSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);
 


### PR DESCRIPTION
## Description
I noticed in this PR #9511 my remark regarding the FrozenSet performance. This PR moved from `ToFrozenSet` to `ToHashSet`. 

Simple Benchmark for creating and looping over the set:

| Method      | Mean     | Error   | StdDev  | Allocated |
|------------ |---------:|--------:|--------:|----------:|
| ToFrozenSet | 276.9 ns | 5.46 ns | 9.98 ns |     384 B |
| ToHashSet   | 134.4 ns | 2.72 ns | 4.63 ns |     248 B |


The reason is that the `FrozenSet` requires more time to be instantiated. Reference [here](https://learn.microsoft.com/en-us/dotnet/api/system.collections.frozen.frozenset-1?view=net-8.0#remarks).

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
