### PR TITLE
Docs: Change Member Table to MudToggleGroup

### DIFF
--- a/src/MudBlazor.Docs/Components/ApiMemberTable.razor
+++ b/src/MudBlazor.Docs/Components/ApiMemberTable.razor
@@ -1,7 +1,7 @@
 ﻿<MudTable T="DocumentedMember" @ref="Table" ServerData="@GetData"
           Breakpoint="@Breakpoint.Sm"
           Elevation="0" Class="mud-width-full " Hover="true" Dense="true"
-          AllowUnsorted="false" GroupBy="@CurrentGroups">   
+          AllowUnsorted="false" GroupBy="@CurrentGroups">
     <GroupHeaderTemplate>
         @if (Grouping == ApiMemberGrouping.Inheritance)
         {
@@ -23,21 +23,21 @@
     </HeaderContent>
     <ToolBarContent>
         <MudGrid Class="pa-0">
-            <MudItem xs="12" md="6" Class="py-0">
-                <MudButtonGroup OverrideStyles="false">
-                    <MudButton Size="Size.Small" Color="Color.Primary" Variant="@GetGroupingVariant(ApiMemberGrouping.None)" OnClick="@(() => OnGroupingChangedAsync(ApiMemberGrouping.None))">None</MudButton>
-                    <MudButton Size="Size.Small" Color="Color.Primary" Variant="@GetGroupingVariant(ApiMemberGrouping.Categories)" OnClick="@(() => OnGroupingChangedAsync(ApiMemberGrouping.Categories))">Category</MudButton>
-                    <MudButton Size="Size.Small" Color="Color.Primary" Variant="@GetGroupingVariant(ApiMemberGrouping.Inheritance)" OnClick="@(() => OnGroupingChangedAsync(ApiMemberGrouping.Inheritance))">Inheritance</MudButton>
-                </MudButtonGroup>
+            <MudItem sm="6" md="6" Class="py-0">
+                <MudToggleGroup T="ApiMemberGrouping" Value="Grouping" ValueChanged="OnGroupingChangedAsync" Size="Size.Small" Rounded="true">
+                    <MudToggleItem Value="ApiMemberGrouping.None">None</MudToggleItem>
+                    <MudToggleItem Value="ApiMemberGrouping.Categories">Category</MudToggleItem>
+                    <MudToggleItem Value="ApiMemberGrouping.Inheritance">Inheritance</MudToggleItem>
+                </MudToggleGroup>
             </MudItem>
             @if (HasProtected())
             {
                 @* There are protected members.  Show a "Show Protected" switch *@
-                <MudItem xs="6" md="3" Class="py-0">
-                    <MudTextField T="string" Value="@Keyword" ValueChanged="OnKeywordChangedAsync" DebounceInterval="300" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                <MudItem sm="6" md="3" Class="py-0">
+                    <MudSwitch T="bool" Size="Size.Small" Color="Color.Primary" Value="@ShowProtected" ValueChanged="OnShowProtectedChangedAsync" Class="pt-2">Show Protected</MudSwitch>
                 </MudItem>
-                <MudItem xs="6" md="3" Class="py-0">
-                    <MudSwitch T="bool" Size="Size.Small" Color="Color.Primary" Value="@ShowProtected" ValueChanged="OnShowProtectedChangedAsync">Show Protected</MudSwitch>
+                <MudItem xs="12" sm="6" md="3" Class="py-0">
+                    <MudTextField T="string" Value="@Keyword" ValueChanged="OnKeywordChangedAsync" DebounceInterval="300" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
                 </MudItem>
             }
             else

--- a/src/MudBlazor.Docs/Components/ApiMemberTable.razor
+++ b/src/MudBlazor.Docs/Components/ApiMemberTable.razor
@@ -39,9 +39,7 @@
                                Value="@ShowProtected"
                                ValueChanged="OnShowProtectedChangedAsync"
                                Size="Size.Small"
-                               Color="Color.Primary">
-                        Show Protected
-                    </MudSwitch>
+                               Color="Color.Primary">Show Protected</MudSwitch>
                 }
 
                 <MudToggleGroup Class="docs-content-api-grouping"

--- a/src/MudBlazor.Docs/Components/ApiMemberTable.razor
+++ b/src/MudBlazor.Docs/Components/ApiMemberTable.razor
@@ -1,6 +1,6 @@
 ﻿<MudTable T="DocumentedMember" @ref="Table" ServerData="@GetData"
           Breakpoint="@Breakpoint.Sm"
-          Elevation="0" Class="mud-width-full " Hover="true" Dense="true"
+          Elevation="0" Class="docs-content-api-table" Hover="true" Dense="true"
           AllowUnsorted="false" GroupBy="@CurrentGroups">
     <GroupHeaderTemplate>
         @if (Grouping == ApiMemberGrouping.Inheritance)
