### PR TITLE
MudDrawer: Make Temporary Drawer non-responsive

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -29,7 +29,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Temporary">
                         <Description>
-                            Temporary Drawers can be opened temporarily above all other content until a section is selected, or until the overlay is clicked if <CodeInline>OverlayAutoClose</CodeInline> is set to true.
+                            The Temporary Drawers can be opened temporarily above all other content until a section is selected, or until the overlay is clicked if <CodeInline>OverlayAutoClose</CodeInline> is set to true. 
+                            This drawer type is not responsive. Temporary Drawers will stay open until the <CodeInline>Open</CodeInline> parameter is set to false again.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(DrawerTemporaryExample)" ShowCode="false">
@@ -40,8 +41,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Persistent">
                         <Description>
-                            Persistent Drawer is outside its container. When opened, it forces other contents to change their size.
-                            Persistent Drawer will stay open until the <CodeInline>Open</CodeInline> parameter is set to false again.
+                            The Persistent Drawer is outside its container. When opened, it forces other contents to change their size.
+                            This drawer type is not responsive. Persistent Drawers will stay open until the <CodeInline>Open</CodeInline> parameter is set to false again.
                         </Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" Code="@nameof(DrawerPersistentExample)" ShowCode="false" Block="true" FullWidth="true">
@@ -52,8 +53,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Responsive">
                         <Description>
-                            Responsive Drawers behaves persistently on wider screens and temporarily on smaller ones.
-                            Opened Drawers close automatically when the window size becomes small, and opens after the original state has been restored.
+                            Responsive Drawers behaves persistently on wider screens and responsively on smaller ones.
+                            Opened Responsive Drawers close automatically when the window size becomes small, and opens after the original state has been restored according to its breakpoint configuration.
                         </Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" Code="@nameof(DrawerResponsiveExample)" ShowCode="false">
@@ -66,7 +67,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Mini">
                         <Description>
-                            Using the Mini variant, the Drawer will shrink (default 56px). It currently only has built-in style support for <CodeInline>MudNavLink</CodeInline>s.
+                            The Mini variant is a variation of the Responsive Drawer. It will responsively shrink to a slim band of icons (default 56px) according do its breakpoint configuration. 
+                            Mini Drawers currently only have built-in style support for <CodeInline>MudNavLink</CodeInline>s.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(DrawerMiniExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -129,7 +129,7 @@
         <DocsPageSection>
             <SectionHeader Title="Custom Breakpoint">
                 <Description>
-                    The switching point for Responsive Drawers can be changed using the <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>.
+                    The switching point for Responsive Drawers (<CodeInline>DrawerVariant.Mini</CodeInline> and <CodeInline>DrawerVariant.Responsive</CodeInline>) can be changed using the <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DrawerBreakpointExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerNonResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerNonResponsiveTest.razor
@@ -1,0 +1,33 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudIconButton id="toggle-drawer-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+    </MudAppBar>
+    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@DrawerVariant.Temporary" Elevation="1">
+    </MudDrawer>
+    <MudMainContent Class="pt-16 px-16">
+        <MudContainer Class="mt-6">
+        </MudContainer>
+    </MudMainContent>
+</MudLayout>
+
+@code{
+    private bool _open;
+    
+    public MudDrawer Drawer { get; set; }
+    
+    [Parameter]
+    public bool InitialOpenState { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _open = InitialOpenState;
+        base.OnInitialized();
+    }
+
+    public void ToggleDrawer()
+    {
+        _open = !_open;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -287,7 +287,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
-        
+
 
         [Test]
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
@@ -568,8 +568,8 @@ namespace MudBlazor.UnitTests.Components
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
         }
-        
-        
+
+
         [Test, Combinatorial]
         public void NonResponsiveKeepInitialOpen_AllBreakpoints(
             [Values(
@@ -590,24 +590,24 @@ namespace MudBlazor.UnitTests.Components
                 Breakpoint.Always
             )] Breakpoint breakpoint,
             [Values(
-                true, 
+                true,
                 false
             )] bool initialState)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
             var comp = Context.RenderComponent<DrawerNonResponsiveTest>(Parameter(nameof(DrawerNonResponsiveTest.InitialOpenState), initialState));
-            
+
             var expectedDrawerCount = initialState ? 1 : 0;
-            
+
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedDrawerCount);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(expectedDrawerCount);
             comp.Instance.Drawer.Open.Should().Be(initialState);
-            
+
             // Make sure that we can toggle the drawer without issues
             comp.Find("#toggle-drawer-button").Click();
-            
+
             var expectedToggledDrawerCount = initialState ? 0 : 1;
-            
+
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedToggledDrawerCount);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(expectedToggledDrawerCount);
             comp.Instance.Drawer.Open.Should().Be(!initialState);

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -287,6 +287,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
+        
 
         [Test]
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
@@ -566,6 +567,50 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#hide-drawer-button").Click();
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
+        }
+        
+        
+        [Test, Combinatorial]
+        public void NonResponsiveKeepInitialOpen_AllBreakpoints(
+            [Values(
+                Breakpoint.None,
+                Breakpoint.Xs,
+                Breakpoint.Sm,
+                Breakpoint.SmAndDown,
+                Breakpoint.SmAndUp,
+                Breakpoint.Md,
+                Breakpoint.MdAndDown,
+                Breakpoint.MdAndUp,
+                Breakpoint.Lg,
+                Breakpoint.LgAndDown,
+                Breakpoint.LgAndUp,
+                Breakpoint.Xl,
+                Breakpoint.XlAndDown,
+                Breakpoint.XlAndUp,
+                Breakpoint.Always
+            )] Breakpoint breakpoint,
+            [Values(
+                true, 
+                false
+            )] bool initialState)
+        {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
+            var comp = Context.RenderComponent<DrawerNonResponsiveTest>(Parameter(nameof(DrawerNonResponsiveTest.InitialOpenState), initialState));
+            
+            var expectedDrawerCount = initialState ? 1 : 0;
+            
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedDrawerCount);
+            comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(expectedDrawerCount);
+            comp.Instance.Drawer.Open.Should().Be(initialState);
+            
+            // Make sure that we can toggle the drawer without issues
+            comp.Find("#toggle-drawer-button").Click();
+            
+            var expectedToggledDrawerCount = initialState ? 0 : 1;
+            
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedToggledDrawerCount);
+            comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(expectedToggledDrawerCount);
+            comp.Instance.Drawer.Open.Should().Be(!initialState);
         }
     }
 }

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -206,7 +206,12 @@ namespace MudBlazor
         /// <item><description><see cref="Breakpoint.LgAndUp"/>: Aliases to <see cref="Breakpoint.Lg"/></description></item> 
         /// <item><description><see cref="Breakpoint.XlAndUp"/>: Aliases to <see cref="Breakpoint.Xl"/></description></item> 
         /// </list> 
