### PR TITLE
Tests: Use more precise selectors for elements

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupChangeMaxTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupChangeMaxTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudButton OnClick="ChangeMax" Variant="Variant.Filled" Class="mb-4">ChangeMax</MudButton><MudText>Max: @max</MudText>
+<MudButton id="change-max-button" OnClick="ChangeMax" Variant="Variant.Filled" Class="mb-4">ChangeMax</MudButton><MudText>Max: @max</MudText>
 <MudAvatarGroup Max="@max" MaxColor="Color.Primary">
     <MudAvatar Color="Color.Primary">AA</MudAvatar>
     <MudAvatar Color="Color.Secondary">BB</MudAvatar>
@@ -17,10 +17,11 @@
 
     void ChangeMax()
     {
-        if(max == 7)
+        if (max == 7)
         {
             max = 0;
-        }else
+        }
+        else
         {
             max++;
         }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupRemoveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/AvatarGroup/AvatarGroupRemoveTest.razor
@@ -1,6 +1,6 @@
 @namespace MudBlazor.UnitTests.TestComponents
 
-<MudButton OnClick="Empty" Variant="Variant.Filled" Class="mb-4">Empty</MudButton>
+<MudButton id="empty-button" OnClick="Empty" Variant="Variant.Filled" Class="mb-4">Empty</MudButton>
 <MudAvatarGroup>
     @for(var _ = 0; _ < count; _++)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
@@ -7,7 +7,7 @@
     }
 </MudDrawerContainer>
 
-<button id="toggle-button" @onclick="@HandleButtonClick">toggle open</button>
+<button id="hide-drawer-button" @onclick="@HandleButtonClick">hide</button>
 
 @code {
     public MudDrawerContainer DrawerContainer;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerTest1.razor
@@ -6,7 +6,8 @@
         <MudDrawer Open="true" Variant="DrawerVariant.Responsive" ClipMode="DrawerClipMode.Always" Anchor="Anchor.Right"></MudDrawer>
     }
 </MudDrawerContainer>
