### PR TITLE
MudDataGrid: Rename _classname to Classname etc

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1120,7 +1120,7 @@ namespace MudBlazor.UnitTests.Components
 
             // open form dialog
             dataGrid.Find("tbody tr button").Click();
-            dataGrid.Instance.isEditFormOpen.Should().BeTrue();
+            dataGrid.Instance._isEditFormOpen.Should().BeTrue();
 
             var field = comp.FindComponents<MudTextField<string>>()[2];
 
@@ -1139,7 +1139,7 @@ namespace MudBlazor.UnitTests.Components
 
             // dialog should still be open and the items data should not have been updated
             using AssertionScope scope = new();
-            dataGrid.Instance.isEditFormOpen.Should().BeTrue();
+            dataGrid.Instance._isEditFormOpen.Should().BeTrue();
             comp.Instance.Items[0].Email.Should().Be("Augusta_Homenick26@mud.com");
         }
 

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -2,9 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Text.Json;
-using System.Threading.Tasks;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -30,30 +28,21 @@ namespace MudBlazor
             }
         }
 
-        internal string computedClass
-        {
-            get
-            {
-                return new CssBuilder(_column.CellClassFunc?.Invoke(_item))
-                    .AddClass(_column.CellClass)
-                    .AddClass("mud-table-cell")
-                    .AddClass("mud-table-cell-hide", _column.HideSmall)
-                    .AddClass("sticky-left", _column.StickyLeft)
-                    .AddClass("sticky-right", _column.StickyRight)
-                    .AddClass($"edit-mode-cell", _dataGrid.EditMode == DataGridEditMode.Cell && _column.Editable)
-                    .Build();
-            }
-        }
-        internal string computedStyle
-        {
-            get
-            {
-                return new StyleBuilder()
-                    .AddStyle(_column.CellStyleFunc?.Invoke(_item))
-                    .AddStyle(_column.CellStyle)
-                    .Build();
-            }
-        }
+        internal string ComputedClass =>
+            new CssBuilder(_column.CellClassFunc?.Invoke(_item))
+                .AddClass(_column.CellClass)
+                .AddClass("mud-table-cell")
+                .AddClass("mud-table-cell-hide", _column.HideSmall)
+                .AddClass("sticky-left", _column.StickyLeft)
+                .AddClass("sticky-right", _column.StickyRight)
+                .AddClass($"edit-mode-cell", _dataGrid.EditMode == DataGridEditMode.Cell && _column.Editable)
+                .Build();
+
+        internal string ComputedStyle =>
+            new StyleBuilder()
+                .AddStyle(_column.CellStyleFunc?.Invoke(_item))
+                .AddStyle(_column.CellStyle)
+                .Build();
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -2,10 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace MudBlazor
 {
 #nullable enable
@@ -32,24 +28,12 @@ namespace MudBlazor
         /// <summary>
         /// Indicates if the cell is currently selected.
         /// </summary>
-        public bool Selected
-        {
-            get
-            {
-                return _selection.Contains(Item);
-            }
-        }
+        public bool Selected => _selection.Contains(Item);
 
         /// <summary>
         /// Indicates if the cell is currently in an open hierarchy.
         /// </summary>
-        public bool Open
-        {
-            get
-            {
-                return OpenHierarchies.Contains(Item);
-            }
-        }
+        public bool Open => OpenHierarchies.Contains(Item);
 
         /// <summary>
         /// Creates a new instance.
@@ -78,22 +62,22 @@ namespace MudBlazor
             /// <summary>
             /// The function which selects the cell.
             /// </summary>
-            public Func<bool, Task> SetSelectedItemAsync { get; init; } = null!;
+            public required Func<bool, Task> SetSelectedItemAsync { get; init; }
 
             /// <summary>
             /// The function which begins editing.
             /// </summary>
-            public Func<Task> StartEditingItemAsync { get; init; } = null!;
+            public required Func<Task> StartEditingItemAsync { get; init; }
 
             /// <summary>
             /// The function which ends editing.
             /// </summary>
-            public Func<Task> CancelEditingItemAsync { get; init; } = null!;
+            public required Func<Task> CancelEditingItemAsync { get; init; }
 
             /// <summary>
             /// The function which toggles hierarchy visibility.
             /// </summary>
-            public Func<Task> ToggleHierarchyVisibilityForItemAsync { get; init; } = null!;
+            public required Func<Task> ToggleHierarchyVisibilityForItemAsync { get; init; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -2,12 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interfaces;
 using MudBlazor.State;
@@ -230,11 +226,7 @@ namespace MudBlazor
         /// The comparison used for values in this column.
         /// </summary>
         [Parameter]
-        public IComparer<object> Comparer
-        {
-            get => _comparer;
-            set => _comparer = value;
-        }
+        public IComparer<object> Comparer { get; set; } = null;
 
         /// <summary>
         /// The function used to sort values in this column.
@@ -439,7 +431,7 @@ namespace MudBlazor
         /// </summary>
         public Action ColumnStateHasChanged { get; set; }
 
-        internal string headerClassname =>
+        internal string HeaderClassname =>
             new CssBuilder("mud-table-cell")
                 .AddClass("mud-table-cell-hide", HideSmall)
                 .AddClass("sticky-left", StickyLeft)
@@ -447,7 +439,7 @@ namespace MudBlazor
                 .AddClass(Class)
                 .Build();
 
-        internal string footerClassname =>
+        internal string FooterClassname =>
             new CssBuilder("mud-table-cell")
                 .AddClass("mud-table-cell-hide", HideSmall)
                 .AddClass(Class)
@@ -508,7 +500,6 @@ namespace MudBlazor
         internal int SortIndex { get; set; } = -1;
         internal HeaderCell<T> HeaderCell { get; set; }
 
-        private IComparer<object> _comparer = null;
         private Func<T, object> _sortBy;
         internal Func<T, object> groupBy;
         internal HeaderContext<T> headerContext;

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -426,11 +426,6 @@ namespace MudBlazor
 
         #endregion
 
-        /// <summary>
-        /// Occurs when this column's state has changed.
-        /// </summary>
-        public Action ColumnStateHasChanged { get; set; }
-
         internal string HeaderClassname =>
             new CssBuilder("mud-table-cell")
                 .AddClass("mud-table-cell-hide", HideSmall)

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -8,7 +8,7 @@
 
 @if (Column != null && !Column.HiddenState.Value)
 {
-    <th scope="col" class="@_classname" style="@_style" colspan="@Column?.HeaderColSpan" @attributes="@UserAttributes">
+    <th scope="col" class="@Classname" style="@Stylename" colspan="@Column?.HeaderColSpan" @attributes="@UserAttributes">
         @if (Column.filterable && Column.FilterTemplate != null)
         {
             @Column.FilterTemplate(Column.FilterContext)

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
 
         private string _classname =>
             new CssBuilder(Column?.HeaderClass)
-                .AddClass(Column?.headerClassname)
+                .AddClass(Column?.HeaderClassname)
                 .AddClass(Class)
                 .AddClass("filter-header-cell")
                 .Build();

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -36,14 +36,14 @@ namespace MudBlazor
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private string _classname =>
+        private string Classname =>
             new CssBuilder(Column?.HeaderClass)
                 .AddClass(Column?.HeaderClassname)
                 .AddClass(Class)
                 .AddClass("filter-header-cell")
                 .Build();
 
-        private string _style =>
+        private string Stylename =>
             new StyleBuilder()
                 .AddStyle(Column?.HeaderStyle)
                 .AddStyle(Style)

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor
@@ -4,7 +4,7 @@
 
 @if (Column != null)
 {
-    <td class="@_classname" style="@_style" colspan="@Column.FooterColSpan" @attributes="@UserAttributes">
+    <td class="@Classname" style="@Stylename" colspan="@Column.FooterColSpan" @attributes="@UserAttributes">
         @if (Column.AggregateDefinition != null)
         {
             @Column.AggregateDefinition?.GetValue(Column.PropertyExpression, items)

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
             new CssBuilder("footer-cell")
                 .AddClass(Column?.FooterClassFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.FooterClass)
-                .AddClass(Column?.footerClassname)
+                .AddClass(Column?.FooterClassname)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
@@ -39,7 +37,7 @@ namespace MudBlazor
         [Parameter]
         public IEnumerable<T> CurrentItems { get; set; }
 
-        private string _classname =>
+        private string Classname =>
             new CssBuilder("footer-cell")
                 .AddClass(Column?.FooterClassFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.FooterClass)
@@ -47,7 +45,7 @@ namespace MudBlazor
                 .AddClass(Class)
                 .Build();
 
-        private string _style =>
+        private string Stylename =>
             new StyleBuilder()
                 .AddStyle(Column?.FooterStyleFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddStyle(Column?.FooterStyle)

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -7,13 +7,13 @@
 
 @if (IsOnlyHeader)
 {
-    <th scope="col" class="mud-table-cell @_classname" style="" @attributes="@UserAttributes">
+    <th scope="col" class="mud-table-cell @Classname" style="" @attributes="@UserAttributes">
         @ChildContent
     </th>
 }
 else if (Column != null && !Column.HiddenState.Value)
 {
-    <th @ref=@_headerElement scope="col" class="@_classname" style="@_style" colspan="@Column.HeaderColSpan" @attributes="@UserAttributes">
+    <th @ref=@_headerElement scope="col" class="@Classname" style="@Stylename" colspan="@Column.HeaderColSpan" @attributes="@UserAttributes">
         @if (DataGrid.DragDropColumnReordering)
         {
             <MudDropZone CanDrop="@((item) => (Column.DragAndDropEnabled ?? true))" ItemDisabled="@((item) => !item.DragAndDropEnabled ?? false)" T="Column<T>" Identifier="@(Column.PropertyName ?? _id)">
@@ -27,7 +27,7 @@ else if (Column != null && !Column.HiddenState.Value)
         @if (resizable)
         {
             <div @onpointerdown=OnResizerPointerDown @onpointerover=OnResizerPointerOver @onpointerleave=OnResizerPointerLeave
-                 class="@_resizerClass" style="@_resizerStyle" />
+                 class="@ResizerClass" style="@ResizerStyle" />
         }
     </th>
 }
@@ -41,7 +41,7 @@ else if (Column != null && !Column.HiddenState.Value)
         <span class="column-header">
             @if (sortable)
             {
-                <span class="@_sortHeaderClass" @onclick="SortChangedAsync">
+                <span class="@SortHeaderClass" @onclick="SortChangedAsync">
                     @if (Column.HeaderTemplate != null)
                     {
                         @Column.HeaderTemplate(Column.headerContext)
@@ -63,10 +63,10 @@ else if (Column != null && !Column.HiddenState.Value)
                     @computedTitle
                 }
             }
-            <span class="@_optionsClass">
+            <span class="@OptionsClass">
                 @if (sortable)
                 {
-                    if (_initialDirection == SortDirection.None)
+                    if (SortDirection == SortDirection.None)
                     {
                         <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
@@ -103,7 +103,7 @@ else if (Column != null && !Column.HiddenState.Value)
                 @if (showColumnOptions)
                 {
                     <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
-                        <MudMenuItem Disabled="@(_initialDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
+                        <MudMenuItem Disabled="@(SortDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {
                             <MudMenuItem OnClick="@AddFilter">@Localizer[LanguageResource.MudDataGrid_Filter]</MudMenuItem>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -2,10 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
@@ -19,6 +15,11 @@ namespace MudBlazor
     /// <typeparam name="T">The kind of item managed by the grid.</typeparam>
     public partial class HeaderCell<T> : MudComponentBase, IDisposable
     {
+        private bool _selected;
+        private bool _isResizing;
+        private double? _resizerHeight;
+        private bool _filtersMenuVisible;
+        private ElementReference _headerElement;
         private string _id = Identifier.Create();
 
         /// <summary>
@@ -48,9 +49,6 @@ namespace MudBlazor
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private SortDirection _initialDirection;
-        private bool _selected;
-
         /// <summary>
         /// The direction to sort values in this column.
         /// </summary>
@@ -58,23 +56,16 @@ namespace MudBlazor
         /// Defaults to <see cref="SortDirection.None"/>.
         /// </remarks>
         [Parameter]
-        public SortDirection SortDirection
-        {
-            get => _initialDirection;
-            set
-            {
-                _initialDirection = value;
-            }
-        }
+        public SortDirection SortDirection { get; set; }
 
-        private string _classname =>
+        private string Classname =>
             new CssBuilder(Column?.HeaderClass)
                 .AddClass(Column?.HeaderClassFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.HeaderClassname)
                 .AddClass(Class)
                 .Build();
 
-        private string _style =>
+        private string Stylename =>
             new StyleBuilder()
                 .AddStyle(Column?.HeaderStyleFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
                 .AddStyle(Column?.HeaderStyle)
@@ -82,31 +73,29 @@ namespace MudBlazor
                 .AddStyle(Style)
                 .Build();
 
-        private string _resizerStyle =>
+        private string ResizerStyle =>
             new StyleBuilder()
                 .AddStyle("height", _resizerHeight?.ToPx() ?? "100%")
                 .AddStyle(Style)
                 .Build();
 
-        private string _resizerClass =>
+        private string ResizerClass =>
             new CssBuilder()
                 .AddClass("mud-resizing", when: _isResizing)
                 .AddClass("mud-resizer")
                 .Build();
 
-        private string _sortHeaderClass =>
+        private string SortHeaderClass =>
             new CssBuilder()
                 .AddClass("sortable-column-header")
                 .AddClass("cursor-pointer", when: !_isResizing)
                 .Build();
 
-        private string _optionsClass =>
+        private string OptionsClass =>
             new CssBuilder()
                 .AddClass("column-options")
                 .AddClass("cursor-pointer", when: !_isResizing)
                 .Build();
-
-        private ElementReference _headerElement;
 
         /// <summary>
         /// The width for this header cell, in pixels.
@@ -116,9 +105,6 @@ namespace MudBlazor
         /// </remarks>
         public double? Width { get; internal set; }
 
-        private double? _resizerHeight;
-        private bool _isResizing;
-        private bool _filtersMenuVisible;
 
         #region Computed Properties and Functions
 
@@ -198,7 +184,7 @@ namespace MudBlazor
         {
             get
             {
-                return _initialDirection switch
+                return SortDirection switch
                 {
                     SortDirection.Descending => "sort-direction-icon mud-direction-desc",
                     SortDirection.Ascending => "sort-direction-icon mud-direction-asc",
@@ -237,12 +223,12 @@ namespace MudBlazor
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
-            _initialDirection = Column?.InitialDirection ?? SortDirection.None;
+            SortDirection = Column?.InitialDirection ?? SortDirection.None;
 
-            if (_initialDirection != SortDirection.None)
+            if (SortDirection != SortDirection.None)
             {
                 // set initial sort
-                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc()));
+                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, SortDirection, Column.GetLocalSortFunc()));
             }
 
             if (DataGrid != null)
@@ -347,13 +333,13 @@ namespace MudBlazor
         {
             if (args.AltKey)
             {
-                if (_initialDirection != SortDirection.None)
+                if (SortDirection != SortDirection.None)
                     await RemoveSortAsync();
 
                 return;
             }
 
-            _initialDirection = _initialDirection switch
+            SortDirection = SortDirection switch
             {
                 SortDirection.Ascending => SortDirection.Descending,
                 _ => SortDirection.Ascending
@@ -362,9 +348,9 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
 
             if (args.CtrlKey && DataGrid.SortMode == SortMode.Multiple)
-                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc(), Column.Comparer));
+                await InvokeAsync(() => DataGrid.ExtendSortAsync(Column.PropertyName, SortDirection, Column.GetLocalSortFunc(), Column.Comparer));
             else
-                await InvokeAsync(() => DataGrid.SetSortAsync(Column.PropertyName, _initialDirection, Column.GetLocalSortFunc(), Column.Comparer));
+                await InvokeAsync(() => DataGrid.SetSortAsync(Column.PropertyName, SortDirection, Column.GetLocalSortFunc(), Column.Comparer));
         }
 
         internal async Task RemoveSortAsync()
@@ -528,7 +514,7 @@ namespace MudBlazor
 
         private void MarkAsUnsorted()
         {
-            _initialDirection = SortDirection.None;
+            SortDirection = SortDirection.None;
             Column.SortIndex = -1;
         }
 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -70,7 +70,7 @@ namespace MudBlazor
         private string _classname =>
             new CssBuilder(Column?.HeaderClass)
                 .AddClass(Column?.HeaderClassFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
-                .AddClass(Column?.headerClassname)
+                .AddClass(Column?.HeaderClassname)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -2,11 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace MudBlazor
 {
 #nullable enable

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -14,12 +14,12 @@
 <CascadingValue IsFixed="true" Value="this">@Columns</CascadingValue>
 
 <CascadingValue IsFixed="true" Value="this">
-    <div @attributes="UserAttributes" class="@_classname" style="@_style">
+    <div @attributes="UserAttributes" class="@Classname" style="@Stylename">
         @if (Items != null || HasServerData)
         {
             @if (ToolBarContent != null)
             {
-                <MudToolBar Class="mud-table-toolbar" Style="@_headerFooterStyle">
+                <MudToolBar Class="mud-table-toolbar" Style="@HeaderFooterStyle">
                     @ToolBarContent
                     @if (ShowMenuIcon)
                     {
@@ -32,13 +32,13 @@
                 @if (ShowMenuIcon)
                 {
                     @*Add the default toolbar.*@
-                    <MudToolBar Class="mud-table-toolbar" Style="@_headerFooterStyle">
+                    <MudToolBar Class="mud-table-toolbar" Style="@HeaderFooterStyle">
                         <MudSpacer />
                         @ToolbarMenu(this)
                     </MudToolBar>
                 }
             }
-            <div @ref=_gridElement class="@_tableClass" style="@_tableStyle">
+            <div @ref=_gridElement class="@TableClass" style="@TableStyle">
                 <MudDropContainer @ref="_dropContainer" T="Column<T>" Items="@RenderedColumns" ItemsSelector="(item, dropzone) => RenderedColumnsItemsSelector(item, dropzone)" ItemDropped="ItemUpdatedAsync" CanDropClass="@DropAllowedClass" NoDropClass="@DropNotAllowedClass" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
                     <ChildContent>
                 <table class="mud-table-root">
@@ -48,7 +48,7 @@
                             @ColGroup
                         </colgroup>
                     }
-                    <thead class="@_headClassname">
+                    <thead class="@HeadClassname">
                         <CascadingValue Name="IsOnlyHeader" IsFixed="true" Value="true">
                             @Header
                         </CascadingValue>
@@ -266,7 +266,7 @@
                                                         }
                                                     </CascadingValue>
                                                 </tr>
-                                                @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !hasHierarchyColumn))
+                                                @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !HasHierarchyColumn))
                                                 {
                                                     <tr class="mud-table-row">
                                                         <td class="mud-table-cell" colspan="1000">
@@ -321,7 +321,7 @@
                                                 }
                                             </CascadingValue>
                                         </tr>
-                                        @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !hasHierarchyColumn))
+                                        @if (ChildRowContent != null && (_openHierarchies.Contains(item) || !HasHierarchyColumn))
                                         {
                                             <tr class="mud-table-row">
                                                 <td class="mud-table-cell" colspan="1000">
@@ -352,7 +352,7 @@
                             </tr>
                         }
                     </tbody>
-                    <tfoot class="@_footClassname">
+                    <tfoot class="@FootClassname">
                         <tr class="mud-table-row">
                             @FooterCells(resolvedPageItems)
                         </tr>
@@ -366,14 +366,14 @@
             </div>
             @if (PagerContent != null)
             {
-                <div class="mud-table-pagination" style="@_headerFooterStyle">
+                <div class="mud-table-pagination" style="@HeaderFooterStyle">
                     @PagerContent
                 </div>
             }
         }
     </div>
     <CascadingValue Value="true" IsFixed Name="IsNested">
-        <MudDialog Options="EditDialogOptions" @bind-Visible="isEditFormOpen">
+        <MudDialog Options="EditDialogOptions" @bind-Visible="_isEditFormOpen">
             <DialogContent>
                 <MudForm @ref="_editForm" FieldChanged="FormFieldChanged">
                     @foreach (var column in RenderedColumns)
@@ -436,7 +436,7 @@
                 {
                     if (!column.HiddenState.Value)
                     {
-                        if (column.AggregateDefinition is not null || column.FooterTemplate is not null || hasFooter)
+                        if (column.AggregateDefinition is not null || column.FooterTemplate is not null || HasFooter)
                         {
                             <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
                         }
@@ -451,7 +451,7 @@
             @{
                 var cell = new Cell<T>(this, column, item);
             }
-            <td data-label="@column.Title" class="@cell.computedClass" style="@cell.computedStyle">
+            <td data-label="@column.Title" class="@cell.ComputedClass" style="@cell.ComputedStyle">
                 @if (column.Editable && !ReadOnly && EditMode == DataGridEditMode.Cell)
                 {
                     if (column.EditTemplate is not null)


### PR DESCRIPTION
## Description
Never used conventions to name as _tableClassName, _style etc. Datagrid shouldn't use that.

Since some were in public API surface (protected) it's a breaking change.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
