### PR TITLE
MudTheme: Fix STJ Deserialization & add test

### DIFF
--- a/src/MudBlazor.UnitTests/Dummy/MudThemeSerializerContext.cs
+++ b/src/MudBlazor.UnitTests/Dummy/MudThemeSerializerContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace MudBlazor.UnitTests.Dummy;
+
+[JsonSerializable(typeof(MudTheme))]
+internal sealed partial class MudThemeSerializerContext : JsonSerializerContext;

--- a/src/MudBlazor.UnitTests/Themes/MudThemeTests.cs
+++ b/src/MudBlazor.UnitTests/Themes/MudThemeTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using MudBlazor.UnitTests.Dummy;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Themes;
+
+#nullable enable
+[TestFixture]
+public class MudThemeTests
+{
+    [Test]
+    public void MudTheme_STJ_SourceGen_Serialization()
+    {
+        var originalMudTheme = new MudTheme
+        {
+            ZIndex = new ZIndex
+            {
+                Drawer = 5000
+            }
+        };
+
+        var mudThemeType = typeof(MudTheme);
+        var context = new MudThemeSerializerContext();
+
+        var jsonString = System.Text.Json.JsonSerializer.Serialize(originalMudTheme, mudThemeType, context);
+        var deserializeMudTheme = (MudTheme)System.Text.Json.JsonSerializer.Deserialize(jsonString, mudThemeType, context)!;
+
+        deserializeMudTheme.ZIndex.Drawer.Should().Be(originalMudTheme.ZIndex.Drawer);
+        deserializeMudTheme.Should().NotBeSameAs(originalMudTheme, "Objects have same values, but instances are different and has on custom Equals");
+    }
+}

--- a/src/MudBlazor/Themes/Models/Typography.cs
+++ b/src/MudBlazor/Themes/Models/Typography.cs
@@ -1,4 +1,6 @@
-﻿namespace MudBlazor
+﻿using System.Text.Json.Serialization;
+
+namespace MudBlazor
 {
 #nullable enable
     /// <summary>
@@ -387,6 +389,21 @@
     /// <summary>
     /// Represents the base typography settings.
     /// </summary>
+    [JsonDerivedType(typeof(DefaultTypography), nameof(DefaultTypography))]
+    [JsonDerivedType(typeof(H1), nameof(H1))]
+    [JsonDerivedType(typeof(H2), nameof(H2))]
+    [JsonDerivedType(typeof(H3), nameof(H3))]
+    [JsonDerivedType(typeof(H4), nameof(H4))]
+    [JsonDerivedType(typeof(H5), nameof(H5))]
+    [JsonDerivedType(typeof(H6), nameof(H6))]
+    [JsonDerivedType(typeof(Subtitle1), nameof(Subtitle1))]
+    [JsonDerivedType(typeof(Subtitle2), nameof(Subtitle2))]
+    [JsonDerivedType(typeof(Body1), nameof(Body1))]
+    [JsonDerivedType(typeof(Body2), nameof(Body2))]
+    [JsonDerivedType(typeof(Input), nameof(Input))]
+    [JsonDerivedType(typeof(Button), nameof(Button))]
+    [JsonDerivedType(typeof(Caption), nameof(Caption))]
+    [JsonDerivedType(typeof(Overline), nameof(Overline))]
     public abstract class BaseTypography
     {
         /// <summary>


### PR DESCRIPTION
## Description
Follow up: https://github.com/MudBlazor/MudBlazor/pull/9434

In case work is done for https://github.com/MudBlazor/MudBlazor/issues/9004, we need a test to ensure we do not break the STJ source generation for `MudTheme`. 

I also didn't realize that, since we are using polymorphism for `BaseTypography`, we need to have a special annotation; otherwise, the deserialization will fail. 

I believe it is generally important for `MudTheme` to be serializable, so you can dump it in JSON and then create a different object from it.

## How Has This Been Tested?
Unit test.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
