### PR TITLE
MudDataGrid Validator [Parameter] (#9860)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -346,5 +346,18 @@
                 <DataGridColumnsPanelExample />
             </SectionContent>
         </DocsPageSection>
+
+    <DocsPageSection>
+            <SectionHeader Title="Validator">
+                <Description>
+                    When a <CodeInline>&lt;MudDataGrid></CodeInline> is used as part of a <CodeInline>MudForm</CodeInline> you might want to
+                    bind the <CodeInline>Validator</CodeInline> property to the outer <CodeInline>MudForm</CodeInline> so that validation
+                    and <CodeInline>IsTouched</CodeInline> states are reflected in/propagated to the outer <CodeInline>MudForm</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(DataGridValidatorExample)" ShowCode="false" Block="true" FullWidth="true">
+                <DataGridValidatorExample />
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -347,7 +347,7 @@
             </SectionContent>
         </DocsPageSection>
 
-    <DocsPageSection>
+        <DocsPageSection>
             <SectionHeader Title="Validator">
                 <Description>
                     When a <CodeInline>&lt;MudDataGrid></CodeInline> is used as part of a <CodeInline>MudForm</CodeInline> you might want to

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridValidatorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridValidatorExample.razor
@@ -1,0 +1,68 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudForm @ref="_form"
+         IsTouchedChanged="this.StateHasChanged"
+         IsValidChanged="this.StateHasChanged">
+    <MudDataGrid T="Item"
+                 Items="_items"
+                 Validator="@(_bindValidatorToForm ? _form : _defaultValidator)">
+        <Columns>
+            <TemplateColumn Title="Name">
+                <CellTemplate>
+                    <MudTextField @bind-Value="context.Item.Name"
+                                  Immediate="true"
+                                  Validation="(string name) => ValidateName(name)" />
+                </CellTemplate>
+            </TemplateColumn>
+        </Columns>
+    </MudDataGrid>
+</MudForm>
+
+<MudStack Row>
+    <MudSwitch Color="Color.Primary" @bind-Value="_bindValidatorToForm">Bind MudDataGrid.Validator to MudForm?</MudSwitch>
+    <MudSwitch ReadOnly="true" Value="_form?.IsTouched">MudForm.IsTouched</MudSwitch>
+    <MudSwitch ReadOnly="true" Value="_form?.IsValid">MudForm.IsValid</MudSwitch>
+</MudStack>
+
+@code
+{
+    private readonly Interfaces.IForm _defaultValidator = new DataGridRowValidator();
+    private MudForm _form;
+    private bool _bindValidatorToForm = true;
+
+    private Item[] _items =
+    [
+        new() { Name = "valid" },
+        new() { Name = "invalid" }
+    ];
+
+    private static string ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "Name is required";
+        }
+
+        if (name == "invalid")
+        {
+            return "Name must not be 'invalid'";
+        }
+
+        return null;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnParametersSetAsync();
+        if (firstRender)
+        {
+            await _form.Validate();
+            _form.ResetTouched();
+        }
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridValidatorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridValidatorExample.razor
@@ -1,8 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudForm @ref="_form"
-         IsTouchedChanged="this.StateHasChanged"
-         IsValidChanged="this.StateHasChanged">
+<MudForm @ref="_form" ValidationDelay="0">
     <MudDataGrid T="Item"
                  Items="_items"
                  Validator="@(_bindValidatorToForm ? _form : _defaultValidator)">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridValidatorTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridValidatorTest.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudForm @ref="_form" ValidationDelay="0">
+    <MudDataGrid Items="@_items" Validator="_form">
+        <Columns>
+            <TemplateColumn>
+                <CellTemplate>
+                    <MudTextField @bind-Value="context.Item.Name" Immediate="true" Required />
+                </CellTemplate>
+            </TemplateColumn>
+        </Columns>
+    </MudDataGrid>
+</MudForm>"
+
+@code {
+    public static string __description__ = "Changing the text field to a non-empty string should set form IsTouched=true and IsValid=true";
+
+    private MudForm _form;
+
+    private readonly Item[] _items =
+    [
+        new()
+    ];
+
+    public class Item
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4645,5 +4645,24 @@ namespace MudBlazor.UnitTests.Components
             items[2].TextContent.Should().Be("Paid training");
             items[3].TextContent.Should().Be("Untranslated");
         }
+
+        [Test]
+        public void DataGridValidatorFormBinding()
+        {
+            var comp = Context.RenderComponent<DataGridValidatorTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridValidatorTest.Item>>().Instance;
+            dataGrid.Validator.Should().BeSameAs(form);
+
+            var textField = comp.FindComponent<MudTextField<string>>();
+            form.IsTouched.Should().BeFalse();
+            form.IsValid.Should().BeFalse();
+
+            // input into text field
+            textField.Find("input").Change("not empty");
+
+            form.IsTouched.Should().BeTrue();
+            form.IsValid.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4658,11 +4658,17 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse();
             form.IsValid.Should().BeFalse();
 
-            // input into text field
-            textField.Find("input").Change("not empty");
+            // input valid value into text field
+            textField.Find("input").Input("not empty");
 
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeTrue();
+
+            // input invalid value into text field
+            textField.Find("input").Input("");
+
+            form.IsTouched.Should().BeTrue();
+            form.IsValid.Should().BeFalse();
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1169,6 +1169,10 @@ namespace MudBlazor
         /// <summary>
         /// The validator which validates values in each row.
         /// </summary>
+        /// <remarks>
+        /// Use to bind validation and touched handling to outer form.
+        /// </remarks>
+        [Parameter]
         public Interfaces.IForm Validator { get; set; } = new DataGridRowValidator();
 
         internal Column<T> GroupedColumn


### PR DESCRIPTION
Expose the `MudDataGrid.Validator` property as a `[Parameter]` so that it can be bound to an outer `MudForm` so that validation and touched state changes are propagated to it.

## Description
This enables using `MudDataGrid` as part of an outer `MudForm` and "relaying" changes of the editor components in `MudDataGrid` rows to the outer `MudForm` so that its `IsValid` and `IsTouched` properties are updated as expected.

Resolves #9860

## How Has This Been Tested?
This can be tested interactively via a new `Data Grid` component section in `MudBlazor.Docs`. See `DataGridValidatorExample.razor`.

There's also unit test `DataGridTests.DataGridValidatorFormBinding` using a `DataGridValidatorTest` component.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
