### PR TITLE
ToggleGroup: Promote from experimental to stable

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -5,12 +5,11 @@
         <Description>
             <DocsPageSection>
                 <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning:</b> Experimental component
+                    <b>Warning:</b> This component is currently under development.
                     <br />
                     <br />
-                    This component is currently under development.
-                    Breaking changes including updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute bug fixes or features.
+                    Breaking changes such as updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
+                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute code.
                 </MudAlert>
             </DocsPageSection>
         </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -5,12 +5,12 @@
         <Description>
             <DocsPageSection>
                 <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning experimental component!</b>
-                </MudAlert>
-                <MudAlert Class="mt-4" Severity="Severity.Error">
-                    This component is still under development and breaking changes may occur even in minor patch releases.<br />
-                    Please <b>ONLY</b> use this component if you are prepared to update your code and adapt to possible API changes.<br />
-                    There might also be changes to the look and feel or to the CSS classes and variable names.
+                    <b>Warning:</b> Experimental component
+                    <br />
+                    <br />
+                    This component is currently under development.
+                    Breaking changes, including updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
+                    Please use it only if you are prepared to adapt your code accordingly and contribute by reporting issues or submitting bug fixes and feature requests.
                 </MudAlert>
             </DocsPageSection>
         </Description>
@@ -20,8 +20,9 @@
 
         <DocsPageSection>
             <SectionHeader Title="Horizontal stepper">
-                <Description>Stepper needs <CodeInline>@nameof(MudStep)</CodeInline> in its child content. Each step can have <CodeInline>@nameof(MudStep.Title)</CodeInline> and <CodeInline>@nameof(MudStep.SecondaryText)</CodeInline> 
-                    so the component can be displayed properly. The reset button is only shown if <CodeInline>@nameof(MudStepper.ShowResetButton)</CodeInline> is set. You might not need it in a real world example but in the docs it is important to be able 
+                <Description>
+                    Stepper needs <CodeInline>@nameof(MudStep)</CodeInline> in its child content. Each step can have <CodeInline>@nameof(MudStep.Title)</CodeInline> and <CodeInline>@nameof(MudStep.SecondaryText)</CodeInline>
+                    so the component can be displayed properly. The reset button is only shown if <CodeInline>@nameof(MudStepper.ShowResetButton)</CodeInline> is set. You might not need it in a real world example but in the docs it is important to be able
                     to reset the stepper so we enabled it everywhere.
                 </Description>
             </SectionHeader>
@@ -75,7 +76,7 @@
                 <Description>
                     If you want to restrict navigation depending on certain conditions, i.e. completion of a form etc. you can do this using the <CodeInline>@nameof(MudStepper.OnPreviewInteraction)</CodeInline> event.<br />
                     <br />
-                    When the user clicks the Next-button, the stepper will try to set the current step completed when the user clicks previous or any other step header, the stepper will try to activate that step. Depending on the user action 
+                    When the user clicks the Next-button, the stepper will try to set the current step completed when the user clicks previous or any other step header, the stepper will try to activate that step. Depending on the user action
                     the <CodeInline>@nameof(StepperInteractionEventArgs).@nameof(StepperInteractionEventArgs.Action)</CodeInline> will be either
                     <CodeInline>@nameof(StepAction.Complete)</CodeInline> or <CodeInline>@nameof(StepAction.Activate)</CodeInline>. The <CodeInline>@nameof(StepperInteractionEventArgs).@nameof(StepperInteractionEventArgs.StepIndex)</CodeInline>
                     indicates which step the user wants to complete or activate (navigate to). By setting the

--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -9,8 +9,8 @@
                     <br />
                     <br />
                     This component is currently under development.
-                    Breaking changes, including updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and contribute by reporting issues or submitting bug fixes and feature requests.
+                    Breaking changes including updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
+                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute bug fixes or features.
                 </MudAlert>
             </DocsPageSection>
         </Description>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
@@ -5,33 +5,19 @@
 @page "/components/MudToggleItem`1"
 
 <DocsPage>
