### PR TITLE
TimeSpanExtensions: Remove not used API & add tests

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Extensions;
+
+#nullable enable
+[TestFixture]
+public class TimeSpanExtensionsTests
+{
+    [Test]
+    public void ToIsoString_ShouldReturnHoursAndMinutes_WhenSecondsAndMillisecondsAreFalse()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(10, 30, 45);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: false, ms: false);
+
+        // Assert
+        result.Should().Be("10:30");
+    }
+
+    [Test]
+    public void ToIsoString_ShouldReturnHoursMinutesAndSeconds_WhenSecondsIsTrueAndMillisecondsAreFalse()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(10, 30, 45);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: true, ms: false);
+
+        // Assert
+        result.Should().Be("10:30-45");
+    }
+
+    [Test]
+    public void ToIsoString_ShouldReturnHoursMinutesSecondsAndMilliseconds_WhenSecondsAndMillisecondsAreTrue()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(0, 10, 30, 45, 123);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: true, ms: true);
+
+        // Assert
+        result.Should().Be("10:30-45,123");
+    }
+
+    [Test]
+    public void ToAmPmHour_ShouldReturnCorrectAmPmHour_WhenTimeIsIn24HourFormat()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(13, 0, 0);
+
+        // Act
+        var result = timeSpan.ToAmPmHour();
+
+        // Assert
+        result.Should().Be(1);
+    }
+
+    [Test]
+    public void ToAmPmHour_ShouldReturn12_WhenTimeIsMidnight()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(0, 0, 0);
+
+        // Act
+        var result = timeSpan.ToAmPmHour();
+
+        // Assert
+        result.Should().Be(12);
+    }
+
+    [Test]
+    public void ToAmPmHour_ShouldReturn12_WhenTimeIsNoon()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(12, 0, 0);
+
+        // Act
+        var result = timeSpan.ToAmPmHour();
+
+        // Assert
+        result.Should().Be(12);
+    }
+}

--- a/src/MudBlazor/Extensions/TimeSpanExtensions.cs
+++ b/src/MudBlazor/Extensions/TimeSpanExtensions.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) MudBlazor
-
-using System;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // ReSharper disable once CheckNamespace
+namespace MudBlazor;
+
 #nullable enable
 internal static class TimeSpanExtensions
 {
@@ -19,11 +21,6 @@ internal static class TimeSpanExtensions
         }
 
         return $"{self.Hours:D2}:{self.Minutes:D2}-{self.Seconds:D2},{self.Milliseconds}";
-    }
-
-    public static string? ToIsoString(this TimeSpan? self, bool seconds = false, bool ms = false)
-    {
-        return self?.ToIsoString(seconds, ms);
     }
 
     public static int ToAmPmHour(this TimeSpan time)


### PR DESCRIPTION
## Description
Remove:
- `string? ToIsoString(this TimeSpan? self, bool seconds = false, bool ms = false)`

As it's not used in our codebase. Since `TimeSpanExtensions` is internal it's not a breaking change, so we can remove what we do not need.

## How Has This Been Tested?
Added unit tests as this file had a poor coverage.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
