### PR TITLE
Popover: Hide all element overflow

### DIFF
--- a/src/MudBlazor/Styles/components/_popover.scss
+++ b/src/MudBlazor/Styles/components/_popover.scss
@@ -3,6 +3,7 @@
   z-index: calc(var(--mud-zindex-popover) + 1);
   position: absolute;
   opacity: 0;
+  overflow: hidden;
 
   &.mud-popover-fixed {
     position: fixed;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

https://try.mudblazor.com/snippet/maGevYFcqSgjKkjX

Hides all overflow from the popover component so that a high border radius won't visibly clip through. I'm unaware of any real world uses of the previous behaviour so it could technically be considered a breaking UI change but with low consequence (simply override the `overflow` style).

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Take note of the hover style on the last menu item:

before

![image](https://github.com/user-attachments/assets/0b16bbde-8e60-4ffb-b380-cce26babc3db)

after

![image](https://github.com/user-attachments/assets/40a2da61-ebb3-4b3b-a3c8-aaa907287169)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
