### PR TITLE
MudPopover: Add XML Documentation for Public Members

### DIFF
--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -60,7 +60,7 @@ namespace MudBlazor
         /// The icon to display when items are collapsed.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>Icons.Material.Filled.SettingsEthernet</c>.  Displays when <see cref="Collapsed"/> and the number of items exceeds <see cref="MaxItems"/>.
+        /// Defaults to <see cref="Icons.Material.Filled.SettingsEthernet" />.  Displays when <see cref="Collapsed"/> and the number of items exceeds <see cref="MaxItems"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Breadcrumbs.Appearance)]

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
@@ -7,7 +11,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a common form component for selecting date, time, and color values.
+    /// A component for selecting date, time, and color values.
     /// </summary>
     /// <typeparam name="T">The type of value being chosen.</typeparam>
     /// <seealso cref="MudPickerContent" />
@@ -21,9 +25,6 @@ namespace MudBlazor
         private bool _keyInterceptorObserving = false;
         private string _elementId = Identifier.Create("picker");
 
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
         public MudPicker() : base(new Converter<T, string>()) { }
 
         protected MudPicker(Converter<T, string> converter) : base(converter) { }

--- a/src/MudBlazor/Components/Picker/MudPickerContent.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPickerContent.razor.cs
@@ -1,10 +1,14 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the content within a <see cref="MudPicker{T}"/>.
+/// The content within a <see cref="MudPicker{T}"/>.
 /// </summary>
 /// <seealso cref="MudPicker{T}" />
 /// <seealso cref="MudPickerToolbar" />

--- a/src/MudBlazor/Components/Picker/MudPickerToolbar.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPickerToolbar.razor.cs
@@ -1,10 +1,14 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the toolbar content of a <see cref="MudPicker{T}"/>.
+/// The toolbar content of a <see cref="MudPicker{T}"/>.
 /// </summary>
 /// <seealso cref="MudPicker{T}" />
 /// <seealso cref="MudPickerContent" />

--- a/src/MudBlazor/Components/Popover/IPopover.cs
+++ b/src/MudBlazor/Components/Popover/IPopover.cs
@@ -13,38 +13,40 @@ namespace MudBlazor;
 public interface IPopover
 {
     /// <summary>
-    /// Gets the unique identifier of the popover.
+    /// The unique identifier of the popover.
     /// </summary>
     Guid Id { get; }
 
     /// <summary>
-    /// Gets the CSS class of the popover.
+    /// The CSS class of the popover.
     /// </summary>
     public string PopoverClass { get; }
 
     /// <summary>
-    /// Gets the inline styles of the popover.
+    /// The inline styles of the popover.
     /// </summary>
     public string PopoverStyles { get; }
 
     /// <summary>
-    /// If true, the popover is visible.
+    /// Shows the popover.
     /// </summary>
     bool Open { get; set; }
 
     /// <summary>
-    /// Use Tag to attach any user data object to the component for your convenience.
+    /// Any user data to link to this popover.
     /// </summary>
     object? Tag { get; set; }
 
     /// <summary>
-    /// UserAttributes carries all attributes you add to the component that don't match any of its parameters.
-    /// They will be splatted onto the underlying HTML tag.
+    /// Any additional attributes to add to this component.
     /// </summary>
+    /// <remarks>
+    /// Use this for any attributes which don't have a parameter.  They will be "splatted" onto the underlying HTML tag.
+    /// </remarks>
     Dictionary<string, object?> UserAttributes { get; set; }
 
     /// <summary>
-    /// Child content of the component.
+    /// The content within this popover.
     /// </summary>
     RenderFragment? ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -1,9 +1,17 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// Displays content as a window over other content.
+    /// </summary>
     public partial class MudPopover : MudPopoverBase
     {
         protected internal override string PopoverClass =>
@@ -39,98 +47,128 @@ namespace MudBlazor
             };
         }
 
+        /// <summary>
+        /// Displays text Right-to-Left.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  This property is set via the <see cref="MudRTLProvider"/>.
+        /// </remarks>
         [CascadingParameter(Name = "RightToLeft")]
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Sets the maxheight the popover can have when open.
+        /// Sets the maximum height, in pixels, of this popover.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public int? MaxHeight { get; set; } = null;
 
         /// <summary>