@@ -22,32 +22,40 @@
         <MudTh>Description</MudTh>
     </HeaderContent>
     <ToolBarContent>
-        <MudGrid Class="pa-0">
-            <MudItem sm="6" md="6" Class="py-0">
-                <MudToggleGroup T="ApiMemberGrouping" Value="Grouping" ValueChanged="OnGroupingChangedAsync" Size="Size.Small" Rounded="true">
+        <div class="docs-content-api-table-toolbar-container">
+            <MudTextField T="string"
+                          Value="@Keyword"
+                          ValueChanged="OnKeywordChangedAsync"
+                          DebounceInterval="300"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Placeholder="Search members" />
+
+            <div class="docs-content-api-table-toolbar-configuration-container">
+                @if (true || HasProtected())
+                {
+                    @* There are protected members.  Show a "Show Protected" switch *@
+                    <MudSwitch T="bool"
+                               Value="@ShowProtected"
+                               ValueChanged="OnShowProtectedChangedAsync"
+                               Size="Size.Small"
+                               Color="Color.Primary">
+                        Show Protected
+                    </MudSwitch>
+                }
+
+                <MudToggleGroup Class="docs-content-api-grouping"
+                                T="ApiMemberGrouping"
+                                Value="Grouping"
+                                ValueChanged="OnGroupingChangedAsync"
+                                Size="Size.Small"
+                                Rounded="true">
                     <MudToggleItem Value="ApiMemberGrouping.None">None</MudToggleItem>
                     <MudToggleItem Value="ApiMemberGrouping.Categories">Category</MudToggleItem>
                     <MudToggleItem Value="ApiMemberGrouping.Inheritance">Inheritance</MudToggleItem>
                 </MudToggleGroup>
-            </MudItem>
-            @if (HasProtected())
-            {
-                @* There are protected members.  Show a "Show Protected" switch *@
-                <MudItem sm="6" md="3" Class="py-0">
-                    <MudSwitch T="bool" Size="Size.Small" Color="Color.Primary" Value="@ShowProtected" ValueChanged="OnShowProtectedChangedAsync" Class="pt-2">Show Protected</MudSwitch>
-                </MudItem>
-                <MudItem xs="12" sm="6" md="3" Class="py-0">
-                    <MudTextField T="string" Value="@Keyword" ValueChanged="OnKeywordChangedAsync" DebounceInterval="300" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
-                </MudItem>
-            }
-            else
-            {
-                @* There are no protected members to hide *@
-                <MudItem xs="12" md="6" Class="py-0">
-                    <MudTextField T="string" Value="@Keyword" ValueChanged="OnKeywordChangedAsync" DebounceInterval="300" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
-                </MudItem>
-            }
-        </MudGrid>
+            </div>
+        </div>
     </ToolBarContent>
     <RowTemplate>
         <MudTd id="@context.Name" DataLabel="Name" Class="docs-content-api-cell">

--- a/src/MudBlazor.Docs/Pages/Api/Api.razor
+++ b/src/MudBlazor.Docs/Pages/Api/Api.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Pages.Api
 
 <style>
-    .mud-table-toolbar { height:90px; }
+    .mud-table-toolbar { height:110px; }
     [id] { scroll-margin-top: 65px; }
 </style>
 

--- a/src/MudBlazor.Docs/Pages/Api/Api.razor
+++ b/src/MudBlazor.Docs/Pages/Api/Api.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Pages.Api
 
 <style>
-    .mud-table-toolbar { height:110px; }
+    .mud-table-toolbar { height: auto; }
     [id] { scroll-margin-top: 65px; }
 </style>
 

--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -168,6 +168,36 @@
   }
 }
 
+.docs-content-api-table {
+  width: 100%;
+}
+
+.docs-content-api-table-toolbar-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  width: 100%;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.docs-content-api-table-toolbar-configuration-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.docs-content-api-grouping {
+  .mud-toggle-item {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+}
+
 @media(min-width: 600px) {
   .docs-content-api-cell:before {
     width: 30% !important;


### PR DESCRIPTION
## Description

This update makes minor changes suggested in #10145 where the API Docs `ApiMemberTable` should use a `MudToggleGroup` to control the grouping of members.  This also slightly adjusts the appearance of the table in `md`, `sm`, and `xs` breakpoints for mobile devices.

Also resolves #8752 

Video after Daniel's improvements:
![ResponsiveDocs](https://github.com/user-attachments/assets/26088556-09b3-432a-bf5f-e286446d1d50)

## How Has This Been Tested?

This was tested visually by using F12 Developer Tools to view the site in Responsive mode as well as for mobile devices.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
