### PR TITLE
Docs: Fix Releases page not linking PR IDs other than 4 in length

### DIFF
--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -60,7 +60,7 @@
         value = Regex.Replace(value, @"((##\s)(?<title>.+))(?<items>.*(?:\r?\n[*] .*)*)", "<h5 class=\"mud-typography mud-typography-h5\">${title}</h5><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
         value = Regex.Replace(value, @"(([*]\s)(?<row>.+))", "<li>${row}</li>");
         value = Regex.Replace(value, @"(@)(\S+)", "<a target=\"_blank\" href=\"https://github.com/$2\" class=\"mud-link mud-default-text mud-link-underline-hover\"><b>@$2</b></a>");
-        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{4})", "<a target=\"_blank\" href=\"$0\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
+        value = Regex.Replace(value, @"https://github.com/MudBlazor/MudBlazor/pull/([0-9]{3,6})", "<a target=\"_blank\" href=\"$0\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$1</b></a>");
         value = Regex.Replace(value, @"([*][*]Full Changelog[*][*]: )(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<p class=\"mud-typography mud-typography-body1\">Full Changelog: <a target=\"_blank\" href=\"$2$3\" class=\"docs-code docs-code-primary\">$3</a></p>");
         return value;
     }
@@ -70,7 +70,7 @@
         value = Regex.Replace(value, @"((###\s)(?<subtitle>.+))(?<items>.*(?:\r?\n-\s[*][*].*)*)", "<h6 class=\"mud-typography mud-typography-h6\">${subtitle}</h6><ul class=\"mt-3 mb-6 px-6\">${items}</ul>");
         value = Regex.Replace(value, @"^(#\s)(?<title>.+)", "<h5 class=\"mud-typography mud-typography-h5 mud-inherit-text\">${title}</h5>");
         value = Regex.Replace(value, @"((-\s[*][*])(?<row>.+))", "<li>${row}</li>");
-        value = Regex.Replace(value, @"(#){1}([0-9]{4}){1}", "<a target=\"_blank\" href=\"https://github.com/MudBlazor/MudBlazor/pull/$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$2</b></a>");
+        value = Regex.Replace(value, @"(#){1}([0-9]{3,6}){1}", "<a target=\"_blank\" href=\"https://github.com/MudBlazor/MudBlazor/pull/$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\"><b>#$2</b></a>");
         value = Regex.Replace(value, @"\[(.*?)\]\((.*?)\)", "<a target=\"_blank\" href=\"$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\">$1</a>");
         value = Regex.Replace(value, @"(https://github.com/MudBlazor/MudBlazor/compare/)(.+)", "<a target=\"_blank\" href=\"$1$2\" class=\"docs-code docs-code-primary\">$2</a>");
         value = Regex.Replace(value, @"(https://github.com/MudBlazor/MudBlazor/milestone/)(.+)", "<a target=\"_blank\" href=\"$1$2\" class=\"docs-code docs-code-primary\">Milestone</a>");


### PR DESCRIPTION
## Description
Resolves #10113. Would previously only match on IDs with 4 in length, now matches on IDs with lengths between 3 and 6.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
