### PR TITLE
Buttons: Use fixed size for layout

### DIFF
--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         protected string Classname => new CssBuilder("mud-button-root mud-button")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
+            .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
             .AddClass($"mud-button-{Size.ToDescriptionString()}")
             .AddClass($"mud-width-full", GetRealFullWith())
             .AddClass($"mud-ripple", Ripple)

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         protected string Classname => new CssBuilder("mud-button-root mud-button")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
-            .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
+            .AddClass($"mud-button-{Size.ToDescriptionString()}")
             .AddClass($"mud-width-full", GetRealFullWith())
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-button-disable-elevation", !DropShadow)

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
             .AddClass($"mud-button-{Variant.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
-            .AddClass($"mud-button-{Size.ToDescriptionString()}")
+            .AddClass($"mud-button-size-{Size.ToDescriptionString()}")
             .AddClass($"mud-width-full", GetRealFullWith())
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-button-disable-elevation", !DropShadow)

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -20,7 +20,7 @@ namespace MudBlazor
             .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !AsButton && Color != Color.Default)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}", AsButton)
-            .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}", AsButton)
+            .AddClass($"mud-button-{Size.ToDescriptionString()}", AsButton)
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-ripple-icon", Ripple && !AsButton)
             .AddClass($"mud-icon-button-size-{Size.ToDescriptionString()}", when: () => Size != Size.Medium)

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
             .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !AsButton && Color != Color.Default)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}", AsButton)
+            .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
             .AddClass($"mud-button-{Size.ToDescriptionString()}", AsButton)
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-ripple-icon", Ripple && !AsButton)

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
             .AddClass($"mud-button-{Variant.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}", AsButton)
             .AddClass($"mud-button-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
-            .AddClass($"mud-button-{Size.ToDescriptionString()}", AsButton)
+            .AddClass($"mud-button-size-{Size.ToDescriptionString()}", AsButton)
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-ripple-icon", Ripple && !AsButton)
             .AddClass($"mud-icon-button-size-{Size.ToDescriptionString()}", when: () => Size != Size.Medium)

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -32,7 +32,7 @@
 }
 
 .mud-button {
-  padding: 6px 16px;
+  padding: 0 16px;
   font-family: var(--mud-typography-button-family);
   font-size: var(--mud-typography-button-size);
   font-weight: var(--mud-typography-button-weight);

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -58,12 +58,12 @@
   }
 }
 