-<button @onclick="@HandleButtonClick" />
+
+<button id="toggle-button" @onclick="@HandleButtonClick">toggle open</button>
 
 @code {
     public MudDrawerContainer DrawerContainer;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -2,7 +2,7 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+        <MudIconButton id="toggle-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>
     <MudDrawer @ref="@Drawer" @bind-Open="@_open" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
     </MudDrawer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -2,7 +2,7 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton id="toggle-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+        <MudIconButton id="toggle-drawer-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>
     <MudDrawer @ref="@Drawer" @bind-Open="@_open" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
     </MudDrawer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Overlay="@Overlay" OverlayAutoClose="@OverlayAutoClose" ClipMode="@ClipMode"></MudDrawer>
-<button id="toggle-button" @onclick="@HandleButtonClick">toggle open</button>
+<button id="toggle-drawer-button" @onclick="@HandleButtonClick">toggle open</button>
 
 @code {
     private bool _open = false;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Overlay="@Overlay" OverlayAutoClose="@OverlayAutoClose" ClipMode="@ClipMode"></MudDrawer>
-<button @onclick="@HandleButtonClick" />
+<button id="toggle-button" @onclick="@HandleButtonClick">toggle open</button>
 
 @code {
     private bool _open = false;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerTest.razor
@@ -15,7 +15,7 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12">
-        <MudButton OnClick="SetSelection">Set Selection</MudButton>
+        <MudButton id="set-selection-button" OnClick="SetSelection">Set Selection</MudButton>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
@@ -7,7 +7,8 @@
               RequiredError="Enter a star"
               Culture="System.Globalization.CultureInfo.InvariantCulture" />
 
-<MudButton Variant="@Variant.Filled" 
+<MudButton id="format-change-button"
+           Variant="@Variant.Filled"
            Color="@Color.Primary"
            OnClick="@LaunchDelayedFormatChange">
     Launch delayed format change
@@ -26,7 +27,7 @@
 
     public int DebounceInterval = 500;
     public int RerenderDelay = 2000;
-    public DateTime Date = new (2023, 07, 12);
+    public DateTime Date = new(2023, 07, 12);
     public string Format = "yyyy/MM/dd";
 
     private int _renderCount;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
@@ -4,13 +4,14 @@
               DebounceInterval="@DebounceInterval"
               Required="@true"
               RequiredError="Enter a star" />
- 
- <MudButton Variant="@Variant.Filled" 
-            Color="@Color.Primary"
-            OnClick="@LaunchDelayedRerender">
-     Launch delayed re-render
- </MudButton>
- 
+
+<MudButton id="re-render-button"
+           Variant="@Variant.Filled"
+           Color="@Color.Primary"
+           OnClick="@LaunchDelayedRerender">
+    Launch delayed re-render
+</MudButton>
+
 <MudText>
     RenderCount: @_renderCount
 </MudText>
@@ -18,7 +19,7 @@
 <MudText>
     Value: @Value
 </MudText>
- 
+
 @code {
     public static string __description__ = "Test user input retention on component refresh before debounce.";
 
@@ -29,7 +30,7 @@
     public int RerenderDelay = 2000;
 
     private int _renderCount;
-    
+
     protected override void OnAfterRender(bool firstRender)
     {
         _renderCount++;
@@ -40,4 +41,4 @@
         await Task.Delay(RerenderDelay);
         StateHasChanged();
     }
- }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
@@ -4,7 +4,7 @@
 
 <MudTooltip>
 	<ChildContent>
-	<MudButton>My Buttion</MudButton>
+	<MudButton id="sample-button">My Buttion</MudButton>
 	</ChildContent>
 	<TooltipContent>
 		<MudPaper Class="my-customer-paper">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
@@ -3,7 +3,7 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <MudTooltip Text="@TooltipTextContent" Touch="@EnableTouch" Placement="Placement.Start">
-	<MudButton>My Buttion</MudButton>
+	<MudButton id="sample-button">My Buttion</MudButton>
 </MudTooltip>
 
 @code {

--- a/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
@@ -146,7 +146,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<AvatarGroupRemoveTest>();
 
-            comp.FindAll("button")[0].Click();
+            comp.Find("#empty-button").Click();
 
             comp.FindComponent<MudAvatarGroup>().Instance._avatars.Count.Should().Be(0);
         }

--- a/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
@@ -84,7 +84,7 @@ namespace MudBlazor.UnitTests.Components
             avatars[3].ClassList.Should().Contain("mud-avatar-group-max-avatar");
 
             // click button to change max avatars to 4
-            comp.FindAll("button")[0].Click();
+            comp.Find("#change-max-button").Click();
 
             // find all avatars again after click
             avatars = comp.FindAll(".mud-avatar").ToArray();
@@ -99,9 +99,9 @@ namespace MudBlazor.UnitTests.Components
             avatars[4].ClassList.Should().Contain("mud-avatar-group-max-avatar");
 
             // click button to change max avatars to 7
-            comp.FindAll("button")[0].Click();
-            comp.FindAll("button")[0].Click();
-            comp.FindAll("button")[0].Click();
+            comp.Find("#change-max-button").Click();
+            comp.Find("#change-max-button").Click();
+            comp.Find("#change-max-button").Click();
 
             // find all avatars again after click
             avatars = comp.FindAll(".mud-avatar").ToArray();
@@ -118,7 +118,7 @@ namespace MudBlazor.UnitTests.Components
             avatars[6].ClassList.Should().NotContain("mud-avatar-group-max-avatar");
 
             // click button one more time to set it to 0
-            comp.FindAll("button")[0].Click();
+            comp.Find("#change-max-button").Click();
 
             // find all avatars again after click
             avatars = comp.FindAll(".mud-avatar").ToArray();
@@ -129,7 +129,7 @@ namespace MudBlazor.UnitTests.Components
             avatars[0].ClassList.Should().Contain("mud-avatar-group-max-avatar");
 
             // click button one more time to set it to 1
-            comp.FindAll("button")[0].Click();
+            comp.Find("#change-max-button").Click();
 
             // find all avatars again after click
             avatars = comp.FindAll(".mud-avatar").ToArray();

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
             // open simple test dialog
             await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>());
             // close by click on cancel button
-            comp.FindAll("button")[0].Click();
+            comp.Find(".mud-dialog-title .mud-button-close").Click();
             result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
             // open simple test dialog

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
             // open simple test dialog
             await comp.InvokeAsync(() => dialogReference = service?.Show<DialogOkCancel>());
             // close by click on cancel button
-            comp.Find(".mud-dialog-title .mud-button-close").Click();
+            comp.FindAll("button")[0].Click();
             result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
             // open simple test dialog

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -61,11 +61,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
             comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(parameter => parameter.OverlayAutoClose, overlayAutoClose));
 
             // Open the drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
             comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
@@ -116,10 +116,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.Overlay), false));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -132,10 +132,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -146,11 +146,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Persistent));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-persistent").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-persistent").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -163,10 +163,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant),
                     DrawerVariant.Persistent), Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-persistent").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -177,11 +177,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-mini").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-mini").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -194,10 +194,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-mini").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -208,11 +208,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -225,11 +225,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(point));
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -252,11 +252,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xl));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -279,11 +279,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(breakpoint == Breakpoint.Xs ? 0 : 1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -297,7 +297,7 @@ namespace MudBlazor.UnitTests.Components
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             // Open drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -315,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.Instance.Drawer.Open.Should().BeFalse();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
@@ -323,7 +323,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             // Open drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
@@ -348,7 +348,7 @@ namespace MudBlazor.UnitTests.Components
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             // Open drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -444,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer manually to check if it opens again
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
 
             // Resize to small, drawer should be open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
@@ -521,7 +521,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             // Open drawer manually to check if it closes again
-            comp.Find("#toggle-button").Click();
+            comp.Find("#toggle-drawer-button").Click();
 
             // Resize to small, drawer should be closed
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
@@ -563,7 +563,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(1);
 
             // Remove drawer
-            comp.Find("#toggle-button").Click();
+            comp.Find("#hide-drawer-button").Click();
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
         }

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -61,11 +61,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
             comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(parameter => parameter.OverlayAutoClose, overlayAutoClose));
 
             // Open the drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
             comp.FindAll("aside+.mud-overlay-drawer").Count.Should().Be(1);
