### PR TITLE
ObserverManager: Use ConcurrentDictionary

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/MoqExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/MoqExtensions.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/src/MudBlazor.UnitTests/Utilities/ObserverManager/ObserverManagerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/ObserverManager/ObserverManagerTests.cs
@@ -2,11 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,6 +23,16 @@ public class ObserverManagerTests
     {
         //Reset on each test
         _observerManager = new ObserverManager<int, string>(NullLogger<ObserverManager<int, string>>.Instance);
+    }
+
+    [Test]
+    public void Constructor_ThrowsException()
+    {
+        // Arrange & Act
+        var construct = () => new ObserverManager<int, string>(null!);
+
+        // Assert
+        construct.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
@@ -223,11 +229,11 @@ public class ObserverManagerTests
 
 
     [Test]
-    public void Unsubscribe_Subscribe_UpdateSubscribe_DebugLogEnabled_LogsDebugInformation()
+    public void Unsubscribe_Subscribe_UpdateSubscribe_TraceLogEnabled_LogsDebugInformation()
     {
         // Arrange
         var loggerMock = new Mock<ILogger>();
-        loggerMock.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        loggerMock.Setup(x => x.IsEnabled(LogLevel.Trace)).Returns(true);
 
         var observerManager = new ObserverManager<int, string>(loggerMock.Object);
 
@@ -241,17 +247,17 @@ public class ObserverManagerTests
 
         // Assert
         loggerMock
-            .VerifyLogging($"Adding entry for {Id}/{Observer}. 1 total observers after add.")
-            .VerifyLogging($"Updating entry for {Id}/{Observer}. 1 total observers.")
-            .VerifyLogging($"Removed entry for {Id}. 0 total observers after remove.");
+            .VerifyLogging($"Adding entry for {Id}/{Observer}. 1 total observers after add.", LogLevel.Trace)
+            .VerifyLogging($"Updating entry for {Id}/{Observer}. 1 total observers.", LogLevel.Trace)
+            .VerifyLogging($"Removed entry for {Id}. 0 total observers after remove.", LogLevel.Trace);
     }
 
     [Test]
-    public async Task NotifyAsync_DefunctObserver_LogsDebugInformation()
+    public async Task NotifyAsync_DefunctObserver_LogsTraceInformation()
     {
         // Arrange
         var loggerMock = new Mock<ILogger>();
-        loggerMock.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        loggerMock.Setup(x => x.IsEnabled(LogLevel.Trace)).Returns(true);
 
         var observerManager = new ObserverManager<int, string>(loggerMock.Object);
 
@@ -273,8 +279,8 @@ public class ObserverManagerTests
 
         // Assert
         loggerMock
-            .VerifyLogging($"Adding entry for {DefunctObserverId}/{DefunctObserver}. 1 total observers after add.")
-            .VerifyLogging($"Removing defunct entry for {DefunctObserverId}. 0 total observers after remove.");
+            .VerifyLogging($"Adding entry for {DefunctObserverId}/{DefunctObserver}. 1 total observers after add.", LogLevel.Trace)
+            .VerifyLogging($"Removing defunct entry for {DefunctObserverId}. 0 total observers after remove.", LogLevel.Trace);
     }
 
     [Test]

--- a/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
+++ b/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs
@@ -2,11 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
 namespace MudBlazor.Utilities.ObserverManager;
@@ -27,7 +24,7 @@ namespace MudBlazor.Utilities.ObserverManager;
 /// </remarks>
 internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> where TIdentity : notnull
 {
-    private readonly Dictionary<TIdentity, ObserverEntry> _observers = new();
+    private readonly ConcurrentDictionary<TIdentity, ObserverEntry> _observers = new();
     private readonly ILogger _log;
 
     /// <summary>
@@ -69,17 +66,17 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
         if (_observers.TryGetValue(id, out var entry))
         {
             entry.Observer = observer;
-            if (_log.IsEnabled(LogLevel.Debug))
+            if (_log.IsEnabled(LogLevel.Trace))
             {
-                _log.LogDebug("Updating entry for {Id}/{Observer}. {Count} total observers.", id, observer, _observers.Count);
+                _log.LogTrace("Updating entry for {Id}/{Observer}. {Count} total observers.", id, observer, _observers.Count);
             }
         }
         else
         {
             _observers[id] = new ObserverEntry(observer);
-            if (_log.IsEnabled(LogLevel.Debug))
+            if (_log.IsEnabled(LogLevel.Trace))
             {
-                _log.LogDebug("Adding entry for {Id}/{Observer}. {Count} total observers after add.", id, observer, _observers.Count);
+                _log.LogTrace("Adding entry for {Id}/{Observer}. {Count} total observers after add.", id, observer, _observers.Count);
             }
         }
     }
@@ -93,9 +90,9 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
     public void Unsubscribe(TIdentity id)
     {
         _observers.Remove(id, out _);
-        if (_log.IsEnabled(LogLevel.Debug))
+        if (_log.IsEnabled(LogLevel.Trace))
         {
-            _log.LogDebug("Removed entry for {Id}. {Count} total observers after remove.", id, _observers.Count);
+            _log.LogTrace("Removed entry for {Id}. {Count} total observers after remove.", id, _observers.Count);
         }
     }
 
@@ -114,7 +111,7 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
     public async Task NotifyAsync(Func<TObserver, Task> notification, Func<TIdentity, TObserver, bool>? predicate = null)
     {
         var defunct = default(List<TIdentity>);
-        foreach (var observer in _observers.ToArray())
+        foreach (var observer in _observers)
         {
             // Skip observers which don't match the provided predicate.
             if (predicate != null && !predicate(observer.Key, observer.Value.Observer))
@@ -140,9 +137,9 @@ internal class ObserverManager<TIdentity, TObserver> : IEnumerable<TObserver> wh
             foreach (var observer in defunct)
             {
                 _observers.Remove(observer, out _);
-                if (_log.IsEnabled(LogLevel.Debug))
+                if (_log.IsEnabled(LogLevel.Trace))
                 {
-                    _log.LogDebug("Removing defunct entry for {Id}. {Count} total observers after remove.", observer, _observers.Count);
+                    _log.LogTrace("Removing defunct entry for {Id}. {Count} total observers after remove.", observer, _observers.Count);
                 }
             }
         }


### PR DESCRIPTION
## Description
Use `ConcurrentDictionary` instead of `Dictionary`.
We wanted to use it before, but had some issues with it: https://github.com/MudBlazor/MudBlazor/pull/6981#issuecomment-1582197308
This is a lot better than copying the list.
I also decided the logs to be `Trace` type, since most people have `Debug` as their minimum even in prod.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
