### PR TITLE
Inputs: Refactor adornment related code

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -26,5 +26,18 @@ namespace MudBlazor.UnitTests.Extensions
             Align.Inherit.ToDescriptionString().Should().Be("inherit");
             Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
         }
+
+        [TestCase(Adornment.Start, Edge.Start)]
+        [TestCase(Adornment.End, Edge.End)]
+        [TestCase(Adornment.None, Edge.False)]
+        [TestCase((Adornment)999, Edge.False)] // Invalid adornment value
+        public void Adornment_ToEdge_Should_ReturnExpectedValue(Adornment adornment, Edge expectedEdge)
+        {
+            // Act
+            var result = adornment.ToEdge();
+
+            // Assert
+            result.Should().Be(expectedEdge);
+        }
     }
 }

--- a/src/MudBlazor/Components/Field/MudField.razor
+++ b/src/MudBlazor/Components/Field/MudField.razor
@@ -8,14 +8,26 @@
         <div class="@Classname">
             @if (Adornment == Adornment.Start)
             {
-                <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" Color="@AdornmentColor" />
+                <MudInputAdornment Class="@AdornmentClassname"
+                                   Icon="@AdornmentIcon"
+                                   Color="@AdornmentColor"
+                                   Size="@IconSize"
+                                   Text="@AdornmentText"
+                                   Edge="@Edge.Start"
+                                   AdornmentClick="@OnAdornmentClick" />
             }
             <div class="@InnerClassname">
                 @ChildContent
             </div>
             @if (Adornment == Adornment.End)
             {
-                <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick"  Color="@AdornmentColor" />
+                <MudInputAdornment Class="@AdornmentClassname"
+                                   Icon="@AdornmentIcon"
+                                   Color="@AdornmentColor"
+                                   Size="@IconSize"
+                                   Text="@AdornmentText"
+                                   Edge="@Edge.End"
+                                   AdornmentClick="@OnAdornmentClick" />
             }
             @if (Variant == Variant.Outlined)
             {

--- a/src/MudBlazor/Components/Field/MudField.razor
+++ b/src/MudBlazor/Components/Field/MudField.razor
@@ -13,7 +13,7 @@
                                    Color="@AdornmentColor"
                                    Size="@IconSize"
                                    Text="@AdornmentText"
-                                   Edge="@Edge.Start"
+                                   Placement="@Adornment.Start"
                                    AdornmentClick="@OnAdornmentClick" />
             }
             <div class="@InnerClassname">
@@ -26,7 +26,7 @@
                                    Color="@AdornmentColor"
                                    Size="@IconSize"
                                    Text="@AdornmentText"
-                                   Edge="@Edge.End"
+                                   Placement="@Adornment.End"
                                    AdornmentClick="@OnAdornmentClick" />
             }
             @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -5,8 +5,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-    //TODO Maybe can inherit from MudBaseInput?
-
+    // TODO: Maybe can inherit from MudBaseInput?
     /// <summary>
     /// A component similar to <see cref="MudTextField{T}"/> which supports custom content.
     /// </summary>
@@ -17,9 +16,9 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
-                .AddClass("mud-input-underline", when: () => Underline && Variant != Variant.Outlined)
-                .AddClass("mud-shrink", when: () => !string.IsNullOrWhiteSpace(ChildContent?.ToString()) || Adornment == Adornment.Start)
+                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
+                .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
+                .AddClass("mud-shrink", () => !string.IsNullOrWhiteSpace(ChildContent?.ToString()) || Adornment == Adornment.Start)
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", Error && !string.IsNullOrEmpty(ErrorText))
                 .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
@@ -28,14 +27,14 @@ namespace MudBlazor
         protected string InnerClassname =>
             new CssBuilder("mud-input-slot")
                 .AddClass("mud-input-root")
