### PR TITLE
MudStepper: Add opt-out Ripple property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Stepper/Examples/StepperNonLinearExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/Examples/StepperNonLinearExample.razor
@@ -1,8 +1,17 @@
 ﻿@namespace MudBlazor.Docs.Examples
+
 <MudPaper Style="width: 800px">
-    <MudStepper NonLinear ShowResetButton>
+    <MudStepper NonLinear ShowResetButton Ripple="Ripple">
         <MudStep Title="Write the code">Most programmers first start writing the code but some experts write the tests first</MudStep>
         <MudStep Title="Write the tests">If you write the tests first you will design a better API when you write the code</MudStep>
         <MudStep Title="Write the documentation" SecondaryText="... or not">Some consider writing readable code more important than writing documentation.</MudStep>
     </MudStepper>
 </MudPaper>
+
+<MudDivider />
+
+<MudSwitch @bind-Value="@Ripple" Color="Color.Primary" Label="Ripple"></MudSwitch>
+
+@code {
+    public bool Ripple { get; set; } = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -32,7 +32,10 @@
 
         <DocsPageSection>
             <SectionHeader Title="Non-linear version">
-                <Description>If you need to jump between the steps, parameter <CodeInline>@nameof(MudStepper.NonLinear)</CodeInline> is there for that.</Description>
+                <Description>
+                    If you need to jump between the steps, parameter <CodeInline>@nameof(MudStepper.NonLinear)</CodeInline> is there for that.
+                    You can opt out of the ripple effect with <CodeInline>@nameof(MudStepper.Ripple)</CodeInline>.
+                </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(StepperNonLinearExample)" ShowCode="false">
                 <StepperNonLinearExample />

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -1,4 +1,5 @@
-﻿using Bunit;
+﻿using AngleSharp.Dom;
+using Bunit;
 using FluentAssertions;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Stepper;
@@ -274,9 +275,9 @@ namespace MudBlazor.UnitTests.Components
             // stepper.WaitForAssertion(() => stepper.RenderCount.Should().Be(2));
 
             // disable step 1
-            stepper.FindAll(".mud-step")[0].ClassList.Should().NotContain("mud-step-disabled");
+            stepper.FindAll(".mud-step")[0].IsDisabled().Should().Be(false);
             await stepper.InvokeAsync(async () => await stepper.Instance.Steps[0].SetDisabledAsync(true));
-            stepper.FindAll(".mud-step")[0].ClassList.Should().Contain("mud-step-disabled");
+            stepper.FindAll(".mud-step")[0].IsDisabled().Should().Be(true);
             // fail step 2
             stepper.FindAll(".mud-step")[1].ClassList.Should().NotContain("mud-step-error");
             stepper.FindAll(".mud-step-label-icon")[1].ClassList.Should().NotContain("mud-error");
@@ -471,9 +472,9 @@ namespace MudBlazor.UnitTests.Components
             });
 
             // disable step 1
-            stepper.FindAll(".mud-step")[0].ClassList.Should().NotContain("mud-step-disabled");
+            stepper.FindAll(".mud-step")[0].IsDisabled().Should().Be(false);
             stepper.FindComponents<MudStep>()[0].SetParametersAndRender(Parameter(nameof(MudStep.Disabled), true));
-            stepper.FindAll(".mud-step")[0].ClassList.Should().Contain("mud-step-disabled");
+            stepper.FindAll(".mud-step")[0].IsDisabled().Should().Be(true);
             // fail step 2
             stepper.FindAll(".mud-step")[1].ClassList.Should().NotContain("mud-step-error");
             stepper.FindAll(".mud-step-label-icon")[1].ClassList.Should().NotContain("mud-error");

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -653,5 +653,59 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
 
         }
+
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void HasRippleClass(bool ripple, bool hasClass)
+        {
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.Ripple, ripple);
+
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "A");
+                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                });
+            });
+
+            var stepButton = stepper.Find(".mud-step");
+
+            if (hasClass)
+            {
+                stepButton.ClassList.Should().Contain("mud-ripple");
+            }
+            else
+            {
+                stepButton.ClassList.Should().NotContain("mud-ripple");
+            }
+        }
+
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void HasClickableClassIfNonLinear(bool nonLinear, bool hasClass)
+        {
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.NonLinear, nonLinear);
+
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "A");
+                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                });
+            });
+
+            var stepButton = stepper.Find(".mud-step");
+
+            if (hasClass)
+            {
+                stepButton.ClassList.Should().Contain("mud-clickable");
+            }
+            else
+            {
+                stepButton.ClassList.Should().NotContain("mud-clickable");
+            }
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -108,15 +108,15 @@ namespace MudBlazor.UnitTests.Components
             });
             // check the stepper content
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0); // can't complete yet
             // step 1 icon should be "1", step 2 icon should be "2"
             stepper.FindAll(".mud-step-label-icon")[0].TextContent.Trimmed().Should().Be("1");
             stepper.FindAll(".mud-step-label-icon")[1].TextContent.Trimmed().Should().Be("2");
             stepper.Find(".mud-stepper-button-next").Click(); // next
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 2");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(false); // previous
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(false); // previous
             stepper.FindAll(".mud-stepper-button-next").Count.Should().Be(0); // no next button when completable
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(1);
             // step 1 icon should be a check mark, step 2 icon should be "2"