@@ -116,10 +116,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.Overlay), false));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -132,10 +132,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -146,11 +146,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Persistent));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-persistent").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-persistent").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -163,10 +163,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant),
                     DrawerVariant.Persistent), Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-persistent").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -177,11 +177,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-mini").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-mini").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -194,10 +194,10 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Mini),
                 Parameter(nameof(DrawerTest1.ClipMode), DrawerClipMode.Always));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer-clipped-always").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-mini").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -208,11 +208,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService();
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+mud-overlay-drawer").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -225,11 +225,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(point));
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -252,11 +252,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xl));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -279,11 +279,11 @@ namespace MudBlazor.UnitTests.Components
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(breakpoint == Breakpoint.Xs ? 0 : 1);
             comp.Instance.Drawer.Open.Should().BeTrue();
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
@@ -297,7 +297,7 @@ namespace MudBlazor.UnitTests.Components
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             // Open drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -315,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.Instance.Drawer.Open.Should().BeFalse();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
@@ -323,7 +323,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
             // Open drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
@@ -348,7 +348,7 @@ namespace MudBlazor.UnitTests.Components
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
             // Open drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -444,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer manually to check if it opens again
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             // Resize to small, drawer should be open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
@@ -521,7 +521,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             // Open drawer manually to check if it closes again
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             // Resize to small, drawer should be closed
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
@@ -563,7 +563,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(1);
 
             // Remove drawer
-            comp.Find("button").Click();
+            comp.Find("#toggle-button").Click();
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
         }

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -37,13 +37,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button").Count.Should().Be(3);
-            comp.Find(".mud-message-box__cancel-button").TrimmedText().Should().Be("Go away!");
-            comp.Find(".mud-message-box__no-button").TrimmedText().Should().Be("Whatever");
-            comp.Find(".mud-message-box__yes-button").TrimmedText().Should().Be("Great");
+
+            // Assert there are exactly 3 buttons
+            var buttons = comp.FindAll(".mud-dialog-actions button");
+            buttons.Count.Should().Be(3);
+
+            // Verify each button's text and class and that they are in the correct order
+            buttons[0].TrimmedText().Should().Be("Go away!"); // First button (Cancel)
+            buttons[0].ClassList.Should().Contain("mud-message-box__cancel-button");
+            buttons[1].TrimmedText().Should().Be("Whatever"); // Second button (No)
+            buttons[1].ClassList.Should().Contain("mud-message-box__no-button");
+            buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
+            buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
             // close message box by clicking on Great.
-            comp.FindAll("button")[clickButtonIndex].Click();
+            comp.FindAll(".mud-dialog-actions button")[clickButtonIndex].Click();
             comp.Markup.Trim().Should().BeEmpty();
             yesNoCancel.Result.Should().Be(expectedResult);
         }
