### PR TITLE
MudCollapse: Rework animation

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Collapse/CollapseBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Collapse/CollapseBindingTest.razor
@@ -1,0 +1,18 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudPaper Class="pa-4">
+    <MudStack Spacing="2">
+        <MudButton id="outside_btn" OnClick="OnExpandCollapseClick">@(_expanded ? "Collapse" : "Expand")</MudButton>
+        <MudDivider />
+        <MudCollapse @bind-Expanded="_expanded">
+            This content is collapsible
+        </MudCollapse>
+    </MudStack>
+</MudPaper>
+<MudSwitch T="bool" Label="Expanded" @bind-Value="_expanded" Color="Color.Primary" />
+@code {
+
+    private bool _expanded = true;
+
+    private void OnExpandCollapseClick() => _expanded = !_expanded;
+}

--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -2,38 +2,16 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-using static MudBlazor.MudCollapse;
 
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class CollapseTests : BunitTest
     {
-        [Test]
-        public async Task Collapse_Test1()
-        {
-            //TO DO for %100 coverage we need js test
-            var comp = Context.RenderComponent<MudCollapse>(Parameter(nameof(MudCollapse.MaxHeight), 1600));
-
-            _ = comp.Instance._state = CollapseState.Exiting;
-            await comp.InvokeAsync(() => comp.Instance.AnimationEndAsync());
-            comp.WaitForAssertion(() => comp.Instance._height.Should().Be(0));
-
-            //MaxHeight accepts minus value?
-            _ = comp.Instance._state = CollapseState.Entering;
-
-            var maxHeightParameter = Parameter(nameof(MudCollapse.MaxHeight), -1);
-            comp.SetParametersAndRender(maxHeightParameter);
-            await comp.InvokeAsync(() => comp.Instance.AnimationEndAsync());
-            await comp.InvokeAsync(() => comp.Instance.UpdateHeightAsync());
-            comp.WaitForAssertion(() => comp.Instance._height.Should().Be(-1));
-        }
-
         [Test]
         public void Collapse_TwoWayBinding_Test1()
         {

--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -15,26 +17,28 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Collapse_TwoWayBinding_Test1()
         {
-            // This is to check the behaviour that ExpandedChanged fires when Expanded is changed outside.
-            // Perhaps this behaviour is not correct as mentioned here https://github.com/MudBlazor/MudBlazor/pull/8041#discussion_r1504480792
-            // Native and MS components don't do that, but to keep the old behaviour for now otherwise this would be a breaking change.
-            var currentValue = false;
-            var comp = Context
-                .RenderComponent<MudCollapse>(parameters => parameters
-                    .Bind(component => component.Expanded, currentValue, newValue => currentValue = newValue));
+            var comp = Context.RenderComponent<CollapseBindingTest>();
+            IElement Button() => comp.Find("#outside_btn");
 
-            SetExpanded(true);
-            currentValue.Should().BeTrue();
-            SetExpanded(false);
-            currentValue.Should().BeFalse();
+            IRenderedComponent<MudSwitch<bool>> MudSwitch() => comp.FindComponent<MudSwitch<bool>>();
+            // Initial state is expanded
+            MudSwitch().Find("input").GetAttribute("aria-checked").Should().Be("true");
 
-            return;
+            // Collapse via button
+            Button().Click();
+            MudSwitch().Find("input").GetAttribute("aria-checked").Should().Be("false");
 
-            void SetExpanded(bool expanded)
-            {
-                var expandedParameter = Parameter(nameof(MudCollapse.Expanded), expanded);
-                comp.SetParametersAndRender(expandedParameter);
-            }
+            // Expand via button
+            Button().Click();
+            MudSwitch().Find("input").GetAttribute("aria-checked").Should().Be("true");
+
+            // Collapse via switch
+            MudSwitch().Find("input").Change(false);
+            MudSwitch().Find("input").GetAttribute("aria-checked").Should().Be("false");
+
+            // Expand via switch
+            MudSwitch().Find("input").Change(true);
+            MudSwitch().Find("input").GetAttribute("aria-checked").Should().Be("true");
         }
     }
 }

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -4,7 +4,7 @@
 
 <div @onanimationend="this.AsNonRenderingEventHandler(AnimationEndAsync)"
      @attributes="UserAttributes" class="@Classname" style="@Stylename">
