### PR TITLE
BrowserViewportService: Add CancellationTokenSource

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
@@ -24,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
             // Sets the initial browser size aka simulating the windows size when the website was opened for the first time
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(browserWindowSize)
                 .Verifiable();
 

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -35,7 +33,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
 
@@ -70,7 +68,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
 
@@ -109,7 +107,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
 
@@ -142,7 +140,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
 
@@ -175,7 +173,7 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
 
@@ -234,11 +232,11 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(GetBrowserSize())
                 .Verifiable();
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>())
                 .Verifiable();
 
@@ -289,13 +287,13 @@ namespace MudBlazor.UnitTests.Components
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
 
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(new BrowserWindowSize { Height = 1080, Width = 1920 });
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(200)).Verifiable();
             jsRuntimeMock
-                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners", It.IsAny<object[]>()))
+                .Setup(expression => expression.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListeners", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>);
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);

--- a/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
@@ -2,10 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -38,8 +35,8 @@ public class BrowserViewportServiceTests
         // Assert
         observer.Notifications.Count.Should().Be(0);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Never);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -58,8 +55,8 @@ public class BrowserViewportServiceTests
         // Assert
         lambdaInvokedCount.Should().Be(0);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Never);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -85,8 +82,8 @@ public class BrowserViewportServiceTests
         // Assert
         observerNotifications.Count.Should().Be(0);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Never);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -105,8 +102,8 @@ public class BrowserViewportServiceTests
         firstNotification.IsImmediate.Should().BeTrue();
         observer.Notifications.Count.Should().Be(1);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Exactly(2));
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -127,8 +124,8 @@ public class BrowserViewportServiceTests
         firstNotification.IsImmediate.Should().BeTrue();
         observerNotifications.Count.Should().Be(1);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Exactly(2));
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -156,8 +153,8 @@ public class BrowserViewportServiceTests
         firstNotification.IsImmediate.Should().BeTrue();
         observerNotifications.Count.Should().Be(1);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Exactly(2));
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -178,8 +175,8 @@ public class BrowserViewportServiceTests
         firstNotification.IsImmediate.Should().BeTrue();
         observer.Notifications.Count.Should().Be(1);
         service.ObserversCount.Should().Be(1);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Exactly(2));
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -228,8 +225,8 @@ public class BrowserViewportServiceTests
         observerNotifications.Count.Should().Be(1);
         service.ObserversCount.Should().Be(1);
         innerObserverOptions.Should().Be(options1Mutated);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()), Times.Exactly(2));
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -318,7 +315,7 @@ public class BrowserViewportServiceTests
 
         // Assert
         service.ObserversCount.Should().Be(2);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -338,7 +335,7 @@ public class BrowserViewportServiceTests
 
         // Assert
         service.ObserversCount.Should().Be(2);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.listenForResize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
     }
 
     [Test]
@@ -462,7 +459,7 @@ public class BrowserViewportServiceTests
 
         // Assert
         service.ObserversCount.Should().Be(0);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -484,7 +481,7 @@ public class BrowserViewportServiceTests
 
         // Assert
         service.ObserversCount.Should().Be(0);
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener", It.IsAny<object[]>()), Times.Exactly(2));
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.cancelListener", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(2));
     }
 
     [Test]
@@ -500,7 +497,7 @@ public class BrowserViewportServiceTests
         var jsRuntimeMock = new Mock<IJSRuntime>();
         var service = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
         jsRuntimeMock
