### PR TITLE
EventUtil: Fix UnsafeAccessor

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonErrorContenCaughtException.razor
@@ -10,8 +10,8 @@
             <MudText>MudFab</MudText>
         </MudIconButton>
     </ChildContent>
-    <ErrorContent>
-        <MudAlert Severity="Severity.Error">Oh my! We caught an error and handled it!</MudAlert>
+    <ErrorContent Context="exception">
+        <MudAlert Severity="Severity.Error">@exception.Message</MudAlert>
     </ErrorContent>
 </ErrorBoundary>
 

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -464,19 +464,19 @@ namespace MudBlazor.UnitTests.Components
 
             // MudButton
             await MudButton().ClickAsync(new MouseEventArgs());
-            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            alertTextFunc().InnerHtml.Should().Be("Something went wrong...");
             await comp.InvokeAsync(comp.Instance.Recover);
             alertTextFunc.Should().Throw<ComponentNotFoundException>();
 
             // MudFab
             await MudFab().ClickAsync(new MouseEventArgs());
-            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            alertTextFunc().InnerHtml.Should().Be("Something went wrong...");
             await comp.InvokeAsync(comp.Instance.Recover);
             alertTextFunc.Should().Throw<ComponentNotFoundException>();
 
             // MudIconButton
             await MudIconButton().ClickAsync(new MouseEventArgs());
-            alertTextFunc().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
+            alertTextFunc().InnerHtml.Should().Be("Something went wrong...");
             await comp.InvokeAsync(comp.Instance.Recover);
             alertTextFunc.Should().Throw<ComponentNotFoundException>();
         }

--- a/src/MudBlazor/Utilities/EventUtil.cs
+++ b/src/MudBlazor/Utilities/EventUtil.cs
@@ -74,8 +74,8 @@ public static class EventUtil
 
     private abstract class ReceiverBase(ComponentBase component) : IHandleEvent
     {
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "DispatchExceptionAsync")]
-        private static extern Task DispatchExceptionAsync(ComponentBase component, Exception exception);
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_renderHandle")]
+        private static extern ref RenderHandle RenderHandle(ComponentBase component);
 
         public async Task HandleEventAsync(EventCallbackWorkItem item, object? arg)
         {
@@ -85,7 +85,7 @@ public static class EventUtil
             }
             catch (Exception ex)
             {
-                await DispatchExceptionAsync(component, ex);
+                await RenderHandle(component).DispatchExceptionAsync(ex);
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes regression: https://github.com/MudBlazor/MudBlazor/pull/9967

The main problem was that `UnsafeAccessor` doesn't work if the visibility is protected. This is a weird limitation, so I had to use `_renderHandle` instead, which is private. Fortunately, the `DispatchExceptionAsync` method of `ComponentBase` points to `_renderHandle`.

I asked the question in the runtime repo about the limitations: https://github.com/dotnet/runtime/discussions/108950 not sure if I get an answer.

The second issue was that the test wasn't fully reliable. It checked that an exception was thrown and received, but it didn't verify that this was the specific exception we intended to throw. In reality it was the exception that the `DispatchExceptionAsync` method was not found, lol. Now the test is fully reliable.

## How Has This Been Tested?
unit test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
