### PR TITLE
MudDataGrid: Accessibility fixes

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5128",
+      "applicationUrl": "https://localhost:7128;http://localhost:5128",
       "launchUrl": "", // change to "components/list" for testing MudList for example but don't commit this change
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7128;http://localhost:5128",
+      "applicationUrl": "http://localhost:5128",
       "launchUrl": "", // change to "components/list" for testing MudList for example but don't commit this change
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -62,7 +62,7 @@
                         }
                     }
                 </MudMenu>
-                <MudIconButton Class="align-self-center" Icon="@Icons.Material.Filled.FilterAltOff" Size="@Size.Small" OnClick="@ClearFilterAsync"></MudIconButton>
+                <MudIconButton Class="align-self-center" Icon="@Icons.Material.Filled.FilterAltOff" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
             </MudStack>
         }
     </th>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -102,7 +102,7 @@ else if (Column != null && !Column.HiddenState.Value)
 
                 @if (showColumnOptions)
                 {
-                    <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true">
+                        <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_Unsort]">
                         <MudMenuItem Disabled="@(_initialDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -102,7 +102,7 @@ else if (Column != null && !Column.HiddenState.Value)
 
                 @if (showColumnOptions)
                 {
-                        <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_Unsort]">
+                        <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
                         <MudMenuItem Disabled="@(_initialDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -102,7 +102,7 @@ else if (Column != null && !Column.HiddenState.Value)
 
                 @if (showColumnOptions)
                 {
-                        <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
+                    <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" AnchorOrigin="Origin.BottomCenter" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
                         <MudMenuItem Disabled="@(_initialDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {
@@ -146,8 +146,8 @@ else if (Column != null && !Column.HiddenState.Value)
                             @DataGrid.Filter(Column.FilterContext.FilterDefinition, Column)
                         </MudItem>
                         <MudItem xs="12" Class="d-flex justify-end">
-                    <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
-                    <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilter]">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
+                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilter]">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
                         </MudItem>
                     </MudGrid>
                 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -146,8 +146,8 @@ else if (Column != null && !Column.HiddenState.Value)
                             @DataGrid.Filter(Column.FilterContext.FilterDefinition, Column)
                         </MudItem>
                         <MudItem xs="12" Class="d-flex justify-end">
-                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
-                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilter]">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
+                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
                         </MudItem>
                     </MudGrid>
                 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -68,11 +68,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (_initialDirection == SortDirection.None)
                     {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync"></MudIconButton>
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
                     else
-                    {                        
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync"></MudIconButton> 
+                    {
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
 
                     if (DataGrid.SortMode == SortMode.Multiple)
@@ -92,11 +92,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (hasFilter)
                     {
-                        <MudIconButton Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" OnClick="@OpenFilters"></MudIconButton>
+                        <MudIconButton Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" OnClick="@AddFilter"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
                     }
                 }
 
@@ -146,8 +146,8 @@ else if (Column != null && !Column.HiddenState.Value)
                             @DataGrid.Filter(Column.FilterContext.FilterDefinition, Column)
                         </MudItem>
                         <MudItem xs="12" Class="d-flex justify-end">
-                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
-                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
+                    <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                    <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilter]">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
                         </MudItem>
                     </MudGrid>
                 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -156,13 +156,13 @@
                                         <MudStack Row="true">
                                             @if (Groupable)
                                             {
-                                                <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudButton>
-                                                <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudButton>
+                                                <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudButton>
+                                                <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudButton>
                                             }
                                             <MudSpacer />
 
-                                            <MudButton OnClick="@HideAllColumnsAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_HideAll]</MudButton>
-                                            <MudButton OnClick="@ShowAllColumnsAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_ShowAll]</MudButton>
+                                            <MudButton OnClick="@HideAllColumnsAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_HideAllColumns]">@Localizer[LanguageResource.MudDataGrid_HideAll]</MudButton>
+                                            <MudButton OnClick="@ShowAllColumnsAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ShowAllColumns]">@Localizer[LanguageResource.MudDataGrid_ShowAll]</MudButton>
                                         </MudStack>
                                     </MudPopover>
                                 }