-            .Setup(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+            .Setup(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
             .ReturnsAsync(new BrowserWindowSize { Width = width, Height = height });
 
         // Act
@@ -540,7 +537,7 @@ public class BrowserViewportServiceTests
         var jsRuntimeMock = new Mock<IJSRuntime>();
         var service = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
         jsRuntimeMock
-            .Setup(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<object[]>()))
+            .Setup(x => x.InvokeAsync<BrowserWindowSize>("mudResizeListener.getBrowserWindowSize", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
             .ReturnsAsync(new BrowserWindowSize
             {
                 // This will return Sm size
@@ -562,8 +559,8 @@ public class BrowserViewportServiceTests
         var jsRuntimeMock = new Mock<IJSRuntime>();
         var service = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
         jsRuntimeMock
-            .Setup(x => x.InvokeAsync<bool>("mudResizeListener.matchMedia", It.IsAny<object[]>()))
-            .ReturnsAsync((string _, object[] args) =>
+            .Setup(x => x.InvokeAsync<bool>("mudResizeListener.matchMedia", It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
+            .ReturnsAsync((string _, CancellationToken _, object[] args) =>
             {
                 var mediaQuery = args[0] as string;
 
@@ -599,7 +596,7 @@ public class BrowserViewportServiceTests
         await service.DisposeAsync();
 
         // Assert
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]
@@ -620,7 +617,7 @@ public class BrowserViewportServiceTests
         await service.DisposeAsync();
 
         // Assert
-        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<object[]>()), Times.Once);
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Services/Browser/ResizeOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/ResizeOptionsTests.cs
@@ -120,6 +120,20 @@ namespace MudBlazor.UnitTests.Services.Browser
         }
 
         [Test]
+        public void Equals_NotTheSame_ObjIsNotResizeOptions()
+        {
+            // Arrange
+            var resizeOptions = new ResizeOptions();
+            var obj = new object();
+
+            // Act
+            var result = resizeOptions.Equals(obj);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Test]
         public void Equals_NotTheSame_DiffersInReportRate()
         {
             var option1 = new ResizeOptions();
@@ -389,8 +403,14 @@ namespace MudBlazor.UnitTests.Services.Browser
         public void GetHashCode_WhenObjectsAreEqual_ReturnsSameHashCode()
         {
             // Arrange
-            var options1 = new ResizeOptions();
-            var options2 = new ResizeOptions();
+            var options1 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<Breakpoint, int> { { Breakpoint.Always, 12 } }
+            };
+            var options2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<Breakpoint, int> { { Breakpoint.Always, 12 } }
+            };
 
             // Act
             var hashCode1 = options1.GetHashCode();

--- a/src/MudBlazor/Interop/ResizeListenerInterop.cs
+++ b/src/MudBlazor/Interop/ResizeListenerInterop.cs
@@ -2,9 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 using Microsoft.JSInterop;
 using MudBlazor.Services;
 
@@ -20,36 +18,36 @@ internal class ResizeListenerInterop
         _jsRuntime = jsRuntime;
     }
 
-    public async ValueTask<bool> MatchMedia(string mediaQuery)
+    public async ValueTask<bool> MatchMedia(string mediaQuery, CancellationToken cancellationToken = default)
     {
-        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(false, "mudResizeListener.matchMedia", mediaQuery);
+        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(false, "mudResizeListener.matchMedia", cancellationToken, mediaQuery);
 
         return value;
     }
 
-    public ValueTask<bool> ListenForResize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotNetObjectReference, ResizeOptions options, Guid javaScriptListerId) where T : class
+    public ValueTask<bool> ListenForResize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotNetObjectReference, ResizeOptions options, Guid javaScriptListerId, CancellationToken cancellationToken = default) where T : class
     {
-        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.listenForResize", dotNetObjectReference, options, javaScriptListerId);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.listenForResize", cancellationToken, dotNetObjectReference, options, javaScriptListerId);
     }
 
-    public ValueTask<bool> CancelListener(Guid javaScriptListerId)
+    public ValueTask<bool> CancelListener(Guid javaScriptListerId, CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListener", javaScriptListerId);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListener", cancellationToken, javaScriptListerId);
     }
 
-    public ValueTask<bool> CancelListeners(Guid[] jsListenerIds)
+    public ValueTask<bool> CancelListeners(Guid[] jsListenerIds, CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListeners", jsListenerIds);
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListeners", cancellationToken, jsListenerIds);
     }
 
-    public ValueTask Dispose()
+    public ValueTask Dispose(CancellationToken cancellationToken = default)
     {
-        return _jsRuntime.InvokeVoidAsyncIgnoreErrors("mudResizeListenerFactory.dispose");
+        return _jsRuntime.InvokeVoidAsyncIgnoreErrors("mudResizeListenerFactory.dispose", cancellationToken);
     }
 
-    public async ValueTask<BrowserWindowSize> GetBrowserWindowSize()
+    public async ValueTask<BrowserWindowSize> GetBrowserWindowSize(CancellationToken cancellationToken = default)
     {
-        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize");
+        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize", cancellationToken);
 
         return value;
     }

--- a/src/MudBlazor/Interop/ResizeListenerInterop.cs
+++ b/src/MudBlazor/Interop/ResizeListenerInterop.cs
@@ -35,6 +35,7 @@ internal class ResizeListenerInterop
         return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListener", cancellationToken, javaScriptListerId);
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Not used in the core for now.")]
     public ValueTask<bool> CancelListeners(Guid[] jsListenerIds, CancellationToken cancellationToken = default)
     {
         return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeListenerFactory.cancelListeners", cancellationToken, jsListenerIds);

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -156,6 +156,11 @@ internal class BrowserViewportService : IBrowserViewportService
     /// <inheritdoc />
     public async Task UnsubscribeAsync(Guid observerId)
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         try
         {
             await _semaphore.WaitAsync();

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -277,6 +277,8 @@ internal class BrowserViewportService : IBrowserViewportService
 
             // Do not send our CancellationTokenSource as it was cancelled.
             await _resizeListenerInterop.Dispose(CancellationToken.None);
+
+            _cancellationTokenSource.Dispose();
         }
     }
 

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -2,11 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -26,6 +22,7 @@ internal class BrowserViewportService : IBrowserViewportService
     private bool _disposed;
     private readonly SemaphoreSlim _semaphore;
     private readonly ResizeListenerInterop _resizeListenerInterop;
+    private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly Lazy<DotNetObjectReference<BrowserViewportService>> _dotNetReferenceLazy;
     private readonly ObserverManager<BrowserViewportSubscription, IBrowserViewportObserver> _observerManager;
 
@@ -50,6 +47,7 @@ internal class BrowserViewportService : IBrowserViewportService
     {
         ResizeOptions = options?.Value ?? new ResizeOptions();
         _semaphore = new SemaphoreSlim(1, 1);
+        _cancellationTokenSource = new CancellationTokenSource();
         _resizeListenerInterop = new ResizeListenerInterop(jsRuntime);
         _observerManager = new ObserverManager<BrowserViewportSubscription, IBrowserViewportObserver>(logger);
         _dotNetReferenceLazy = new Lazy<DotNetObjectReference<BrowserViewportService>>(CreateDotNetObjectReference);
@@ -177,7 +175,7 @@ internal class BrowserViewportService : IBrowserViewportService
     /// <inheritdoc />
     public async Task<bool> IsMediaQueryMatchAsync(string mediaQuery)
     {
-        return await _resizeListenerInterop.MatchMedia(mediaQuery);
+        return await _resizeListenerInterop.MatchMedia(mediaQuery, CancellationToken.None);
     }
 
     /// <inheritdoc />
@@ -234,7 +232,7 @@ internal class BrowserViewportService : IBrowserViewportService
 
         // Note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
         // But there is potential problem, if there are no active observers, you are stuck will old cached value, it's not clear if such cases should be handled
-        _latestWindowSize ??= await _resizeListenerInterop.GetBrowserWindowSize();
+        _latestWindowSize ??= await _resizeListenerInterop.GetBrowserWindowSize(CancellationToken.None);
 
         if (_latestWindowSize == null)
             return Breakpoint.Xs;
@@ -255,37 +253,31 @@ internal class BrowserViewportService : IBrowserViewportService
     /// <inheritdoc />
     public async Task<BrowserWindowSize> GetCurrentBrowserWindowSizeAsync()
     {
-        return await _resizeListenerInterop.GetBrowserWindowSize();
+        return await _resizeListenerInterop.GetBrowserWindowSize(CancellationToken.None);
     }
 
     /// <inheritdoc />
     public ValueTask DisposeAsync()
     {
-        return DisposeAsyncCore(true);
+        return DisposeAsyncCore();
     }
 
-    private ValueTask DisposeAsyncCore(bool disposing)
+    private async ValueTask DisposeAsyncCore()
     {
         if (!_disposed)
         {
-            if (disposing)
+            _disposed = true;
+            await _cancellationTokenSource.CancelAsync();
+            _observerManager.Clear();
+
+            if (_dotNetReferenceLazy.IsValueCreated)
             {
-                _observerManager.Clear();
-
-                if (_dotNetReferenceLazy.IsValueCreated)
-                {
-                    _dotNetReferenceLazy.Value.Dispose();
-                }
-
-                // https://github.com/MudBlazor/MudBlazor/pull/5367#issuecomment-1258649968
-                // Fixed in NET8
-                _ = _resizeListenerInterop.Dispose();
+                _dotNetReferenceLazy.Value.Dispose();
             }
 
-            _disposed = true;
+            // Do not send our CancellationTokenSource as it was cancelled.
+            await _resizeListenerInterop.Dispose(CancellationToken.None);
         }
-
-        return ValueTask.CompletedTask;
     }
 
 
@@ -328,7 +320,7 @@ internal class BrowserViewportService : IBrowserViewportService
             // Create new listener on JS side
             var dotNetReference = _dotNetReferenceLazy.Value;
             var jsListenerId = Guid.NewGuid();
-            await _resizeListenerInterop.ListenForResize(dotNetReference, clonedOptions, jsListenerId);
+            await _resizeListenerInterop.ListenForResize(dotNetReference, clonedOptions, jsListenerId, _cancellationTokenSource.Token);
 
             return new BrowserViewportSubscription(jsListenerId, observerId, clonedOptions);
         }
@@ -352,7 +344,7 @@ internal class BrowserViewportService : IBrowserViewportService
         if (observersWithSameJsListenerIdCount == 1)
         {
             // This is the last observer with such JavaScriptListenerId therefore we need to remove it on the JS side.
-            await _resizeListenerInterop.CancelListener(subscription.JavaScriptListenerId);
+            await _resizeListenerInterop.CancelListener(subscription.JavaScriptListenerId, _cancellationTokenSource.Token);
         }
 
         return subscription;

--- a/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
@@ -41,7 +41,6 @@ namespace MudBlazor
 #if !DEBUG
             catch (ObjectDisposedException)
             {
-                return (false, fallbackValue);
             }
 #endif
         }