-        /// If true, will apply default MudPaper classes.
+        /// Displays content within a <see cref="MudPaper"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public bool Paper { get; set; } = true;
 
         /// <summary>
-        /// Determines whether the popover has a drop-shadow. Default is true.
+        /// Shows a drop shadow to help this popover stand out.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public bool DropShadow { get; set; } = true;
 
         /// <summary>
-        /// The higher the number, the heavier the drop-shadow.
+        /// The amount of drop shadow to apply.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="MudGlobal.PopoverDefaults.Elevation"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public int Elevation { set; get; } = MudGlobal.PopoverDefaults.Elevation;
 
         /// <summary>
-        /// If true, border-radius is set to 0.
+        /// Displays square borders around this popover.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the CSS <c>border-radius</c> is set to <c>0</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public bool Square { get; set; }
 
         /// <summary>
-        /// If true the popover will be fixed position instead of absolute.
+        /// Displays this popover in a fixed position.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>False</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Behavior)]
         public bool Fixed { get; set; }
 
         /// <summary>
-        /// Sets the length of time that the opening transition takes to complete.
+        /// The length of time that the opening transition takes to complete.
         /// </summary>
         /// <remarks>
-        /// Set globally via <see cref="MudGlobal.TransitionDefaults.Duration"/>.
+        /// Defaults to <see cref="MudGlobal.TransitionDefaults.Duration"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public double Duration { get; set; } = MudGlobal.TransitionDefaults.Duration.TotalMilliseconds;
 
         /// <summary>
-        /// Sets the amount of time in milliseconds to wait from opening the popover before beginning to perform the transition. 
+        /// The amount of time, in milliseconds, from opening the popover to beginning the transition. 
         /// </summary>
         /// <remarks>
-        /// Set globally via <see cref="MudGlobal.TransitionDefaults.Delay"/>.
+        /// Defaults to <see cref="MudGlobal.TransitionDefaults.Delay"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public double Delay { get; set; } = MudGlobal.TransitionDefaults.Delay.TotalMilliseconds;
 
         /// <summary>
-        /// Set the anchor point on the element of the popover.
-        /// The anchor point will determinate where the popover will be placed.
+        /// The location this popover will appear relative to its parent container.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.TopLeft"/>.  Use <see cref="TransformOrigin"/> to control the direction of the popover from this point.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public Origin AnchorOrigin { get; set; } = Origin.TopLeft;
 
         /// <summary>
-        /// Sets the intersection point if the anchor element. At this point the popover will lay above the popover. 
-        /// This property in conjunction with AnchorPlacement determinate where the popover will be placed.
+        /// The direction this popover will appear relative to the <see cref="Origin"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.TopLeft"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public Origin TransformOrigin { get; set; } = Origin.TopLeft;
 
         /// <summary>
-        /// Set the overflow behavior of a popover and controls how the element should react if there is not enough space for the element to be visible
-        /// Defaults to none, which doens't apply any overflow logic
+        /// The behavior applied when there is not enough space for this popover to be visible.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
 
         /// <summary>
-        /// If true, the popover will have the same width at its parent element, default to false
+        /// Expands this popover to have the same width as the parent container.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
         public bool RelativeWidth { get; set; } = false;

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -9,8 +9,9 @@ using Microsoft.JSInterop;
 namespace MudBlazor;
 
 #nullable enable
+
 /// <summary>