@@ -179,12 +179,12 @@
                                                     @Filter(f, null)
                                                 }
                                             </MudStack>
-                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_AddFilter]</MudButton>
+                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]">@Localizer[LanguageResource.MudDataGrid_AddFilter]</MudButton>
                                             @if (HasServerData)
                                             {
-                                                <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFiltersAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_Apply]</MudButton>
+                                                <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFiltersAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilters]">@Localizer[LanguageResource.MudDataGrid_Apply]</MudButton>
                                             }
-                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFiltersAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFiltersAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilters]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
                                         }
                                         else
                                         {
@@ -215,7 +215,7 @@
                                         <td class="mud-table-cell @groupClass" colspan="1000" style="background-color:var(--mud-palette-background-gray);@groupStyle">
                                             <MudIconButton Class="mud-table-row-expander"
                                            Icon="@(g.Expanded ? Icons.Material.Filled.ExpandMore : Icons.Material.Filled.ChevronRight)"
-                                           OnClick="@(() => ToggleGroupExpansion(g))" />
+                                           OnClick="@(() => ToggleGroupExpansion(g))" aria-label="@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]" />
 
                                             @if (GroupedColumn.GroupTemplate == null)
                                             {
@@ -402,8 +402,8 @@
                 </MudForm>
             </DialogContent>
             <DialogActions>
-                <MudButton Variant="Variant.Filled" Color="Color.Default" OnClick="@CancelEditingItemAsync" Class="px-10">@Localizer[LanguageResource.MudDataGrid_Cancel]</MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@CommitItemChangesAsync" Class="px-10">@Localizer[LanguageResource.MudDataGrid_Save]</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Default" OnClick="@CancelEditingItemAsync" Class="px-10" aria-label="@Localizer[LanguageResource.MudDataGrid_CancelEditingItem]">@Localizer[LanguageResource.MudDataGrid_Cancel]</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@CommitItemChangesAsync" Class="px-10" aria-label="@Localizer[LanguageResource.MudDataGrid_CommitItemChanges]">@Localizer[LanguageResource.MudDataGrid_Save]</MudButton>
             </DialogActions>
         </MudDialog>
     </CascadingValue>
@@ -520,7 +520,7 @@
             {
                 <MudGrid Spacing="0">
                     <MudItem xs="1" Class="d-flex">
-                        <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end"></MudIconButton>
+                        <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end" aria-label="@Localizer[LanguageResource.MudDataGrid_RemoveFilter]"></MudIconButton>
                     </MudItem>
                     <MudItem xs="4">
                         <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Column]" Dense="true" Margin="@Margin.Dense"

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -215,7 +215,7 @@
                                         <td class="mud-table-cell @groupClass" colspan="1000" style="background-color:var(--mud-palette-background-gray);@groupStyle">
                                             <MudIconButton Class="mud-table-row-expander"
                                            Icon="@(g.Expanded ? Icons.Material.Filled.ExpandMore : Icons.Material.Filled.ChevronRight)"
-                                           OnClick="@(() => ToggleGroupExpansion(g))" aria-label="@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]" />
+                                           OnClick="@(() => ToggleGroupExpansion(g))" aria-label="@Localizer[LanguageResource.MudDataGrid_ToggleGroupExpansion]" />
 
                                             @if (GroupedColumn.GroupTemplate == null)
                                             {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -156,13 +156,13 @@
                                         <MudStack Row="true">
                                             @if (Groupable)
                                             {
-                                                <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudButton>
-                                                <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudButton>
+                                                <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudButton>
+                                                <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudButton>
                                             }
                                             <MudSpacer />
 
-                                            <MudButton OnClick="@HideAllColumnsAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_HideAllColumns]">@Localizer[LanguageResource.MudDataGrid_HideAll]</MudButton>
-                                            <MudButton OnClick="@ShowAllColumnsAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ShowAllColumns]">@Localizer[LanguageResource.MudDataGrid_ShowAll]</MudButton>
+                                            <MudButton OnClick="@HideAllColumnsAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_HideAll]</MudButton>
+                                            <MudButton OnClick="@ShowAllColumnsAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_ShowAll]</MudButton>
                                         </MudStack>
                                     </MudPopover>
                                 }
@@ -179,12 +179,12 @@
                                                     @Filter(f, null)
                                                 }
                                             </MudStack>
-                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]">@Localizer[LanguageResource.MudDataGrid_AddFilter]</MudButton>
+                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_AddFilter]</MudButton>
                                             @if (HasServerData)
                                             {
-                                                <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFiltersAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ApplyFilters]">@Localizer[LanguageResource.MudDataGrid_Apply]</MudButton>
+                                                <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@ApplyFiltersAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_Apply]</MudButton>
                                             }