@@ -82,7 +81,6 @@ namespace MudBlazor
 #if !DEBUG
             catch (ObjectDisposedException)
             {
-                return (false, fallbackValue);
             }
 #endif
         }
@@ -124,7 +122,7 @@ namespace MudBlazor
 #if !DEBUG
             catch (ObjectDisposedException)
             {
-                return (false, fallbackValue);
+                return false;
             }
 #endif
         }
@@ -170,7 +168,7 @@ namespace MudBlazor
 #if !DEBUG
             catch (ObjectDisposedException)
             {
-                return (false, fallbackValue);
+                return false;
             }
 #endif
         }

--- a/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
@@ -38,6 +38,12 @@ namespace MudBlazor
             catch (TaskCanceledException)
             {
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
 
         /// <summary>
@@ -73,6 +79,12 @@ namespace MudBlazor
             catch (TaskCanceledException)
             {
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
 
         /// <summary>
@@ -109,6 +121,12 @@ namespace MudBlazor
             {
                 return false;
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
 
         /// <summary>
@@ -149,6 +167,12 @@ namespace MudBlazor
             {
                 return false;
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
 
         /// <summary>
@@ -213,6 +237,12 @@ namespace MudBlazor
             {
                 return (false, fallbackValue);
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
 
         /// <summary>
@@ -243,7 +273,8 @@ namespace MudBlazor
             }
 #endif
             // catch prerending errors since there is no browser at this point.
-            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender",
+                                                           StringComparison.InvariantCultureIgnoreCase))
             {
                 return (false, fallbackValue);
             }
@@ -255,6 +286,12 @@ namespace MudBlazor
             {
                 return (false, fallbackValue);
             }
+#if !DEBUG
+            catch (ObjectDisposedException)
+            {
+                return (false, fallbackValue);
+            }
+#endif
         }
     }
 }

