### PR TITLE
MudAutocomplete: Fix Text coersion on Tab key (OnBlur or CloseMenu)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -5,12 +5,12 @@
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1"
                          ResetValueOnEmptyText="@resetValueOnEmptyText"
-                         CoerceText="@coerceText" CoerceValue="@coerceValue" />
+                         CoerceText="@coerceText" CoerceValue="@coerceValue" SelectValueOnTab="@selectedOnTab" />
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search2"
                          ResetValueOnEmptyText="@resetValueOnEmptyText"
-                         CoerceText="@coerceText" CoerceValue="@coerceValue"
+                         CoerceText="@coerceText" CoerceValue="@coerceValue" SelectValueOnTab="@selectedOnTab"
                          AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" />
     </MudItem>
     <MudItem xs="12" md="12">
@@ -22,6 +22,8 @@
         <MudSwitch @bind-Value="resetValueOnEmptyText" Color="Color.Primary">Reset Value on empty Text</MudSwitch>
         <MudSwitch @bind-Value="coerceText" Color="Color.Secondary">Coerce Text to Value</MudSwitch>
         <MudSwitch @bind-Value="coerceValue" Color="Color.Tertiary">Coerce Value to Text (if not found)</MudSwitch>
+        <MudSwitch @bind-Value="selectedOnTab" Color="Color.Tertiary">Select Value On Tab Key Press</MudSwitch>
+
     </MudItem>
 </MudGrid>
 
@@ -29,6 +31,7 @@
     private bool resetValueOnEmptyText;
     private bool coerceText;
     private bool coerceValue;
+    private bool selectedOnTab;
     private string value1, value2;
     private string[] states =
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCoersionAndBlur.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCoersionAndBlur.razor
@@ -2,7 +2,7 @@
 @using System.Threading
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
+<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="0" PopoverClass="autocomplete-popover-class" />
 <MudTextField id="textFieldBlurTest" T="string" Label="US States" @bind-Value="value1" />
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCoersionAndBlur.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTestCoersionAndBlur.razor
@@ -1,0 +1,41 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+@using System.Threading
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" PopoverClass="autocomplete-popover-class" />
+<MudTextField id="textFieldBlurTest" T="string" Label="US States" @bind-Value="value1" />
+
+@code {
+    public static string __description__ = "Initial value should be shown and popup should not open.";
+
+    private string value1 = "Alabama";
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(50, token);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -240,7 +240,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Blur();
 
-            // Assert : CoercedValue disabled, so value is set on focus lost
+            // Assert : CoercedValue enabled, so value is set on focus lost
 
             comp.Instance.Text.Should().Be("ABC");
             comp.Instance.Value.Should().Be("ABC");
@@ -379,6 +379,54 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Austria");
         }
+
+        [Test]
+        public async Task AutocompleteTextCoercionOnTabKeyTest()
+        {
+            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
+            autocompletecomp.SetParam(x => x.CoerceText, true);
+
+            // check initial state
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Alabama");
+
+            // set a value the search won't find
+            autocompletecomp.SetParam(a => a.Text, "Austria");
+            autocomplete.Text.Should().Be("Austria");
+
+            // now trigger the coercion by call MudInput.BlurAsync
+            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Alabama");
+        }
+
+        [Test]
+        public async Task AutocompleteTextCoercionAndResetIfEmptyTextTest()
+        {
+            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
+            autocompletecomp.SetParam(x => x.CoerceText, true);
+            autocompletecomp.SetParam(x => x.ResetValueOnEmptyText, true);
+
+            // check initial state
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Alabama");
+
+            // set a value the search won't find
+            autocompletecomp.SetParam(a => a.Text, "");
+            autocomplete.Text.Should().Be(null);
+
+            // now trigger the coercion by call MudInput.BlurAsync
+            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            autocomplete.Value.Should().Be(null);
+            autocomplete.Text.Should().Be(expected: null);
+        }
+
 
         [Test]
         public async Task Autocomplete_Should_TolerateNullFromSearchFunc()

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -407,7 +407,6 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
             autocompletecomp.SetParam(x => x.CoerceText, true);
             autocompletecomp.SetParam(x => x.ResetValueOnEmptyText, true);
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -363,10 +363,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCoercionOffTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
             autocompletecomp.SetParam(x => x.CoerceText, false);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
@@ -386,7 +385,6 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
             autocompletecomp.SetParam(x => x.CoerceText, true);
 
             // check initial state

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -955,8 +955,6 @@ namespace MudBlazor
                 return CoerceValueToTextAsync();
             }
 
-            //CoerceTextToValueAsync();
-
             return OnBlur.InvokeAsync(args);
             // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value,
             // resulting in a premature validation. thus, don't call base

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -976,7 +976,7 @@ namespace MudBlazor
             if (!CoerceText)
                 return Task.CompletedTask;
 
-            if (string.IsNullOrEmpty(Text) && ResetValueOnEmptyText)
+            if (ResetValueOnEmptyText && string.IsNullOrEmpty(Text))
                 return Task.CompletedTask;
 
             _debounceTimer?.Dispose();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -789,9 +789,8 @@ namespace MudBlazor
                     {
                         if (SelectValueOnTab)
                             await OnEnterKeyAsync();
-                        else
-                            Open = false;
                     }
+                    await CloseMenuAsync();
                     break;
                 case "ArrowDown":
                     if (Open)
@@ -956,6 +955,8 @@ namespace MudBlazor
                 return CoerceValueToTextAsync();
             }
 
+            //CoerceTextToValueAsync();
+
             return OnBlur.InvokeAsync(args);
             // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value,
             // resulting in a premature validation. thus, don't call base
@@ -975,6 +976,9 @@ namespace MudBlazor
         private Task CoerceTextToValueAsync()
         {
             if (!CoerceText)
+                return Task.CompletedTask;
+
+            if (string.IsNullOrEmpty(Text) && ResetValueOnEmptyText)
                 return Task.CompletedTask;
 
             _debounceTimer?.Dispose();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Related issues / PRs: #3824, #3825, #8914

The component was invalid closing the Menu on Tab Key Down, just by setting Open = false. By this way never call the `CoerceTextToValueAsync()` method. Instead, now it's changed to `await CloseMenuAsync();`.

Another unexpected behavior that appeared after this fix is about combining `ResetValueOnEmptyText` and `CoerceText`.  The `CoerceText` was forcing the last valid value to Text even with empty input. Now `Value` and `Text` are set to null on empty text.


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
- Visual tests;
- Unit tests: `AutocompleteTextCoercionOnTabKeyTest()` and `AutocompleteTextCoercionAndResetIfEmptyTextTest`.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

- Fix for Close Menu called on `OnInputKeyDownAsync` by Tab key, now calling CloseMenuAsync() and CoerceTextToValueAsync() correctly (even on blur), instead just settings `Open = false`;

- Fixed `CoerceTextToValueAsync()` to skip coersion if `ResetValueOnEmptyText = true` and `Text = string.Empty`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