-                .AddClass("mud-input-slot-nopadding", when: () => InnerPadding == false)
+                .AddClass("mud-input-slot-nopadding", () => InnerPadding == false)
                 .AddClass($"mud-input-root-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
                 .Build();
 
         protected string AdornmentClassname =>
-            new CssBuilder("mud-input-adornment")
+            new CssBuilder()
                 .AddClass($"mud-input-adornment-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-text", !string.IsNullOrEmpty(AdornmentText))
                 .AddClass($"mud-input-root-filled-shrink", Variant == Variant.Filled)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -112,7 +112,8 @@
                        Icon="@ClearIcon"
                        Size="@Size.Small"
                        OnClick="@HandleClearButtonAsync"
-                       aria-label="@Localizer[LanguageResource.MudInput_Clear]" />
+                       aria-label="@Localizer[LanguageResource.MudInput_Clear]"
+                       tabindex="-1" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -9,14 +9,13 @@
     @if (Adornment == Adornment.Start)
     {
         <MudInputAdornment Class="@AdornmentClassname"
-                Icon="@AdornmentIcon"
-                Color="@AdornmentColor"
-                Size="@IconSize"
-                Text="@AdornmentText"
-                Edge="@Edge.Start"
-                AdornmentClick="@OnAdornmentClick"
-                AriaLabel="@AdornmentAriaLabel"
-        />
+                           Icon="@AdornmentIcon"
+                           Color="@AdornmentColor"
+                           Size="@IconSize"
+                           Text="@AdornmentText"
+                           Edge="@Edge.Start"
+                           AdornmentClick="@OnAdornmentClick"
+                           AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (AutoGrow || Lines > 1)
@@ -109,26 +108,23 @@
     @if (GetClearable() && !GetDisabledState())
     {
         <MudIconButton Class="@ClearButtonClassname"
-                    Color="@Color.Default"
-                    Icon="@ClearIcon"
-                    Size="@Size.Small"
-                    OnClick="@ClearButtonClickHandlerAsync"
-                    aria-label="@Localizer[LanguageResource.MudInput_Clear]"
-                    tabindex="-1"
-                />
+                       Color="@Color.Default"
+                       Icon="@ClearIcon"
+                       Size="@Size.Small"
+                       OnClick="@HandleClearButtonAsync"
+                       aria-label="@Localizer[LanguageResource.MudInput_Clear]" />
     }
 
     @if (Adornment == Adornment.End)
     {
         <MudInputAdornment Class="@AdornmentClassname"
-                Icon="@AdornmentIcon"
-                Color="@AdornmentColor"
-                Size="@IconSize"
-                Text="@AdornmentText"
-                Edge="@Edge.End"
-                AdornmentClick="@OnAdornmentClick"
-                AriaLabel="@AdornmentAriaLabel"
-        />
+                           Icon="@AdornmentIcon"
+                           Color="@AdornmentColor"
+                           Size="@IconSize"
+                           Text="@AdornmentText"
+                           Edge="@Edge.End"
+                           AdornmentClick="@OnAdornmentClick"
+                           AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -13,7 +13,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.Start"
+                           Placement="@Adornment.Start"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }
@@ -122,7 +122,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.End"
+                           Placement="@Adornment.End"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor.Utilities;
@@ -14,10 +12,14 @@ namespace MudBlazor
     public partial class MudInput<T> : MudBaseInput<T>
     {
         protected string Classname =>
-           new CssBuilder(
-               MudInputCssHelper.GetClassname(this,
-                   () => HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || ShrinkLabel))
-            .AddClass("mud-input-auto-grow", when: () => AutoGrow)
+            new CssBuilder(
+                MudInputCssHelper.GetClassname(this,
+                    () => HasNativeHtmlPlaceholder() ||
+                          !string.IsNullOrEmpty(Text) ||
+                          Adornment == Adornment.Start ||
+                          !string.IsNullOrWhiteSpace(Placeholder) ||
+                          ShrinkLabel))
+            .AddClass("mud-input-auto-grow", () => AutoGrow)
             .Build();
 
         protected string InputClassname => MudInputCssHelper.GetInputClassname(this);
@@ -25,12 +27,12 @@ namespace MudBlazor
         protected string AdornmentClassname => MudInputCssHelper.GetAdornmentClassname(this);
 
         protected string ClearButtonClassname =>
-                    new CssBuilder("mud-input-clear-button")
-                    .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
-                    .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
-                    .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
-                    .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
-                    .Build();
+            new CssBuilder("mud-input-clear-button")
+            .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
+            .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
+            .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
+            .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
+            .Build();
 
         /// <summary>
         /// The type of input collected by this component.
@@ -224,7 +226,7 @@ namespace MudBlazor
         /// </summary>
         private bool GetClearable() => Clearable && ((Value is string stringValue && !string.IsNullOrWhiteSpace(stringValue)) || (Value is not string && Value is not null));
 
-        protected virtual async Task ClearButtonClickHandlerAsync(MouseEventArgs e)
+        protected virtual async Task HandleClearButtonAsync(MouseEventArgs e)
         {
             await SetTextAsync(string.Empty, updateValue: true);
             await ElementReference.FocusAsync();

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -11,6 +11,11 @@ namespace MudBlazor
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
     public partial class MudInput<T> : MudBaseInput<T>
     {
+        private ElementReference _elementReference1;
+        private string _oldText = null;
+        private string _internalText;
+        private bool _shouldInitAutoGrow;
+
         protected string Classname =>
             new CssBuilder(
                 MudInputCssHelper.GetClassname(this,
@@ -28,10 +33,10 @@ namespace MudBlazor
 
         protected string ClearButtonClassname =>
             new CssBuilder("mud-input-clear-button")
-            .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
-            .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
-            .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
-            .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
+                .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
+                .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
+                .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
+                .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
             .Build();
 
         /// <summary>
@@ -72,7 +77,6 @@ namespace MudBlazor
         {
             return Task.CompletedTask;
         }
-
         /// <summary>
         /// The content within this input component.
         /// </summary>
@@ -86,8 +90,6 @@ namespace MudBlazor
         /// The reference to the HTML element for this component.
         /// </summary>
         public ElementReference ElementReference { get; private set; }
-
-        private ElementReference _elementReference1;
 
         /// <inheritdoc />
         public override async ValueTask FocusAsync()
@@ -224,7 +226,20 @@ namespace MudBlazor
         /// <summary>
         /// If true, Clearable is true and there is a non null value (non-string for string values)
         /// </summary>
-        private bool GetClearable() => Clearable && ((Value is string stringValue && !string.IsNullOrWhiteSpace(stringValue)) || (Value is not string && Value is not null));
+        private bool GetClearable()
+        {
+            if (!Clearable)
+            {
+                return false;
+            }
+
+            if (Value is string stringValue)
+            {
+                return !string.IsNullOrWhiteSpace(stringValue);
+            }
+
+            return Value is not string and not null;
+        }
 
         protected virtual async Task HandleClearButtonAsync(MouseEventArgs e)
         {
@@ -232,10 +247,6 @@ namespace MudBlazor
             await ElementReference.FocusAsync();
             await OnClearButtonClick.InvokeAsync(e);
         }
-
-        private string _oldText = null;
-        private string _internalText;
-        private bool _shouldInitAutoGrow;
 
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
@@ -321,8 +332,13 @@ namespace MudBlazor
         // Certain HTML5 inputs (dates and color) have a native placeholder
         private bool HasNativeHtmlPlaceholder()
         {
-            return GetInputType() is InputType.Color or InputType.Date or InputType.DateTimeLocal or InputType.Month
-                or InputType.Time or InputType.Week;
+            return GetInputType()
+                is InputType.Color
+                or InputType.Date
+                or InputType.DateTimeLocal
+                or InputType.Month
+                or InputType.Time
+                or InputType.Week;
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MudBlazor.Internal
+@using MudBlazor.Extensions
 
 <div class="@Classname">
     @if (!string.IsNullOrWhiteSpace(Text))
@@ -16,7 +17,7 @@
             <MudIconButton Class="mud-input-adornment-icon-button"
                            Icon="@Icon"
                            OnClick="@AdornmentClick"
-                           Edge="@Edge"
+                           Edge="@(Placement.ToEdge())"
                            Size="@Size"
                            Color="@Color"
                            aria-label="@AriaLabel"

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -1,19 +1,35 @@
 ﻿@namespace MudBlazor.Internal
 
-<div class="@Class">
+<div class="@Classname">
     @if (!string.IsNullOrWhiteSpace(Text))
     {
-        <MudText Color="@Color" tabindex="-1">@Text</MudText>
+        <MudText Class="mud-input-adornment-text"
+                 Color="@Color"
+                 tabindex="-1">
+            @Text
+        </MudText>
     }
     else if (!string.IsNullOrWhiteSpace(Icon))
     {
         @if (AdornmentClick.HasDelegate)
         {
-            <MudIconButton Class="mud-input-adornment-icon-button" Icon="@Icon" OnClick="@AdornmentClick" Edge="@Edge" Size="@Size" Color="@Color" aria-label="@AriaLabel" tabindex="-1" />
+            <MudIconButton Class="mud-input-adornment-icon-button"
+                           Icon="@Icon"
+                           OnClick="@AdornmentClick"
+                           Edge="@Edge"
+                           Size="@Size"
+                           Color="@Color"
+                           aria-label="@AriaLabel"
+                           tabindex="-1" />
         }
         else
         {
-            <MudIcon Class="mud-input-adornment-icon" Icon="@Icon" Size="@Size" Color="@Color" aria-label="@AriaLabel" tabindex="-1" />
+            <MudIcon Class="mud-input-adornment-icon"
+                     Icon="@Icon"
+                     Size="@Size"
+                     Color="@Color"
+                     aria-label="@AriaLabel"
+                     tabindex="-1" />
         }
     }
 </div>

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
@@ -40,13 +40,13 @@ public partial class MudInputAdornment
     public string Icon { get; set; }
 
     /// <summary>
-    /// The amount of negative margin applied to the icon.
+    /// Specifies the position of the adornment within the field.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Edge.False"/>.  Other values are <see cref="Edge.Start"/> and <see cref="Edge.End"/>.
+    /// Defaults to <see cref="Adornment.None"/>.
     /// </remarks>
     [Parameter]
-    public Edge Edge { get; set; }
+    public Adornment Placement { get; set; }
 
     /// <summary>
     /// The size of the icon.

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor.Internal;
 
@@ -12,6 +13,11 @@ namespace MudBlazor.Internal;
 /// </summary>
 public partial class MudInputAdornment
 {
+    protected string Classname =>
+        new CssBuilder("mud-input-adornment")
+            .AddClass(Class)
+            .Build();
+
     /// <summary>
     /// The CSS classes for this adornment.
     /// </summary>

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -20,9 +20,9 @@ internal static class MudInputCssHelper
             .AddClass($"mud-input-{baseInput.Variant.ToDescriptionString()}")
             .AddClass($"mud-input-{baseInput.Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(baseInput.Label))
             .AddClass($"mud-input-adorned-{baseInput.Adornment.ToDescriptionString()}", baseInput.Adornment != Adornment.None)
-            .AddClass($"mud-input-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
-            .AddClass("mud-input-underline", when: () => baseInput.Underline && baseInput.Variant != Variant.Outlined)
-            .AddClass("mud-shrink", when: shrinkWhen)
+            .AddClass($"mud-input-margin-{baseInput.Margin.ToDescriptionString()}", () => baseInput.Margin != Margin.None)
+            .AddClass("mud-input-underline", () => baseInput.Underline && baseInput.Variant != Variant.Outlined)
+            .AddClass("mud-shrink", shrinkWhen)
             .AddClass("mud-disabled", baseInput.Disabled)
             .AddClass("mud-input-error", baseInput.HasErrors)
             .AddClass("mud-ltr", baseInput.GetInputType() == InputType.Email || baseInput.GetInputType() == InputType.Telephone)
@@ -41,7 +41,7 @@ internal static class MudInputCssHelper
             .AddClass("mud-input-root")
             .AddClass($"mud-input-root-{baseInput.Variant.ToDescriptionString()}")
             .AddClass($"mud-input-root-adorned-{baseInput.Adornment.ToDescriptionString()}", baseInput.Adornment != Adornment.None)
-            .AddClass($"mud-input-root-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
+            .AddClass($"mud-input-root-margin-{baseInput.Margin.ToDescriptionString()}", () => baseInput.Margin != Margin.None)
             .AddClass(baseInput.Class)
             .Build();
 
@@ -52,7 +52,7 @@ internal static class MudInputCssHelper
     /// <param name="baseInput">The input control to use.</param>
     /// <returns>A set of CSS classes.</returns>
     public static string GetAdornmentClassname<T>(MudBaseInput<T> baseInput) =>
-        new CssBuilder("mud-input-adornment")
+        new CssBuilder()
             .AddClass($"mud-input-adornment-{baseInput.Adornment.ToDescriptionString()}", baseInput.Adornment != Adornment.None)
             .AddClass($"mud-text", !string.IsNullOrEmpty(baseInput.AdornmentText))
             .AddClass($"mud-input-root-filled-shrink", baseInput.Variant == Variant.Filled)

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -8,7 +8,14 @@
 <div class="@Classname" style="@Style">
     @if (Adornment == Adornment.Start)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" AriaLabel="@AdornmentAriaLabel" />
+        <MudInputAdornment Class="@AdornmentClassname"
+                           Icon="@AdornmentIcon"
+                           Color="@AdornmentColor"
+                           Size="@IconSize"
+                           Text="@AdornmentText"
+                           Edge="@Edge.Start"
+                           AdornmentClick="@OnAdornmentClick"
+                           AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (InputType == InputType.Hidden && ChildContent != null)
@@ -65,7 +72,14 @@
 
     @if (Adornment == Adornment.End)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" AriaLabel="@AdornmentAriaLabel" />
+        <MudInputAdornment Class="@AdornmentClassname"
+                           Icon="@AdornmentIcon"
+                           Color="@AdornmentColor"
+                           Size="@IconSize"
+                           Text="@AdornmentText"
+                           Edge="@Edge.End"
+                           AdornmentClick="@OnAdornmentClick"
+                           AriaLabel="@AdornmentAriaLabel" />
     }
 
     @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -13,7 +13,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.Start"
+                           Placement="@Adornment.Start"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }
@@ -77,7 +77,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.End"
+                           Placement="@Adornment.End"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -92,7 +92,8 @@
                        Icon="@ClearIcon"
                        Size="@Size.Small"
                        OnClick="@HandleClearButtonAsync"
-                       aria-label="@Localizer[LanguageResource.MudInput_Clear]" />
+                       aria-label="@Localizer[LanguageResource.MudInput_Clear]"
+                       tabindex="-1" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -12,7 +12,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.Start"
+                           Placement="@Adornment.Start"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }
@@ -102,7 +102,7 @@
                            Color="@AdornmentColor"
                            Size="@IconSize"
                            Text="@AdornmentText"
-                           Edge="@Edge.End"
+                           Placement="@Adornment.End"
                            AdornmentClick="@OnAdornmentClick"
                            AriaLabel="@AdornmentAriaLabel" />
     }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
     /// A text input which conforms user input to a specific format while typing. 
     /// <remarks>
     /// Note that MudMask is recommended to be used in WASM projects only because it has known problems
-    /// in BSS, especiall with high network latency.
+    /// in BSS, especially with high network latency.
     /// </remarks>
     /// </summary>
     public partial class MudMask : MudBaseInput<string>
@@ -29,11 +29,9 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
-                .AddClass("mud-input-underline", when: () => Underline && Variant != Variant.Outlined)
-                .AddClass("mud-shrink",
-                    when: () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start ||
-                                !string.IsNullOrWhiteSpace(Placeholder))
+                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
+                .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
+                .AddClass("mud-shrink", () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder))
                 .AddClass("mud-disabled", GetDisabledState())
                 .AddClass("mud-input-error", HasErrors)
                 .AddClass("mud-ltr", GetInputType() == InputType.Email || GetInputType() == InputType.Telephone)
@@ -46,12 +44,12 @@ namespace MudBlazor
                 .AddClass("mud-input-root")
                 .AddClass($"mud-input-root-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-root-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
                 .AddClass(Class)
                 .Build();
 
         protected string AdornmentClassname =>
-            new CssBuilder("mud-input-adornment")
+            new CssBuilder()
                 .AddClass($"mud-input-adornment-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-text", !string.IsNullOrEmpty(AdornmentText))
                 .AddClass($"mud-input-root-filled-shrink", Variant == Variant.Filled)
@@ -59,12 +57,12 @@ namespace MudBlazor
                 .Build();
 
         protected string ClearButtonClassname =>
-            new CssBuilder()
-                // .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
-                .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End)
-                // .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
-                .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End)
-                .Build();
+            new CssBuilder("mud-input-clear-button")
+            // .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
+            .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End)
+            // .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
+            .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End)
+            .Build();
 
 
         private ElementReference _elementReference;

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -19,10 +19,11 @@ namespace MudBlazor
     /// </summary>
     public partial class MudMask : MudBaseInput<string>
     {
-        public MudMask()
-        {
-            TextUpdateSuppression = false;
-        }
+        private ElementReference _elementReference;
+        private ElementReference _elementReference1;
+        private IJsEvent _jsEvent;
+        private string _elementId = Identifier.Create("mask");
+        private IMask _mask = new PatternMask("** **-** **");
 
         protected string Classname =>
             new CssBuilder("mud-input")
@@ -37,7 +38,7 @@ namespace MudBlazor
                 .AddClass("mud-ltr", GetInputType() == InputType.Email || GetInputType() == InputType.Telephone)
                 .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
                 .AddClass(Class)
-                .Build();
+            .Build();
 
         protected string InputClassname =>
             new CssBuilder("mud-input-slot")
@@ -46,7 +47,7 @@ namespace MudBlazor
                 .AddClass($"mud-input-root-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
                 .AddClass(Class)
-                .Build();
+            .Build();
 
         protected string AdornmentClassname =>
             new CssBuilder()
@@ -54,30 +55,21 @@ namespace MudBlazor
                 .AddClass($"mud-text", !string.IsNullOrEmpty(AdornmentText))
                 .AddClass($"mud-input-root-filled-shrink", Variant == Variant.Filled)
                 .AddClass(Class)
-                .Build();
+            .Build();
 
         protected string ClearButtonClassname =>
             new CssBuilder("mud-input-clear-button")
-            // .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
-            .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End)
-            // .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
-            .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End)
+                // .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
+                .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End)
+                // .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
+                .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End)
             .Build();
-
-
-        private ElementReference _elementReference;
-        private ElementReference _elementReference1;
-        private IJsEvent _jsEvent;
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 
         [Inject] private IJsEventFactory _jsEventFactory { get; set; }
         [Inject] private IJsApiService _jsApiService { get; set; }
-
-        private string _elementId = Identifier.Create("mask");
-
-        private IMask _mask = new PatternMask("** **-** **");
 
         /// <summary>
         /// The content within this input.
@@ -126,6 +118,7 @@ namespace MudBlazor
         private void UpdateClearable(object value)
         {
             var showClearable = Clearable && !string.IsNullOrWhiteSpace(Text);
+
             if (_showClearable != showClearable)
                 _showClearable = showClearable;
         }
@@ -144,10 +137,16 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Appearance)]
         public string ClearIcon { get; set; } = Icons.Material.Filled.Clear;
 