-        /// Setting the value to <see cref="Breakpoint.None"/> will always close the drawer, while <see cref="Breakpoint.Always"/> will always keep it open. 
+        /// <para>
+        /// Setting the value to <see cref="Breakpoint.None"/> will always close the drawer, while <see cref="Breakpoint.Always"/> will always keep it open.
+        /// </para>
+        /// <para>
+        /// Applies when <see cref="Variant" /> is set to <see cref="DrawerVariant.Responsive"/> or <see cref="DrawerVariant.Mini" />.
+        /// </para>
         /// </remarks> 
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -454,6 +454,11 @@ namespace MudBlazor
             if (browserViewportEventArgs.IsImmediate)
             {
                 _lastUpdatedBreakpoint = browserViewportEventArgs.Breakpoint;
+                if (!IsResponsiveOrMini())
+                {
+                    return;
+                }
+                
                 if (HandleBreakpointNone())
                 {
                     await InitialOpenState(false);

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -458,7 +458,7 @@ namespace MudBlazor
                 {
                     return;
                 }
-                
+
                 if (HandleBreakpointNone())
                 {
                     await InitialOpenState(false);


### PR DESCRIPTION
## Description
Not setting a breakpoint with a Temporary drawer as auto-open (_open being true on initial render) should still open on smaller devices. In a larger window this opens automatically, but when scaled down. It doesn't actually open, due to the immediate response from ViewportService. 

Possible work-arounds:
Setting the breakpoint parameter on drawer to something like Breakpoint.Xs does give expected result but does feel like a weird problem since the breakpoint parameter is documented to only be related to resposive drawers.

Other solutions considered:
Setting breakpoint to `Breakpoint.Always` but then `_open` isnt respected (So having it NOT auto open doesnt work. It always opens). Another solution that might have been possible is `Breakpoint.None`, but then we are back at not respecting `_open` for auto-opening.

A short example with some notes in TryMudblazor (https://try.mudblazor.com/snippet/caGobEGTREtbcRBn)

## How Has This Been Tested?
A new unit test has been added, which checks to make sure that for all the breakpoints returned from Viewport service, the initial state set in the drawer is kept, **if the drawer is not response/mini**.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