-    <div @ref="_wrapper" class="mud-collapse-wrapper">
+    <div class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent
         </div>

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-@using System.Globalization
 
 <div @ontransitionend="this.AsNonRenderingEventHandler(AnimationEndAsync)"
      @attributes="UserAttributes" class="@Classname" style="@Stylename">

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -2,8 +2,9 @@
 @inherits MudComponentBase
 @using System.Globalization
 
-<div @onanimationend="this.AsNonRenderingEventHandler(AnimationEndAsync)"
+<div @ontransitionend="this.AsNonRenderingEventHandler(AnimationEndAsync)"
      @attributes="UserAttributes" class="@Classname" style="@Stylename">
+    <div></div>
     <div class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -4,7 +4,6 @@
 
 <div @ontransitionend="this.AsNonRenderingEventHandler(AnimationEndAsync)"
      @attributes="UserAttributes" class="@Classname" style="@Stylename">
-    <div></div>
     <div class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -84,10 +82,7 @@ namespace MudBlazor
             await ExpandedChanged.InvokeAsync(_expandedState.Value);
         }
 
-        /// <summary>
-        /// Completes an ongoing animation.
-        /// </summary>
-        public Task AnimationEndAsync()
+        private Task AnimationEndAsync()
         {
             if (_state == CollapseState.Entering)
             {
@@ -99,6 +94,7 @@ namespace MudBlazor
                 _state = CollapseState.Exited;
                 StateHasChanged();
             }
+
             return OnAnimationEnd.InvokeAsync(_expandedState.Value);
         }
     }

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -10,13 +10,13 @@ namespace MudBlazor
     /// </summary>
     public partial class MudCollapse : MudComponentBase
     {
-        internal enum CollapseState
+        private enum CollapseState
         {
             Entering, Entered, Exiting, Exited
         }
 
         private readonly ParameterState<bool> _expandedState;
-        internal CollapseState _state = CollapseState.Exited;
+        private CollapseState _state = CollapseState.Exited;
 
         protected string Classname => new CssBuilder("mud-collapse-container")
             .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -75,11 +75,11 @@ namespace MudBlazor
                 .WithChangeHandler(OnExpandedParameterChangedAsync);
         }
 
-        private async Task OnExpandedParameterChangedAsync()
+        private Task OnExpandedParameterChangedAsync(ParameterChangedEventArgs<bool> args)
         {
-            _state = _expandedState.Value ? CollapseState.Entering : CollapseState.Exiting;
+            _state = args.Value ? CollapseState.Entering : CollapseState.Exiting;
 
-            await ExpandedChanged.InvokeAsync(_expandedState.Value);
+            return Task.CompletedTask;
         }
 
         private Task AnimationEndAsync()

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor.State;
@@ -19,26 +17,19 @@ namespace MudBlazor
             Entering, Entered, Exiting, Exited
         }
 
-        internal double _height;
         private readonly ParameterState<bool> _expandedState;
-        private bool _isRendered;
-        private bool _updateHeight;
-        private ElementReference _wrapper;
         internal CollapseState _state = CollapseState.Exited;
-
-        protected string Stylename => new StyleBuilder()
-            .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
-            .AddStyle("height", "auto", _state == CollapseState.Entered)
-            .AddStyle("height", _height.ToPx(), _state is CollapseState.Entering or CollapseState.Exiting)
-            .AddStyle("animation-duration", $"{CalculatedAnimationDuration.ToString("#.##", CultureInfo.InvariantCulture)}s", _state == CollapseState.Entering)
-            .AddStyle(Style)
-            .Build();
 
         protected string Classname => new CssBuilder("mud-collapse-container")
             .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
             .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
             .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
             .AddClass(Class)
+            .Build();
+
+        protected string Stylename => new StyleBuilder()
+            .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
+            .AddStyle(Style)
             .Build();
 
         /// <summary>
@@ -88,70 +79,9 @@ namespace MudBlazor
 
         private async Task OnExpandedParameterChangedAsync()
         {
-            if (_isRendered)
-            {
-                _state = _expandedState.Value ? CollapseState.Entering : CollapseState.Exiting;
-                await UpdateHeightAsync();
-                _updateHeight = true;
-            }
-            else if (_expandedState.Value)
-            {
-                _state = CollapseState.Entered;
-            }
+            _state = _expandedState.Value ? CollapseState.Entering : CollapseState.Exiting;
 
             await ExpandedChanged.InvokeAsync(_expandedState.Value);
-        }
-
-        /// <summary>
-        /// Modified Animation duration that scales with height parameter.
-        /// Basic implementation for now but should be a math formula to allow it to scale between 0.1s and 1s for the effect to be consistently smooth.
-        /// </summary>
-        private double CalculatedAnimationDuration
-        {
-            get
-            {
-                return MaxHeight switch
-                {
-                    null => Math.Min(_height / 800.0, 1),
-                    <= 200 => 0.2,
-                    <= 600 => 0.4,
-                    <= 1400 => 0.6,
-                    _ => 1
-                };
-            }
-        }
-
-        internal async Task UpdateHeightAsync()
-        {
-            try
-            {
-                _height = (await _wrapper.MudGetBoundingClientRectAsync())?.Height ?? 0;
-            }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException)
-            {
-                _height = 0;
-            }
-
-            if (_height > MaxHeight)
-            {
-                _height = MaxHeight.Value;
-            }
-        }
-
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                _isRendered = true;
-                await UpdateHeightAsync();
-            }
-            else if (_updateHeight && _state is CollapseState.Entering or CollapseState.Exiting)
-            {
-                _updateHeight = false;
-                await UpdateHeightAsync();
-                StateHasChanged();
-            }
-            await base.OnAfterRenderAsync(firstRender);
         }
 
         /// <summary>

