### PR TITLE
MudAutocomplete: Fix ResetAsync without debounce not opening the menu

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
@@ -1,0 +1,49 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States"
+                 @bind-Value="value1" SearchFunc="@SearchStates" DebounceInterval="DebounceInterval" />
+
+@code {
+    public static string __description__ = "Autocomplete to input a US state";
+
+    [Parameter]
+    public int DebounceInterval { get; set; }
+
+    public int SearchFuncCallCount { get; private set; }
+
+    private string value1;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> SearchStates(string value, CancellationToken token)
+    {
+        SearchFuncCallCount++;
+
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(50, token);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -793,6 +793,42 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("");
         }
 
+        /// <summary>
+        /// When calling ResetAsync() without debounce,
+        /// so menu should be closed, Text empty and Value null.
+        /// </summary>
+        [Test]
+        public async Task ResetAsync_WithoutDebounce_SoTextEmptyAndValueNull()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            {
+                parameters.Add(a => a.DebounceInterval, 0);
+            });
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // Assert : initial state, menu closed and text/value null
+
+            comp.Markup.Should().NotContain("mud-popover-open");
+            autocomplete.Open.Should().BeFalse();
+            autocomplete.Value.Should().BeNull();
+            autocomplete.Text.Should().BeNull();
+            comp.Instance.SearchFuncCallCount.Should().Be(0);
+
+            // Act : Call ResetAsync()
+
+            await comp.InvokeAsync(autocomplete.ResetAsync);
+
+            // Assert : menu closed, text empty and value null
+
+            comp.Markup.Should().NotContain("mud-popover-open");
+            autocomplete.Value.Should().BeNull();
+            autocomplete.Text.Should().BeEmpty();
+            comp.Instance.SearchFuncCallCount.Should().Be(0);
+        }
+
         [Test]
         public async Task Autocomplete_Should_Not_Select_Disabled_Item()
         {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -738,11 +738,11 @@ namespace MudBlazor
                 _isCleared = true;
                 Open = false;
 
-                await SetTextAsync(null, updateValue: false);
-                await CoerceValueToTextAsync();
+                await SetTextAsync("", updateValue: false);
+                await SetValueAsync(default(T), updateText: false);
 
                 if (_elementReference != null)
-                    await _elementReference.SetText("");
+                    await _elementReference.ResetAsync();
 
                 _debounceTimer?.Dispose();
                 StateHasChanged();


### PR DESCRIPTION
## Description

With `DebounceInterval=0`, the method `ResetAsync` open the menu.

Fixes #10052

## How Has This Been Tested?

I added a test to reproduce the bug.

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.