### PR TITLE
Fix for tab was not accounting for badge in width

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTabs>
+    <MudTabPanel Text="A long Text" BadgeData='"live"' BadgeColor="Color.Info" />
+    <MudTabPanel Text="Even much long Text" BadgeData='"live"' BadgeColor="Color.Info" />
+    <MudTabPanel Text="Short" BadgeData='"live"' BadgeColor="Color.Info" />
+</MudTabs>
+
+@code {
+    public static string __description__ = "Tabs with long names and a badge";
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
@@ -1,4 +1,3 @@
-﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudTabs>
     <MudTabPanel Text="A long Text" BadgeData='"live"' BadgeColor="Color.Info" />

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -128,7 +128,7 @@
 }
 
 .mud-tab {
-  width: 100%;
+  width: fit-content;
   display: inline-flex;
   padding: 6px 12px;
   min-height: 48px;
@@ -204,9 +204,21 @@
 }
 
 .mud-tab-badge {
-  margin-left: 8px;
-  margin-inline-start: 8px;
-  margin-inline-end: unset;
+  &.mud-badge-root {
+    position: static; // Override absolute positioning from _badge.scss
+    margin-left: 8px; 
+
+    .mud-badge-wrapper {
+      position: static; // Override absolute positioning
+      width: auto; // Allow natural width
+      pointer-events: auto;
+    }
+
+    .mud-badge {
+      position: static; // Override absolute positioning
+      display: inline-flex;
+    }
+  }
 }
 
 @each $color in $mud-palette-colors {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
The mud-tab class was attempting to incorporate the mud-badge into it's width but was unable to because of the absolutely positioning of the mud-badge. I altered the way the mud-tab-badge treats a mud-badge-root, mud-badge-wrapper, and finally the mud-badge. The tab now properly accounts for the badge in sizing.

<!-- Note any issues that are resolved by this PR -->
resolves #1668 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
Added a test example to the UnitTests.Viewer as well as the below gifs
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