-                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFiltersAsync" Color="@Color.Primary" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilters]">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                                            <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Remove" OnClick="@ClearFiltersAsync" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
                                         }
                                         else
                                         {
@@ -402,8 +402,8 @@
                 </MudForm>
             </DialogContent>
             <DialogActions>
-                <MudButton Variant="Variant.Filled" Color="Color.Default" OnClick="@CancelEditingItemAsync" Class="px-10" aria-label="@Localizer[LanguageResource.MudDataGrid_CancelEditingItem]">@Localizer[LanguageResource.MudDataGrid_Cancel]</MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@CommitItemChangesAsync" Class="px-10" aria-label="@Localizer[LanguageResource.MudDataGrid_CommitItemChanges]">@Localizer[LanguageResource.MudDataGrid_Save]</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Default" OnClick="@CancelEditingItemAsync" Class="px-10">@Localizer[LanguageResource.MudDataGrid_Cancel]</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@CommitItemChangesAsync" Class="px-10">@Localizer[LanguageResource.MudDataGrid_Save]</MudButton>
             </DialogActions>
         </MudDialog>
     </CascadingValue>

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 @typeparam T
+@using MudBlazor.Resources
 @inject InternalMudLocalizer Localizer
 
 <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
@@ -35,10 +36,10 @@
     @if (ShowNavigation)
     {
         <div class="mud-table-pagination-actions">
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.First))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Previous))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Next))" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Last))" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.First))" aria-label="@Localizer[LanguageResource.MudDataGridPager_FirstPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Previous))" aria-label="@Localizer[LanguageResource.MudDataGridPager_PreviousPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Next))" aria-label="@Localizer[LanguageResource.MudDataGridPager_NextPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Last))" aria-label="@Localizer[LanguageResource.MudDataGridPager_LastPage]" />
         </div>
     }
 

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -390,32 +390,11 @@
   <data name="MudStepper_Complete" xml:space="preserve">
     <value>Complete</value>
   </data>
-  <data name="MudDataGrid_ApplyFilter" xml:space="preserve">
-    <value>Apply Filter</value>
-  </data>
-  <data name="MudDataGrid_ApplyFilters" xml:space="preserve">
-    <value>Apply Filters</value>
-  </data>
-  <data name="MudDataGrid_CancelEditingItem" xml:space="preserve">
-    <value>Cancel Editing Item</value>
-  </data>
   <data name="MudDataGrid_ClearFilter" xml:space="preserve">
     <value>Clear Filter</value>
   </data>
-  <data name="MudDataGrid_ClearFilters" xml:space="preserve">
-    <value>Clear Filters</value>
-  </data>
-  <data name="MudDataGrid_CommitItemChanges" xml:space="preserve">
-    <value>Commit Item Changes</value>
-  </data>
-  <data name="MudDataGrid_HideAllColumns" xml:space="preserve">
-    <value>Hide All Columns</value>
-  </data>
   <data name="MudDataGrid_OpenFilters" xml:space="preserve">
     <value>Open Filters</value>
