### PR TITLE
EventListener: Use [JsonSourceGenerationOptions] & cleanup

### DIFF
--- a/src/MudBlazor/Services/EventManager/EventListener.cs
+++ b/src/MudBlazor/Services/EventManager/EventListener.cs
@@ -2,74 +2,19 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace MudBlazor
 {
-    public interface IEventListenerFactory
-    {
-        IEventListener Create();
-    }
-
-    public class EventListenerFactory : IEventListenerFactory
-    {
-        private readonly IServiceProvider _provider;
-
-        public EventListenerFactory(IServiceProvider provider)
-        {
-            _provider = provider;
-        }
-
-        public IEventListener Create() =>
-            new EventListener(_provider.GetRequiredService<IJSRuntime>());
-    }
-
-    public interface IEventListener : IAsyncDisposable
-    {
-        /// <summary>
-        /// Listing to a javascript event
-        /// </summary>
-        /// <typeparam name="T">The type of the event args for instance MouseEventArgs for mousemove</typeparam>
-        /// <param name="eventName">Name of the DOM event without "on"</param>
-        /// <param name="elementId">The value of the id field of the DOM element</param>
-        /// <param name="projectionName">The name of a JS function (relative to window) that used to project the event before it is send back to .NET. Can be null, if no projection is needed </param>
-        /// <param name="throotleInterval">The delay between the last time the event occurred and the callback is fired. Set to zero, if no delay is requested</param>
-        /// <param name="callback">The method that is invoked, if the DOM element is fired. Object will be of type T</param>
-        /// <returns>A unique identifier for the event subscription. Should be used to cancel the subscription</returns>
-        Task<Guid> Subscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string eventName, string elementId, string projectionName, int throotleInterval, Func<object, Task> callback);
-
-        /// <summary>
-        /// Listing to a javascript event on the document itself
-        /// </summary>
-        /// <typeparam name="T">The type of the event args for instance MouseEventArgs for mousemove</typeparam>
-        /// <param name="eventName">Name of the DOM event without "on"</param>
-        /// <param name="throotleInterval">The delay between the last time the event occurred and the callback is fired. Set to zero, if no delay is requested</param>
-        /// <param name="callback">The method that is invoked, if the DOM element is fired. Object will be of type T</param>
-        /// <returns>A unique identifier for the event subscription. Should be used to cancel the subscription</returns>
-        Task<Guid> SubscribeGlobal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string eventName, int throotleInterval, Func<object, Task> callback);
-
-        /// <summary>
-        /// Cancel (unsubscribe) the listening to a DOM event, previous connected by Subscribe
-        /// </summary>
-        /// <param name="key">The unique event identifier</param>
-        /// <returns>true for if the event listener was detached, false if not</returns>
-        Task<bool> Unsubscribe(Guid key);
-    }
-
     public class EventListener : IEventListener, IDisposable
     {
         private readonly IJSRuntime _jsRuntime;
         private readonly DotNetObjectReference<EventListener> _dotNetRef;
-        private bool _disposed = false;
+        private bool _disposed;
 
-        private Dictionary<Guid, (Type eventType, Func<object, Task> callback)> _callbackResolver = new();
+        private readonly Dictionary<Guid, (Type eventType, Func<object, Task> callback)> _callbackResolver = new();
 
         [DynamicDependency(nameof(OnEventOccur))]
         public EventListener(IJSRuntime runtime)
@@ -83,16 +28,7 @@ namespace MudBlazor
         {
             if (_callbackResolver.TryGetValue(key, out var element) && element.callback != null)
             {
-                // Do not move this as static field.
-                // Otherwise, you wil JsonSerializerOptions instances cannot be modified once encapsulated by a JsonSerializerContext exception when using STJ Source Generator.
-                // In net9 remove this and add [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)] instead.
-                // Alternative we could set TypeInfoResolver for JsonSerializerOptions, but the trimmer will complain that it's unsafe which is not true.
-                var jsonSerializerOptions = new JsonSerializerOptions
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    PropertyNameCaseInsensitive = true,
-                };
-                var @event = JsonSerializer.Deserialize(eventData, element.eventType, new WebEventJsonContext(jsonSerializerOptions));
+                var @event = JsonSerializer.Deserialize(eventData, element.eventType, WebEventJsonContext.Default);
                 await element.callback.Invoke(@event);
             }
         }
@@ -148,8 +84,6 @@ namespace MudBlazor
             return key;
         }
 
-        #region disposing
-
         public async ValueTask DisposeAsync()
         {
             if (_disposed) { return; }
@@ -200,7 +134,5 @@ namespace MudBlazor
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
-
-        #endregion
     }
 }

