### PR TITLE
Build: Include "refactor" and "reverter" in release notes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,8 +5,6 @@ changelog:
       - docs
       - tests
       - dependency
-      - refactor
-      - reverted
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
## Description
I think it makes no sense to exclude 'reverter' from release notes as how will you know if something was reverted (potentially fixing an issue) if it’s not included in the release note?
Additionally, in the past, some important PRs were excluded from the release notes because they contained the label 'reverted,' even though they also had other labels like 'bug' and 'enhancement.' You can refactor something while fixing or adding new features.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