--- a/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
+++ b/src/MudBlazor/Services/IIJSRuntimeExtensions.cs
@@ -271,8 +271,7 @@ namespace MudBlazor
             }
 #endif
             // catch prerending errors since there is no browser at this point.
-            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender",
-                                                           StringComparison.InvariantCultureIgnoreCase))
+            catch (InvalidOperationException ex) when (ex.Message.Contains("prerender", StringComparison.InvariantCultureIgnoreCase))
             {
                 return (false, fallbackValue);
             }


### PR DESCRIPTION
## Description
Add `CancellationTokenSource` as was done for `PopoverService`.

The logic is as follows:

It was reported in https://github.com/MudBlazor/MudBlazor/pull/3963:

> Blazor will call `DisposeAsync` while `OnAfterRenderAsync` is still executing. Apparently, this is by design, and when it occurs with a `MudPopover` component, it results in the handler being detached before it is reinitialized, leaving the JS objects in the browser.

If this happens, `DisposeAsync` will cancel the token. Even if `OnAfterRenderAsync` inadvertently calls our `SubscribeAsync`, the JS call will not be made because the `CancellationTokenSource` has been canceled (and disposed) by that time. Our `InvokeAsyncWithErrorHandling` handles both `TaskCanceledException` and `ObjectDisposedException`, when the the JS call fails nothing will happen. We do not concern ourselves with the swallowed exceptions from `InvokeAsyncWithErrorHandling`, as if the service is disposed, it is unusable anyway.

## How Has This Been Tested?
Existing tests.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