--- a/src/MudBlazor/Services/EventManager/EventListenerFactory.cs
+++ b/src/MudBlazor/Services/EventManager/EventListenerFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor;
+
+public class EventListenerFactory : IEventListenerFactory
+{
+    private readonly IServiceProvider _provider;
+
+    public EventListenerFactory(IServiceProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public IEventListener Create() =>
+        new EventListener(_provider.GetRequiredService<IJSRuntime>());
+}

--- a/src/MudBlazor/Services/EventManager/IEventListener.cs
+++ b/src/MudBlazor/Services/EventManager/IEventListener.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MudBlazor;
+
+public interface IEventListener : IAsyncDisposable
+{
+    /// <summary>
+    /// Listing to a javascript event
+    /// </summary>
+    /// <typeparam name="T">The type of the event args for instance MouseEventArgs for mousemove</typeparam>
+    /// <param name="eventName">Name of the DOM event without "on"</param>
+    /// <param name="elementId">The value of the id field of the DOM element</param>
+    /// <param name="projectionName">The name of a JS function (relative to window) that used to project the event before it is send back to .NET. Can be null, if no projection is needed </param>
+    /// <param name="throotleInterval">The delay between the last time the event occurred and the callback is fired. Set to zero, if no delay is requested</param>
+    /// <param name="callback">The method that is invoked, if the DOM element is fired. Object will be of type T</param>
+    /// <returns>A unique identifier for the event subscription. Should be used to cancel the subscription</returns>
+    Task<Guid> Subscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string eventName, string elementId, string projectionName, int throotleInterval, Func<object, Task> callback);
+
+    /// <summary>
+    /// Listing to a javascript event on the document itself
+    /// </summary>
+    /// <typeparam name="T">The type of the event args for instance MouseEventArgs for mousemove</typeparam>
+    /// <param name="eventName">Name of the DOM event without "on"</param>
+    /// <param name="throotleInterval">The delay between the last time the event occurred and the callback is fired. Set to zero, if no delay is requested</param>
+    /// <param name="callback">The method that is invoked, if the DOM element is fired. Object will be of type T</param>
+    /// <returns>A unique identifier for the event subscription. Should be used to cancel the subscription</returns>
+    Task<Guid> SubscribeGlobal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string eventName, int throotleInterval, Func<object, Task> callback);
+
+    /// <summary>
+    /// Cancel (unsubscribe) the listening to a DOM event, previous connected by Subscribe
+    /// </summary>
+    /// <param name="key">The unique event identifier</param>
+    /// <returns>true for if the event listener was detached, false if not</returns>
+    Task<bool> Unsubscribe(Guid key);
+}

--- a/src/MudBlazor/Services/EventManager/IEventListenerFactory.cs
+++ b/src/MudBlazor/Services/EventManager/IEventListenerFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+public interface IEventListenerFactory
+{
+    IEventListener Create();
+}

--- a/src/MudBlazor/Services/EventManager/WebEventJsonContext.cs
+++ b/src/MudBlazor/Services/EventManager/WebEventJsonContext.cs
@@ -7,21 +7,19 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using ErrorEventArgs = Microsoft.AspNetCore.Components.Web.ErrorEventArgs;
 
-namespace MudBlazor
-{
-    [JsonSerializable(typeof(EventArgs))]
-    [JsonSerializable(typeof(ChangeEventArgs))]
-    [JsonSerializable(typeof(ClipboardEventArgs))]
-    [JsonSerializable(typeof(DragEventArgs))]
-    [JsonSerializable(typeof(ErrorEventArgs))]
-    [JsonSerializable(typeof(FocusEventArgs))]
-    [JsonSerializable(typeof(KeyboardEventArgs))]
-    [JsonSerializable(typeof(MouseEventArgs))]
-    [JsonSerializable(typeof(PointerEventArgs))]
-    [JsonSerializable(typeof(ProgressEventArgs))]
-    [JsonSerializable(typeof(TouchEventArgs))]
-    [JsonSerializable(typeof(WheelEventArgs))]
-    internal sealed partial class WebEventJsonContext : JsonSerializerContext
-    {
-    }
-}
+namespace MudBlazor;
+
+[JsonSerializable(typeof(EventArgs))]
+[JsonSerializable(typeof(ChangeEventArgs))]
+[JsonSerializable(typeof(ClipboardEventArgs))]
+[JsonSerializable(typeof(DragEventArgs))]
+[JsonSerializable(typeof(ErrorEventArgs))]
+[JsonSerializable(typeof(FocusEventArgs))]
+[JsonSerializable(typeof(KeyboardEventArgs))]
+[JsonSerializable(typeof(MouseEventArgs))]
+[JsonSerializable(typeof(PointerEventArgs))]
+[JsonSerializable(typeof(ProgressEventArgs))]
+[JsonSerializable(typeof(TouchEventArgs))]
+[JsonSerializable(typeof(WheelEventArgs))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+internal sealed partial class WebEventJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Description
Now when .net7 is dropped we can use the `[JsonSourceGenerationOptions]` API and not create `JsonSerializerOptions` instance on each `OnEventOccur` call. Moving it as static was not an option since it would introduce a regression: https://github.com/MudBlazor/MudBlazor/pull/8979

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