+        public MudMask()
+        {
+            TextUpdateSuppression = false;
+        }
+
         protected override async Task OnInitializedAsync()
         {
             if (Text != Mask.Text)
                 await SetTextAsync(Mask.Text, updateValue: false);
+
             await base.OnInitializedAsync();
         }
 
@@ -214,6 +213,7 @@ namespace MudBlazor
                             await UpdateAsync();
                             return;
                         }
+
                         Mask.Backspace();
                         await UpdateAsync();
                         return;
@@ -350,6 +350,7 @@ namespace MudBlazor
             {
                 (_, text, _) = BaseMask.SplitSelection(text, Mask.Selection.Value);
             }
+
             _jsApiService.CopyToClipboardAsync(text);
         }
 
@@ -357,6 +358,7 @@ namespace MudBlazor
         {
             if (text == null || GetReadOnlyState())
                 return;
+
             Mask.Insert(text);
             await UpdateAsync();
         }

--- a/src/MudBlazor/Enums/Adornment.cs
+++ b/src/MudBlazor/Enums/Adornment.cs
@@ -1,14 +1,30 @@
 ﻿using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Specifies the position of an adornment in a field.
+/// </summary>
+/// <remarks>
+/// Adornments can be placed at the start or end of a field, or not displayed at all.
+/// </remarks>
+public enum Adornment
 {
-    public enum Adornment
-    {
-        [Description("none")]
-        None,
-        [Description("start")]
-        Start,
-        [Description("end")]
-        End
-    }
+    /// <summary>
+    /// No adornment is displayed.
+    /// </summary>
+    [Description("none")]
+    None,
+
+    /// <summary>
+    /// The adornment is placed at the start of the field.
+    /// </summary>
+    [Description("start")]
+    Start,
+
+    /// <summary>
+    /// The adornment is placed at the end of the field.
+    /// </summary>
+    [Description("end")]
+    End,
 }

