### PR TITLE
Docs: Improved Responsiveness for Mobile Devices

### DIFF
--- a/src/MudBlazor.Docs/Components/ApiMemberTable.razor
+++ b/src/MudBlazor.Docs/Components/ApiMemberTable.razor
@@ -1,5 +1,6 @@
 ﻿<MudTable T="DocumentedMember" @ref="Table" ServerData="@GetData"
-          Elevation="0" Class="mud-width-full" Hover="true" Dense="true"
+          Breakpoint="@Breakpoint.Sm"
+          Elevation="0" Class="mud-width-full " Hover="true" Dense="true"
           AllowUnsorted="false" GroupBy="@CurrentGroups">   
     <GroupHeaderTemplate>
         @if (Grouping == ApiMemberGrouping.Inheritance)
@@ -36,7 +37,7 @@
                     <MudTextField T="string" Value="@Keyword" ValueChanged="OnKeywordChangedAsync" DebounceInterval="300" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
                 </MudItem>
                 <MudItem xs="6" md="3" Class="py-0">
-                    <MudSwitch T="bool" Size="Size.Small" Value="@ShowProtected" ValueChanged="OnShowProtectedChangedAsync">Show Protected</MudSwitch>
+                    <MudSwitch T="bool" Size="Size.Small" Color="Color.Primary" Value="@ShowProtected" ValueChanged="OnShowProtectedChangedAsync">Show Protected</MudSwitch>
                 </MudItem>
             }
             else
@@ -49,7 +50,7 @@
         </MudGrid>
     </ToolBarContent>
     <RowTemplate>
-        <MudTd id="@context.Name" DataLabel="Name">
+        <MudTd id="@context.Name" DataLabel="Name" Class="docs-content-api-cell">
             @if (Mode == ApiMemberTableMode.Methods)
             {
                 <CodeInline Class="pr-0">@($"{context.Name}(")</CodeInline>
@@ -120,18 +121,18 @@
                 </MudTooltip>
             }
         </MudTd>
-        <MudTd DataLabel="Type">
+        <MudTd DataLabel="Type" Class="docs-content-api-cell">
             <ApiTypeLink Type="@context.Type" TypeName="@context.TypeName" TypeFriendlyName="@context.TypeFriendlyName" />
         </MudTd>
         @if (Mode == ApiMemberTableMode.Methods && !string.IsNullOrEmpty(((DocumentedMethod)context).Returns))
         {
-            <MudTd DataLabel="Returns">      
+            <MudTd DataLabel="Returns" Class="docs-content-api-cell">
                 <ApiText Text="@(context.Summary + " " + context.Remarks + "  Returns: " + ((DocumentedMethod)context).Returns)" />
             </MudTd>
         }
         else
         {
-            <MudTd DataLabel="Description">
+            <MudTd DataLabel="Description" Class="docs-content-api-cell docs-content-api-description">
                 <ApiText Text="@(context.Summary + " " + context.Remarks)" />
             </MudTd>
         }

--- a/src/MudBlazor.Docs/Pages/Api/Api.razor
+++ b/src/MudBlazor.Docs/Pages/Api/Api.razor
@@ -2,6 +2,10 @@
 @using MudBlazor.Docs.Components
 @namespace MudBlazor.Docs.Pages.Api
 
+<style>
+    .mud-table-toolbar { height:90px; }
+</style>
+
 <DocsPage>
     @if (DocumentedType != null)
     {

--- a/src/MudBlazor.Docs/Pages/Api/Api.razor
+++ b/src/MudBlazor.Docs/Pages/Api/Api.razor
@@ -4,6 +4,7 @@
 
 <style>
     .mud-table-toolbar { height:90px; }
+    [id] { scroll-margin-top: 65px; }
 </style>
 
 <DocsPage>

--- a/src/MudBlazor.UnitTests/Components/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Documentation/ApiMemberTableTests.cs
@@ -53,7 +53,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "Classname" protected property should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"Classname\">");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">");
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "Classname" protected property should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"Classname\">");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">");
     }
 
     /// <summary>
@@ -87,7 +87,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "BeginValidateAsync" protected method should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"BeginValidateAsync\">");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "BeginValidateAsync" protected method should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"BeginValidateAsync\">");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "CurrentView" protected field should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"CurrentView\">");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">");
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a switch for protected properties
         comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
         // The "CurrentView" protected field should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell\" id=\"CurrentView\">");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">");
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

This update fixes some issues reported in #10092:

- [X] Member Table should wrap Description text properly in Mobile Mode.
- [X] Member Table should not show overlapping controls within toolbar.
- [X] Member Table "Show Protected" switch should be more clearly visible when enabled.
- [X] "internal override" members should not be shown.
- [X] Linking to members should show them on-screen.

![image](https://github.com/user-attachments/assets/e0944d2f-2216-42bf-8317-16afaffdfb08)

## How Has This Been Tested?

This was tested by observing the documentation for `MudPopover` using F12 Debugger Tools and various mobile devices.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