@@ -124,8 +124,8 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-step-label-icon")[1].TextContent.Trimmed().Should().Be("2");
             stepper.Find(".mud-stepper-button-previous").Click(); // prev
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0); // can't complete yet
             // step 1 icon should be a check mark, step 2 icon should be "2"
             stepper.FindAll(".mud-step-label-icon")[0].QuerySelectorAll("path").Last().GetAttribute("d").Should().Be("M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z");
@@ -167,16 +167,16 @@ namespace MudBlazor.UnitTests.Components
             });
 
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false);
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false);
             stepper.Find(".mud-stepper-button-next").Click(); // next
 
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(3);
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(true);
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(false);
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(true);
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(false);
             stepper.Find(".mud-stepper-button-previous").Click(); // prev
 
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true);
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true);
             stepper.Find(".mud-stepper-button-previous").Click(); // prev
         }
 
@@ -200,21 +200,21 @@ namespace MudBlazor.UnitTests.Components
             });
             // check the stepper content
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-skip").HasAttribute("disabled").Should().Be(false); // skippable step
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-skip").IsDisabled().Should().Be(false); // skippable step
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0); // can't complete yet
             stepper.Find(".mud-stepper-button-skip").Click(); // skip
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 2");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(false); // previous
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(false); // previous
             stepper.FindAll(".mud-stepper-button-skip").Count.Should().Be(0); // non-skippable step
             stepper.FindAll(".mud-stepper-button-next").Count.Should().Be(0); // no next button on last step
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(1); // next
             stepper.Find(".mud-stepper-button-previous").Click(); // prev
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-skip").HasAttribute("disabled").Should().Be(false); // skippable step
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-skip").IsDisabled().Should().Be(false); // skippable step
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0); // can't complete yet, because step 2 is not Completed yet
         }
 
@@ -394,15 +394,15 @@ namespace MudBlazor.UnitTests.Components
             });
             // check the stepper content
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0);
             // step 1 icon should be "1", step 2 icon should be "2"
             stepper.FindAll(".mud-step-label-icon")[0].TextContent.Trimmed().Should().Be("1");
             stepper.FindAll(".mud-step-label-icon")[1].TextContent.Trimmed().Should().Be("2");
             await stepper.InvokeAsync(async () => await stepper.Instance.NextStepAsync()); // next
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 2");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(false); // previous
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(false); // previous
             stepper.FindAll(".mud-stepper-button-next").Count.Should().Be(0);
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(1);
             // step 1 icon should be a check mark, step 2 icon should be "2"
@@ -410,8 +410,8 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-step-label-icon")[1].TextContent.Trimmed().Should().Be("2");
             await stepper.InvokeAsync(async () => await stepper.Instance.PreviousStepAsync());  // prev
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Contain("step 1");
-            stepper.Find(".mud-stepper-button-previous").HasAttribute("disabled").Should().Be(true); // previous
-            stepper.Find(".mud-stepper-button-next").HasAttribute("disabled").Should().Be(false); // next
+            stepper.Find(".mud-stepper-button-previous").IsDisabled().Should().Be(true); // previous
+            stepper.Find(".mud-stepper-button-next").IsDisabled().Should().Be(false); // next
             stepper.FindAll(".mud-stepper-button-complete").Count.Should().Be(0);
             // step 1 icon should be a check mark, step 2 icon should be "2"
             stepper.FindAll(".mud-step-label-icon")[0].QuerySelectorAll("path").Last().GetAttribute("d").Should().Be("M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z");

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -12,8 +12,8 @@
             string stepClassname = new CssBuilder()
                 .AddClass("mud-step")
                 .AddClass("active", isActive)
-                .AddClass("mud-clickable", NonLinear && !step.DisabledState.Value)
                 .AddClass("mud-ripple", Ripple)
