### PR TITLE
MudPopover: Fix regression with respect to direction and location and z-index 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDirectionAndLocationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverDirectionAndLocationTest.razor
@@ -1,0 +1,122 @@
+﻿<MudPopoverProvider></MudPopoverProvider>
+
+<MudGrid>
+    <MudItem xs="3">
+        <MudText Typo="Typo.h6">Anchor Origin</MudText>
+        <MudRadioGroup T="Origin" @bind-Value="AnchorOrigin" Class="d-flex flex-column">
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.CenterLeft">Center-Left</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.CenterCenter">Center-Center</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.CenterRight">Center-Right</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomLeft">Bottom-Left</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomCenter">Bottom-Center</MudRadio>
+            <MudRadio Color="Color.Primary" Dense="true" Value="Origin.BottomRight">Bottom-Right</MudRadio>
+        </MudRadioGroup>
+    </MudItem>
+    <MudItem xs="6" Class="d-flex justify-center align-center">
+        <MudBadge Origin="@AnchorOrigin" Color="Color.Primary" Dot="true" Overlap="true" Elevation="4" BadgeClass="ma-2">
+            <MudPaper Elevation="0" Outlined="true" Class="pa-12">
+                <MudPopover OverflowBehavior="OverflowBehavior.FlipNever" Open="true" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="pa-4">
+                    <MudText Typo="Typo.body2" Class="px-4 py-1">The content of the popover</MudText>
+                    <div class="@GetLocation()" style="top:0; left:0;">
+                        <MudIcon Icon="@GetIcon()" Color="Color.Secondary" Class="" />
+                    </div>
+                </MudPopover>
+            </MudPaper>
+        </MudBadge>
+    </MudItem>
+    <MudItem xs="3">
+        <MudText Typo="Typo.h6">Transform Origin</MudText>
+        <MudRadioGroup T="Origin" @bind-Value="TransformOrigin" Class="d-flex flex-column">
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopLeft">Top-Left</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopCenter">Top-Center</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.TopRight">Top-Right</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.CenterLeft">Center-Left</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.CenterCenter">Center-Center</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.CenterRight">Center-Right</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.BottomLeft">Bottom-Left</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.BottomCenter">Bottom-Center</MudRadio>
+            <MudRadio Color="Color.Secondary" Dense="true" Value="Origin.BottomRight">Bottom-Right</MudRadio>
+        </MudRadioGroup>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public static string __description__ = "Popover Direction and Location Test";
+
+    public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+    public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+
+    public string GetIcon()
+    {
+        string icon = "";
+
+        switch (TransformOrigin)
+        {
+            case Origin.TopLeft:
+                icon = Icons.Material.Filled.SouthEast;
+                break;
+            case Origin.TopCenter:
+                icon = Icons.Material.Filled.South;
+                break;
+            case Origin.TopRight:
+                icon = Icons.Material.Filled.SouthWest;
+                break;
+            case Origin.CenterLeft:
+                icon = Icons.Material.Filled.East;
+                break;
+            case Origin.CenterCenter:
+                icon = Icons.Material.Filled.ZoomOutMap;
+                break;
+            case Origin.CenterRight:
+                icon = Icons.Material.Filled.West;
+                break;
+            case Origin.BottomLeft:
+                icon = Icons.Material.Filled.NorthEast;
+                break;
+            case Origin.BottomCenter:
+                icon = Icons.Material.Filled.North;
+                break;
+            case Origin.BottomRight:
+                icon = Icons.Material.Filled.NorthWest;
+                break;
+        }
+        return icon;
+    }
+
+    public string GetLocation()
+    {
+        string align = "";
+        string justify = "";
+        string[] pos = TransformOrigin.ToDescriptionString().Split("-");
+
+        if (pos[0] == "center")
+        {
+            align = "align-center";
+        }
+        else if (pos[0] == "top")
+        {
+            align = "align-start";
+        }
+        else if (pos[0] == "bottom")
+        {
+            align = "align-end";
+        }
+        if (pos[1] == "left")
+        {
+            justify = "justify-start";
+        }
+        else if (pos[1] == "right")
+        {
+            justify = "justify-end";
+        }
+        else if (pos[1] == "center")
+        {
+            justify = "justify-center";
+        }
+
+        return $"absolute mud-height-full mud-width-full d-flex {align} {justify}";
+    }
+}

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -342,9 +342,11 @@ window.mudpopoverHelper = {
 
     updatePopoverZIndex: function (popoverContentNode, parentNode) {
         // find the first parent mud-popover if it exists
-        let parentPopover = parentNode.closest('.mud-popover');                
+        let parentPopover = parentNode.closest('.mud-popover'); 
+        let parentOfPopover = popoverContentNode.parentNode;
         // get --mud-zindex-popover from root
         let newZIndex = window.mudpopoverHelper.basePopoverZIndex + 1;
+        const origZIndex = popoverContentNode.style['z-index'];
         const contentZIndex = popoverContentNode.style['z-index'];
         // normal nested position update
         if (parentPopover) {
@@ -358,6 +360,15 @@ window.mudpopoverHelper = {
                 newZIndex = parseInt(parentZIndexValue) + 1;
             }
             popoverContentNode.style['z-index'] = newZIndex;
+        }
+        // nested popover inside any other child element
+        else if (parentOfPopover) {
+            const computedStyle = window.getComputedStyle(parentOfPopover);
+            const tooltipZIndexValue = computedStyle.getPropertyValue('z-index');
+            if (tooltipZIndexValue !== 'auto') {
+                newZIndex = parseInt(tooltipZIndexValue) + 1;
+            }
+            popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.baseTooltipZIndex + 1, origZIndex ?? 1);
         }
         // tooltip container update 
         // (it's not technically a nested popover but when nested inside popover components it doesn't set zindex properly)
@@ -408,10 +419,8 @@ class MudPopover {
                     window.mudpopoverHelper.placePopoverByNode(target);
                 }
                 else if (mutation.attributeName == 'data-ticks') {
-                    // I can't think of any good reason to use data-ticks property but I don't want to remove it until 
-                    // I'm sure it's not used by anything. When/If this is deleted remove the handler updating data-ticks from 
-                    // the mudpopover component
-                    return;
+                    // data-ticks are important for Direction and Location, it doesn't reposition
+                    // if they aren't there                    
                     const tickAttribute = target.getAttribute('data-ticks');
 
                     const tickValues = [];
@@ -441,7 +450,8 @@ class MudPopover {
                     }
 
                     const sortedTickValues = tickValues.sort((x, y) => x - y);
-
+                    // z-index calculation not used here
+                    continue;
                     for (let i = 0; i < parent.children.length; i++) {
                         const childNode = parent.children[i];
                         const tickValue = parseInt(childNode.getAttribute('data-ticks'));

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -273,7 +273,7 @@ window.mudpopoverHelper = {
                     }
 
                     // will be covered by appbar so adjust zindex with appbar as parent
-                    if (top + offsetY < 0 &&
+                    if (top + offsetY < appBarOffset &&
                         appBarElements.length > 0) {
                         this.updatePopoverZIndex(popoverContentNode, appBarElements[0]);
                         //console.log(`top: ${top} | offsetY: ${offsetY} | total: ${top + offsetY} | appBarOffset: ${appBarOffset}`);

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -344,11 +344,11 @@ window.mudpopoverHelper = {
 
     updatePopoverZIndex: function (popoverContentNode, parentNode) {
         // find the first parent mud-popover if it exists
-        let parentPopover = parentNode.closest('.mud-popover'); 
-        let parentOfPopover = popoverContentNode.parentNode;
+        const parentPopover = parentNode.closest('.mud-popover'); 
+        const parentOfPopover = popoverContentNode.parentNode;
         // get --mud-zindex-popover from root
         let newZIndex = window.mudpopoverHelper.basePopoverZIndex + 1;
-        let origZIndex = parseInt(popoverContentNode.style['z-index']) || 1;
+        const origZIndex = parseInt(popoverContentNode.style['z-index']) || 1;
         const contentZIndex = popoverContentNode.style['z-index'];
         // normal nested position update
         if (parentPopover) {

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -265,20 +265,22 @@ window.mudpopoverHelper = {
                 else {
                     // did not flip, ensure the left and top are inside bounds
                     // appbaroffset is another section
-                    if (left + offsetX < 0) {
+                    if (left + offsetX < 0 && // it's starting left of the screen
+                        Math.abs(left + offsetX) < selfRect.width) { // it's not starting so far left the entire box would be hidden
                         left = Math.max(0, left + offsetX);
                         // set offsetX to 0 to avoid double offset
                         offsetX = 0;
                     }
 
-                    // will be covered by appbar
-                    if (top + offsetY < appBarOffset &&
+                    // will be covered by appbar so adjust zindex with appbar as parent
+                    if (top + offsetY < 0 &&
                         appBarElements.length > 0) {
                         this.updatePopoverZIndex(popoverContentNode, appBarElements[0]);
                         //console.log(`top: ${top} | offsetY: ${offsetY} | total: ${top + offsetY} | appBarOffset: ${appBarOffset}`);
                     }
 
-                    if (top + offsetY < 0) {
+                        if (top + offsetY < 0 && // it's starting above the screen
+                            Math.abs(top + offsetY) < selfRect.height) { // it's not starting so far above the entire box would be hidden
                         top = Math.max(0, top + offsetY);
                         // set offsetY to 0 to avoid double offset
                         offsetY = 0;
@@ -346,7 +348,7 @@ window.mudpopoverHelper = {
         let parentOfPopover = popoverContentNode.parentNode;
         // get --mud-zindex-popover from root
         let newZIndex = window.mudpopoverHelper.basePopoverZIndex + 1;
-        const origZIndex = popoverContentNode.style['z-index'];
+        let origZIndex = parseInt(popoverContentNode.style['z-index']) || 1;
         const contentZIndex = popoverContentNode.style['z-index'];
         // normal nested position update
         if (parentPopover) {
@@ -368,7 +370,7 @@ window.mudpopoverHelper = {
             if (tooltipZIndexValue !== 'auto') {
                 newZIndex = parseInt(tooltipZIndexValue) + 1;
             }
-            popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.baseTooltipZIndex + 1, origZIndex ?? 1);
+            popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.baseTooltipZIndex + 1, origZIndex);
         }
         // tooltip container update 
         // (it's not technically a nested popover but when nested inside popover components it doesn't set zindex properly)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Fixes regression issue in #10089 
Added logic to handle the other popover scenario 
  - when not a child of a popover but a child of a higher z-index non-popover

Reimplemented data-ticks, commented out the z-index placement here and got rid of my line skipping this portion.
  - Data-Ticks cause the position updates to happen

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visual tests in first comment

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