--- a/src/MudBlazor/Interop/EventHandlers.cs
+++ b/src/MudBlazor/Interop/EventHandlers.cs
@@ -4,5 +4,5 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor;
 
 // used in MudCollapse
-[EventHandler("onanimationend", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: false)]
+[EventHandler("ontransitionend", typeof(EventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 public static class EventHandlers;

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -1,17 +1,17 @@
 .mud-collapse-container {
   overflow: hidden;
   display: grid;
-  grid-template-rows: min-content 0fr;
+  grid-template-rows: minmax(0, 0fr);
   transition: grid-template-rows 300ms ease-in-out;
 }
 
 .mud-collapse-entering {
-  grid-template-rows: min-content 1fr;
+  grid-template-rows: minmax(0, 1fr);
 }
 
 .mud-collapse-entered {
   overflow: initial;
-  grid-template-rows: min-content 1fr;
+  grid-template-rows: minmax(0, 1fr);
 }
 
 .mud-collapse-hidden {

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -11,6 +11,7 @@
 
 .mud-collapse-entered {
   overflow: initial;
+  grid-template-rows: min-content 1fr;
 }
 
 .mud-collapse-hidden {

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -1,38 +1,16 @@
-﻿.mud-collapse-container {
-  height: 0px;
+.mud-collapse-container {
   overflow: hidden;
-}
-
-@keyframes mud-expand-anim {
-  from {
-    height: 0;
-  }
+  display: grid;
+  grid-template-rows: min-content 0fr;
+  transition: grid-template-rows 300ms ease-in-out;
 }
 
 .mud-collapse-entering {
-  animation: mud-expand-anim 1s ease-in-out 0ms 1 forwards;
-
-  &.mud-navgroup-collapse {
-    animation-duration: 300ms !important;
-  }
+  grid-template-rows: min-content 1fr;
 }
 
 .mud-collapse-entered {
   overflow: initial;
-}
-
-@keyframes mud-collapse-anim {
-  to {
-    height: 0;
-  }
-}
-
-.mud-collapse-exiting {
-  animation: mud-collapse-anim 0.5s cubic-bezier(0, 1, 0, 1) 0ms 1 forwards;
-
-  &.mud-navgroup-collapse {
-    animation-duration: 300ms;
-  }
 }
 
 .mud-collapse-hidden {
@@ -40,6 +18,7 @@
 }
 
 .mud-collapse-wrapper {
+  overflow: hidden;
   display: flex;
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes #8939 by reworking the animation entirely to use CSS transitions on a grid display as opposed to calculating the height through JavaScript. This should be more performant and stable.

Impacts other components like the Expansion Panels, Tree View, Nav Menu. I'd like it if someone with more experience with those components can try the new transition effect locally.
 
## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before: https://github.com/MudBlazor/MudBlazor/issues/8939#issuecomment-2422443682

After:

https://github.com/user-attachments/assets/5633b99a-59ec-492f-9be0-a7a8db28fb9f

Animation is now a static 300ms which is between 50% slower and 333% faster, depending on how tall the content was before.

`CollapseState`,  `_state`, `AnimationEndAsync` are now private but I don't believe I made any other breaking changes aside from rewriting the CSS obviously (but the CSS classes themselves are still the same).

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
