### PR TITLE
ResizeObserver: Clean up, make implementations internal, add xmodoc

### DIFF
--- a/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
@@ -1,26 +1,66 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-
-    public delegate void SizeChanged(IDictionary<ElementReference, BoundingClientRect> changes);
-
-    public interface IResizeObserver : IAsyncDisposable, IDisposable
+#nullable enable
+    /// <summary>
+    /// Interface for observing resize events on elements.
+    /// </summary>
+    public interface IResizeObserver : IAsyncDisposable
     {
-        Task<BoundingClientRect> Observe(ElementReference element);
-        Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);
-        Task Unobserve(ElementReference element);
-
-        double GetWidth(ElementReference reference);
-        double GetHeight(ElementReference reference);
-        BoundingClientRect GetSizeInfo(ElementReference reference);
-
+        /// <summary>
+        /// Event triggered when the size of an observed element changes.
+        /// </summary>
         event SizeChanged OnResized;
 
+        /// <summary>
+        /// Observes the specified element for resize events.
+        /// </summary>
+        /// <param name="element">The element to observe.</param>
+        /// <returns>A task that represents the asynchronous operation, containing the bounding client rectangle of the observed element.</returns>
+        Task<BoundingClientRect?> Observe(ElementReference element);
+
+        /// <summary>
+        /// Observes the specified elements for resize events.
+        /// </summary>
+        /// <param name="elements">The elements to observe.</param>
+        /// <returns>A task that represents the asynchronous operation, containing the bounding client rectangles of the observed elements.</returns>
+        Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);
+
+        /// <summary>
+        /// Stops observing the specified element for resize events.
+        /// </summary>
+        /// <param name="element">The element to stop observing.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task Unobserve(ElementReference element);
+
+        /// <summary>
+        /// Gets the width of the specified element.
+        /// </summary>
+        /// <param name="reference">The element reference.</param>
+        /// <returns>The width of the element.</returns>
+        double GetWidth(ElementReference reference);
+
+        /// <summary>
+        /// Gets the height of the specified element.
+        /// </summary>
+        /// <param name="reference">The element reference.</param>
+        /// <returns>The height of the element.</returns>
+        double GetHeight(ElementReference reference);
+
+        /// <summary>
+        /// Gets the size information of the specified element.
+        /// </summary>
+        /// <param name="reference">The element reference.</param>
+        /// <returns>The bounding client rectangle of the element.</returns>
+        BoundingClientRect? GetSizeInfo(ElementReference reference);
+
+        /// <summary>
+        /// Checks if the specified element is being observed.
+        /// </summary>
+        /// <param name="reference">The element reference.</param>
+        /// <returns>True if the element is being observed, otherwise false.</returns>
         bool IsElementObserved(ElementReference reference);
     }
 }

--- a/src/MudBlazor/Services/ResizeObserver/IResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ResizeObserver/IResizeObserverFactory.cs
@@ -1,8 +1,21 @@
-﻿namespace MudBlazor.Services
+﻿namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Factory interface for creating instances of <see cref="IResizeObserver"/>.
+/// </summary>
+public interface IResizeObserverFactory
 {
-    public interface IResizeObserverFactory
-    {
-        IResizeObserver Create(ResizeObserverOptions options);
-        IResizeObserver Create();
-    }
+    /// <summary>
+    /// Creates a new instance of <see cref="IResizeObserver"/>.
+    /// </summary>
+    /// <returns>A new instance of <see cref="IResizeObserver"/>.</returns>
+    IResizeObserver Create();
+
+    /// <summary>
+    /// Creates a new instance of <see cref="IResizeObserver"/> with the specified options.
+    /// </summary>
+    /// <param name="options">The options to configure the resize observer.</param>
+    /// <returns>A new instance of <see cref="IResizeObserver"/>.</returns>
+    IResizeObserver Create(ResizeObserverOptions options);
 }

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -10,39 +6,51 @@ using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-    public class ResizeObserver : IResizeObserver, IAsyncDisposable
+#nullable enable
+    /// <summary>
+    /// Observes resize events on elements and provides size information.
+    /// </summary>
+    internal sealed class ResizeObserver : IResizeObserver
     {
-        private bool _isDisposed = false;
-
+        private bool _disposed;
         private readonly IJSRuntime _jsRuntime;
         private readonly Guid _id = Guid.NewGuid();
         private readonly ResizeObserverOptions _options;
         private readonly DotNetObjectReference<ResizeObserver> _dotNetRef;
         private readonly Dictionary<Guid, ElementReference> _cachedValueIds = new();
-        private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
+        private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new(ElementReferenceComparer.Default);
 
+        /// <inheritdoc />
+        public event SizeChanged? OnResized;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResizeObserver"/> class.
+        /// </summary>
+        /// <param name="jsRuntime">The JavaScript runtime.</param>
+        /// <param name="options">The options to configure the resize observer.</param>
         [DynamicDependency(nameof(OnSizeChanged))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SizeChangeUpdateInfo))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BoundingClientRect))]