-/// Base class for implementing Popover component.
+/// A base class for implementing Popover components.
 /// </summary>
 /// <remarks>
 /// This class provides a base implementation for a Popover component. It implements the <see cref="IPopover"/> interface

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -8,6 +8,16 @@ using MudBlazor.Interfaces;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// A required component which manages all MudBlazor popovers.
+    /// </summary>
+    /// <remarks>
+    /// This component is required for MudBlazor components to display popovers properly.  It is typically added to your main layout page.
+    /// </remarks>
+    /// <seealso cref="MudThemeProvider"/>
+    /// <seealso cref="MudDialogProvider"/>
+    /// <seealso cref="MudSnackbarProvider"/>
     public partial class MudPopoverProvider : IDisposable, IPopoverObserver
     {
         private bool _isConnectedToService = false;
@@ -16,17 +26,25 @@ namespace MudBlazor
         internal IPopoverService PopoverService { get; set; } = null!;
 
         /// <summary>
-        /// In some scenarios we need more than one ThemeProvider, but we must not have more than one
-        /// PopoverProvider. Set a cascading value with UsePopoverProvider=false to prevent it.
+        /// Controls whether this provider is enabled.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// If more than one <see cref="MudPopoverProvider"/> is detected, this property will be <c>false</c> to ensure only one instance is active.
+        /// Can be overridden by setting a cascading parameter of <c>UsePopoverProvider</c> to <c>false</c>.
+        /// </remarks>
         [CascadingParameter(Name = "UsePopoverProvider")]
         public bool Enabled { get; set; } = true;
 
+        /// <summary>
+        /// Releases resources used by this provider.
+        /// </summary>
         public void Dispose()
         {
             PopoverService.Unsubscribe(this);
         }
 
+        /// <inheritdoc />
         protected override void OnInitialized()
         {
             if (Enabled == false)
@@ -38,6 +56,7 @@ namespace MudBlazor
             _isConnectedToService = true;
         }
 
+        /// <inheritdoc />
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
@@ -58,6 +77,7 @@ namespace MudBlazor
             }
         }
 