--- a/src/MudBlazor/Enums/Edge.cs
+++ b/src/MudBlazor/Enums/Edge.cs
@@ -1,28 +1,47 @@
 ﻿using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Specifies where a negative margin is applied within a layout component.
+/// This is typically used in conjunction with elements that have leading or trailing adornments.
+/// </summary>
+/// <remarks>
+/// Negative margins are often applied to ensure adornments or icons align more closely with the edge of the component.
+/// Depending on the design requirements, this margin can be applied at the start or end of an element,
+/// or not applied at all (default behavior).
+/// </remarks>
+public enum Edge
 {
     /// <summary>
-    /// Indicates the location of any negative margin.
+    /// No negative margin is applied to the element.
     /// </summary>
-    public enum Edge
-    {
-        /// <summary>
-        /// No negative margin is applied.
-        /// </summary>
-        [Description("false")]
-        False,
+    /// <remarks>
+    /// This is the default behavior, meaning the element maintains its normal margins without adjustments.
+    /// It is used when there is no need to modify the element’s margin for adornments or icons.
+    /// </remarks>
+    [Description("false")]
+    False,
 
-        /// <summary>
-        /// A negative margin is applied at the start.
-        /// </summary>
-        [Description("start")]
-        Start,
+    /// <summary>
+    /// A negative margin is applied to the start of the element.
+    /// </summary>
+    /// <remarks>
+    /// This reduces the space at the start (leading side) of the element. It is typically used when an adornment, 
+    /// such as an icon or label, is positioned at the beginning of the component and needs to be aligned more closely 
+    /// with the left edge in left-to-right layouts (or the right edge in right-to-left layouts).
+    /// </remarks>
+    [Description("start")]
+    Start,
 
-        /// <summary>
-        /// A negative margin is applied at the end.
-        /// </summary>
-        [Description("end")]
-        End
-    }
+    /// <summary>
+    /// A negative margin is applied to the end of the element.
+    /// </summary>
+    /// <remarks>
+    /// This reduces the space at the end (trailing side) of the element. It is commonly used when an adornment, 
+    /// such as an icon or label, is positioned at the end of the component and requires alignment with the right 
+    /// edge in left-to-right layouts (or the left edge in right-to-left layouts).
+    /// </remarks>
+    [Description("end")]
+    End,
 }

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -28,5 +28,20 @@
 
             return [];
         }
+
+        /// <summary>
+        /// Converts an <see cref="Adornment"/> to its corresponding <see cref="Edge"/> value.
+        /// </summary>
+        /// <param name="adornment">The adornment value to convert.</param>
+        /// <returns>The corresponding <see cref="Edge"/> value.</returns>
+        internal static Edge ToEdge(this Adornment adornment)
+        {
+            return adornment switch
+            {
+                Adornment.Start => Edge.Start,
+                Adornment.End => Edge.End,
+                _ => Edge.False
+            };
+        }
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Laying the groundwork for future adornment improvements by getting the code updated to raise parity in the different implementations.

See #10046, #8945 for context.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

- Formats certain code/markup to normalize them with other places
- Hooks up `AdornmentColor` in `MudField`
- MudInputAdornment now accepts a `Adornment Placement` property, replacing the `Edge Edge` in order to be more explicit
- Improves docs for Adornment and Edge enum types
- Moves `mud-input-adornment` class directly into MudInputAdornment which now has a CSS builder
- Adds missing `tabindex=-1` to the Clear button in MudMask
- Adds missing `mud-input-clear-button` to the Clear button in MudMask
- Adds missing `mud-input-adornment-text` class to the text adornment type

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