-        public ResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions> options = null)
+        public ResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions>? options = null)
         {
             _dotNetRef = DotNetObjectReference.Create(this);
             _jsRuntime = jsRuntime;
             _options = options?.Value ?? new ResizeObserverOptions();
         }
 
-        public async Task<BoundingClientRect> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
+        /// <inheritdoc />
+        public async Task<BoundingClientRect?> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
 
+        /// <inheritdoc />
         public async Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
         {
-            var filteredElements = elements.Where(x => x.Context != null && _cachedValues.ContainsKey(x) == false).ToList();
-            if (filteredElements.Any() == false)
+            var filteredElements = elements.Where(x => x.Context is not null && !_cachedValues.ContainsKey(x)).ToList();
+            if (!filteredElements.Any())
             {
                 return Array.Empty<BoundingClientRect>();
             }
 
-            List<Guid> elementIds = new();
+            var elementIds = new List<Guid>();
 
             foreach (var item in filteredElements)
             {
@@ -51,37 +59,53 @@ namespace MudBlazor.Services
                 _cachedValueIds.Add(id, item);
             }
 
-            var result = await _jsRuntime.InvokeAsync<IEnumerable<BoundingClientRect>>("mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options) ?? Array.Empty<BoundingClientRect>();
+            var result = await _jsRuntime.InvokeAsyncWithErrorHandling(Array.Empty<BoundingClientRect>(),
+                "mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options);
             var counter = 0;
-            foreach (var item in result)
+            foreach (var item in result.value)
             {
                 _cachedValues.Add(filteredElements.ElementAt(counter), item);
                 counter++;
             }
 
-            return result;
+            return result.value;
         }
 
+        /// <inheritdoc />
         public async Task Unobserve(ElementReference element)
         {
             var elementId = _cachedValueIds.FirstOrDefault(x => x.Value.Id == element.Id).Key;
-            if (elementId == default) { return; }
+            if (elementId == default)
+            {
+                return;
+            }
 
-            //if the unobserve happens during a component teardown, the try-catch is a safe guard to prevent a "pseudo" exception
-            try { await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.disconnect", _id, elementId); } catch (Exception) { }
+            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.disconnect", _id, elementId);
 
             _cachedValueIds.Remove(elementId);
             _cachedValues.Remove(element);
         }
 
+        /// <inheritdoc />
         public bool IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
 
-        public record SizeChangeUpdateInfo(Guid Id, BoundingClientRect Size);
+        /// <inheritdoc />
+        public BoundingClientRect? GetSizeInfo(ElementReference reference) => _cachedValues.GetValueOrDefault(reference);
 
+        /// <inheritdoc />
+        public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
+
+        /// <inheritdoc />
+        public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
+
+        /// <summary>
+        /// Invoked by JavaScript when the size of an observed element changes.
+        /// </summary>
+        /// <param name="changes">The changes in size.</param>
         [JSInvokable]
         public void OnSizeChanged(IEnumerable<SizeChangeUpdateInfo> changes)
         {
-            Dictionary<ElementReference, BoundingClientRect> parsedChanges = new();
+            var parsedChanges = new Dictionary<ElementReference, BoundingClientRect>(ElementReferenceComparer.Default);
             foreach (var item in changes)
             {
                 if (_cachedValueIds.TryGetValue(item.Id, out var elementRef))
@@ -94,48 +118,46 @@ namespace MudBlazor.Services
             OnResized?.Invoke(parsedChanges);
         }
 
-        public event SizeChanged OnResized;
-
-        public BoundingClientRect GetSizeInfo(ElementReference reference)
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
         {
-            return _cachedValues.TryGetValue(reference, out var existing) ? existing : null;
-        }
-
-        public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
-        public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing && _isDisposed == false)
+            if (!_disposed)
             {
-                _isDisposed = true;
+                _disposed = true;
+
+                await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.cancelListener", _id);
+
                 _dotNetRef.Dispose();
                 _cachedValueIds.Clear();
                 _cachedValues.Clear();
-
-                //in a fire and forget manner, we just "trying" to cancel the listener. So, we are not interested in an potential error 
-                try { _ = _jsRuntime.InvokeVoidAsync($"mudResizeObserver.cancelListener", _id); } catch (Exception) { }
             }
         }
 
-        public void Dispose()
+        /// <summary>
+        /// Represents the size change update information.
+        /// </summary>
+        /// <param name="Id">The identifier of the element.</param>
+        /// <param name="Size">The new size of the element.</param>
+        public record SizeChangeUpdateInfo(Guid Id, BoundingClientRect Size);
+
+        /// <summary>
+        /// Comparer for <see cref="ElementReference"/> to improve performance.
+        /// </summary>
+        /// <remarks>
+        /// This is needed because runtime provided implementation is not efficient for struct.
+        /// </remarks>
+        private class ElementReferenceComparer : IEqualityComparer<ElementReference>
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+            /// <inheritdoc />
+            public bool Equals(ElementReference x, ElementReference y) => x.Id == y.Id;
 
-        public async ValueTask DisposeAsync()
-        {
-            if (_isDisposed) { return; }
+            /// <inheritdoc />
+            public int GetHashCode(ElementReference obj) => obj.Id.GetHashCode();
 
-            _isDisposed = true;
-
-            _dotNetRef.Dispose();
-            _cachedValueIds.Clear();
-            _cachedValues.Clear();
-
-            //in a fire and forget manner, we just "trying" to cancel the listener. So, we are not interested in an potential error 
-            try { await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.cancelListener", _id); } catch (Exception) { }
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
+            public static ElementReferenceComparer Default { get; } = new();
         }
     }
 }

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -154,7 +154,7 @@ namespace MudBlazor.Services
             /// <inheritdoc />
             public int GetHashCode(ElementReference obj)
             {
-                // Do not modify this null workaround, as the Id can be null when ElementReference as default(ElementReference).
+                // Do not modify this null workaround, as the Id can be null when ElementReference is initialized as default(ElementReference).
                 // Although the nullable annotation suggests otherwise, we use this unconventional object pattern instead of an if-else statement 
                 // to suppress the nullable annotation.
                 return obj is { Id: null } ? 0 : obj.Id.GetHashCode();

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -59,16 +59,16 @@ namespace MudBlazor.Services
                 _cachedValueIds.Add(id, item);
             }
 
-            var result = await _jsRuntime.InvokeAsyncWithErrorHandling(Array.Empty<BoundingClientRect>(),
-                "mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options);
+            var result = (await _jsRuntime.InvokeAsyncWithErrorHandling<BoundingClientRect[]?>(Array.Empty<BoundingClientRect>(),
+                "mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options)).value ?? Array.Empty<BoundingClientRect>();
             var counter = 0;
-            foreach (var item in result.value)
+            foreach (var item in result)
             {
                 _cachedValues.Add(filteredElements.ElementAt(counter), item);
                 counter++;
             }
 
-            return result.value;
+            return result;
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -146,13 +146,19 @@ namespace MudBlazor.Services
         /// <remarks>
         /// This is needed because runtime provided implementation is not efficient for struct.
         /// </remarks>
-        private class ElementReferenceComparer : IEqualityComparer<ElementReference>
+        internal class ElementReferenceComparer : IEqualityComparer<ElementReference>
         {
             /// <inheritdoc />
             public bool Equals(ElementReference x, ElementReference y) => x.Id == y.Id;
 
             /// <inheritdoc />
-            public int GetHashCode(ElementReference obj) => obj.Id.GetHashCode();
+            public int GetHashCode(ElementReference obj)
+            {
+                // Do not modify this null workaround, as the Id can be null when ElementReference as default(ElementReference).
+                // Although the nullable annotation suggests otherwise, we use this unconventional object pattern instead of an if-else statement 
+                // to suppress the nullable annotation.
+                return obj is { Id: null } ? 0 : obj.Id.GetHashCode();
+            }
 
             /// <summary>
             /// Gets the default instance of the comparer.

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserverFactory.cs
@@ -1,26 +1,39 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
-namespace MudBlazor.Services
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Factory for creating instances of <see cref="IResizeObserver"/>.
+/// </summary>
+internal sealed class ResizeObserverFactory : IResizeObserverFactory
 {
-    public class ResizeObserverFactory : IResizeObserverFactory
+    private readonly IServiceProvider _provider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResizeObserverFactory"/> class.
+    /// </summary>
+    /// <param name="provider">The service provider.</param>
+    public ResizeObserverFactory(IServiceProvider provider)
     {
-        private readonly IServiceProvider _provider;
+        _provider = provider;
+    }
 
-        public ResizeObserverFactory(IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+    /// <inheritdoc />
+    public IResizeObserver Create()
+    {
+        var options = _provider.GetService<IOptions<ResizeObserverOptions>>();
 
-        public IResizeObserver Create(ResizeObserverOptions options) =>
-            new ResizeObserver(_provider.GetRequiredService<IJSRuntime>(), new OptionsWrapper<ResizeObserverOptions>(options));
+        return Create(options?.Value ?? new ResizeObserverOptions());
+    }
 
-        public IResizeObserver Create()
-        {
-            var options = _provider.GetService<IOptions<ResizeObserverOptions>>();
-            return Create(options?.Value ?? new ResizeObserverOptions());
-        }
+    /// <inheritdoc />
+    public IResizeObserver Create(ResizeObserverOptions options)
+    {
+        var jsRuntime = _provider.GetRequiredService<IJSRuntime>();
+
+        return new ResizeObserver(jsRuntime, new OptionsWrapper<ResizeObserverOptions>(options));
     }
 }

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserverOptions.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserverOptions.cs
@@ -8,8 +8,10 @@ public class ResizeObserverOptions
 {
     /// <summary>
     /// Timespan in milliseconds after the browser detects the last change and notifies the interop service.
-    /// Setting this value too low can cause poor application performance.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>200</c>.  Setting this value too low can cause poor application performance.
+    /// </remarks>
     public int ReportRate { get; set; } = 200;
 
     /// <summary>

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserverOptions.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserverOptions.cs
@@ -1,16 +1,19 @@
-﻿namespace MudBlazor.Services
-{
-    public class ResizeObserverOptions
-    {
-        /// <summary>
-        /// Timepsan in milliseconds after the browser detect the last chance and notify the interop service.
-        /// Setting this value too low can cause poor application performance.
-        /// </summary>
-        public int ReportRate { get; set; } = 200;
+﻿namespace MudBlazor.Services;
 
-        /// <summary>
-        /// Report resize events in the browser's console.
-        /// </summary>
-        public bool EnableLogging { get; set; } = false;
-    }
+#nullable enable
+/// <summary>
+/// Options for configuring the <see cref="IResizeObserver"/>.
+/// </summary>
+public class ResizeObserverOptions
+{
+    /// <summary>
+    /// Timespan in milliseconds after the browser detects the last change and notifies the interop service.
+    /// Setting this value too low can cause poor application performance.
+    /// </summary>
+    public int ReportRate { get; set; } = 200;
+
+    /// <summary>
+    /// Report resize events in the browser's console.
+    /// </summary>
+    public bool EnableLogging { get; set; }
 }

--- a/src/MudBlazor/Services/ResizeObserver/SizeChanged.cs
+++ b/src/MudBlazor/Services/ResizeObserver/SizeChanged.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Delegate for handling size change events.
+/// </summary>
+/// <param name="changes">A dictionary containing the elements and their corresponding bounding client rectangles that have changed size.</param>
+public delegate void SizeChanged(IDictionary<ElementReference, BoundingClientRect> changes);


### PR DESCRIPTION
## Description
Improves overall code quality
The implementation should always be internal.
Removed `IDiposable`.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