-.mud-button-small {
+.mud-button-size-small {
   height: 30.75px;
   font-size: 0.8125rem;
 }
 
-.mud-button-large {
+.mud-button-size-large {
   height: 42.25px;
   font-size: 0.9375rem;
 }
@@ -114,13 +114,13 @@
     padding: 5px;
   }
 
-  &.mud-button-small {
+  &.mud-button-size-small {
     &.mud-icon-button {
       padding: 4px;
     }
   }
 
-  &.mud-button-large {
+  &.mud-button-size-large {
     &.mud-icon-button {
       padding: 4px;
     }
@@ -172,13 +172,13 @@
     padding: 6px;
   }
 
-  &.mud-button-small {
+  &.mud-button-size-small {
     &.mud-icon-button {
       padding: 5px;
     }
   }
 
-  &.mud-button-large {
+  &.mud-button-size-large {
     &.mud-icon-button {
       padding: 5px;
     }

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -33,6 +33,7 @@
 
 .mud-button {
   padding: 0 16px;
+  height: 36.5px;
   font-family: var(--mud-typography-button-family);
   font-size: var(--mud-typography-button-size);
   font-weight: var(--mud-typography-button-weight);
@@ -55,6 +56,16 @@
   &:focus-visible, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
+}
+
+.mud-button-small {
+  height: 30.75px;
+  font-size: 0.8125rem;
+}
+
+.mud-button-large {
+  height: 42.25px;
+  font-size: 0.9375rem;
 }
 
 .mud-button-label {
@@ -220,52 +231,6 @@
   border-color: currentColor;
 }
 
-.mud-button-text-size-small {
-  padding: 4px 5px;
-  font-size: 0.8125rem;
-}
-
-.mud-button-text-size-large {
-  padding: 8px 11px;
-  font-size: 0.9375rem;
-}
-
-.mud-button-outlined-size-small {
-  padding: 3px 9px;
-  font-size: 0.8125rem;
-
-  &.mud-icon-button {
-    padding: 4px;
-  }
-}
-
-.mud-button-outlined-size-large {
-  padding: 7px 21px;
-  font-size: 0.9375rem;
-
-  &.mud-icon-button {
-    padding: 4px;
-  }
-}
-
-.mud-button-filled-size-small {
-  padding: 4px 10px;
-  font-size: 0.8125rem;
-
-  &.mud-icon-button {
-    padding: 5px;
-  }
-}
-
-.mud-button-filled-size-large {
-  padding: 8px 22px;
-  font-size: 0.9375rem;
-
-  &.mud-icon-button {
-    padding: 5px;
-  }
-}
-
 .mud-button-full-width {
   width: 100%;
 }
@@ -299,10 +264,6 @@
     }
   }
 }
-
-
-
-
 
 .mud-button-icon-size-small > *:first-child {
   font-size: 18px;

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -114,6 +114,18 @@
     padding: 5px;
   }
 
+  &.mud-button-small {
+    &.mud-icon-button {
+      padding: 4px;
+    }
+  }
+
+  &.mud-button-large {
+    &.mud-icon-button {
+      padding: 4px;
+    }
+  }
+
   @media(hover: hover) and (pointer: fine) {
     &:hover {
       background-color: var(--mud-palette-action-default-hover);
@@ -158,6 +170,18 @@
 
   &.mud-icon-button {
     padding: 6px;
+  }
+
+  &.mud-button-small {
+    &.mud-icon-button {
+      padding: 5px;
+    }
+  }
+
+  &.mud-button-large {
+    &.mud-icon-button {
+      padding: 5px;
+    }
   }
 
   @media(hover: hover) and (pointer: fine) {

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -1,6 +1,7 @@
 .mud-icon-button {
   flex: 0 0 auto;
-  padding: 12px;
+  height: 42px;
+  width: 42px;
   overflow: visible;
   font-size: 1.5rem;
   text-align: center;
@@ -72,23 +73,29 @@
   margin-inline-start: unset;
 }
 
-.mud-icon-button-size-small {
-  padding: 3px;
+.mud-icon-button-size-medium {
+  height: 36px;
+  width: 36px;
   font-size: 1.125rem;
-
-  &.mud-icon-button-edge-start {
-    margin-left: -3px;
-    margin-inline-start: -3px;
-    margin-inline-end: unset;
-  }
-
-  &.mud-icon-button-edge-end {
-    margin-right: -3px;
-    margin-inline-end: -3px;
-    margin-inline-start: unset;
-  }
 }
 
+.mud-icon-button-size-small {
+  height: 30px;
+  width: 30px;
+  font-size: 1.125rem;
+
+  //&.mud-icon-button-edge-start {
+  //  margin-left: -3px;
+  //  margin-inline-start: -3px;
+  //  margin-inline-end: unset;
+  //}
+
+  //&.mud-icon-button-edge-end {
+  //  margin-right: -3px;
+  //  margin-inline-end: -3px;
+  //  margin-inline-start: unset;
+  //}
+}
 
 .mud-icon-button-size-large.mud-button > .mud-icon-button-label > .mud-icon-size-large {
   font-size: 2rem;

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -84,17 +84,17 @@
   width: 30px;
   font-size: 1.125rem;
 
-  //&.mud-icon-button-edge-start {
-  //  margin-left: -3px;
-  //  margin-inline-start: -3px;
-  //  margin-inline-end: unset;
-  //}
+  &.mud-icon-button-edge-start {
+    margin-left: -3px;
+    margin-inline-start: -3px;
+    margin-inline-end: unset;
+  }
 
-  //&.mud-icon-button-edge-end {
-  //  margin-right: -3px;
-  //  margin-inline-end: -3px;
-  //  margin-inline-start: unset;
-  //}
+  &.mud-icon-button-edge-end {
+    margin-right: -3px;
+    margin-inline-end: -3px;
+    margin-inline-start: unset;
+  }
 }
 
 .mud-icon-button-size-large.mud-button > .mud-icon-button-label > .mud-icon-size-large {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Part of #8884. Resolves  #4160. Resolves #5306.

Switches from using padding, which allows the inner content to change the size, to a precise, fixed number of pixels that conforms to [Material Design 2](https://m2.material.io/components/buttons#usage).

This can be a breaking visual change depending on how the buttons are used; for example, if they were previously allowed to stretch, they will no longer do so.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