+                .AddClass("mud-clickable", NonLinear && !step.DisabledState.Value)
                 .AddClass("mud-step-error", step.HasErrorState.Value)
                 .AddClass("mud-step-completed", step.CompletedState.Value)
                 .Build();

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -12,14 +12,14 @@
             string stepClassname = new CssBuilder()
                 .AddClass("mud-step")
                 .AddClass("active", isActive)
-                .AddClass("mud-ripple", NonLinear && !step.DisabledState.Value)
-                .AddClass("mud-step-disabled", step.DisabledState.Value)
+                .AddClass("mud-clickable", NonLinear && !step.DisabledState.Value)
+                .AddClass("mud-ripple", Ripple)
                 .AddClass("mud-step-error", step.HasErrorState.Value)
                 .AddClass("mud-step-completed", step.CompletedState.Value)
                 .Build();
 
-            <button class="@stepClassname" role="tab" aria-controls="@step.Title" aria-selected="@(isActive.ToString().ToLower())"
-                    @onclick="@(async e => await OnStepClickAsync(step, e))">
+            <button class="@stepClassname" role="tab" type="button" aria-controls="@step.Title" aria-selected="@(isActive.ToString().ToLower())"
+                    @onclick="@(async e => await OnStepClickAsync(step, e))" disabled="@step.DisabledState.Value">
                 @RenderStepLabel(step, isActive)
             </button>
 

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -186,6 +186,16 @@ public partial class MudStepper : MudComponentBase
     public bool CenterLabels { get; set; }
 
     /// <summary>
+    /// Displays a ripple effect when the step is clicked.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public bool Ripple { get; set; } = true;
+
+    /// <summary>
     /// If there is too many steps, the navigation becomes scrollable.
     /// </summary>
     [Parameter]
@@ -450,11 +460,8 @@ public partial class MudStepper : MudComponentBase
         await UpdateStepAsync(_steps[0], new MouseEventArgs(), StepAction.Activate);
     }
 
-    private async Task OnStepClickAsync(MudStep step, MouseEventArgs e)
+    private Task OnStepClickAsync(MudStep step, MouseEventArgs e)
     {
-        if (NonLinear)
-        {
-            await UpdateStepAsync(step, e, StepAction.Activate);
-        }
+        return UpdateStepAsync(step, e, StepAction.Activate);
     }
 }

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -189,7 +189,7 @@ public partial class MudStepper : MudComponentBase
     /// Displays a ripple effect when the step is clicked.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>false</c>.
+    /// Affects only non-linear steppers. Defaults to <c>false</c>.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]

--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -8,19 +8,27 @@
       padding: 24px;
       position: relative;
       cursor: default;
+      pointer-events: none;
+      user-select: text;
 
-      &.mud-ripple {
-        transition: background-color 250ms cubic-bezier(.4,0,.2,1) 0ms,box-shadow 250ms cubic-bezier(.4,0,.2,1) 0ms,border 250ms cubic-bezier(.4,0,.2,1) 0ms;
+      &.mud-clickable {
         cursor: pointer;
+        pointer-events: auto;
         user-select: none;
+        transition: background-color 250ms cubic-bezier(.4,0,.2,1) 0ms,box-shadow 250ms cubic-bezier(.4,0,.2,1) 0ms,border 250ms cubic-bezier(.4,0,.2,1) 0ms;
 
-        &:hover {
+        @media(hover: hover) and (pointer: fine) {
+          &:hover {
+            background-color: var(--mud-palette-action-default-hover);
+          }
+        }
+
+        &:focus-visible, &:active {
           background-color: var(--mud-palette-action-default-hover);
         }
       }
 
-      &.mud-step-disabled {
-
+      &:disabled {
         .mud-step-label-icon {
           background-color: var(--mud-palette-lines-default) !important;
           color: var(--mud-palette-text-disabled) !important;
@@ -61,6 +69,7 @@
         .mud-step-label-content {
           width: 100%;
           color: var(--mud-palette-text-secondary);
+          --mud-ripple-color: var(--mud-palette-text-secondary);
           text-align: start;
         }
 
@@ -72,6 +81,7 @@
       &.active {
         .mud-step-label-content {
           color: var(--mud-palette-text-primary);
+          --mud-ripple-color: var(--mud-palette-text-primary);
         }
       }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- Adds `Ripple` property, true by default, along with a switch in the NonLinear example to try it
- The `mud-step-disabled` class was removed and now the `disabled` button attribute is used
- The step button now has `type="button"` defined to fix accessibility warning
- Makes styles use library `mud-clickable`
- Ripple is now highlighted with the text color
- Allows selection of the step text if it's not acting as a button

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

https://github.com/user-attachments/assets/97f091bb-24cc-4561-ac76-ec0dced8a79a



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