-  </data>
-  <data name="MudDataGrid_ShowAllColumns" xml:space="preserve">
-    <value>Show All Columns</value>
   </data>
   <data name="MudDataGrid_ToggleGroupExpansion" xml:space="preserve">
     <value>Toggle Group Expansion</value>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -390,4 +390,49 @@
   <data name="MudStepper_Complete" xml:space="preserve">
     <value>Complete</value>
   </data>
+  <data name="MudDataGrid_ApplyFilter" xml:space="preserve">
+    <value>Apply Filter</value>
+  </data>
+  <data name="MudDataGrid_ApplyFilters" xml:space="preserve">
+    <value>Apply Filters</value>
+  </data>
+  <data name="MudDataGrid_CancelEditingItem" xml:space="preserve">
+    <value>Cancel Editing Item</value>
+  </data>
+  <data name="MudDataGrid_ClearFilter" xml:space="preserve">
+    <value>Clear Filter</value>
+  </data>
+  <data name="MudDataGrid_ClearFilters" xml:space="preserve">
+    <value>Clear Filters</value>
+  </data>
+  <data name="MudDataGrid_CommitItemChanges" xml:space="preserve">
+    <value>Commit Item Changes</value>
+  </data>
+  <data name="MudDataGrid_HideAllColumns" xml:space="preserve">
+    <value>Hide All Columns</value>
+  </data>
+  <data name="MudDataGrid_OpenFilters" xml:space="preserve">
+    <value>Open Filters</value>
+  </data>
+  <data name="MudDataGrid_ShowAllColumns" xml:space="preserve">
+    <value>Show All Columns</value>
+  </data>
+  <data name="MudDataGrid_ToggleGroupExpansion" xml:space="preserve">
+    <value>Toggle Group Expansion</value>
+  </data>
+  <data name="MudDataGrid_RemoveFilter" xml:space="preserve">
+    <value>Remove Filter</value>
+  </data>
+  <data name="MudDataGridPager_FirstPage" xml:space="preserve">
+    <value>First Page</value>
+  </data>
+  <data name="MudDataGridPager_PreviousPage" xml:space="preserve">
+    <value>Previous Page</value>
+  </data>
+  <data name="MudDataGridPager_NextPage" xml:space="preserve">
+    <value>Next Page</value>
+  </data>
+  <data name="MudDataGridPager_LastPage" xml:space="preserve">
+    <value>LastPage</value>
+  </data>
 </root>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -435,4 +435,7 @@
   <data name="MudDataGridPager_LastPage" xml:space="preserve">
     <value>LastPage</value>
   </data>
+  <data name="MudDataGrid_ShowColumnOptions" xml:space="preserve">
+    <value>Show Column Options</value>
+  </data>
 </root>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -433,7 +433,7 @@
     <value>Next Page</value>
   </data>
   <data name="MudDataGridPager_LastPage" xml:space="preserve">
-    <value>LastPage</value>
+    <value>Last Page</value>
   </data>
   <data name="MudDataGrid_ShowColumnOptions" xml:space="preserve">
     <value>Show Column Options</value>


### PR DESCRIPTION
Adding aria-labels to fix accessibility issues resulting in a significant reduction in wave tool errors on the MudDataGrid component page

With Changes:

![image](https://github.com/user-attachments/assets/607b47ba-8d21-4e63-892f-bb327196bacb)

Without:

![image](https://github.com/user-attachments/assets/78cd2743-aac8-41db-853a-ad0f2c8ab6cc)

Aria Labels have been added to
- Filter Header Cell
  - Clear Filter
- Header Cell
  - Sort Changed
  - Open Filters
  - Add Filter
  - Show Column Options
- Mud Data Grid
  - Toggle Group Expansion
  - Remove Filter
- Mud Data Grid Pager
  - First Page
  - Previous Page
  - Next Page
  - Last Page   

## Description
Following the rejection of https://github.com/MudBlazor/MudBlazor/pull/5719

The fixes would have been useful to fix many of the empty button error messages on the data grid

I have put together some changes that hopefully reintroduces those fixes but in a style more similar to that which gets accepted in https://github.com/MudBlazor/MudBlazor/pull/9064

## How Has This Been Tested?
visually and WAVE tool 

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