+        /// <inheritdoc />
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender && Enabled && PopoverService.PopoverOptions.ThrowOnDuplicateProvider)

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -6,6 +9,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// A circle-shaped indicator of progress for an ongoing operation.
+    /// </summary>
+    /// <seealso cref="MudProgressLinear"/>
     public partial class MudProgressCircular : MudComponentBase
     {
         private int _svgValue;
@@ -28,38 +36,71 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
-        /// The color of the component. It supports the theme colors.
+        /// The color of this component.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The size of the component.
+        /// The size of this component.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
-        /// Constantly animates, does not follow any value.
+        /// Displays a constant animation without any value.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="Value"/> will be ignored.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Behavior)]
         public bool Indeterminate { get; set; }
 
+        /// <summary>
+        /// The lowest possible value.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0.0</c>.  Usually a percentage.  Should be lower than <see cref="Max"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Behavior)]
         public double Min { get; set; } = 0.0;
 
+        /// <summary>
+        /// The highest possible value.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>100.0</c>.  Usually a percentage.  Should be higher than <see cref="Min"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Behavior)]
         public double Max { get; set; } = 100.0;
 
+        /// <summary>
+        /// The current progress amount.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  Only applies when <see cref="Indeterminate"/> is <c>False</c>.  Should be between <see cref="Min"/> and <see cref="Max"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Behavior)]
         public double Value { get; set; }
 
+        /// <summary>
+        /// The thickness of the circle.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>3</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public int StrokeWidth { get; set; } = 3;
@@ -79,6 +120,7 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        /// <inheritdoc />
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -6,6 +9,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// A line-shaped indicator of progress for an ongoing operation.
+    /// </summary>
+    /// <seealso cref="MudProgressCircular"/>
     public partial class MudProgressLinear : MudComponentBase
     {
         private readonly ParameterState<double> _minState;
@@ -28,82 +36,118 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
-        /// The color of the component. It supports the theme colors.
+        /// The color of this component.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The size of the component.
+        /// The size of this component.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
         public Size Size { get; set; } = Size.Small;
 
         /// <summary>
-        /// Constantly animates, does not follow any value.
+        /// Displays a constant animation without any value.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="Value"/> will be ignored.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public bool Indeterminate { get; set; } = false;
 
         /// <summary>
-        /// If true, the buffer value will be used.
+        /// Displays an additional value ahead of <see cref="Value" />.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the value of <see cref="BufferValue"/> is displayed.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public bool Buffer { get; set; } = false;
 
         /// <summary>
-        /// If true, border-radius is set to the themes default value.
+        /// Displays a rounded border.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the CSS <c>border-radius</c> is set to the theme's default value.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
         public bool Rounded { get; set; } = false;
 
         /// <summary>
-        /// Adds stripes to the filled part of the linear progress.
+        /// Displays animated stripes for the value portion of this progress bar.
         /// </summary>
+        /// <remarks>
+        /// Default to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
         public bool Striped { get; set; } = false;
 
         /// <summary>
-        /// If true, the progress bar  will be displayed vertically.
+        /// Displays this progress bar vertically.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
         public bool Vertical { get; set; } = false;
 
         /// <summary>
-        /// Child content of component.
+        /// The content within this progress bar.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// The minimum allowed value of the linear progress. Should not be equal to max.
+        /// The lowest possible value.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0.0</c>.  Usually a percentage.  Should be lower than <see cref="Max"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Min { get; set; } = 0.0;
 
         /// <summary>
-        /// The maximum allowed value of the linear progress. Should not be equal to min.
+        /// The highest possible value.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>100.0</c>.  Usually a percentage.  Should be higher than <see cref="Min"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Max { get; set; } = 100.0;
 
         /// <summary>
-        /// The current value of the linear progress. Should be between min and max.
+        /// The current progress amount.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  Only applies when <see cref="Indeterminate"/> is <c>false</c>.  Should be between <see cref="Min"/> and <see cref="Max"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Value { get; set; }
 
+        /// <summary>
+        /// The amount to display ahead of the value.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  Only shows when <see cref="Buffer"/> is <c>true</c> and <see cref="Indeterminate"/> is <c>false</c>.  Typically a value greater than <see cref="Value"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double BufferValue { get; set; }
@@ -153,15 +197,31 @@ namespace MudBlazor
             return value / total * 100.0;
         }
 
+        /// <summary>
+        /// The calculated value percentage based on <see cref="Min"/>, <see cref="Max"/>, and <see cref="Value"/>.
+        /// </summary>
+        /// <returns>A value between <c>0.0</c> and <c>100.0</c>.</returns>
         public double GetValuePercent() => GetPercentage(_valueState.Value);
 
+        /// <summary>
+        /// The calculated buffer value percentage based on <see cref="Min"/>, <see cref="Max"/>, and <see cref="BufferValue"/>.
+        /// </summary>
+        /// <returns>A value between <c>0.0</c> and <c>100.0</c>.</returns>
         public double GetBufferPercent() => GetPercentage(_bufferValueState.Value);
 
         private string GetStyleBarTransform(double input) =>
             Vertical ? $"transform: translateY({(int)Math.Round(100 - input)}%);" : $"transform: translateX(-{(int)Math.Round(100 - input)}%);";
 
+        /// <summary>
+        /// Gets the CSS transform to apply based on the current value percentage.
+        /// </summary>
+        /// <returns>A CSS transform.</returns>
         public string GetStyledBar1Transform() => GetStyleBarTransform(ValuePercent);
 
+        /// <summary>
+        /// Gets the CSS transform to apply based on the current buffer value percentage.
+        /// </summary>
+        /// <returns>A CSS transform.</returns>
         public string GetStyledBar2Transform() => GetStyleBarTransform(BufferPercent);
     }
 }