@@ -75,13 +83,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button").Count.Should().Be(3);
-            comp.Find(".mud-message-box__cancel-button").TrimmedText().Should().Be("Go away!");
-            comp.Find(".mud-message-box__no-button").TrimmedText().Should().Be("Whatever");
-            comp.Find(".mud-message-box__yes-button").TrimmedText().Should().Be("Great");
+
+            // Assert there are exactly 3 buttons
+            var buttons = comp.FindAll(".mud-dialog-actions button");
+            buttons.Count.Should().Be(3);
+
+            // Verify each button's text and class and that they are in the correct order
+            buttons[0].TrimmedText().Should().Be("Go away!"); // First button (Cancel)
+            buttons[0].ClassList.Should().Contain("mud-message-box__cancel-button");
+            buttons[1].TrimmedText().Should().Be("Whatever"); // Second button (No)
+            buttons[1].ClassList.Should().Contain("mud-message-box__no-button");
+            buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
+            buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
             // close message box by clicking on Great.
-            comp.FindAll("button")[clickButtonIndex].Click();
+            comp.FindAll(".mud-dialog-actions button")[clickButtonIndex].Click();
             comp.Markup.Trim().Should().BeEmpty();
             yesNoCancel.Result.Should().Be(expectedResult);
         }
@@ -137,10 +153,18 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button").Count.Should().Be(3);
-            comp.Find(".mud-message-box__cancel-button").TrimmedText().Should().Be("Go away!");
-            comp.Find(".mud-message-box__no-button").TrimmedText().Should().Be("Whatever");
-            comp.Find(".mud-message-box__yes-button").TrimmedText().Should().Be("Great");
+
+            // Assert there are exactly 3 buttons
+            var buttons = comp.FindAll(".mud-dialog-actions button");
+            buttons.Count.Should().Be(3);
+
+            // Verify each button's text and class and that they are in the correct order
+            buttons[0].TrimmedText().Should().Be("Go away!"); // First button (Cancel)
+            buttons[0].ClassList.Should().Contain("mud-message-box__cancel-button");
+            buttons[1].TrimmedText().Should().Be("Whatever"); // Second button (No)
+            buttons[1].ClassList.Should().Contain("mud-message-box__no-button");
+            buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
+            buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
             await comp.InvokeAsync(() => dialog.DialogInstance?.HandleKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }));
 
@@ -202,10 +226,18 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button").Count.Should().Be(3);
-            comp.Find(".mud-message-box__cancel-button").TrimmedText().Should().Be("Go away!");
-            comp.Find(".mud-message-box__no-button").TrimmedText().Should().Be("Whatever");
-            comp.Find(".mud-message-box__yes-button").TrimmedText().Should().Be("Great");
+
+            // Assert there are exactly 3 buttons
+            var buttons = comp.FindAll(".mud-dialog-actions button");
+            buttons.Count.Should().Be(3);
+
+            // Verify each button's text and class and that they are in the correct order
+            buttons[0].TrimmedText().Should().Be("Go away!"); // First button (Cancel)
+            buttons[0].ClassList.Should().Contain("mud-message-box__cancel-button");
+            buttons[1].TrimmedText().Should().Be("Whatever"); // Second button (No)
+            buttons[1].ClassList.Should().Contain("mud-message-box__no-button");
+            buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
+            buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
             await comp.InvokeAsync(() => dialog.DialogInstance?.HandleKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }));
 
@@ -262,10 +294,18 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button").Count.Should().Be(3);
-            comp.Find(".mud-message-box__cancel-button").TrimmedText().Should().Be("Go away!");
-            comp.Find(".mud-message-box__no-button").TrimmedText().Should().Be("Whatever");
-            comp.Find(".mud-message-box__yes-button").TrimmedText().Should().Be("Great");
+
+            // Assert there are exactly 3 buttons
+            var buttons = comp.FindAll(".mud-dialog-actions button");
+            buttons.Count.Should().Be(3);
+
+            // Verify each button's text and class and that they are in the correct order
+            buttons[0].TrimmedText().Should().Be("Go away!"); // First button (Cancel)
+            buttons[0].ClassList.Should().Contain("mud-message-box__cancel-button");
+            buttons[1].TrimmedText().Should().Be("Whatever"); // Second button (No)
+            buttons[1].ClassList.Should().Contain("mud-message-box__no-button");
+            buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
+            buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
             await comp.InvokeAsync(() => dialog.DialogInstance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape" }));
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -660,7 +660,7 @@ namespace MudBlazor.UnitTests.Components
             var input = comp.Find("div.mud-input-control");
 
             // No button when initialized
-            comp.FindAll("button").Should().BeEmpty();
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
 
             input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -669,11 +669,11 @@ namespace MudBlazor.UnitTests.Components
             items[1].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("2"));
