### PR TITLE
IJSRuntimeExtensions: Fix when pre-rendering

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
@@ -153,14 +153,18 @@ namespace MudBlazor.UnitTests
         public async Task InvokeAsyncWithErrorHandling_ShouldReturnFallbackValue_WhenUnsupportedJavaScriptRuntime()
         {
             // Arrange
-            var jsRuntime = new UnsupportedJavaScriptRuntime();
+            var jsRuntime1 = new UnsupportedJavaScriptRuntime();
+            var jsRuntime2 = new RemoteJSRuntime();
 
             // Act
-            var result = await jsRuntime.InvokeAsyncWithErrorHandling("fallback", "myMethod", 42, "blub");
+            var result1 = await jsRuntime1.InvokeAsyncWithErrorHandling("fallback1", "myMethod1", 42, "blub1");
+            var result2 = await jsRuntime2.InvokeAsyncWithErrorHandling("fallback2", "myMethod2", 43, "blub2");
 
             // Assert
-            result.success.Should().BeFalse();
-            result.value.Should().Be("fallback");
+            result1.success.Should().BeFalse();
+            result1.value.Should().Be("fallback1");
+            result2.success.Should().BeFalse();
+            result2.value.Should().Be("fallback2");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Mocks/RemoteJSRuntime.cs
+++ b/src/MudBlazor.UnitTests/Mocks/RemoteJSRuntime.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.JSInterop;
+
+namespace MudBlazor.UnitTests.Mocks;
+
+// DO NOT rename the class as it's essential for the test to work.
+#nullable enable
+internal class RemoteJSRuntime : IJSRuntime
+{
+    private const string Message =
+        "JavaScript interop calls cannot be issued at this time. This is because the component is being " +
+        "statically rendered. When prerendering is enabled, JavaScript interop calls can only be performed " +
+        "during the OnAfterRenderAsync lifecycle method.";
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        => throw new InvalidOperationException(Message);
+
+    ValueTask<TValue> IJSRuntime.InvokeAsync<TValue>(string identifier, object?[]? args)
+        => throw new InvalidOperationException(Message);
+}

--- a/src/MudBlazor/Extensions/IJSRuntimeExtensions.cs
+++ b/src/MudBlazor/Extensions/IJSRuntimeExtensions.cs
@@ -289,10 +289,14 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Checks if the IJSRuntime instance is of type UnsupportedJavaScriptRuntime.
+        /// Checks if the IJSRuntime instance is of type UnsupportedJavaScriptRuntime or RemoteJSRuntime.
         /// </summary>
         /// <param name="jsRuntime">The IJSRuntime instance to check.</param>
-        /// <returns>True if the instance is of type UnsupportedJavaScriptRuntime; otherwise, false.</returns>
-        private static bool IsUnsupportedJavaScriptRuntime(this IJSRuntime jsRuntime) => jsRuntime.GetType().Name == "UnsupportedJavaScriptRuntime";
+        /// <returns>True if the instance is of type UnsupportedJavaScriptRuntime or RemoteJSRuntime; otherwise, false.</returns>
+        private static bool IsUnsupportedJavaScriptRuntime(this IJSRuntime jsRuntime)
+        {
+            return jsRuntime.GetType().Name == "RemoteJSRuntime" ||
+                   jsRuntime.GetType().Name == "UnsupportedJavaScriptRuntime";
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/10141

Regression from: https://github.com/MudBlazor/MudBlazor/pull/9997

Apparently, there are are two `JSRuntime` types that throw similar error:
`UnsupportedJavaScriptRuntime` during static SSR.
`RemoteJSRuntime` - during SSR pre-render.
In the #9997 I removed when it was just checking for word "prerending" in the exception message and went for checking the JS runtime type instead.
The `IsJsInteropAvailable` doesn't help here, as it happening not on a component level, but during pre-render the DI is disposing the whole container, the `BrowserViewportService` is part of it, and it invokes `DisposeAsync` that has a JS call, so there is nothing better than just ignore this errors.

## How Has This Been Tested?
Manually + bUnit test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
