### PR TITLE
MudToggleGroup: Fix icon margins

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
-        [Test]
+        [Test(Description = "Ensures the checkmark is a direct descendant of the button label, is using the right name, and correctly contains a custom class definition")]
         public void ToggleGroup_CheckMarkClass()
         {
             var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
@@ -161,7 +161,7 @@ namespace MudBlazor.UnitTests.Components
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a").Add(x => x.UnselectedIcon, @Icons.Material.Filled.Coronavirus));
             });
 
-            comp.Find(".mud-button-label > span").ClassList.Should().Contain("c69");
+            comp.Find(".mud-button-label > .mud-toggle-item-check-icon").ClassList.Should().Contain("c69");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor
@@ -12,9 +12,14 @@
            Color="@(Parent?.Color ?? Color.Default)"
            Variant="@(Selected ? Variant.Filled : Variant.Outlined)"
            Disabled="Disabled || (Parent?.Disabled ?? false)"
-           Ripple="Parent?.Ripple == true"
-           StartIcon="@GetCurrentIcon()"
-           IconClass="@CheckMarkClassname">
+           Ripple="Parent?.Ripple == true">
+    @if (!string.IsNullOrWhiteSpace(GetCurrentIcon()))
+    {
+        <MudIcon Class="@CheckMarkClassname"
+                 Disabled="Disabled"
+                 Icon="@GetCurrentIcon()"
+                 Size="Parent?.Size ?? Size.Medium" />
+    }
     @if (ChildContent is not null)
     {
         <div class="mud-toggle-item-content">

--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -55,14 +55,29 @@
   & > .mud-button-label {
     min-height: 20px;
   }
+
+  .mud-toggle-item-check-icon {
+    margin: 0 6px;
+    font-size: 20px;
+  }
 }
 
 .mud-toggle-item-size-small {
   padding: 4px;
+
+  .mud-toggle-item-check-icon {
+    margin: 0 4px;
+    font-size: 18px;
+  }
 }
 
 .mud-toggle-item-size-large {
   padding: 8px;
+
+  .mud-toggle-item-check-icon {
+    margin: 0 8px;
+    font-size: 22px;
+  }
 }
 
 .mud-toggle-item-fixed > .mud-button-label:has(>.mud-toggle-item-check-icon) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

The checkmark icon didn't have enough padding on the side and touched the borders of the element.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before

![image](https://github.com/user-attachments/assets/f6b093f2-c393-405f-bae4-452195fbe819)

After

![image](https://github.com/user-attachments/assets/903cbf2c-6bdd-4f73-8331-4e4315906034)


![image](https://github.com/user-attachments/assets/77a3e0cb-8d16-49c0-ad0a-ddae0973195b)


Nothing changed if you don't have the icon enabled

![image](https://github.com/user-attachments/assets/647fd8c5-e621-41af-a545-4549e8a784c5)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
