### PR TITLE
MudNavGroup: Add TitleContent parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuGroupTitleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuGroupTitleExample.razor
@@ -1,0 +1,38 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Class="py-3" Elevation="0">
+    <MudNavMenu>
+        <MudText Typo="Typo.h6" Class="px-4">My Application</MudText>
+        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
+        <MudDivider Class="my-2" />
+        <MudNavLink Href="/dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="/servers">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudNavGroup Title="Settings" Expanded="true">
+            <TitleContent>
+                <MudBadge Icon="@Icons.Material.Filled.ErrorOutline" 
+                          Color="Color.Error" 
+                          Origin="@(RightToLeft ? Origin.CenterLeft : Origin.CenterRight)" 
+                          BadgeClass="mx-2">
+                    Settings
+                </MudBadge>
+            </TitleContent>
+            <ChildContent>
+                <MudNavLink Href="/users">Users</MudNavLink>
+                <MudNavLink Href="/security">
+                    <MudBadge Content="3" 
+                              Color="Color.Error" 
+                              Origin="@(RightToLeft ? Origin.CenterLeft : Origin.CenterRight)" 
+                              BadgeClass="mx-2">
+                        Security
+                    </MudBadge>
+                </MudNavLink>
+            </ChildContent>
+        </MudNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>
+
+@code {
+    [CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -91,6 +91,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Customizing the Group Title">
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(NavMenuGroupTitleExample)" DarkenBackground="true" ShowCode="false">
+                <NavMenuGroupTitleExample />
+            </SectionContent>
+        </DocsPageSection>
+        
+        <DocsPageSection>
             <SectionHeader Title="OnClick">
                 <Description>
                     The <CodeInline>OnClick</CodeInline> handler provides a way to invoke an action instead of (or in conjunction with) <CodeInline>Href</CodeInline> navigation.

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
@@ -20,7 +20,14 @@
             <MudIcon Disabled="@Disabled" Icon="@Icon" Color="@IconColor" Class="@IconClassname" />
         }
         <div Class="mud-nav-link-text">
-            @Title
+            @if (TitleContent is not null)
+            {
+                @TitleContent
+            }
+            else
+            {
+                @Title
+            }
         </div>
         @if (!HideExpandIcon)
         {

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -72,6 +72,16 @@ namespace MudBlazor
         private NavigationContext? ParentNavigationContext { get; set; }
 
         /// <summary>
+        /// The content within the title area.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  When set, overrides the <see cref="Title"/> property.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Behavior)]
+        public RenderFragment? TitleContent { get; set; }
+
+        /// <summary>
         /// The text shown for this group.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
A TitleContent render fragment was added in the component MudNavGroup. There was a way to add custom content to all the other Nav Menu's components except this one. The implementation is very similar to MudExpansionPanel's TitleContent where TitleContent takes precedence over Title.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
No test were added. An example has been added in the docs. It has only been tested visually since the change doesn't include any logic.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Here the example added in the docs for this new feature:
### LTR
![image](https://github.com/user-attachments/assets/5e5d434d-1d92-49b0-92e4-99cd9b4c64e6)
### RTL:
![image](https://github.com/user-attachments/assets/1d2171a1-a4a4-4a8d-befa-8a798196a9ca)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
