### PR TITLE
MudBreadcrumbs: Change HTML structure and semantics for accessibility

### DIFF
--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
@@ -8,29 +8,31 @@
 }
 
 <CascadingValue Value="this" IsFixed="true">
-    <ul @attributes="UserAttributes" class="@Classname" style="@Style">
-        @if (MaxItems != null && Collapsed && Items.Count > MaxItems)
-        {
-            <BreadcrumbLink Item="Items[0]"></BreadcrumbLink>
-            <BreadcrumbSeparator></BreadcrumbSeparator>
-            <li class="mud-breadcrumbs-expander" @onclick="Expand">
-                <MudIcon Icon="@ExpanderIcon" Size="Size.Small"></MudIcon>
-            </li>
-            <BreadcrumbSeparator></BreadcrumbSeparator>
-            <BreadcrumbLink Item="Items[^1]"></BreadcrumbLink>
-        }
-        else
-        {
-            @for (var i = 0; i < Items.Count; i++)
+    <nav>
+        <ol @attributes="UserAttributes" class="@Classname" style="@Style">
+            @if (MaxItems != null && Collapsed && Items.Count > MaxItems)
             {
-                var item = Items[i];
-                <BreadcrumbLink Item="item"></BreadcrumbLink>
-
-                if (i != Items.Count - 1)
+                <BreadcrumbLink Item="Items[0]"></BreadcrumbLink>
+                <BreadcrumbSeparator></BreadcrumbSeparator>
+                <li class="mud-breadcrumbs-expander" @onclick="Expand">
+                    <MudIcon Icon="@ExpanderIcon" Size="Size.Small"></MudIcon>
+                </li>
+                <BreadcrumbSeparator></BreadcrumbSeparator>
+                <BreadcrumbLink Item="Items[^1]"></BreadcrumbLink>
+            }
+            else
+            {
+                @for (var i = 0; i < Items.Count; i++)
                 {
-                    <BreadcrumbSeparator></BreadcrumbSeparator>
+                    var item = Items[i];
+                    <BreadcrumbLink Item="item"></BreadcrumbLink>
+
+                    if (i != Items.Count - 1)
+                    {
+                        <BreadcrumbSeparator></BreadcrumbSeparator>
+                    }
                 }
             }
-        }
-    </ul>
+        </ol>
+    </nav>
 </CascadingValue>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Part of https://github.com/MudBlazor/MudBlazor/issues/9063

Changes the breadcrumbs list from an unordered list to an ordered list and wraps that in a nav element. This is pretty standard among the ones I checked (Bootstrap, MUI, Ant)

Attributes etc are still applied to the list itself but if the `ul` was directly referenced or the structure in CSS this will change it for the user.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

The diff is largely whitespace changes.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