-    <DocsPageHeader Title="Toggle Group" SubTitle="A bunch of toggle buttons forming a selection of values to choose from with various selection modes.">
-        <Description>
-            <MudText>See also: <MudLink Href="/components/buttongroup">Button Group</MudLink></MudText>
-            <DocsPageSection>           
-                <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning experimental component!</b>
-                </MudAlert>
-                <MudAlert Class="mt-4" Severity="Severity.Error">
-                    This component is under development and breaking changes may occur even in minor patch releases.<br/>
-                    If you are prepared to update your code and adapt to changes, please try it out and help us mature it
-                    by reporting issues or contributing bug fixes and features.
-                </MudAlert>
-            </DocsPageSection>
-        </Description>
-    </DocsPageHeader>    
-       
+    <DocsPageHeader Title="Toggle Group" SubTitle="A group of toggle buttons offering various selection modes for choosing between multiple values." />
+
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader Title="Usage">
                 <Description>
-                    The <CodeInline>MudToggleGroup</CodeInline> holds a number of <CodeInline>MudToggleItems</CodeInline> 
-                    and semantically groups them together into a selection. The items can be configured to show text or 
-                    custom content such as an icon. To show a check mark set the <CodeInline>CheckMark</CodeInline> parameter. 
+                    The <CodeInline>MudToggleGroup</CodeInline> holds a number of <CodeInline>MudToggleItems</CodeInline>
+                    and semantically groups them together into a selection. The items can be configured to show text or
+                    custom content such as an icon. To show a check mark set the <CodeInline>CheckMark</CodeInline> parameter.
                     The check mark will push the text to the side by default. If you don't want this you can set
                     the <CodeInline>FixedContent</CodeInline> parameter to counterbalance the checkmark with padding on the right.
                     <MudAlert Severity="Severity.Info" Class="mt-3">
-                        If you don't set the <CodeInline>Text</CodeInline> property the items will simply show the 
+                        If you don't set the <CodeInline>Text</CodeInline> property the items will simply show the
                         <CodeInline>Value</CodeInline> if you didn't define the child content of a <CodeInline>MudToggleItem</CodeInline>.
                     </MudAlert>
                 </Description>
@@ -45,8 +31,8 @@
             <SectionHeader Title="Selection Mode">
                 <Description>
                     <CodeInline>MudToggleGroup</CodeInline> has three different selection modes: <CodeInline>SelectionMode.SingleSelection</CodeInline>,
-                    <CodeInline>SelectionMode.MultiSelection</CodeInline> and <CodeInline>SelectionMode.ToggleSelection</CodeInline>. 
-                    Single selection is the default and allows only one choice to be selected at the same time, just like in a radio group. 
+                    <CodeInline>SelectionMode.MultiSelection</CodeInline> and <CodeInline>SelectionMode.ToggleSelection</CodeInline>.
+                    Single selection is the default and allows only one choice to be selected at the same time, just like in a radio group.
                     With multi-selection many items can be selected at the same time or none. Toggle-selection is an exclusive single
                     selection which allows toggling off the selected value so that nothing is selected.
                     <MudAlert Severity="Severity.Info" Class="mt-3">
@@ -54,7 +40,7 @@
                         won't work. Also, the type of the item's value must match the group's <CodeInline>T</CodeInline> parameter.
                     </MudAlert>
                     <MudAlert Severity="Severity.Info" Class="mt-3">
-                        Make sure to bind the toggle group's <CodeInline>Value</CodeInline> property in single- and toggle-selection mode 
+                        Make sure to bind the toggle group's <CodeInline>Value</CodeInline> property in single- and toggle-selection mode
                         and <CodeInline>Values</CodeInline> with multi-selection.
                     </MudAlert>
                 </Description>
@@ -78,7 +64,7 @@
         <DocsPageSection>
             <SectionHeader Title="Custom Content">
                 <Description>
-                    <CodeInline>MudToggleItem</CodeInline> supports customization of its content with a 
+                    <CodeInline>MudToggleItem</CodeInline> supports customization of its content with a
                     <CodeInline>RenderFragment<CodeInline Tag>bool</CodeInline></CodeInline> where the parameter conveys
                     whether or not the item is currently selected. In the example the <CodeInline>context</CodeInline>
                     variable was used to color the selected chip green.


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Removes the experimental warning from the docs of the MudToggleGroup component in order to indicate it's new status as a stable component that is safe to use in production.

If we have to make any fundamental changes they will be reserved for major releases (like v8).

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/user-attachments/assets/b8f483f1-683b-4195-9d16-8dfb61a30112)

Along with removing the warning for the toggle group, this updates the style of the warning for the new MudStepper.

![image](https://github.com/user-attachments/assets/18bf50a0-b291-49ba-b496-d1e2a44fa7ff)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