-            comp.Find("button").Should().NotBeNull();
+            comp.Find(".mud-input-clear-button").Should().NotBeNull();
             // Selection cleared and button removed after clicking clear button
-            comp.Find("button").Click();
+            comp.Find(".mud-input-clear-button").Click();
             comp.WaitForAssertion(() => select.Instance.Value.Should().BeNullOrEmpty());
-            comp.FindAll("button").Should().BeEmpty();
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
             // Clear button click handler should have been invoked
             comp.Instance.ClearButtonClicked.Should().BeTrue();
         }
@@ -1073,7 +1073,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MultiSelectWithCustomComparerTest>();
             // print the generated html
             // Click select button
-            comp.Find("button").Click();
+            comp.Find("#set-selection-button").Click();
             // Check input text
             comp.Find("input").GetAttribute("value").Should().Be("Selected Cafe Latte, Selected Espresso");
             // Click to render the menu

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1,10 +1,6 @@
 ﻿#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
@@ -370,43 +366,43 @@ namespace MudBlazor.UnitTests.Components
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
-            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll("button");
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
+            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
             // click next page
             PagingButtons()[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
             // last page
             PagingButtons()[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(true);
             // previous page
             PagingButtons()[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
             // first page
             PagingButtons()[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
         }
 
         /// <summary>
@@ -458,28 +454,28 @@ namespace MudBlazor.UnitTests.Components
             pager.Value.Should().Be(20);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(60));
             pager.Value.Should().Be(60);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(true);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(10));
             pager.Value.Should().Be(10);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
         }
 
         /// <summary>
@@ -499,10 +495,10 @@ namespace MudBlazor.UnitTests.Components
             pager.Value.Should().Be(int.MaxValue);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true); //buttons are disabled
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true); //buttons are disabled
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(true);
             pager.Value.Should().Be(int.MaxValue);
         }
 
@@ -523,28 +519,28 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("3");
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 99");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
             // last page
             comp.FindAll("div.mud-table-pagination-actions button")[3].Click(); // last >
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("28");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("29");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("30");
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(false);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(true);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(100));
             pager.Value.Should().Be(100);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
-            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
-            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-first-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(true);
+            comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(true);
         }
 
         /// <summary>
@@ -576,7 +572,7 @@ namespace MudBlazor.UnitTests.Components
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
-            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll("button");
+            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
             // goto page 3
             PagingButtons()[2].Click();
             PagingButtons()[2].Click();

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1,13 +1,9 @@
 ﻿#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using FluentValidation;
@@ -1034,7 +1030,7 @@ namespace MudBlazor.UnitTests.Components
             // trigger first value change
             await Task.Delay(comp.Instance.DebounceInterval);
             // trigger delayed re-render
-            comp.Find("button").Click();
+            comp.Find("#re-render-button").Click();
             // imitate "typing in progress" by extending the debounce interval until component re-renders
             var elapsedTime = 0;
             var currentText = "test";

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -416,14 +416,14 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<TextFieldClearableTest>();
             var textField = comp.FindComponent<MudTextField<string>>();
             // No button when initialized
-            comp.FindAll("button").Should().BeEmpty();
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
 
             // Button shows after entering text
             comp.Find("input").Change("text");
             textField.Instance.Value.Should().Be("text");
-            comp.Find("button").Should().NotBeNull();
+            comp.Find(".mud-input-clear-button").Should().NotBeNull();
             // Text cleared and button removed after clicking clear button
-            comp.Find("button").Click();
+            comp.Find(".mud-input-clear-button").Click();
             textField.Instance.Value.Should().BeNullOrEmpty();
             comp.FindAll("button").Should().BeEmpty();
             // Clear button click handler should have been invoked
@@ -432,10 +432,10 @@ namespace MudBlazor.UnitTests.Components
             // Button shows again after entering text
             comp.Find("input").Change("text");
             textField.Instance.Value.Should().Be("text");
