### PR TITLE
Chore: Drop CollectionExtensions for .NET 9+

### DIFF
--- a/src/MudBlazor/Extensions/CollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/CollectionExtensions.cs
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET8_0
+
 namespace MudBlazor;
 
 #nullable enable
@@ -112,3 +114,5 @@ internal static class CollectionExtensions
         return list.Count > 0 ? list[0] : default;
     }
 }
+
+#endif


### PR DESCRIPTION
This PR removes the recently added `CollectionExtensions` for .NET 9 and above. These extensions were initially introduced to boost performance. However, starting with .NET 9, LINQ methods have become faster than type-specific methods, so it makes sense to limit the use of these custom extensions to .NET 8.