### PR TITLE
MudAutocomplete: Coerce value immediately

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States"
+<MudAutocomplete id="autocompleteLabelTest" T="string?" Label="US States"
                  @bind-Value:get="Value" @bind-Value:set="ValueChanged" ResetValueOnEmptyText="ResetValueOnEmptyText"
                  SearchFunc="@SearchStates" DebounceInterval="DebounceInterval"
                  CoerceText="CoerceText" CoerceValue="CoerceValue" Immediate="Immediate"/>
@@ -12,7 +12,7 @@
     public string? Value { get; set; }
 
     [Parameter]
-    public EventCallback<string> ValueChanged { get; set; }
+    public EventCallback<string?> ValueChanged { get; set; }
 
     [Parameter]
     public bool ResetValueOnEmptyText { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStates.razor
@@ -1,8 +1,8 @@
 <MudPopoverProvider />
 
 <MudAutocomplete id="autocompleteLabelTest" T="string" Label="US States"
-                 @bind-Value="Value" ResetValueOnEmptyText="ResetValueOnEmptyText"
-                 SearchFunc="@SearchStates" DebounceInterval="DebounceInterval" 
+                 @bind-Value:get="Value" @bind-Value:set="ValueChanged" ResetValueOnEmptyText="ResetValueOnEmptyText"
+                 SearchFunc="@SearchStates" DebounceInterval="DebounceInterval"
                  CoerceText="CoerceText" CoerceValue="CoerceValue" Immediate="Immediate"/>
 
 @code {
@@ -10,6 +10,9 @@
 
     [Parameter]
     public string? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<string> ValueChanged { get; set; }
 
     [Parameter]
     public bool ResetValueOnEmptyText { get; set; }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -203,6 +203,101 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task OnTextChanged_WithCoerceValueAndNotCoerceTextAndImmediateNotDebounce_SetValueAndOpenMenuImmediately()
+        {
+            // Arrange
+
+            var valueChangedCount = 0;
+            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            {
+                parameters.Add(p => p.DebounceInterval, 0);
+                parameters.Add(p => p.CoerceText, false);
+                parameters.Add(p => p.CoerceValue, true);
+                parameters.Add(p => p.Immediate, true);
+                parameters.Add(p => p.ValueChanged, v => valueChangedCount++);
+            });
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // Assert : initial state, menu closed and text/value null
+
+            comp.Markup.Should().NotContain("mud-popover-open");
+            autocomplete.Open.Should().BeFalse();
+            autocomplete.Value.Should().BeNull();
+            autocomplete.Text.Should().BeNull();
+            comp.Instance.SearchFuncCallCount.Should().Be(0);
+            valueChangedCount.Should().Be(0);
+
+            // Act
+
+            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+
+            // Assert : debounce disable, so menu is opened immediately
+
+            autocomplete.Open.Should().BeTrue();
+            comp.Markup.Should().Contain("mud-popover-open");
+
+            // Assert : CoercedValue and immediate enabled, so value is set immediately on text input
+
+            autocompletecomp.Instance.Text.Should().Be("Al");
+            autocompletecomp.Instance.Value.Should().Be("Al");
+            valueChangedCount.Should().Be(1);
+        }
+
+        [Test]
+        public async Task OnTextChanged_CoerceValueAndNotCoerceTextAndImmediateAndDebounce_SetValueImmediatelyButDelaysMenuOpening()
+        {
+            // Arrange
+
+            var valueChangedCount = 0;
+            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            {
+                parameters.Add(p => p.DebounceInterval, 500);
+                parameters.Add(p => p.CoerceText, false);
+                parameters.Add(p => p.CoerceValue, true);
+                parameters.Add(p => p.Immediate, true);
+                parameters.Add(p => p.ValueChanged, v => valueChangedCount++);
+            });
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            // Assert : initial state, menu closed and text/value null
+
+            comp.Markup.Should().NotContain("mud-popover-open");
+            autocomplete.Open.Should().BeFalse();
+            autocomplete.Value.Should().BeNull();
+            autocomplete.Text.Should().BeNull();
+            comp.Instance.SearchFuncCallCount.Should().Be(0);
+            valueChangedCount.Should().Be(0);
+
+            // Act
+
+            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+
+            // Assert : debounce enable, so menu is not opened immediately
+
+            autocomplete.Open.Should().BeFalse();
+            comp.Markup.Should().NotContain("mud-popover-open");
+
+            // Assert : CoercedValue and immediate enabled, so value is set immediately on text input
+
+            autocompletecomp.Instance.Text.Should().Be("Al");
+            autocompletecomp.Instance.Value.Should().Be("Al");
+            valueChangedCount.Should().Be(1);
+
+            // Act : Wait the debounce timer that open the menu
+
+            autocompletecomp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
+            autocompletecomp.WaitForAssertion(() => comp.Markup.Should().Contain("mud-popover-open"));
+
+            // Assert : value and text unchanged
+
+            autocompletecomp.Instance.Text.Should().Be("Al");
+            autocompletecomp.Instance.Value.Should().Be("Al");
+            valueChangedCount.Should().Be(1);
+        }
+
+        [Test]
         public async Task CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
         {
             // Arrange

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -575,6 +575,8 @@ namespace MudBlazor
 
             if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 await SetValueAsync(default(T), updateText);
+            else if(Immediate)
+                await CoerceValueToTextAsync();
 
             if (DebounceInterval <= 0)
                 await OpenMenuAsync();
@@ -710,18 +712,6 @@ namespace MudBlazor
             {
                 // Open after the search has finished if we're still focused (UI), or were never focused in the first place (programmatically).
                 Open = true;
-            }
-
-            if (Immediate && _items?.Length == 0)
-            {
-                await CoerceValueToTextAsync();
-                StateHasChanged();
-                return;
-            }
-
-            if (Immediate && !CoerceText)
-            {
-                await CoerceValueToTextAsync();
             }
 
             StateHasChanged();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -575,7 +575,7 @@ namespace MudBlazor
 
             if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 await SetValueAsync(default(T), updateText);
-            else if(Immediate)
+            else if (Immediate)
                 await CoerceValueToTextAsync();
 
             if (DebounceInterval <= 0)


### PR DESCRIPTION
## Description

Before this PR, the value is coerced after the search. But the search can be delayed, which also delays the coercing of value :
![old_behavior](https://github.com/user-attachments/assets/ccc08b89-6c5b-4e14-a6bb-722a377b3a20)

After this PR, the value is coerced immediately :
![new_behavior](https://github.com/user-attachments/assets/a259fba3-01df-4466-a69d-e8b29dce05f3)

Fixes #9420

## How Has This Been Tested?

I added test.
I checked the doc page

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