-            comp.Find("button").Should().NotBeNull();
+            comp.Find(".mud-input-clear-button").Should().NotBeNull();
             // Button removed after clearing text by typing
             comp.Find("input").Change(string.Empty);
-            comp.FindAll("button").Should().BeEmpty();
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
         }
 
         [Test]
@@ -447,7 +447,7 @@ namespace MudBlazor.UnitTests.Components
             );
 
             // Button should have tabindex -1
-            comp.Find("button").GetAttribute("tabindex").Should().Be("-1");
+            comp.Find(".mud-input-clear-button").GetAttribute("tabindex").Should().Be("-1");
         }
 
         #region ValidationAttribute support
@@ -1070,7 +1070,7 @@ namespace MudBlazor.UnitTests.Components
             // ensure text is updated on initialize
             textField.Text.Should().Be(comp.Instance.Date.Date.ToString(comp.Instance.Format, CultureInfo.InvariantCulture));
             // trigger the format change
-            comp.Find("button").Click();
+            comp.Find("#format-change-button").Click();
             // imitate "typing in progress" by extending the debounce interval until component re-renders
             var elapsedTime = 0;
             var currentText = comp.Instance.Date.Date.ToString(comp.Instance.Format, CultureInfo.InvariantCulture);

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -39,7 +39,7 @@ namespace MudBlazor.UnitTests.Components
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
 
             // content should always be visible
-            var button = comp.Find("button");
+            var button = comp.Find("#sample-button");
             button.TextContent.Should().Be("My Buttion");
 
             button.ParentElement.ClassList.Should().Contain("mud-tooltip-root");
@@ -91,7 +91,7 @@ namespace MudBlazor.UnitTests.Components
                 ));
 
             // content should always be visible
-            var button = comp.Find("button");
+            var button = comp.Find("#sample-button");
             button.TextContent.Should().Be("My Buttion");
 
             button.ParentElement.ClassList.Should().Contain("mud-tooltip-root");
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<TooltipWithRenderFragmentContentTest>();
 
             // content should always be visible
-            var button = comp.Find("button");
+            var button = comp.Find("#sample-button");
             button.TextContent.Should().Be("My Buttion");
 
             button.ParentElement.ClassList.Should().Contain("mud-tooltip-root");

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -23,7 +23,7 @@
                 }
                 @if (GetCloseButton())
                 {
-                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" Icon="@CloseIcon" @onclick="Cancel" class="mud-button-close" />
+                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" Icon="@CloseIcon" @onclick="Cancel" Class="mud-button-close" />
                 }
             </div>
          }

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -43,10 +43,10 @@
     @if (!HidePagination)
     {
         <div class="mud-table-pagination-actions">
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@FirstIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.First))" aria-label="@Localizer[LanguageResource.MudTablePager_FirstPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@BeforeIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Previous))" aria-label="@Localizer[LanguageResource.MudTablePager_PreviousPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@NextIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Next))" aria-label="@Localizer[LanguageResource.MudTablePager_NextPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@LastIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Last))" aria-label="@Localizer[LanguageResource.MudTablePager_LastPage]" />
+            <MudIconButton Class="mud-flip-x-rtl mud-table-pagination-first-button" Icon="@FirstIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.First))" aria-label="@Localizer[LanguageResource.MudTablePager_FirstPage]" />
+            <MudIconButton Class="mud-flip-x-rtl mud-table-pagination-before-button" Icon="@BeforeIcon" Disabled="@BackButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Previous))" aria-label="@Localizer[LanguageResource.MudTablePager_PreviousPage]" />
+            <MudIconButton Class="mud-flip-x-rtl mud-table-pagination-next-button" Icon="@NextIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Next))" aria-label="@Localizer[LanguageResource.MudTablePager_NextPage]" />
+            <MudIconButton Class="mud-flip-x-rtl mud-table-pagination-last-button" Icon="@LastIcon" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table?.NavigateTo(Page.Last))" aria-label="@Localizer[LanguageResource.MudTablePager_LastPage]" />
         </div>
     }
     @if (HorizontalAlignment == HorizontalAlignment.Start ||


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Spun off from #10046. The goal is to give key elements specific names so they can be accessed directly instead of by index of a generic name.

- Hardens tests against indirect changes from other components
- Looks for order in MessageBox tests in addition to the existence of class names and text
- Adds new classnames to the buttons in the MudTablePager (so not strictly a "Tests" PR)

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