--- a/src/MudBlazor/Components/Radio/IMudRadioGroup.cs
+++ b/src/MudBlazor/Components/Radio/IMudRadioGroup.cs
@@ -1,9 +1,12 @@
-﻿namespace MudBlazor
-{
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
 #nullable enable
-    internal interface IMudRadioGroup
-    {
-        //This interface need to throw exception properly.
-        void CheckGenericTypeMatch(object selectItem);
-    }
+internal interface IMudRadioGroup
+{
+    //This interface need to throw exception properly.
+    void CheckGenericTypeMatch(object selectItem);
 }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
@@ -6,6 +10,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// An option from a set of mutually exclusive options, often as part of a <see cref="MudRadioGroup{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of value being selected, often a <c>bool</c>.</typeparam>
+    /// <seealso cref="MudRadioGroup{T}" />
     public partial class MudRadio<T> : MudBooleanInput<T>
     {
         private IMudRadioGroup? _parent;
@@ -53,21 +63,27 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The base color of the component in its none active/unchecked state. It supports the theme colors.
+        /// The color to use when in an unchecked state.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public Color? UncheckedColor { get; set; } = null;
 
         /// <summary>
-        /// If true, compact padding will be applied.
+        /// Uses compact vertical padding.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public bool Dense { get; set; }
 
         /// <summary>
-        /// The icon to display for a checked state.
+        /// The icon displayed when in a checked state.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.RadioButtonChecked"/>.
@@ -77,7 +93,7 @@ namespace MudBlazor
         public string CheckedIcon { get; set; } = Icons.Material.Filled.RadioButtonChecked;
 
         /// <summary>
-        /// The icon to display for an unchecked state.
+        /// The icon displayed when in an unchecked state.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Icons.Material.Filled.RadioButtonUnchecked"/>.
@@ -118,6 +134,12 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// Checks this radio button.
+        /// </summary>
+        /// <remarks>
+        /// When part of a <see cref="MudRadioGroup{T}"/>, other values will be unchecked.
+        /// </remarks>
         public Task SelectAsync()
         {
             if (MudRadioGroup is not null)
@@ -167,6 +189,7 @@ namespace MudBlazor
             }
         }
 
+        /// <inheritdoc />
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
@@ -177,6 +200,7 @@ namespace MudBlazor
             }
         }
 
