### PR TITLE
Build: Disable Renovate Badges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
         "config:recommended"
     ],
     "ignorePresets": [
-        ":ignoreModulesAndTests"
+        ":ignoreModulesAndTests",
+        "mergeConfidence:all-badges"
     ],
     "labels": [
         "dependency"


### PR DESCRIPTION
This PR disables the badges columns in the renovate PR description.

Before:
![image](https://github.com/user-attachments/assets/d161b6b8-86df-464c-bf96-a2ae897405ac)

After:
![image](https://github.com/user-attachments/assets/4b35b303-8931-4b9a-9df4-2c0d13e2f6ee)