+        /// <inheritdoc />
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
@@ -197,6 +221,7 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
+        /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {
             await base.DisposeAsyncCore();

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
@@ -9,6 +9,11 @@ using MudBlazor.Utilities.Exceptions;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// A group of <see cref="MudRadio{T}"/> components.
+    /// </summary>
+    /// <typeparam name="T">The type of value being selected.</typeparam>
     public partial class MudRadioGroup<T> : MudFormComponent<T, T>, IMudRadioGroup
     {
         private MudRadio<T>? _selectedRadio;
@@ -33,41 +38,65 @@ namespace MudBlazor
         private bool ParentReadOnly { get; set; }
 
         /// <summary>
-        /// User class names for the input, separated by space
+        /// The CSS classes for this button group.
         /// </summary>
+        /// <remarks>
+        /// Multiple classes must be separated by spaces.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public string? InputClass { get; set; }
 
         /// <summary>
-        /// User style definitions for the input
+        /// The CSS styles for this button group.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public string? InputStyle { get; set; }
 
+        /// <summary>
+        /// The content within this button group.
+        /// </summary>
+        /// <remarks>
+        /// Usually a set of <see cref="MudRadio{T}"/> components.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
+        /// <summary>
+        /// The unique name for this button group.
+        /// </summary>
         [Parameter]
         [Category(CategoryTypes.Radio.Behavior)]
         public string Name { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// If true, the input will be disabled.
+        /// Prevents the user from interacting with this group.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool Disabled { get; set; }
 
         /// <summary>
-        /// If true, the input will be read-only.
+        /// Prevents the selected value from being changed.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool ReadOnly { get; set; }
 
+        /// <summary>
+        /// The current value.
+        /// </summary>
+        /// <remarks>
+        /// When this value changes, the <see cref="ValueChanged"/> event occurs.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Radio.Data)]
         public T? Value
@@ -76,6 +105,9 @@ namespace MudBlazor
             set => SetSelectedOptionAsync(value, true, updateValue: false).CatchAndLog();
         }
 
+        /// <summary>
+        /// Occurs whenever <see cref="Value"/> has changed.
+        /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
 
@@ -103,6 +135,11 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// Tests whether the specified value is valid for this button.
+        /// </summary>
+        /// <param name="selectItem">The value to examine.</param>
+        /// <exception cref="GenericTypeMismatchException">Raised if the specified value does not match <c>T</c>.</exception>
         public void CheckGenericTypeMatch(object selectItem)
         {
             var itemT = selectItem.GetType().GenericTypeArguments[0];

--- a/src/MudBlazor/Enums/OverflowBehavior.cs
+++ b/src/MudBlazor/Enums/OverflowBehavior.cs
@@ -12,19 +12,19 @@ namespace MudBlazor;
 public enum OverflowBehavior
 {
     /// <summary>
-    /// No special behavior will occur as the browser is scrolled.
+    /// Prevents any adjustment of the component, even if it would overflow the container.
     /// </summary>
     [Description("flip-never")]
     FlipNever,
 
     /// <summary>
-    /// The component will display on-screen when opened.
+    /// Flips the component if it would overflow its container, but only when it first opens.  Does not update dynamically if overflow changes afterwards.
     /// </summary>
     [Description("flip-onopen")]
     FlipOnOpen,
 
     /// <summary>
-    /// The component will remain visible even when the browser is scrolled.
+    /// Flips the component if it would overflow its container, dynamically adjusting as necessary to prevent overflow.
     /// </summary>
     [Description("flip-always")]
     FlipAlways,

--- a/src/MudBlazor/Enums/OverflowBehavior.cs
+++ b/src/MudBlazor/Enums/OverflowBehavior.cs
@@ -1,15 +1,31 @@
-﻿using System;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Controls how a component behaves when the browser is scrolled.
+/// </summary>
+public enum OverflowBehavior
 {
-    public enum OverflowBehavior
-    {
-        [Description("flip-never")]
-        FlipNever,
-        [Description("flip-onopen")]
-        FlipOnOpen,
-        [Description("flip-always")]
-        FlipAlways,
-    }
+    /// <summary>
+    /// No special behavior will occur as the browser is scrolled.
+    /// </summary>
+    [Description("flip-never")]
+    FlipNever,
+
+    /// <summary>
+    /// The component will display on-screen when opened.
+    /// </summary>
+    [Description("flip-onopen")]
+    FlipOnOpen,
+
+    /// <summary>
+    /// The component will remain visible even when the browser is scrolled.
+    /// </summary>
+    [Description("flip-always")]
+    FlipAlways,
 }


### PR DESCRIPTION
## Description

This update adds XML documentation for `MudPopover` through `MudRadioGroup`, and related types:

* MudPopover
* MudPopoverBase
* MudPopoverProvider
* MudProgressCircular
* MudProgressLinear
* MudRadio
* MudRadioGroup
* OverflowBehavior Enum

There's also a small change to `MudBreadcrumbs` to use the `<see cref />` tag for icons to make sure they display properly in the docs.

## How Has This Been Tested?

This was tested by observing the documentation tooltips for modified MudBlazor components:

#### MudPopover

![image](https://github.com/user-attachments/assets/a49dd2af-bbde-4898-b0c9-b5eb31ee699c)
![image](https://github.com/user-attachments/assets/c009b208-35b8-4438-a047-1fd77aebfe7d)
![image](https://github.com/user-attachments/assets/375d5810-e327-4214-aa5b-4b9c16b254ff)

#### MudPopoverProvider

![image](https://github.com/user-attachments/assets/ae282b2b-9694-4305-8bae-4d792f39c2ce)

#### OverflowBehavior

![image](https://github.com/user-attachments/assets/f558edff-f685-4d16-b50a-809a0502d916)

#### MudProgressCircular

![image](https://github.com/user-attachments/assets/ea6b3f8a-e8cb-4508-a2e9-d9ab0284f535)
![image](https://github.com/user-attachments/assets/1ad3b030-51b7-4ade-9155-e5f842fcb4c0)
![image](https://github.com/user-attachments/assets/6a26e237-f39f-4119-9e40-753b09447f4d)

#### MudProgressLinear

![image](https://github.com/user-attachments/assets/880c289e-fb41-496e-82f2-9243bcd7c15f)
![image](https://github.com/user-attachments/assets/149cfa3c-971b-45a8-a0d4-17e316854777)

#### MudRadio

![image](https://github.com/user-attachments/assets/c70805bf-35be-47ba-b2a7-16ebcb0c9475)
![image](https://github.com/user-attachments/assets/223d92b1-bd22-47cf-bf20-98c94e73633e)

#### MudRadioGroup

![image](https://github.com/user-attachments/assets/be6ad1be-3fe2-4b1c-9342-62771b3fc8a0)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
