### PR TITLE
Tests: Fix CS1998 and remove the pragma for this rule

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) mudblazor 2021
 // License MIT
 
-#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
 using System.Reflection;
@@ -25,12 +24,12 @@ namespace MudBlazor.UnitTests.Components
         /// Initial value should be shown and popup should not open.
         /// </summary>
         [Test]
-        public async Task AutocompleteTest1()
+        public void AutocompleteTest1()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
             //No popover-open, due it's closed
             comp.Markup.Should().NotContain("mud-popover-open");
 
@@ -39,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("Alabama");
 
             // now let's type a different state to see the popup open
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<string>>().ToArray();
@@ -58,7 +57,7 @@ namespace MudBlazor.UnitTests.Components
         /// Popup should open when 3 characters are typed and close when below.
         /// </summary>
         [Test]
-        public async Task AutocompleteTest2()
+        public void AutocompleteTest2()
         {
             var comp = Context.RenderComponent<AutocompleteTest2>();
             // select elements needed for the test
@@ -139,16 +138,16 @@ namespace MudBlazor.UnitTests.Components
         public async Task AutocompleteCoercionTest()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.DebounceInterval, 0);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S.
+            autocompleteComponent.SetParam(a => a.Text, "Austria"); // not part of the U.S.
             // Open must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
-            autocompletecomp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
+            autocompleteComponent.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             autocomplete.Value.Should().Be("Alabama");
@@ -163,15 +162,15 @@ namespace MudBlazor.UnitTests.Components
         public async Task AutocompleteCoerceValueTest()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
-            autocompletecomp.SetParam(x => x.CoerceValue, true); // if CoerceValue==true CoerceText will be ignored
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.DebounceInterval, 0);
+            autocompleteComponent.SetParam(x => x.CoerceValue, true); // if CoerceValue==true CoerceText will be ignored
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            autocompletecomp.SetParam(p => p.Text, "Austria"); // not part of the U.S.
+            autocompleteComponent.SetParam(p => p.Text, "Austria"); // not part of the U.S.
 
             // now trigger the coercion by toggling the the menu (it won't even open for invalid values, but it will coerce)
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
@@ -183,27 +182,27 @@ namespace MudBlazor.UnitTests.Components
         /// Test to cover issue #5993.
         /// </summary>
         [Test]
-        public async Task AutocompleteImmediateCoerceValueTest()
+        public void AutocompleteImmediateCoerceValueTest()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
-            autocompletecomp.SetParam(x => x.CoerceValue, true);
-            autocompletecomp.SetParam(x => x.CoerceText, false);
-            autocompletecomp.SetParam(x => x.Immediate, true);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.DebounceInterval, 0);
+            autocompleteComponent.SetParam(x => x.CoerceValue, true);
+            autocompleteComponent.SetParam(x => x.CoerceText, false);
+            autocompleteComponent.SetParam(x => x.Immediate, true);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            autocompletecomp.SetParam(p => p.Text, "Austria"); // not part of the U.S.
+            autocompleteComponent.SetParam(p => p.Text, "Austria"); // not part of the U.S.
 
             comp.WaitForAssertion(() => autocomplete.Value.Should().Be("Austria"));
             autocomplete.Text.Should().Be("Austria");
         }
 
         [Test]
-        public async Task CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
+        public void CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
         {
             // Arrange
 
@@ -241,7 +240,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
+        public void NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnBlur()
         {
             // Arrange
 
@@ -279,7 +278,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnEnter()
+        public void CoerceValueAndNotCoerceTextAndNotImmediate_ValueSetOnEnter()
         {
             // Arrange
 
@@ -290,7 +289,6 @@ namespace MudBlazor.UnitTests.Components
                 parameters.Add(a => a.Immediate, false);
                 parameters.Add(a => a.DebounceInterval, 0);
             });
-            var ccc = comp.FindComponent<MudInput<string>>();
 
             // Assert : Initial
 
@@ -317,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueNotSetOnEnter()
+        public void NotCoerceValueAndNotCoerceTextAndNotImmediate_ValueNotSetOnEnter()
         {
             // Arrange
 
@@ -328,7 +326,6 @@ namespace MudBlazor.UnitTests.Components
                 parameters.Add(a => a.Immediate, false);
                 parameters.Add(a => a.DebounceInterval, 0);
             });
-            var ccc = comp.FindComponent<MudInput<string>>();
 
             // Assert : Initial
 
@@ -358,15 +355,15 @@ namespace MudBlazor.UnitTests.Components
         public async Task AutocompleteCoercionOffTest()
         {
             var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.CoerceText, false);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.CoerceText, false);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
-            autocompletecomp.SetParam(a => a.Text, "Austria");
+            autocompleteComponent.SetParam(a => a.Text, "Austria");
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             autocomplete.Value.Should().Be("Alabama");
@@ -374,58 +371,57 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task AutocompleteTextCoercionOnTabKeyTest()
+        public void AutocompleteTextCoercionOnTabKeyTest()
         {
             var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.CoerceText, true);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.CoerceText, true);
 
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
 
             // set a value the search won't find
-            autocompletecomp.SetParam(a => a.Text, "Austria");
+            autocompleteComponent.SetParam(a => a.Text, "Austria");
             autocomplete.Text.Should().Be("Austria");
 
             // now trigger the coercion by call MudInput.BlurAsync
-            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
         }
 
         [Test]
-        public async Task AutocompleteTextCoercionAndResetIfEmptyTextTest()
+        public void AutocompleteTextCoercionAndResetIfEmptyTextTest()
         {
             var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-            autocompletecomp.SetParam(x => x.CoerceText, true);
-            autocompletecomp.SetParam(x => x.ResetValueOnEmptyText, true);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            autocompleteComponent.SetParam(x => x.CoerceText, true);
+            autocompleteComponent.SetParam(x => x.ResetValueOnEmptyText, true);
 
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
 
             // set a value the search won't find
-            autocompletecomp.SetParam(a => a.Text, "");
+            autocompleteComponent.SetParam(a => a.Text, "");
             autocomplete.Text.Should().Be(null);
 
             // now trigger the coercion by call MudInput.BlurAsync
-            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be(expected: null);
         }
 
-
         [Test]
-        public async Task Autocomplete_Should_TolerateNullFromSearchFunc()
+        public void Autocomplete_Should_TolerateNullFromSearchFunc()
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.DebounceInterval, 0);
-                a.Add(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>(async (s, token) => null)); // <--- searchfunc returns null instead of sequence
+                a.Add(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, token) => Task.FromResult<IEnumerable<string>>(null))); // <--- searchfunc returns null instead of sequence
             });
             // enter a text so the search func will return null, and it shouldn't throw an exception
             comp.SetParam(a => a.Text, "Do not throw");
@@ -434,7 +430,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_ReadOnly_Should_Not_Open()
+        public void Autocomplete_ReadOnly_Should_Not_Open()
         {
             var comp = Context.RenderComponent<AutocompleteTest5>();
             comp.FindAll(".mud-input-adornment-icon-button")[0].Click();
@@ -442,7 +438,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task AutocompleteReadOnlyShouldNotHaveClearButton()
+        public void AutocompleteReadOnlyShouldNotHaveClearButton()
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>(p => p
                 .Add(x => x.Text, "some value")
@@ -459,7 +455,7 @@ namespace MudBlazor.UnitTests.Components
         /// MoreItemsTemplate should render when there are more items than the MaxItems limit
         /// </summary>
         [Test]
-        public async Task AutocompleteTest6()
+        public void AutocompleteTest6()
         {
             var comp = Context.RenderComponent<AutocompleteTest6>();
 
@@ -467,7 +463,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
+            mudText[^1].InnerHtml.Should().Contain("Not all items are shown"); //ensure the text is shown
 
             comp.FindAll("div.mud-popover .mud-autocomplete-more-items").Count.Should().Be(1);
         }
@@ -476,7 +472,7 @@ namespace MudBlazor.UnitTests.Components
         /// NoItemsTemplate should render when there are no items
         /// </summary>
         [Test]
-        public async Task AutocompleteTest7()
+        public void AutocompleteTest7()
         {
             var comp = Context.RenderComponent<AutocompleteTest7>();
 
@@ -484,7 +480,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("No items found, try another search"); //ensure the text is shown
+            mudText[^1].InnerHtml.Should().Contain("No items found, try another search"); //ensure the text is shown
 
             comp.FindAll("div.mud-popover .mud-autocomplete-no-items").Count.Should().Be(1);
         }
@@ -497,20 +493,19 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             //insert "Calif"
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             await Task.Delay(100);
-            var args = new KeyboardEventArgs();
-            args.Key = "Enter";
+            var args = new KeyboardEventArgs { Key = "Enter" };
 
             //press Enter key
-            autocompletecomp.Find("input").KeyUp(args);
+            autocompleteComponent.Find("input").KeyUp(args);
 
             //The value of the input should be California
-            comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("California"));
+            comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("California"));
 
             //and the autocomplete it's closed
             autocomplete.Open.Should().BeFalse();
@@ -526,15 +521,15 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<AutocompleteSetParametersInitialization>();
             // select elements needed for the test
             await Task.Delay(100);
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<ExternalList>>();
-            autocompletecomp.Find("input").GetAttribute("value").Should().Be("One");
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<ExternalList>>();
+            autocompleteComponent.Find("input").GetAttribute("value").Should().Be("One");
         }
 
         /// <summary>
         /// Test for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/1415"/>
         /// </summary>
         [Test]
-        public async Task Autocomplete_OnBlurShouldBeCalled()
+        public void Autocomplete_OnBlurShouldBeCalled()
         {
             var calls = 0;
             Action<FocusEventArgs> fn = (args) => calls++;
@@ -550,7 +545,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task AutoCompleteClearableTest()
+        public void AutoCompleteClearableTest()
         {
             var comp = Context.RenderComponent<AutocompleteTestClearable>();
 
@@ -576,8 +571,8 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_Validate_Data_Attribute_Fail()
         {
             var comp = Context.RenderComponent<AutocompleteValidationDataAttrTest>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
             await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
             // Set invalid option
             await comp.InvokeAsync(() => autocomplete.SelectOptionAsync("Quux"));
@@ -595,8 +590,8 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_Validate_Data_Attribute_Success()
         {
             var comp = Context.RenderComponent<AutocompleteValidationDataAttrTest>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
             await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
             // Set valid option
             await comp.InvokeAsync(() => autocomplete.SelectOptionAsync("Qux"));
@@ -629,22 +624,22 @@ namespace MudBlazor.UnitTests.Components
         /// Test for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/1761"/>
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_Close_OnTab()
+        public void Autocomplete_Should_Close_OnTab()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             // Should be closed
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-            // Lets type something to cause it to open
-            autocompletecomp.Find("input").Input("Calif");
+            // Let's type something to cause it to open
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-            // Lets call blur on the input and confirm that it closed
-            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            // Let's call blur on the input and confirm that it closed
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and does not select the selected value (California)
@@ -653,23 +648,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_SelectValue_On_Tab_With_SelectValueOnTab()
+        public void Autocomplete_Should_SelectValue_On_Tab_With_SelectValueOnTab()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.SelectValueOnTab, true);
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComponent.SetParam(x => x.SelectValueOnTab, true);
+            var autocomplete = autocompleteComponent.Instance;
 
             // Should be closed
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Lets type something to cause it to open
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
-            autocompletecomp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and selects the selected value (California)
@@ -688,12 +683,12 @@ namespace MudBlazor.UnitTests.Components
         /// </para>
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_NotCloseDropdownOnInputBlur()
+        public void Autocomplete_Should_NotCloseDropdownOnInputBlur()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             //No popover-open, due it's closed
             comp.Markup.Should().NotContain("mud-popover-open");
@@ -703,14 +698,14 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("Alabama");
 
             // now let's type a different state to see the popup open
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<string>>().ToArray();
             items.Length.Should().Be(1);
             items.First().Markup.Should().Contain("California");
 
             // now, we blur the input and assert that the popover is still open.
-            autocompletecomp.Find("input").Blur();
+            autocompleteComponent.Find("input").Blur();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
         }
 
@@ -722,9 +717,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.CoerceValue, true);
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComponent.SetParam(x => x.CoerceValue, true);
+            var autocomplete = autocompleteComponent.Instance;
 
             //No popover-open, due it's closed
             comp.Markup.Should().NotContain("mud-popover-open");
@@ -741,7 +736,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("");
 
             // now let's type a different state
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<string>>().ToArray();
             items.Length.Should().Be(1);
@@ -758,7 +753,7 @@ namespace MudBlazor.UnitTests.Components
         /// When calling Clear(), menu should closed, Value and Text should be cleared.
         /// </summary>
         [Test]
-        public async Task Autocomplete_CheckTextValueCleared_OnClear()
+        public void Autocomplete_CheckTextValueCleared_OnClear()
         {
             // define some constant values
             var alaskaString = "Alaska";
@@ -800,9 +795,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             // select elements needed for the test
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.CoerceValue, true);
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComponent.SetParam(x => x.CoerceValue, true);
+            var autocomplete = autocompleteComponent.Instance;
 
             //No popover-open, due it's closed
             comp.Markup.Should().NotContain("mud-popover-open");
@@ -819,13 +814,13 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Text.Should().Be("");
 
             // now let's type a different state
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<string>>().ToArray();
             items.Length.Should().Be(1);
             items.First().Markup.Should().Contain("California");
 
-            // Reseting it should close popover and set Text and Value to null again
+            // Resetting it should close popover and set Text and Value to null again
             await comp.InvokeAsync(autocomplete.ResetAsync);
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             autocomplete.Value.Should().Be(null);
@@ -863,8 +858,8 @@ namespace MudBlazor.UnitTests.Components
             {
                 parameters.Add(a => a.DebounceInterval, 0);
             });
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             // Assert : initial state, menu closed and text/value null
 
@@ -904,8 +899,8 @@ namespace MudBlazor.UnitTests.Components
                 parameters.Add(a => a.CoerceValue, coerceValue);
                 parameters.Add(a => a.Immediate, immediate);
             });
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             // Assert : initial state, menu closed and text/value null
 
@@ -1004,110 +999,110 @@ namespace MudBlazor.UnitTests.Components
             await ImproveChanceOfSuccess(async () =>
             {
                 var comp = Context.RenderComponent<AutocompleteChangeBoundObjectTest>();
-                var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-                var autocomplete = autocompletecomp.Instance;
-                autocompletecomp.SetParametersAndRender(parameters => parameters.Add(p => p.DebounceInterval, 0));
-                autocompletecomp.SetParametersAndRender(parameters => parameters.Add(p => p.CoerceText, true));
+                var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+                var autocomplete = autocompleteComponent.Instance;
+                autocompleteComponent.SetParametersAndRender(parameters => parameters.Add(p => p.DebounceInterval, 0));
+                autocompleteComponent.SetParametersAndRender(parameters => parameters.Add(p => p.CoerceText, true));
                 // this needs to be false because in the unit test the autocomplete's input does not lose focus state on click of another button.
                 // TextUpdateSuppression is used to avoid binding to change the input text while typing.
-                autocompletecomp.SetParametersAndRender(parameters => parameters.Add(p => p.TextUpdateSuppression, false));
+                autocompleteComponent.SetParametersAndRender(parameters => parameters.Add(p => p.TextUpdateSuppression, false));
                 // check initial state
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Florida"));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Florida"));
                 autocomplete.Value.Should().Be("Florida");
                 autocomplete.Text.Should().Be("Florida");
 
                 //Get the button to toggle the value
                 comp.Find(".toggle-value-button").Click();
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Georgia"));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Georgia"));
                 autocomplete.Value.Should().Be("Georgia");
                 autocomplete.Text.Should().Be("Georgia");
 
                 //Change the value of the current bound value component
                 //insert "Alabam"
-                autocompletecomp.Find("input").Input("Alabam");
+                autocompleteComponent.Find("input").Input("Alabam");
                 await Task.Delay(100);
 
                 //press Enter key
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 //ensure autocomplete is closed and new value is committed/bound
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "NumpadEnter" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "NumpadEnter" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown" }));
 
                 //The value of the input should be Alabama
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Alabama"));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
                 autocomplete.Value.Should().Be("Alabama");
                 autocomplete.Text.Should().Be("Alabama");
 
                 //Again Change the bound object
                 comp.Find(".toggle-value-button").Click();
 
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Florida"));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Florida"));
                 autocomplete.Value.Should().Be("Florida");
                 autocomplete.Text.Should().Be("Florida");
 
                 //Change the bound object back and check again.
                 comp.Find(".toggle-value-button").Click();
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Alabama"));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
                 autocomplete.Value.Should().Be("Alabama");
                 autocomplete.Text.Should().Be("Alabama");
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Alabama"));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Tab" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Tab" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
 
-                autocompletecomp.SetParam("SelectValueOnTab", true);
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
-                comp.WaitForAssertion(() => autocompletecomp.Find("input").GetAttribute("value").Should().Be("Alabama"));
+                autocompleteComponent.SetParam("SelectValueOnTab", true);
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
+                comp.WaitForAssertion(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true }));
-                comp.WaitForAssertion(() => autocompletecomp.Instance.Value.Should().Be(null));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true }));
+                comp.WaitForAssertion(() => autocompleteComponent.Instance.Value.Should().Be(null));
 
-                await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
+                await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
                 //Check popover is closed if coerce text is true (it fixed with a PR)
                 autocomplete.CoerceText = true;
-                await comp.InvokeAsync(() => autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+                await comp.InvokeAsync(() => autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());
-                await autocompletecomp.Find("input").InputAsync(new ChangeEventArgs() { Value = "abc" });
+                await autocompleteComponent.Find("input").InputAsync(new ChangeEventArgs() { Value = "abc" });
                 await comp.InvokeAsync(async () => await autocomplete.SelectAsync());
                 await comp.InvokeAsync(async () => await autocomplete.SelectRangeAsync(0, 1));
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
-                await autocompletecomp.Find("input").InputAsync(new ChangeEventArgs() { Value = "" });
+                await autocompleteComponent.Find("input").InputAsync(new ChangeEventArgs() { Value = "" });
                 comp.WaitForAssertion(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());
@@ -1116,7 +1111,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_Support_Sync_Search()
+        public void Autocomplete_Should_Support_Sync_Search()
         {
             var root = Context.RenderComponent<AutocompleteSyncTest>();
 
@@ -1143,14 +1138,11 @@ namespace MudBlazor.UnitTests.Components
         /// This test a bugfix where changing the icon property would not cause the icon to visually change until the autocomplete was opened or closed
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_ChangeAdornmentIcon()
+        public void Autocomplete_Should_ChangeAdornmentIcon()
         {
             var icon = Parameter(nameof(AutocompleteAdornmentChange.Icon), Icons.Material.Filled.Abc);
             var comp = Context.RenderComponent<AutocompleteAdornmentChange>(icon);
             var instance = comp.Instance;
-
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
 
             var markupBefore = comp.Find("svg.mud-icon-root").Children.ToMarkup().Trim();
 
@@ -1165,14 +1157,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_NotIndicateLoadingByDefault()
+        public void Autocomplete_Should_NotIndicateLoadingByDefault()
         {
             // Arrange
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
 
             // Test
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
@@ -1180,21 +1172,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicator()
+        public void Autocomplete_Should_IndicateLoadingWithCircularProgressIndicator()
         {
             // TODO: use a TaskCompletionSource that allows control over the search task
             // for reliable testing.  Applies to other tests like this one.
-            // Currently we increase the load time to 50mms to catch the progress UI
+            // Currently, we increase the load time to 50mms to catch the progress UI
 
             // Arrange
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.ShowProgressIndicator, true);
-            autocompletecomp.SetParam(x => x.Adornment, null);
-            autocompletecomp.SetParam(x => x.Adornment, null);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComponent.SetParam(x => x.ShowProgressIndicator, true);
+            autocompleteComponent.SetParam(x => x.Adornment, null);
+            autocompleteComponent.SetParam(x => x.Adornment, null);
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
 
             // Test show
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
@@ -1207,17 +1199,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicatorAndAdornmentAdjustment()
+        public void Autocomplete_Should_IndicateLoadingWithCircularProgressIndicatorAndAdornmentAdjustment()
         {
             // Arrange
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            autocompletecomp.SetParam(x => x.ShowProgressIndicator, true);
-            autocompletecomp.SetParam(x => x.AdornmentIcon, Icons.Material.Filled.Info);
-            autocompletecomp.SetParam(x => x.Adornment, Adornment.End);
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            autocompleteComponent.SetParam(x => x.ShowProgressIndicator, true);
+            autocompleteComponent.SetParam(x => x.AdornmentIcon, Icons.Material.Filled.Info);
+            autocompleteComponent.SetParam(x => x.Adornment, Adornment.End);
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
 
             // Test show
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
@@ -1232,7 +1224,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_IndicateLoadingWithCustomProgressIndicator()
+        public void Autocomplete_Should_IndicateLoadingWithCustomProgressIndicator()
         {
             // Arrange
             RenderFragment fragment = builder =>
@@ -1259,7 +1251,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_IndicateLoadingWithProgressIndicatorInsidePopover()
+        public void Autocomplete_Should_IndicateLoadingWithProgressIndicatorInsidePopover()
         {
             // Arrange
             RenderFragment fragment = builder =>
@@ -1268,13 +1260,13 @@ namespace MudBlazor.UnitTests.Components
             };
 
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
-            autocompletecomp.SetParam(x => x.ShowProgressIndicator, true);
-            autocompletecomp.SetParam(p => p.ProgressIndicatorInPopoverTemplate, fragment);
+            autocompleteComponent.SetParam(x => x.ShowProgressIndicator, true);
+            autocompleteComponent.SetParam(p => p.ProgressIndicatorInPopoverTemplate, fragment);
 
             comp.Markup.Should().NotContain("Loading...");
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
 
             // Test show
             comp.WaitForAssertion(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
@@ -1289,7 +1281,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_Cancel_Search()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             // Arrange first call
 
@@ -1297,7 +1289,7 @@ namespace MudBlazor.UnitTests.Components
 
             var first = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompleteComponent.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 cancelToken = cancellationToken;
                 // Return task that never completes.
@@ -1316,7 +1308,7 @@ namespace MudBlazor.UnitTests.Components
 
             var second = new TaskCompletionSource<IEnumerable<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
+            autocompleteComponent.SetParam(p => p.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, cancellationToken) =>
             {
                 return second.Task;
             }));
@@ -1337,7 +1329,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_FullWidth()
+        public void Autocomplete_FullWidth()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
             var autocompleteComp = comp.FindComponent<MudAutocomplete<string>>();
@@ -1352,25 +1344,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_HaveValueWithTextChangedEvent()
+        public void Autocomplete_Should_HaveValueWithTextChangedEvent()
         {
             // Arrange
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             const string testText = "testText";
             string eventText = null;
-            autocompletecomp.Instance.TextChanged = new EventCallbackFactory().Create<string>(this, v =>
+            autocompleteComponent.Instance.TextChanged = new EventCallbackFactory().Create<string>(this, v =>
             {
                 eventText = v;
             });
 
             // Act
             // enter a text so the TextChanged event will fire
-            autocompletecomp.SetParam(a => a.Text, testText);
+            autocompleteComponent.SetParam(a => a.Text, testText);
 
             // Assert
-            autocompletecomp.WaitForAssertion(() => eventText.Should().Be(testText));
+            autocompleteComponent.WaitForAssertion(() => eventText.Should().Be(testText));
         }
 
         [Test]
@@ -1384,18 +1376,18 @@ namespace MudBlazor.UnitTests.Components
             var virginiaString = "Virginia";
 
             var comp = Context.RenderComponent<AutocompleteStrictFalseTest>();
-            var autocompletecomp = comp.FindComponents<MudAutocomplete<AutocompleteStrictFalseTest.State>>()[index];
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponents<MudAutocomplete<AutocompleteStrictFalseTest.State>>()[index];
+            var autocomplete = autocompleteComponent.Instance;
 
             //search for and select California
-            autocompletecomp.Find("input").Input("Calif");
+            autocompleteComponent.Find("input").Input("Calif");
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
-            await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+            await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.Text.Should().Be(californiaString);
             autocomplete.Value.StateName.Should().Be(californiaString);
 
             //California should appear as index 5 and be selected
-            await comp.InvokeAsync(autocompletecomp.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
+            await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<AutocompleteStrictFalseTest.State>>().ToArray();
             items.Length.Should().Be(10);
@@ -1403,17 +1395,17 @@ namespace MudBlazor.UnitTests.Components
             items.ToList().IndexOf(item).Should().Be(5);
             comp.WaitForAssertion(() => items.Single(s => s.Markup.Contains(californiaString)).Find(listItemQuerySelector).ClassList.Should().Contain(selectedItemClassName));
 
-            await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" })); // Close autocomplete.
+            await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" })); // Close autocomplete.
 
             //search for and select Virginia
-            autocompletecomp.Find("input").Input("Virginia");
+            autocompleteComponent.Find("input").Input("Virginia");
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
-            await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+            await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.Text.Should().Be(virginiaString);
             autocomplete.Value.StateName.Should().Be(virginiaString);
 
             //West Virginia is not in the first 10 states, so it should not appear in the list
-            await comp.InvokeAsync(autocompletecomp.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
+            await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
             var items2 = comp.FindComponents<MudListItem<AutocompleteStrictFalseTest.State>>().ToArray();
             items2.Length.Should().Be(10);
@@ -1426,9 +1418,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_Not_Throw_When_SearchFunc_Is_Null()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
-            autocompletecomp.SetParam(p => p.SearchFunc, null);
+            autocompleteComponent.SetParam(p => p.SearchFunc, null);
 
             comp.Find("input").Input("Foo");
 
@@ -1438,11 +1430,11 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_Raise_KeyDown_KeyUp_Event()
+        public void Autocomplete_Should_Raise_KeyDown_KeyUp_Event()
         {
             //Create comp
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var result = new List<string>();
             //create eventCallback
             var customEvent = new EventCallbackFactory().Create<KeyboardEventArgs>("A", () => result.Add("keyevent thrown"));
@@ -1450,13 +1442,13 @@ namespace MudBlazor.UnitTests.Components
             //set eventCallback
             //SetCallback also possible
             //autocompletecomp.SetCallback(p => p.OnKeyDown, (KeyboardEventArgs e ) => result.Add("keyevent thrown"));
-            autocompletecomp.SetParam(p => p.OnKeyDown, customEvent);
-            autocompletecomp.SetParam(p => p.OnKeyUp, customEvent);
+            autocompleteComponent.SetParam(p => p.OnKeyDown, customEvent);
+            autocompleteComponent.SetParam(p => p.OnKeyUp, customEvent);
 
             result.Should().BeEmpty();
             //Act
-            autocompletecomp.Find("input").KeyDown("a");
-            autocompletecomp.Find("input").KeyUp("a");
+            autocompleteComponent.Find("input").KeyDown("a");
+            autocompleteComponent.Find("input").KeyUp("a");
             //Assert
             result.Count.Should().Be(2);
         }
@@ -1475,18 +1467,18 @@ namespace MudBlazor.UnitTests.Components
             var disabledItemString = "carrot";
 
             var comp = Context.RenderComponent<AutocompleteStrictFalseSelectedHighlight>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             // Select the peach list item
-            autocompletecomp.Find("input").Input(selectedItemString);
+            autocompleteComponent.Find("input").Input(selectedItemString);
             comp.WaitForAssertion(() => comp.Find(popoverSelector).ClassList.Should().Contain("mud-popover-open"));
-            await comp.InvokeAsync(async () => await autocompletecomp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
+            await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.Text.Should().Be(selectedItemString);
             autocomplete.Value.Should().Be(selectedItemString);
 
             // Opening the list of autocomplete
-            await comp.InvokeAsync(autocompletecomp.Instance.OpenMenuAsync);
+            await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync);
             comp.WaitForAssertion(() => comp.Find(popoverSelector).ClassList.Should().Contain("mud-popover-open"));
             var listItems = comp.FindComponents<MudListItem<string>>().ToArray();
 
@@ -1503,7 +1495,7 @@ namespace MudBlazor.UnitTests.Components
         /// https://github.com/MudBlazor/MudBlazor/issues/6475
         /// </summary>
         [Test]
-        public async Task Autocomplete_Reset_Value_ShouldBe_Empty()
+        public void Autocomplete_Reset_Value_ShouldBe_Empty()
         {
             var component = Context.RenderComponent<AutocompleteResetTest>();
             var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
@@ -1529,7 +1521,7 @@ namespace MudBlazor.UnitTests.Components
         /// BeforeItemsTemplate should render when there are items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_LoadListStartWhenSetAndThereAreItems()
+        public void Autocomplete_Should_LoadListStartWhenSetAndThereAreItems()
         {
             var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
 
@@ -1546,7 +1538,7 @@ namespace MudBlazor.UnitTests.Components
         /// AfterItemsTemplate should render when there are items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_LoadListEndWhenSetAndThereAreItems()
+        public void Autocomplete_Should_LoadListEndWhenSetAndThereAreItems()
         {
             var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
 
@@ -1554,7 +1546,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             var mudText = comp.FindAll("p.mud-typography");
-            mudText[mudText.Count - 1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
+            mudText[^1].InnerHtml.Should().Contain("EndList_Content"); //ensure the text is shown
 
             comp.FindAll("div.mud-popover .mud-autocomplete-after-items").Count.Should().Be(1);
         }
@@ -1563,7 +1555,7 @@ namespace MudBlazor.UnitTests.Components
         /// BeforeItemsTemplate should not render when there are no items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_Not_LoadListStartWhenSet()
+        public void Autocomplete_Should_Not_LoadListStartWhenSet()
         {
             var comp = Context.RenderComponent<AutocompleteListStartRendersTest>();
 
@@ -1577,7 +1569,7 @@ namespace MudBlazor.UnitTests.Components
         /// AfterItemsTemplate should not render when there are no items
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_Not_LoadListEndWhenSet()
+        public void Autocomplete_Should_Not_LoadListEndWhenSet()
         {
             var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
 
@@ -1588,13 +1580,13 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_ApplyListItemClass()
+        public void Autocomplete_Should_ApplyListItemClass()
         {
             var comp = Context.RenderComponent<AutocompleteTest1>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var listItemClassTest = "list-item-class-test";
 
-            autocompletecomp.SetParam(a => a.ListItemClass, listItemClassTest);
+            autocompleteComponent.SetParam(a => a.ListItemClass, listItemClassTest);
             comp.Find("div.mud-input-control input").Focus();
 
             comp.WaitForAssertion(() => comp.Find("div.mud-list-item").ClassList.Should().Contain(listItemClassTest));
@@ -1603,7 +1595,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Autocomplete_Should_OpenMenuOnFocus(bool openOnFocus)
+        public void Autocomplete_Should_OpenMenuOnFocus(bool openOnFocus)
         {
             var comp = Context.RenderComponent<AutocompleteFocusTest>();
             comp.SetParam(a => a.OpenOnFocus, openOnFocus);
@@ -1623,7 +1615,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick()
+        public void Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick()
         {
             var comp = Context.RenderComponent<AutocompleteFocusTest>();
             comp.SetParam(a => a.OpenOnFocus, false);
@@ -1638,9 +1630,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Autocomplete_ReturnedItemsCount_Should_Be_Accurate()
+        public void Autocomplete_ReturnedItemsCount_Should_Be_Accurate()
         {
-            Task<IEnumerable<string>> search(string value, CancellationToken token)
+            Task<IEnumerable<string>> Search(string value, CancellationToken token)
             {
                 var values = new string[] { "Lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit" };
                 return Task.FromResult(values.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
@@ -1649,7 +1641,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudAutocomplete<string>>();
             comp.SetParametersAndRender(p => p
                 .Add(x => x.Value, "nothing will ever match this")
-                .Add(x => x.SearchFunc, search)
+                .Add(x => x.SearchFunc, Search)
                 .Add(x => x.DebounceInterval, 0));
 
             int? count = null;
@@ -1657,10 +1649,10 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Input("Lorem");
             comp.WaitForAssertion(() => count.Should().Be(1));
-            ;
+            
             comp.Find("input").Input("ip");
             comp.WaitForAssertion(() => count.Should().Be(2));
-            ;
+            
             comp.Find("input").Input("wtf");
             comp.WaitForAssertion(() => count.Should().Be(0));
         }
@@ -1769,11 +1761,10 @@ namespace MudBlazor.UnitTests.Components
         public void AutocompleteItemTemplateDisplayTest()
         {
             var comp = Context.RenderComponent<AutocompleteItemTemplateDisplayTest>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             // Search for a to get Alabama, Alaska, American Samoa,...
-            autocompletecomp.Find("input").Input("a");
+            autocompleteComponent.Find("input").Input("a");
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // Any state with 'l' is disabled: ItemDisabledFunc="@((string state) => (state.Contains('l')))"
@@ -1873,6 +1864,7 @@ namespace MudBlazor.UnitTests.Components
         }
 #nullable disable
 
+        [Test]
         public void Autocomplete_Attribute_Should_Exist()
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>();
@@ -1880,6 +1872,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("off");
         }
 
+        [Test]
         public void Should_Override_Autocomplete_Attribute_With_UserAttributes()
         {
             var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
@@ -1900,12 +1893,12 @@ namespace MudBlazor.UnitTests.Components
             // Arrange
 
             var comp = Context.RenderComponent<AutocompleteResetValueOnEmptyText>();
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
 
             // Act
 
-            autocompletecomp.Find("input").Input("");
+            autocompleteComponent.Find("input").Input("");
 
             // Assert
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1649,10 +1649,10 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Input("Lorem");
             comp.WaitForAssertion(() => count.Should().Be(1));
-            
+
             comp.Find("input").Input("ip");
             comp.WaitForAssertion(() => count.Should().Be(2));
-            
+
             comp.Find("input").Input("wtf");
             comp.WaitForAssertion(() => count.Should().Be(0));
         }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -421,12 +421,16 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.DebounceInterval, 0);
-                a.Add(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, token) => Task.FromResult<IEnumerable<string>>(null))); // <--- searchfunc returns null instead of sequence
+                a.Add(x => x.SearchFunc, (_, _) => Task.FromResult<IEnumerable<string>>(null)); // <--- searchfunc returns null instead of sequence
             });
             // enter a text so the search func will return null, and it shouldn't throw an exception
-            comp.SetParam(a => a.Text, "Do not throw");
-            comp.SetParam(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((s, token) => null)); // <-- search func returns null instead of task!
-            comp.SetParam(a => a.Text, "Don't throw here neither");
+            var setText1 = () => comp.SetParam(a => a.Text, "Do not throw");
+            var setSearchFunc = () => comp.SetParam(x => x.SearchFunc, new Func<string, CancellationToken, Task<IEnumerable<string>>>((_, _) => null)); // <-- search func returns null instead of task!
+            var setText2 = () => comp.SetParam(a => a.Text, "Don't throw here neither");
+
+            setText1.Should().NotThrow();
+            setSearchFunc.Should().NotThrow();
+            setText2.Should().NotThrow();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/BunitTest.cs
+++ b/src/MudBlazor.UnitTests/Components/BunitTest.cs
@@ -61,5 +61,19 @@ namespace MudBlazor.UnitTests.Components
             }
             await testAction();
         }
+
+        protected void ImproveChanceOfSuccess(Action testAction)
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                try
+                {
+                    testAction();
+                    return;
+                }
+                catch (Exception) { /*we don't care here*/ }
+            }
+            testAction();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1,17 +1,11 @@
-﻿#pragma warning disable CS1998 // async without await
-#pragma warning disable IDE1006 // leading underscore
+﻿#pragma warning disable IDE1006 // leading underscore
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.ColorPicker;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -147,7 +141,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Default()
+        public void Default()
         {
             var comp = Context.RenderComponent<MudColorPicker>();
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
 using System.Globalization;
@@ -419,7 +418,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_SetParameters_ServerData_Items_Throw()
+        public void DataGrid_SetParameters_ServerData_Items_Throw()
         {
             var serverDataFunc =
                 new Func<GridState<TestModel1>, Task<GridData<TestModel1>>>((x) => throw new NotImplementedException());
@@ -437,7 +436,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_SetParameters_ServerData_QuickFilter_Throw()
+        public void DataGrid_SetParameters_ServerData_QuickFilter_Throw()
         {
             var serverDataFunc =
                 new Func<GridState<TestModel1>, Task<GridData<TestModel1>>>((x) => throw new NotImplementedException());
@@ -451,7 +450,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_SetParameters_VirtualizeServerData_QuickFilter_Throw()
+        public void DataGrid_SetParameters_VirtualizeServerData_QuickFilter_Throw()
         {
             var virtualizeServerDataFunc =
                 new Func<GridStateVirtualize<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
@@ -465,7 +464,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_SetParameters_ServerData_VirtualizeServerData_Throw()
+        public void DataGrid_SetParameters_ServerData_VirtualizeServerData_Throw()
         {
             var serverDataFunc =
                 new Func<GridState<TestModel1>, Task<GridData<TestModel1>>>((x) => throw new NotImplementedException());
@@ -486,7 +485,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_SetParameters_Items_VirtualizeServerData_Throw()
+        public void DataGrid_SetParameters_Items_VirtualizeServerData_Throw()
         {
             var virtualizeServerDataFunc =
                 new Func<GridStateVirtualize<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
@@ -538,7 +537,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridCustomComparerTest()
+        public void DataGridCustomComparerTest()
         {
             var comp = Context.RenderComponent<DataGridSelectionComparerTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionComparerTest.Person>>();
@@ -621,7 +620,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridMultiSelectionTest_Should_Not_Render_Footer_If_ShowInFooter_Is_False()
+        public void DataGridMultiSelectionTest_Should_Not_Render_Footer_If_ShowInFooter_Is_False()
         {
             var comp = Context.RenderComponent<DataGridMultiSelectionTest>(
                 Parameter(nameof(MudBlazor.UnitTests.TestComponents.DataGrid.DataGridMultiSelectionTest.ShowInFooter), false));
@@ -700,7 +699,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridEditableSelectionTest()
+        public void DataGridEditableSelectionTest()
         {
             var comp = Context.RenderComponent<DataGridEditableWithSelectColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditableWithSelectColumnTest.Item>>();
@@ -724,7 +723,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridInlineEditVirtualizeServerDataTest()
+        public void DataGridInlineEditVirtualizeServerDataTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditVirtualizeServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditVirtualizeServerDataTest.Item>>();
@@ -831,7 +830,7 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
-        public async Task DataGridPaginationPageSizeDropDownTest()
+        public void DataGridPaginationPageSizeDropDownTest()
         {
             var comp = Context.RenderComponent<DataGridPaginationTest>(self => self.Add(x => x.PageSizeDropDown, false));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
@@ -870,7 +869,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridPaginationNoItemsTest()
+        public void DataGridPaginationNoItemsTest()
         {
             var comp = Context.RenderComponent<DataGridPaginationNoItemsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationNoItemsTest.Item>>();
@@ -913,7 +912,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridInlineEditTest()
+        public void DataGridInlineEditTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditTest.Model>>();
@@ -936,7 +935,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridInlineEditWithNullableChangeTest()
+        public void DataGridInlineEditWithNullableChangeTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithNullableTest.Model>>();
@@ -951,7 +950,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridInlineEditWithNullableTest()
+        public void DataGridInlineEditWithNullableTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithNullableTest.Model>>();
@@ -974,7 +973,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridInlineEditWithTemplateTest()
+        public void DataGridInlineEditWithTemplateTest()
         {
             var comp = Context.RenderComponent<DataGridCellEditWithTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithTemplateTest.Model>>();
@@ -1004,7 +1003,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridDialogEditTest()
+        public void DataGridDialogEditTest()
         {
             var comp = Context.RenderComponent<DataGridFormEditTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditTest.Model>>();
@@ -1045,7 +1044,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test(Description = "Checks if there is no NRE exception when nested property has a null value somewhere in the middle.")]
-        public async Task DataGridNoNullExceptionWhenNestedPropertyNullValue()
+        public void DataGridNoNullExceptionWhenNestedPropertyNullValue()
         {
             var comp = Context.RenderComponent<DataGridNestedNullPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNestedNullPropertyTest.Model>>();
@@ -1058,7 +1057,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test(Description = "Checks if clone strategy is working, if we used default one it would fail as STJ doesn't support abstract classes without additional configuration.")]
-        public async Task DataGridDialogEditCloneStrategyTest1()
+        public void DataGridDialogEditCloneStrategyTest1()
         {
             var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
@@ -1094,7 +1093,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridDialogEditCloneStrategyTest2()
+        public void DataGridDialogEditCloneStrategyTest2()
         {
             var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>(parameters => parameters
                 .Add(p => p.CloneStrategy, SystemTextJsonDeepCloneStrategy<DataGridFormEditCloneStrategyTest.Movement>.Instance));
@@ -1119,7 +1118,7 @@ namespace MudBlazor.UnitTests.Components
         /// DataGrid edit form should trigger the FormFieldChanged event
         /// </summary>
         [Test]
-        public async Task DataGridFormFieldChangedTest()
+        public void DataGridFormFieldChangedTest()
         {
             var comp = Context.RenderComponent<DataGridFormFieldChangedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormFieldChangedTest.Item>>();
@@ -1135,7 +1134,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridFormValidationErrorsPreventUpdateTest()
+        public void DataGridFormValidationErrorsPreventUpdateTest()
         {
             var comp = Context.RenderComponent<DataGridFormValidationErrorsPreventUpdateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormValidationErrorsPreventUpdateTest.Model>>();
@@ -1166,7 +1165,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridVisualStylingTest()
+        public void DataGridVisualStylingTest()
         {
             var comp = Context.RenderComponent<DataGridVisualStylingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridVisualStylingTest.Item>>();
@@ -1245,7 +1244,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridEditComplexPropertyExpressionTest()
+        public void DataGridEditComplexPropertyExpressionTest()
         {
             var comp = Context.RenderComponent<DataGridEditComplexPropertyExpressionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditComplexPropertyExpressionTest.Item>>();
@@ -1272,7 +1271,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridOnContextMenuClickWhenIsGrouped()
+        public void DataGridOnContextMenuClickWhenIsGrouped()
         {
             var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
@@ -1355,7 +1354,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FilterDefinitionStringTest()
+        public void FilterDefinitionStringTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -1804,7 +1803,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FilterDefinitionBoolTest()
+        public void FilterDefinitionBoolTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -1860,7 +1859,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FilterDefinitionEnumTest()
+        public void FilterDefinitionEnumTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -1949,7 +1948,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FilterDefinitionDateTimeTest()
+        public void FilterDefinitionDateTimeTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -2220,7 +2219,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FilterDefinitionNumberTest()
+        public void FilterDefinitionNumberTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -2463,7 +2462,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridClickFilterButtonTest()
+        public void DataGridClickFilterButtonTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -2666,7 +2665,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridColGroupTest()
+        public void DataGridColGroupTest()
         {
             var comp = Context.RenderComponent<DataGridColGroupTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColGroupTest.Model>>();
@@ -2743,7 +2742,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridHeaderTemplateTest()
+        public void DataGridHeaderTemplateTest()
         {
             var comp = Context.RenderComponent<DataGridHeaderTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHeaderTemplateTest.Model>>();
@@ -2767,7 +2766,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridRowDetailClosedTest()
+        public void DataGridRowDetailClosedTest()
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
@@ -2776,7 +2775,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridRowDetailButtonDisabledTest()
+        public void DataGridRowDetailButtonDisabledTest()
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
@@ -2802,7 +2801,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridRowDetailInitiallyExpandedMultipleTest()
+        public void DataGridRowDetailInitiallyExpandedMultipleTest()
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
@@ -2824,7 +2823,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridChildRowContentTest()
+        public void DataGridChildRowContentTest()
         {
             var comp = Context.RenderComponent<DataGridChildRowContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridChildRowContentTest.Model>>();
@@ -2833,7 +2832,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridLoadingTest()
+        public void DataGridLoadingTest()
         {
             var comp = Context.RenderComponent<DataGridLoadingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridLoadingTest.Model>>();
@@ -2842,7 +2841,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridNoRecordsContentTest()
+        public void DataGridNoRecordsContentTest()
         {
             var comp = Context.RenderComponent<DataGridNoRecordsContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNoRecordsContentTest.Model>>();
@@ -2851,7 +2850,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridFooterTemplateTest()
+        public void DataGridFooterTemplateTest()
         {
             var comp = Context.RenderComponent<DataGridFooterTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFooterTemplateTest.Model>>();
@@ -2908,7 +2907,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridCellTemplateTest()
+        public void DataGridCellTemplateTest()
         {
             var comp = Context.RenderComponent<DataGridCellTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellTemplateTest.Model>>();
@@ -3136,7 +3135,7 @@ namespace MudBlazor.UnitTests.Components
         //}
 
         [Test]
-        public async Task DataGridShowMenuIconTest()
+        public void DataGridShowMenuIconTest()
         {
             var comp = Context.RenderComponent<DataGridShowMenuIconTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridShowMenuIconTest.Item>>();
@@ -3204,7 +3203,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridFilterableFalseTest()
+        public void DataGridFilterableFalseTest()
         {
             var comp = Context.RenderComponent<DataGridFilterableFalseTest>();
 
@@ -3298,7 +3297,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridShowFilterIconTest()
+        public void DataGridShowFilterIconTest()
         {
             var comp = Context.RenderComponent<DataGridCustomFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomFilteringTest.Model>>();
@@ -3388,7 +3387,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridColumnFilterRowPropertyTest()
+        public void DataGridColumnFilterRowPropertyTest()
         {
             var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
 
@@ -3400,7 +3399,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridColumnFilterRowPropertyClearTest()
+        public void DataGridColumnFilterRowPropertyClearTest()
         {
             var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
@@ -3432,7 +3431,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridColumnFilterRowPropertyClearAllTest()
+        public void DataGridColumnFilterRowPropertyClearAllTest()
         {
             var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
@@ -3448,7 +3447,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridStickyColumnsTest()
+        public void DataGridStickyColumnsTest()
         {
             var comp = Context.RenderComponent<DataGridStickyColumnsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsTest.Model>>();
@@ -3458,7 +3457,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridStickyColumnsResizerTest()
+        public void DataGridStickyColumnsResizerTest()
         {
             var comp = Context.RenderComponent<DataGridStickyColumnsResizerTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsResizerTest.Model>>();
@@ -3503,7 +3502,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridAggregationTest()
+        public void DataGridAggregationTest()
         {
             var comp = Context.RenderComponent<DataGridAggregationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridAggregationTest.Model>>();
@@ -3513,7 +3512,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridSequenceContainsNoElementsTest()
+        public void DataGridSequenceContainsNoElementsTest()
         {
             var comp = Context.RenderComponent<DataGridSequenceContainsNoElementsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSequenceContainsNoElementsTest.Model>>();
@@ -3522,7 +3521,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridObservabilityTest()
+        public void DataGridObservabilityTest()
         {
             var comp = Context.RenderComponent<DataGridObservabilityTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridObservabilityTest.Model>>();
@@ -3541,7 +3540,7 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(8);
         }
 
-        public async Task TableFilterGuid()
+        public void TableFilterGuid()
         {
             var comp = Context.RenderComponent<DataGridFilterGuid<Guid>>();
             var grid = comp.Instance.MudGridRef;
@@ -3580,16 +3579,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TableFilterNullableGuid()
+        public void TableFilterNullableGuid()
         {
-            var comp = Context.RenderComponent<DataGridFilterGuid<Nullable<Guid>>>();
+            var comp = Context.RenderComponent<DataGridFilterGuid<Guid?>>();
             var grid = comp.Instance.MudGridRef;
 
             grid.Items.Count().Should().Be(2);
             grid.FilteredItems.Count().Should().Be(2);
             var guidColumn = grid.RenderedColumns.FirstOrDefault(x => x.PropertyName == "Id");
 
-            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
+            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid?>.WeatherForecast>()
             {
                 Column = guidColumn,
                 Operator = "equals",
@@ -3600,7 +3599,7 @@ namespace MudBlazor.UnitTests.Components
             grid.FilteredItems.Count().Should().Be(0);
 
             grid.FilterDefinitions.Clear();
-            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
+            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid?>.WeatherForecast>()
             {
                 Column = guidColumn,
                 Operator = "equals",
@@ -3611,7 +3610,7 @@ namespace MudBlazor.UnitTests.Components
             grid.FilteredItems.FirstOrDefault()?.Id.Should().Be(comp.Instance.Guid1);
 
             grid.FilterDefinitions.Clear();
-            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Nullable<Guid>>.WeatherForecast>()
+            grid.FilterDefinitions.Add(new FilterDefinition<DataGridFilterGuid<Guid?>.WeatherForecast>()
             {
                 Column = guidColumn,
                 Operator = "not equals",
@@ -3682,7 +3681,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridCultureColumnFilterTest()
+        public void DataGridCultureColumnFilterTest()
         {
             var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
@@ -3723,7 +3722,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridCultureColumnFilterHeaderTest()
+        public void DataGridCultureColumnFilterHeaderTest()
         {
             var comp = Context.RenderComponent<DataGridCultureEditableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
@@ -3747,7 +3746,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridCultureColumnOverridesTest()
+        public void DataGridCultureColumnOverridesTest()
         {
             var comp = Context.RenderComponent<DataGridCulturesTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCulturesTest.Model>>();
@@ -3954,7 +3953,7 @@ namespace MudBlazor.UnitTests.Components
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseTest.Fruit>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
-            await comp.InvokeAsync(async () => dataGrid.Instance.ExpandAllGroups());
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllGroups());
             dataGrid.Render();
             // after all groups are expanded
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(7);
@@ -3990,7 +3989,7 @@ namespace MudBlazor.UnitTests.Components
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseServerDataTest.Fruit>>();
 
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(2));
-            await comp.InvokeAsync(async () => dataGrid.Instance.ExpandAllGroups());
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllGroups());
             dataGrid.Render();
             // after all groups are expanded
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
@@ -4246,7 +4245,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ShouldSetIsGenderGroupedToTrueWhenGroupingIsApplied()
+        public void ShouldSetIsGenderGroupedToTrueWhenGroupingIsApplied()
         {
             // Render the DataGridGroupingTest component for testing.
             var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
@@ -4283,7 +4282,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridDynamicColumnsTest()
+        public void DataGridDynamicColumnsTest()
         {
             var comp = Context.RenderComponent<DataGridDynamicColumnsTest>();
 
@@ -4336,7 +4335,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [SetCulture("en-US")]
-        public async Task DataGridServerGroupUngroupingTest()
+        public void DataGridServerGroupUngroupingTest()
         {
             var comp = Context.RenderComponent<DataGridServerDataColumnGroupingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<Examples.Data.Models.Element>>();
@@ -4383,7 +4382,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridGroupingTestBoundAndUnboundScenarios()
+        public void DataGridGroupingTestBoundAndUnboundScenarios()
         {
             var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnGroupingTest.Model>>();
@@ -4478,7 +4477,7 @@ namespace MudBlazor.UnitTests.Components
             rows.Count.Should().Be(12, because: "1 header row + 10 data rows + 1 footer row");
             var cells = dataGrid.FindAll("td");
             cells.Count.Should().Be(10, because: "We have 10 data rows with one group collapsed");
-            await comp.InvokeAsync(async () => dataGrid.Instance.ExpandAllGroups());
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllGroups());
             rows = dataGrid.FindAll("tr");
             rows.Count.Should().Be(32, because: "1 header row + 10 data rows + 1 footer row + 10 group rows + 10 footer group rows");
             cells = dataGrid.FindAll("td");
@@ -4509,7 +4508,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await dataGrid.Instance.ReloadServerData());
             cells = dataGrid.FindAll("td");
             cells.Count.Should().Be(10, because: "We have 10 data rows with one group collapsed from next page");
-            await comp.InvokeAsync(async () => dataGrid.Instance.ExpandAllGroups());
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllGroups());
             cells = dataGrid.FindAll("td");
             cells.Count.Should().Be(30, because: "We have next 10 data rows with one group + 10*2 cells inside groups");
             //cells should have data from next page
@@ -4537,7 +4536,7 @@ namespace MudBlazor.UnitTests.Components
 
         /// <summary>
         /// Reproduce the bug from https://github.com/MudBlazor/MudBlazor/issues/9585
-        /// When a column is hiden by the menu and the precedent column is resized, then the app crash
+        /// When a column is hidden by the menu and the precedent column is resized, then the app crash
         /// </summary>
         [Test]
         public async Task DataGrid_ResizeColumn_WhenNeighboringColumnIsHidden()
@@ -4582,7 +4581,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Mouse click down
             var resizer = comp.FindAll(".mud-resizer").ElementAt(0);
-            await comp.InvokeAsync(async () => resizer.PointerDown());
+            await comp.InvokeAsync(() => resizer.PointerDown());
 
             // Mouse move and release
             var resizeService = dgComp.Instance.ResizeService;

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3514,10 +3514,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridSequenceContainsNoElementsTest()
         {
-            var comp = Context.RenderComponent<DataGridSequenceContainsNoElementsTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSequenceContainsNoElementsTest.Model>>();
+            // Arrange & Act
+            var component = Context.RenderComponent<DataGridSequenceContainsNoElementsTest>();
+            var dataGridComponent = () => component.FindComponent<MudDataGrid<DataGridSequenceContainsNoElementsTest.Model>>();
 
             // This test will result in an error if the 'sequence contains no elements' issue is present.
+            // Assert
+            dataGridComponent.Should().NotThrow();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -1,9 +1,4 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System;
-using System.Threading.Tasks;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
@@ -11,7 +6,6 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Tabs;
 using NUnit.Framework;
 
@@ -27,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DefaultValues()
+        public void DefaultValues()
         {
             var comp = Context.RenderComponent<MudDynamicTabs>();
             var tabs = comp.Instance;
@@ -56,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task BasicParameters()
+        public void BasicParameters()
         {
             var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
 
@@ -179,7 +173,6 @@ namespace MudBlazor.UnitTests.Components
 
                 comp.Instance.CloseClicked.Should().HaveCount(i + 1);
             }
-
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1,18 +1,11 @@
-﻿#pragma warning disable CS1998 // async without await
-
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.Dummy;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -27,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         /// Clearing the value of a required textfield should set form's IsValid to false.
         /// </summary>
         [Test]
-        public async Task FormIsValidTest()
+        public void FormIsValidTest()
         {
             var comp = Context.RenderComponent<FormIsValidTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -69,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task FormIsValidTest2()
+        public void FormIsValidTest2()
         {
             var comp = Context.RenderComponent<FormIsValidTest2>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -84,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         /// Form should update the bound variables valid and touched whenever they change.
         /// </summary>
         [Test]
-        public async Task FormIsValidTest3()
+        public void FormIsValidTest3()
         {
             var comp = Context.RenderComponent<FormIsValidTest3>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -105,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
         /// Form should update the bound variable valid to true even though it is set false upon first render because there is no required field.
         /// </summary>
         [Test]
-        public async Task FormIsValidTest4()
+        public void FormIsValidTest4()
         {
             var comp = Context.RenderComponent<FormIsValidTest4>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -237,13 +230,11 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().Be(false);
         }
 
-
-
         /// <summary>
         /// Custom validation func should be called to determine whether or not a form value is good
         /// </summary>
         [Test]
-        public async Task FormValidationTest1()
+        public void FormValidationTest1()
         {
             var validationFunc = new Func<string, bool>(x => x?.StartsWith("Marilyn") == true);
             var comp = Context.RenderComponent<FormValidationTest>(ComponentParameter.CreateParameter("validation", validationFunc));
@@ -289,7 +280,7 @@ namespace MudBlazor.UnitTests.Components
         /// Custom validation func should be called to determine whether or not a form value is good
         /// </summary>
         [Test]
-        public async Task FormValidationTest2()
+        public void FormValidationTest2()
         {
             var validationFunc = new Func<string, string>(s =>
             {
@@ -346,7 +337,7 @@ namespace MudBlazor.UnitTests.Components
         /// Validate that first async validation call returning after second call will not override result of second call
         /// </summary>
         [Test]
-        public async Task FormAsyncValidationTest()
+        public void FormAsyncValidationTest()
         {
             const int ValidDelay = 100;
             const int InvalidDelay = 200;
@@ -410,7 +401,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task EditFormOnFieldChangedTest()
+        public void EditFormOnFieldChangedTest()
         {
             var comp = Context.RenderComponent<EditFormOnFieldChangedTest>();
             var textFields = comp.FindAll("input");
@@ -443,7 +434,7 @@ namespace MudBlazor.UnitTests.Components
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]
-        public async Task FormWithCheckboxTest()
+        public void FormWithCheckboxTest()
         {
             var comp = Context.RenderComponent<FormWithCheckBoxAndTextFieldsTest>();
             var textFields = comp.FindAll("input");
@@ -473,7 +464,7 @@ namespace MudBlazor.UnitTests.Components
         /// be valid if the checkbox is not required.
         /// </summary>
         [Test]
-        public async Task FormWithCheckboxTest2()
+        public void FormWithCheckboxTest2()
         {
             var comp = Context.RenderComponent<FormWithCheckBoxAndTextFieldsTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -484,7 +475,7 @@ namespace MudBlazor.UnitTests.Components
         /// Form should become valid as soon as all required fields are filled in correctly.
         /// </summary>
         [Test]
-        public async Task Form_Should_BecomeValidIfUntouchedFieldsAreNotRequired()
+        public void Form_Should_BecomeValidIfUntouchedFieldsAreNotRequired()
         {
             var comp = Context.RenderComponent<FormValidationTest2>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -498,7 +489,7 @@ namespace MudBlazor.UnitTests.Components
         /// Form should become invalid as soon as an in-convertible value is entered.
         /// </summary>
         [Test]
-        public async Task Form_Should_BecomeInValidWhenAConversionErrorOccurs()
+        public void Form_Should_BecomeInValidWhenAConversionErrorOccurs()
         {
             var comp = Context.RenderComponent<FormConversionErrorTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -514,7 +505,7 @@ namespace MudBlazor.UnitTests.Components
         /// Testing the functionality of the MudForm example from the docs.
         /// </summary>
         [Test]
-        public async Task MudFormExampleTest()
+        public void MudFormExampleTest()
         {
             var comp = Context.RenderComponent<MudFormExample>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -578,7 +569,7 @@ namespace MudBlazor.UnitTests.Components
         /// Clearing the value of a required radiogroup should set form's IsValid to false.
         /// </summary>
         [Test]
-        public async Task FormWithRadioGroupIsValidTest()
+        public void FormWithRadioGroupIsValidTest()
         {
             var comp = Context.RenderComponent<FormWithRadioGroupTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -685,7 +676,7 @@ namespace MudBlazor.UnitTests.Components
         /// DatePicker should be validated like every other form component
         /// </summary>
         [Test]
-        public async Task FormWithDatePickerTest()
+        public void FormWithDatePickerTest()
         {
             var comp = Context.RenderComponent<FormWithDatePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -714,7 +705,7 @@ namespace MudBlazor.UnitTests.Components
         /// DatePicker should be validated like every other form component
         /// </summary>
         [Test]
-        public async Task Form_Should_ValidateDatePickerTest()
+        public void Form_Should_ValidateDatePickerTest()
         {
             var comp = Context.RenderComponent<FormWithDatePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -807,7 +798,7 @@ namespace MudBlazor.UnitTests.Components
         /// TimePicker should be validated like every other form component
         /// </summary>
         [Test]
-        public async Task FormWithTimePickerTest()
+        public void FormWithTimePickerTest()
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -836,7 +827,7 @@ namespace MudBlazor.UnitTests.Components
         /// TimePicker should be validated like every other form component
         /// </summary>
         [Test]
-        public async Task Form_Should_ValidateTimePickerTest()
+        public void Form_Should_ValidateTimePickerTest()
         {
             var comp = Context.RenderComponent<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1030,7 +1021,7 @@ namespace MudBlazor.UnitTests.Components
         /// Testing the functionality of the EditForm example from the docs.
         /// </summary>
         [Test]
-        public async Task EditFormExample_EmptyValidation()
+        public void EditFormExample_EmptyValidation()
         {
             var comp = Context.RenderComponent<EditFormExample>();
             // same effect as clicking the validate button
@@ -1050,7 +1041,7 @@ namespace MudBlazor.UnitTests.Components
         /// Testing the functionality of the EditForm example from the docs.
         /// </summary>
         [Test]
-        public async Task EditFormExample_FillInValues()
+        public void EditFormExample_FillInValues()
         {
             var comp = Context.RenderComponent<EditFormExample>();
             comp.FindAll("input")[0].Change("Rick Sanchez");
@@ -1079,7 +1070,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <see cref="https://github.com/MudBlazor/MudBlazor/issues/1229"/>
         [Test]
-        public async Task EditForm_Validation_NullContext()
+        public void EditForm_Validation_NullContext()
         {
             var comp = Context.RenderComponent<EditFormIssue1229>();
             // Check first run attribute
@@ -1475,7 +1466,7 @@ namespace MudBlazor.UnitTests.Components
         /// Only the top SubscribeToParentForm fields should be registered inside the form.
         /// </summary>
         [Test]
-        public async Task MudForm_Should_RegisterOnlyTopSubscribeToParentFormFormControls()
+        public void MudForm_Should_RegisterOnlyTopSubscribeToParentFormFormControls()
         {
             var comp = Context.RenderComponent<FormShouldRegisterOnlyTopSubscribeToParentFormFormControlsTest>();
             var form = comp.FindComponent<MudFormTestable>().Instance;
@@ -1487,7 +1478,7 @@ namespace MudBlazor.UnitTests.Components
         /// Test the cascading validaton parameter to override field validations or not depending of context.
         /// </summary>
         [Test]
-        public async Task MudForm_Validation_Should_OverrideFieldValidation()
+        public void MudForm_Validation_Should_OverrideFieldValidation()
         {
             var comp = Context.RenderComponent<FormValidationOverrideFieldValidationTest>();
             var textFields = comp.FindComponents<MudTextField<string>>();
@@ -1510,7 +1501,7 @@ namespace MudBlazor.UnitTests.Components
         /// triggering validation. Validations requiring "Form" or "For" properties should not crash.
         /// </summary>
         [Test]
-        public async Task FieldValidationWithoutRequiredForm_ShouldNot_Validate()
+        public void FieldValidationWithoutRequiredForm_ShouldNot_Validate()
         {
             var comp = Context.RenderComponent<FieldValidationWithoutRequiredFormTest>();
 
@@ -1597,7 +1588,7 @@ namespace MudBlazor.UnitTests.Components
         /// When Validation is set on a Form, it should only set validation on fields that have a For parameter
         /// </summary>
         [Test]
-        public async Task FormAutoValidationSetTest()
+        public void FormAutoValidationSetTest()
         {
             var comp = Context.RenderComponent<FormAutomaticValidationTest>();
             var textComps = comp.FindComponents<MudTextField<string>>();
@@ -1615,11 +1606,11 @@ namespace MudBlazor.UnitTests.Components
             dateComps[1].Instance.Validation.Should().BeNull(); //Validation is not set
         }
 
-        /// <summaryReadonly
+        /// <summary>
         /// Ensures that all child components are Readonly when the Form is Readonly
         /// </summary>
         [Test]
-        public async Task FormReadonlyTest()
+        public void FormReadonlyTest()
         {
             var comp = Context.RenderComponent<FormReadOnlyDisabledTest>();
 
@@ -1688,7 +1679,7 @@ namespace MudBlazor.UnitTests.Components
         /// Ensures that all child components are Disabled when the Form is Disabled
         /// </summary>
         [Test]
-        public async Task FormDisabledTest()
+        public void FormDisabledTest()
         {
             var comp = Context.RenderComponent<FormReadOnlyDisabledTest>();
 
@@ -1777,7 +1768,7 @@ namespace MudBlazor.UnitTests.Components
         /// Ensures the child MudForm correctly inherits ReadOnly and applies it to its children
         /// </summary>
         [Test]
-        public async Task FormNestedReadOnlyTest()
+        public void FormNestedReadOnlyTest()
         {
             var comp = Context.RenderComponent<FormNestedReadOnlyDisabledTest>();
             comp.FindAll(".mud-checkbox.mud-readonly").Count.Should().Be(0);
@@ -1799,7 +1790,7 @@ namespace MudBlazor.UnitTests.Components
         /// Ensures the child MudForm correctly inherits Disabled and applies it to its children
         /// </summary>
         [Test]
-        public async Task FormNestedDisabledTest()
+        public void FormNestedDisabledTest()
         {
             var comp = Context.RenderComponent<FormNestedReadOnlyDisabledTest>();
             comp.FindAll(".mud-checkbox.mud-disabled").Count.Should().Be(0);
@@ -1818,7 +1809,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FormWithChildFormTest()
+        public void FormWithChildFormTest()
         {
             var comp = Context.RenderComponent<FormWithChildForm>();
             var childFormSwitch = comp.Find(".mud-switch-input");
@@ -1870,7 +1861,7 @@ namespace MudBlazor.UnitTests.Components
         /// CheckBox should be validated like every other form component when ticked using mouse
         /// </summary>
         [Test]
-        public async Task FormWithCheckBoxTest_When_CheckBoxTickedUsingMouse()
+        public void FormWithCheckBoxTest_When_CheckBoxTickedUsingMouse()
         {
             var comp = Context.RenderComponent<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1902,7 +1893,7 @@ namespace MudBlazor.UnitTests.Components
         /// CheckBox should be validated like every other form component when ticked using keyboard
         /// </summary>
         [Test]
-        public async Task FormWithCheckBoxTest_When_CheckBoxTickedUsingKeyboard()
+        public void FormWithCheckBoxTest_When_CheckBoxTickedUsingKeyboard()
         {
             var comp = Context.RenderComponent<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1931,7 +1922,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task FormSpacingClass()
+        public void FormSpacingClass()
         {
             var comp = Context.RenderComponent<MudForm>();
 

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -1,27 +1,25 @@
-﻿#pragma warning disable CS1998 // async without await
-
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests.Components
+namespace MudBlazor.UnitTests.Components;
+
+#nullable enable
+[TestFixture]
+public class InputTests : BunitTest
 {
-    [TestFixture]
-    public class InputTests : BunitTest
+    [Test]
+    public void ReadOnlyShouldNotHaveClearButton()
     {
-        [Test]
-        public void ReadOnlyShouldNotHaveClearButton()
-        {
-            var comp = Context.RenderComponent<MudInput<string>>(p => p
-                .Add(x => x.Text, "some value")
-                .Add(x => x.Clearable, true)
-                .Add(x => x.ReadOnly, false));
+        var comp = Context.RenderComponent<MudInput<string>>(p => p
+            .Add(x => x.Text, "some value")
+            .Add(x => x.Clearable, true)
+            .Add(x => x.ReadOnly, false));
 
-            comp.FindAll(".mud-input-clear-button").Count.Should().Be(1);
+        comp.FindAll(".mud-input-clear-button").Count.Should().Be(1);
 
-            comp.SetParametersAndRender(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
-            comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
-        }
-#nullable disable
+        comp.SetParametersAndRender(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
+        comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
     }
+#nullable disable
 }

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -2,15 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CS1998 // async without await
-
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Mask;
 using NUnit.Framework;
 
@@ -22,7 +16,6 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Test all IsMatch variants: letter, digit and symbols.
         /// </summary>
-        /// <returns></returns>
         [Test]
         public async Task MaskTest_Fundamentals1()
         {
@@ -744,7 +737,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.SetParam(p => p.ReadOnly, false);
             // paste
-            await comp.InvokeAsync(async () =>
+            await comp.InvokeAsync(() =>
             {
                 mask.OnSelect(0, mask.Text.Length);
                 mask.OnPaste("2222 2222 2222 2222");
@@ -763,7 +756,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DifferentMaskImplementationTests()
+        public void DifferentMaskImplementationTests()
         {
             // arrange
             var comp = Context.RenderComponent<DifferentMaskImplementationTest>();

--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -1,14 +1,7 @@
-﻿
-#pragma warning disable CS1998 // async without await
-
-using System;
-using System.Threading.Tasks;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
-using MudBlazor.UnitTests.TestComponents.Link;
 using MudBlazor.UnitTests.TestComponents.NavLink;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -28,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("_parent", "noopener noreferrer")]
         [TestCase("_top", "noopener noreferrer")]
         [TestCase("myFrameName", "noopener noreferrer")]
-        public async Task NavLink_CheckRelAttribute(string target, string expectedRel)
+        public void NavLink_CheckRelAttribute(string target, string expectedRel)
         {
             var comp = Context.RenderComponent<MudNavLink>(Parameter(nameof(MudNavLink.Target), target));
             // print the generated html
@@ -37,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NavLink_CheckOnClickEvent()
+        public void NavLink_CheckOnClickEvent()
         {
             var clicked = false;
             var comp = Context.RenderComponent<MudNavLink>(EventCallback(nameof(MudNavLink.OnClick), (MouseEventArgs args) => { clicked = true; }));
@@ -48,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NavLink_Active()
+        public void NavLink_Active()
         {
             const string activeClass = "Custom__nav_active_css";
             var comp = Context.RenderComponent<MudNavLink>(Parameter(nameof(MudNavLink.ActiveClass), activeClass));
@@ -57,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NavLink_Enabled_CheckNavigation()
+        public void NavLink_Enabled_CheckNavigation()
         {
             var comp = Context.RenderComponent<NavLinkDisabledTest>(Parameter(nameof(NavLinkDisabledTest.Disabled), false));
             comp.Find("a").Click();
@@ -65,7 +58,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NavLink_Disabled_CheckNoNavigation()
+        public void NavLink_Disabled_CheckNoNavigation()
         {
             var comp = Context.RenderComponent<NavLinkDisabledTest>(Parameter(nameof(NavLinkDisabledTest.Disabled), true));
             comp.Find("a").Click();

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -2,14 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CS1998 // async without await
 #pragma warning disable BL0005 // Set parameter outside component
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using FluentValidation;
@@ -93,7 +88,7 @@ namespace MudBlazor.UnitTests.Components
         /// Setting the value to null should not cause a validation error
         /// </summary>
         [TestCaseSource(nameof(TypeCases))]
-        public async Task NumericField_WithNullableTypes_ShouldAllowNulls<T>(T value) where T : struct
+        public void NumericField_WithNullableTypes_ShouldAllowNulls<T>(T value) where T : struct
         {
             var comp = Context.RenderComponent<MudNumericField<T?>>(ComponentParameter.CreateParameter("Value", value));
             // print the generated html
@@ -214,7 +209,7 @@ namespace MudBlazor.UnitTests.Components
         /// FluentValidation rules can be used for validating a NumericFields
         /// </summary>
         [Test]
-        public async Task NumericFieldFluentValidationTest1()
+        public void NumericFieldFluentValidationTest1()
         {
             var validator = new FluentValueValidator<string>(x => x.Cascade(CascadeMode.Stop)
                 .NotEmpty()
@@ -236,7 +231,7 @@ namespace MudBlazor.UnitTests.Components
         /// Validate handling of decimal support & precision kept
         /// </summary>
         [Test]
-        public async Task NumericField_HandleDecimalPrecisionAndValues()
+        public void NumericField_HandleDecimalPrecisionAndValues()
         {
             var comp = Context.RenderComponent<MudNumericField<decimal>>();
             var numericField = comp.Instance;
@@ -256,7 +251,7 @@ namespace MudBlazor.UnitTests.Components
         /// An unstable converter should not cause an infinite update loop. This test must complete in under 1 sec!
         /// </summary>
         [Test, CancelAfter(1000)]
-        public async Task NumericFieldUpdateLoopProtectionTest()
+        public void NumericFieldUpdateLoopProtectionTest()
         {
             var comp = Context.RenderComponent<MudNumericField<int>>();
             // these conversion funcs are nonsense of course, but they are designed this way to
@@ -273,7 +268,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_Should_FireValueChangedOnTextParameterChange()
+        public void NumericField_Should_FireValueChangedOnTextParameterChange()
         {
             var changed_value = 4;
             var comp = Context.RenderComponent<MudNumericField<int>>(EventCallback<int>("ValueChanged", x => changed_value = x));
@@ -282,7 +277,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_Should_FireTextChangedOnValueParameterChange()
+        public void NumericField_Should_FireTextChangedOnValueParameterChange()
         {
             var changed_text = "4";
             var comp = Context.RenderComponent<MudNumericField<int>>(EventCallback<string>("TextChanged", x => changed_text = x));
@@ -291,7 +286,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_Should_FireTextAndValueChangedOnTextInput()
+        public void NumericField_Should_FireTextAndValueChangedOnTextInput()
         {
             var changed_value = 4;
             string changed_text = null;
@@ -328,7 +323,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task NumericField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
+        public void NumericField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
         {
             var comp = Context.RenderComponent<NumericFieldRequiredTest>();
             var numericField = comp.FindComponent<MudNumericField<int?>>().Instance;
@@ -345,7 +340,7 @@ namespace MudBlazor.UnitTests.Components
         /// <param name="value"></param>
         /// <returns></returns>
         [TestCaseSource(nameof(TypeCases))]
-        public async Task NumericField_OfAnyType_Should_Render<T>(T value)
+        public void NumericField_OfAnyType_Should_Render<T>(T value)
         {
             Assert.DoesNotThrow(() => Context.RenderComponent<MudNumericField<T>>(), $"{typeof(MudNumericField<>)}<{typeof(T)}> render failed.");
         }
@@ -354,7 +349,7 @@ namespace MudBlazor.UnitTests.Components
         /// Increment / Decrement via up / down keys should work
         /// </summary>
         [Test]
-        public async Task NumericFieldTest_KeyboardInput()
+        public void NumericFieldTest_KeyboardInput()
         {
             var comp = Context.RenderComponent<MudNumericField<double>>();
             comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
@@ -386,7 +381,7 @@ namespace MudBlazor.UnitTests.Components
         /// KeyDown disabled, should not do anything
         /// </summary>
         [Test]
-        public async Task NumericFieldTest_KeyboardInput_Disabled()
+        public void NumericFieldTest_KeyboardInput_Disabled()
         {
             var comp = Context.RenderComponent<MudNumericField<double>>();
             comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
@@ -405,7 +400,7 @@ namespace MudBlazor.UnitTests.Components
         /// KeyDown readonly, should not do anything
         /// </summary>
         [Test]
-        public async Task NumericFieldTest_KeyboardInput_Readonly()
+        public void NumericFieldTest_KeyboardInput_Readonly()
         {
             var comp = Context.RenderComponent<MudNumericField<double>>();
             comp.SetParam(x => x.Culture, CultureInfo.InvariantCulture);
@@ -424,7 +419,7 @@ namespace MudBlazor.UnitTests.Components
         /// MouseWheel actions should work
         /// </summary>
         [Test]
-        public async Task NumericFieldTest_MouseWheel()
+        public void NumericFieldTest_MouseWheel()
         {
             var comp = Context.RenderComponent<MudNumericField<double>>();
             comp.SetParam(x => x.Value, 1234.56);
@@ -470,7 +465,7 @@ namespace MudBlazor.UnitTests.Components
         /// MouseWheel actions should work on Firefox
         /// </summary>
         [Test]
-        public async Task NumericFieldTest_Wheel_Firefox()
+        public void NumericFieldTest_Wheel_Firefox()
         {
             var comp = Context.RenderComponent<MudNumericField<double>>();
             comp.SetParam(x => x.Value, 1234.56);
@@ -516,7 +511,7 @@ namespace MudBlazor.UnitTests.Components
         /// NumericalField Formats input according to culture
         /// </summary>
         [Test]
-        public async Task NumericFieldTestCultureFormat()
+        public void NumericFieldTestCultureFormat()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
             var inputs = comp.FindAll("input");
@@ -554,7 +549,7 @@ namespace MudBlazor.UnitTests.Components
         /// NumericalField will not accept illegal chars
         /// </summary>
         [Test]
-        public async Task NumericField_should_RejectIllegalCharacters()
+        public void NumericField_should_RejectIllegalCharacters()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
             //german
@@ -587,7 +582,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_should_ReformatTextOnBlur()
+        public void NumericField_should_ReformatTextOnBlur()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
             // english
@@ -627,7 +622,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [TestCaseSource(nameof(TypeCases))]
-        public async Task NumericFieldMinMax<T>(T value)
+        public void NumericFieldMinMax<T>(T value)
         {
             var min = (T)Convert.ChangeType(1, typeof(T));
             var max = (T)Convert.ChangeType(10, typeof(T));
@@ -647,7 +642,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [TestCaseSource(nameof(TypeCases))]
-        public async Task NumericFieldMinMaxNullable<T>(T value) where T : struct
+        public void NumericFieldMinMaxNullable<T>(T value) where T : struct
         {
             var min = (T)Convert.ChangeType(1, typeof(T));
             var max = (T)Convert.ChangeType(10, typeof(T));
@@ -767,7 +762,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         [TestCase(10, 20, 15)]
         [TestCase(-20, -10, -15)]
-        public async Task NumericFieldCanBeCleared(int min, int max, int value)
+        public void NumericFieldCanBeCleared(int min, int max, int value)
         {
             var comp = Context.RenderComponent<MudNumericField<int?>>();
             comp.SetParam(x => x.Min, min);
@@ -784,7 +779,7 @@ namespace MudBlazor.UnitTests.Components
         /// Special format with currency format should not result in error
         /// </summary>
         [Test]
-        public async Task NumericFieldWithCurrencyFormat()
+        public void NumericFieldWithCurrencyFormat()
         {
             var comp = Context.RenderComponent<MudNumericField<int?>>();
             comp.SetParam(x => x.Format, "€0");
@@ -811,7 +806,7 @@ namespace MudBlazor.UnitTests.Components
         /// Test that thousands separator is parsed properly
         /// </summary>
         [Test]
-        public async Task NumericFieldThousandsSeparator()
+        public void NumericFieldThousandsSeparator()
         {
             var comp = Context.RenderComponent<MudNumericField<int?>>();
             var numericField = comp.Instance;
@@ -867,7 +862,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DebouncedNumericField_Should_RenderDefaultValueTextOnFirstRender()
+        public void DebouncedNumericField_Should_RenderDefaultValueTextOnFirstRender()
         {
             var defaultValue = 1;
             var converter = new DefaultConverter<int>();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1,19 +1,10 @@
-﻿#pragma warning disable CS1998 // async without await
-#pragma warning disable IDE1006 // leading underscore
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.Dummy;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Select;
 using NUnit.Framework;
 using static MudBlazor.UnitTests.TestComponents.Select.SelectWithEnumTest;
-
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -163,7 +154,7 @@ namespace MudBlazor.UnitTests.Components
         /// After clicking the second item, the render fragment should update
         /// </summary>
         [Test]
-        public async Task SelectWithEnumTest()
+        public void SelectWithEnumTest()
         {
             var comp = Context.RenderComponent<SelectWithEnumTest>();
             // select elements needed for the test
@@ -434,9 +425,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MultiSelect_ShouldCallValidationFunc()
+        public void MultiSelect_ShouldCallValidationFunc()
         {
-            await ImproveChanceOfSuccess(async () =>
+            ImproveChanceOfSuccess(() =>
             {
                 var comp = Context.RenderComponent<MultiSelectTest1>();
                 // print the generated html
@@ -619,9 +610,8 @@ namespace MudBlazor.UnitTests.Components
         /// We filled the multiselect with initial selected values, that must
         /// show in the value of the input as a comma separated list of strings
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task MultiSelect_Initial_Values()
+        public void MultiSelect_Initial_Values()
         {
             var comp = Context.RenderComponent<MultiSelectWithInitialValues>();
             // print the generated html
@@ -629,7 +619,7 @@ namespace MudBlazor.UnitTests.Components
             // select the input of the select
             var input = comp.Find("input");
             //the value of the input
-            var value = input.Attributes.Where(a => a.LocalName == "value").First().Value;
+            var value = input.Attributes.First(a => a.LocalName == "value").Value;
             value.Should().Be("FirstA, SecondA");
         }
 
@@ -637,9 +627,8 @@ namespace MudBlazor.UnitTests.Components
         /// We filled the multiselect with initial selected values.
         /// Then the returned text in the selection is customized.
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task MultiSelectCustomizedTextTest()
+        public void MultiSelectCustomizedTextTest()
         {
             var comp = Context.RenderComponent<MultiSelectCustomizedTextTest>();
 
@@ -647,14 +636,14 @@ namespace MudBlazor.UnitTests.Components
             var input = comp.Find("input");
 
             // The value of the input
-            var value = input.Attributes.Where(a => a.LocalName == "value").First().Value;
+            var value = input.Attributes.First(a => a.LocalName == "value").Value;
 
             // Value is equal to the customized values returned by the method
             value.Should().Be("Selected values: FirstA, SecondA");
         }
 
         [Test]
-        public async Task SelectClearableTest()
+        public void SelectClearableTest()
         {
             var comp = Context.RenderComponent<SelectClearableTest>();
             var select = comp.FindComponent<MudSelect<string>>();
@@ -834,7 +823,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Select_Should_AllowReloadingItems()
+        public void Select_Should_AllowReloadingItems()
         {
             var comp = Context.RenderComponent<ReloadSelectItemsTest>();
             var select = comp.FindComponent<MudSelect<string>>();
@@ -1035,7 +1024,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task SelectTest_KeyboardNavigation_MultiSelect_Focus()
+        public void SelectTest_KeyboardNavigation_MultiSelect_Focus()
         {
             var comp = Context.RenderComponent<MultiSelectTest6>();
             var select = comp.FindComponent<MudSelect<string>>();

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1353,7 +1353,11 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataNull()
         {
-            _ = Context.RenderComponent<TableServerSideDataTest6>();
+            // Arrange & Act
+            var renderComponent = () => Context.RenderComponent<TableServerSideDataTest6>();
+
+            // Assert
+            renderComponent.Should().NotThrow();
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1,12 +1,10 @@
-﻿#pragma warning disable CS1998 // async without await
-#pragma warning disable BL0005 // Set parameter outside component
+﻿#pragma warning disable BL0005 // Set parameter outside component
 
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Table;
 using NUnit.Framework;
 
@@ -430,7 +428,7 @@ namespace MudBlazor.UnitTests.Components
         /// page size option initial value test. Initial value should not be 10 since PageSizeOption is set to be new int[]{8, 16, 32}
         /// </summary>
         [Test]
-        public async Task TablePageSizeOptions()
+        public void TablePageSizeOptions()
         {
             var comp = Context.RenderComponent<TablePageSizeOptionsTest>();
             // print the generated html
@@ -548,7 +546,7 @@ namespace MudBlazor.UnitTests.Components
         /// simple filter with pager
         /// </summary>
         [Test]
-        public async Task TablePagingFilter()
+        public void TablePagingFilter()
         {
             var comp = Context.RenderComponent<TablePagingTest1>();
             var searchString = comp.Find("#searchString");
@@ -566,7 +564,7 @@ namespace MudBlazor.UnitTests.Components
         /// adjust current page when filtereditems.count is less than the current page start item index
         /// </summary>
         [Test]
-        public async Task TablePagingFilterAdjustCurrentPage()
+        public void TablePagingFilterAdjustCurrentPage()
         {
             var comp = Context.RenderComponent<TablePagingTest1>();
             // print the generated html
@@ -1147,7 +1145,7 @@ namespace MudBlazor.UnitTests.Components
         /// Even without a MudTablePager the table should call ServerReload to get the items on start.
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest1()
+        public void TableServerSideDataTest1()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest1>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
@@ -1160,7 +1158,7 @@ namespace MudBlazor.UnitTests.Components
         /// The table should call ServerReload to get the items for the current page according to MudTablePager
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest2()
+        public void TableServerSideDataTest2()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest2>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
@@ -1186,7 +1184,7 @@ namespace MudBlazor.UnitTests.Components
         /// In this case, the items should be sorted with descending order.
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest3()
+        public void TableServerSideDataTest3()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest3>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
@@ -1208,7 +1206,7 @@ namespace MudBlazor.UnitTests.Components
         /// (IEnumerable variation).
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest4()
+        public void TableServerSideDataTest4()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest4>();
             comp.WaitForAssertion(() => comp.FindAll("tr").Count.Should().Be(4)); // three rows + header row
@@ -1227,7 +1225,7 @@ namespace MudBlazor.UnitTests.Components
         /// (IQueryable variation).
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest4b()
+        public void TableServerSideDataTest4b()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest4b>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
@@ -1245,7 +1243,7 @@ namespace MudBlazor.UnitTests.Components
         /// The server-side load callback should be called only once per page change
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest5()
+        public void TableServerSideDataTest5()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest5>();
             comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
@@ -1294,7 +1292,7 @@ namespace MudBlazor.UnitTests.Components
         /// The server-side load callback should be called only once per sort change
         /// </summary>
         [Test]
-        public async Task TableServerSideDataTest6()
+        public void TableServerSideDataTest6()
         {
             var comp = Context.RenderComponent<TableServerSideDataTest5>();
             comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
@@ -1353,9 +1351,9 @@ namespace MudBlazor.UnitTests.Components
         /// The table should not crash if its ServerData Items are null
         /// </summary>
         [Test]
-        public async Task TableServerSideDataNull()
+        public void TableServerSideDataNull()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest6>();
+            _ = Context.RenderComponent<TableServerSideDataTest6>();
         }
 
         /// <summary>
@@ -1376,7 +1374,7 @@ namespace MudBlazor.UnitTests.Components
         /// The table should not render its NoContent fragment prior to loading server data
         /// </summary>
         [Test]
-        public async Task TableServerDataLoadingTest()
+        public void TableServerDataLoadingTest()
         {
             var comp = Context.RenderComponent<TableServerDataLoadingTest>();
             comp.Instance.NoRecordsHasRendered.Should().BeFalse();
@@ -1435,7 +1433,7 @@ namespace MudBlazor.UnitTests.Components
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]
-        public async Task TableRowClassStyleTest()
+        public void TableRowClassStyleTest()
         {
             var comp = Context.RenderComponent<TableRowClassStyleTest>();
             var trs = comp.FindAll("tr");
@@ -1464,7 +1462,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TableInlineEdit_SetValidatorModel()
+        public void TableInlineEdit_SetValidatorModel()
         {
             var comp = Context.RenderComponent<TableInlineEditTest>();
             var validator = comp.Instance.Table.Validator;
@@ -1481,7 +1479,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TableInlineEdit_TableRowValidator()
+        public void TableInlineEdit_TableRowValidator()
         {
             var comp = Context.RenderComponent<TableInlineEditTest>();
             var validator = new TableRowValidatorTest();
@@ -1503,7 +1501,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TableApplyButtonPosition.StartAndEnd)]
         [TestCase(TableApplyButtonPosition.Start)]
         [TestCase(TableApplyButtonPosition.End)]
-        public async Task TableInlineEdit_ApplyButtonPosition(TableApplyButtonPosition position)
+        public void TableInlineEdit_ApplyButtonPosition(TableApplyButtonPosition position)
         {
             var comp = Context.RenderComponent<TableInlineEditTestApplyButtons>(
                 p => p.Add(x => x.ApplyButtonPosition, position));
@@ -1550,7 +1548,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TableInlineEdit_RowSwitching()
+        public void TableInlineEdit_RowSwitching()
         {
             var comp = Context.RenderComponent<TableInlineEditTest>();
 
@@ -1571,7 +1569,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TableInlineEdit_RowSwitchingBlocked()
+        public void TableInlineEdit_RowSwitchingBlocked()
         {
             var comp = Context.RenderComponent<TableInlineEditRowBlockingTest>();
 
@@ -1640,7 +1638,7 @@ namespace MudBlazor.UnitTests.Components
         /// This test validates the processing of the Commit and Cancel buttons for an inline editing table.
         /// </summary>
         [Test]
-        public async Task TableInlineEditCancelTest()
+        public void TableInlineEditCancelTest()
         {
             var comp = Context.RenderComponent<TableInlineEditCancelTest>();
 
@@ -1679,7 +1677,7 @@ namespace MudBlazor.UnitTests.Components
         /// This test validates the processing of the Commit and Cancel buttons for an inline editing table.
         /// </summary>
         [Test]
-        public async Task TableInlineEditCancel2Test()
+        public void TableInlineEditCancel2Test()
         {
             var comp = Context.RenderComponent<TableInlineEditCancelTest>();
 
@@ -1711,7 +1709,7 @@ namespace MudBlazor.UnitTests.Components
         /// This test validates the behavior of RowEditPreview. It should run after SelectedItem has been updated.
         /// </summary>
         [Test]
-        public async Task TableInlineEditCancel3Test()
+        public void TableInlineEditCancel3Test()
         {
             var comp = Context.RenderComponent<TableInlineEditCancelTest>();
             var taskCompletionSource = new TaskCompletionSource<bool>();
@@ -1760,7 +1758,7 @@ namespace MudBlazor.UnitTests.Components
         /// by clicking on another row, the previous row is no longer editable. Meaning there are always only 2 buttons
         /// </summary>
         [Test]
-        public async Task TableInlineEditCancel4Test()
+        public void TableInlineEditCancel4Test()
         {
             // Get access to the test table
             var comp = Context.RenderComponent<TableInlineEditCancelNoSelectedItemTest>();
@@ -1797,7 +1795,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, TableApplyButtonPosition.Start, TableEditButtonPosition.Start)]
         [TestCase(false, TableApplyButtonPosition.StartAndEnd, TableEditButtonPosition.StartAndEnd)]
         [TestCase(false, TableApplyButtonPosition.End, TableEditButtonPosition.End)]
-        public async Task TableEditButtonRenderTest(bool customButton, TableApplyButtonPosition buttonApplyPosition, TableEditButtonPosition buttonEditPosition)
+        public void TableEditButtonRenderTest(bool customButton, TableApplyButtonPosition buttonApplyPosition, TableEditButtonPosition buttonEditPosition)
         {
             IRenderedComponent<ComponentBase> comp;
             if (customButton)
@@ -1854,7 +1852,7 @@ namespace MudBlazor.UnitTests.Components
         /// Tests the trigger of the edit button
         /// </summary>
         [Test]
-        public async Task TableEditButtonTriggerTest()
+        public void TableEditButtonTriggerTest()
         {
             var comp = Context.RenderComponent<TableEditButtonRenderTest>();
             var trs = comp.FindAll("tr");
@@ -1876,7 +1874,7 @@ namespace MudBlazor.UnitTests.Components
         /// Tests the trigger of the custom edit button
         /// </summary>
         [Test]
-        public async Task TableCustomEditButtonTriggerTest()
+        public void TableCustomEditButtonTriggerTest()
         {
             var comp = Context.RenderComponent<TableCustomEditButtonRenderTest>();
             var trs = comp.FindAll("tr");
@@ -1898,7 +1896,7 @@ namespace MudBlazor.UnitTests.Components
         /// Row item data should be passed to EditButtonContext
         /// </summary>
         [Test]
-        public async Task TableCustomEditButtonItemContext()
+        public void TableCustomEditButtonItemContext()
         {
             var comp = Context.RenderComponent<TableCustomEditButtonItemContextRenderTest>();
 
@@ -1917,7 +1915,7 @@ namespace MudBlazor.UnitTests.Components
         /// Ensures clicking a different button does not switch the row
         /// </summary>
         [Test]
-        public async Task TableEditButtonRowSwitchBlockTest()
+        public void TableEditButtonRowSwitchBlockTest()
         {
             var comp = Context.RenderComponent<TableEditButtonRenderTest>(parameters => parameters
                     .Add(p => p.BlockRowSwitching, true));
@@ -1940,7 +1938,7 @@ namespace MudBlazor.UnitTests.Components
         /// Clicking the edit button should not trigger the row click event
         /// </summary>
         [Test]
-        public async Task TableEditButtonNoRowTrigger()
+        public void TableEditButtonNoRowTrigger()
         {
             var timesClicked = 0;
             void OnRowClick()
@@ -1967,7 +1965,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task TableGroupingTest()
+        public void TableGroupingTest()
         {
             // without grouping, to ensure that anything was broken:
             var comp = Context.RenderComponent<TableGroupingTest>();
@@ -2084,24 +2082,24 @@ namespace MudBlazor.UnitTests.Components
             comp.Render();
 
             table.SelectedItems.Count.Should().Be(0);
-            Inputs().Where(x => x.IsChecked()).Count().Should().Be(0);
+            Inputs().Count(x => x.IsChecked()).Should().Be(0);
 
             Inputs()[1].Change(true); // LMP1
             table.SelectedItems.Count.Should().Be(2);
 
-            Inputs().Where(x => x.IsChecked()).Count().Should().Be(5);
+            Inputs().Count(x => x.IsChecked()).Should().Be(5);
 
             Buttons()[0].Click(); //collapse
             Buttons()[0].Click(); //expand
             //selected item should persist
             table.SelectedItems.Count.Should().Be(2);
 
-            Inputs().Where(x => x.IsChecked()).Count().Should().Be(5);
+            Inputs().Count(x => x.IsChecked()).Should().Be(5);
 
             Inputs()[1].Change(false);
             table.SelectedItems.Count.Should().Be(0);
 
-            Inputs().Where(x => x.IsChecked()).Count().Should().Be(0);
+            Inputs().Count(x => x.IsChecked()).Should().Be(0);
 
         }
 
@@ -2110,7 +2108,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task TableGroupingAndPaginationTest()
+        public void TableGroupingAndPaginationTest()
         {
             // without grouping, to ensure that anything was broken:
             var comp = Context.RenderComponent<TableGroupingTest2>();
@@ -2147,7 +2145,6 @@ namespace MudBlazor.UnitTests.Components
             table.Context.Rows.Count.Should().Be(1);
             tr = comp.FindAll("tr").ToArray();
             tr.Length.Should().Be(6); // 01 Table header + 02 Group Headers + 02 Group Footers + 01 Entries
-
         }
 
 
@@ -2156,7 +2153,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task TableGroupIsInitiallyExpandedTest()
+        public void TableGroupIsInitiallyExpandedTest()
         {
             // group by Racing Category and collapse groups as default:
             var comp = Context.RenderComponent<TableGroupingTest>();
@@ -2174,7 +2171,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ExpandAndCollapsAllGroupsTest()
+        public void ExpandAndCollapseAllGroupsTest()
         {
             var comp = Context.RenderComponent<TableGroupingTest>();
             var table = comp.Instance.TableInstance;
@@ -2199,9 +2196,8 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Tests the correct output when filter does not return any matching elements
         /// </summary>
-        /// <returns>The awaitable <see cref="Task"/></returns>
         [Test]
-        public async Task TablePagerInfoTextTest()
+        public void TablePagerInfoTextTest()
         {
             // create the component
             var tableComponent = Context.RenderComponent<TablePagerInfoTextTest>();
@@ -2266,7 +2262,7 @@ namespace MudBlazor.UnitTests.Components
         /// Tests checks that RowsPerPage Parameter is two-way bindable
         /// </summary>
         [Test]
-        public async Task RowsPerPageParameterTwoWayBinding()
+        public void RowsPerPageParameterTwoWayBinding()
         {
             var rowsPerPage = 5;
             var newRowsPerPage = 25;
@@ -2369,12 +2365,12 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        /// <summary>
         /// Issue #3033
         /// Tests changing RowsPerPage Parameter from code - Table should re-render new RowsPerPage parameter and parameter value should be set
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task RowsPerPageChangeValueFromCode()
+        public void RowsPerPageChangeValueFromCode()
         {
             var testComponent = Context.RenderComponent<TablePagerChangeRowsPerPageTest>();
             var table = testComponent.FindComponent<MudTable<string>>().Instance;
@@ -2391,9 +2387,8 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Tests whether record type table items are kept track of when edited
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task TableRecordEditingMultiSelectTest()
+        public void TableRecordEditingMultiSelectTest()
         {
             var comp = Context.RenderComponent<TableRecordComparerTest>();
             var table = comp.FindComponent<MudTable<TableRecordComparerTest.Element>>().Instance;
@@ -2433,7 +2428,6 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Setting a comparer should be reflected in all layers of the table
         /// </summary>
-        /// <returns></returns>
         [Test]
         public async Task TableComparerContextTest()
         {
@@ -2457,9 +2451,8 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Using a virtualized table with multiselection must preserve checked items
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task TestVirtualizedTableWithMultiSelection()
+        public void TestVirtualizedTableWithMultiSelection()
         {
             var comp = Context.RenderComponent<TableMultiSelectionVirtualizedTest>();
             var table = comp.FindComponent<MudTable<TableMultiSelectionVirtualizedTest.TestItem>>();
@@ -2489,7 +2482,7 @@ namespace MudBlazor.UnitTests.Components
         /// Selecting the 'Select All' checkbox should trigger the 'SelectedItemsChanged' event only once
         /// </summary>
         [Test]
-        public async Task TestSelectedItemsChanedWithMultiSelection()
+        public void TestSelectedItemsChangedWithMultiSelection()
         {
             var comp = Context.RenderComponent<TableMultiSelectionSelectedItemsChangedTest>();
             var selectAllCheckbox = comp.Find("input");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable CS1998 // async without await
-#pragma warning disable BL0005 // Set parameter outside component
+﻿#pragma warning disable BL0005 // Set parameter outside component
 
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -10,7 +9,6 @@ using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.Dummy;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Field;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.UnitTests.TestComponents.TextField;
@@ -39,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>
         [Test]
-        public async Task TextFieldLabelFor()
+        public void TextFieldLabelFor()
         {
             var comp = Context.RenderComponent<FieldTest>();
             var label = comp.FindAll(".mud-input-label");
@@ -89,7 +87,7 @@ namespace MudBlazor.UnitTests.Components
         /// Setting the value to null should not cause a validation error
         /// </summary>
         [Test]
-        public async Task TextFieldWithNullableTypes()
+        public void TextFieldWithNullableTypes()
         {
             var comp = Context.RenderComponent<MudTextField<int?>>(ComponentParameter.CreateParameter("Value", 17));
             // print the generated html
@@ -105,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
         /// Setting an invalid number should show the conversion error message
         /// </summary>
         [Test]
-        public async Task TextFieldConversionError()
+        public void TextFieldConversionError()
         {
             var comp = Context.RenderComponent<MudTextField<int?>>();
             // print the generated html
@@ -133,7 +131,6 @@ namespace MudBlazor.UnitTests.Components
             //input value has changed, DebounceInterval is 0, so Value should change in TextField immediately
             textField.Value.Should().Be("Some Value");
         }
-
 
         /// <summary>
         /// Value should not change immediately. Should respect the Debounce Interval
@@ -218,7 +215,7 @@ namespace MudBlazor.UnitTests.Components
         /// FluentValidation rules can be used for validating a TextFields
         /// </summary>
         [Test]
-        public async Task TextFieldFluentValidationTest1()
+        public void TextFieldFluentValidationTest1()
         {
             var validator = new FluentValueValidator<string>(x => x.Cascade(CascadeMode.Stop)
                 .NotEmpty()
@@ -241,7 +238,7 @@ namespace MudBlazor.UnitTests.Components
         /// An unstable converter should not cause an infinite update loop. This test must complete in under 1 sec!
         /// </summary>
         [Test, CancelAfter(1000)]
-        public async Task TextFieldUpdateLoopProtectionTest()
+        public void TextFieldUpdateLoopProtectionTest()
         {
             var comp = Context.RenderComponent<MudTextField<string>>();
             // these conversion funcs are nonsense of course, but they are designed this way to
@@ -258,7 +255,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_Should_FireValueChangedOnTextParameterChange()
+        public void TextField_Should_FireValueChangedOnTextParameterChange()
         {
             string changed_value = null;
             var comp = Context.RenderComponent<MudTextField<string>>(EventCallback<string>("ValueChanged", x => changed_value = x));
@@ -267,7 +264,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_Should_FireTextChangedOnValueParameterChange()
+        public void TextField_Should_FireTextChangedOnValueParameterChange()
         {
             string changed_text = null;
             var comp = Context.RenderComponent<MudTextField<string>>(EventCallback<string>("TextChanged", x => changed_text = x));
@@ -276,7 +273,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_Should_FireTextAndValueChangedOnTextInput()
+        public void TextField_Should_FireTextAndValueChangedOnTextInput()
         {
             string changed_value = null;
             string changed_text = null;
@@ -293,9 +290,8 @@ namespace MudBlazor.UnitTests.Components
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
         /// already fulfill the requirement of Required="true". If it is a valid value is a different question.
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task TextField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
+        public void TextField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
         {
             var comp = Context.RenderComponent<MudTextField<int?>>(ComponentParameter.CreateParameter("Required", true));
             var textfield = comp.Instance;
@@ -310,9 +306,8 @@ namespace MudBlazor.UnitTests.Components
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
         /// already fulfill the requirement of Required="true". If it is a valid value is a different question.
         /// </summary>
-        /// <returns></returns>
         [Test]
-        public async Task TextField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
+        public void TextField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
         {
             var comp = Context.RenderComponent<TextFieldRequiredTest>();
             var textfield = comp.FindComponent<MudTextField<string>>().Instance;
@@ -325,13 +320,13 @@ namespace MudBlazor.UnitTests.Components
         /// This is based on a bug reported by a user
         /// </summary>
         [Test]
-        public async Task DebouncedTextField_ShouldNot_ThrowException()
+        public void DebouncedTextField_ShouldNot_ThrowException()
         {
             Context.RenderComponent<DebouncedTextFieldTest>();
         }
 
         [Test]
-        public async Task TextFieldMultiline_CheckRenderedText()
+        public void TextFieldMultiline_CheckRenderedText()
         {
             var text = "Hello world!";
             var comp = Context.RenderComponent<MudTextField<string>>(
@@ -339,7 +334,6 @@ namespace MudBlazor.UnitTests.Components
                 Parameter(nameof(MudTextField<string>.Lines), 2));
             // print the generated html
             // select elements needed for the test
-            var textfield = comp.Instance;
             comp.Find("textarea").InnerHtml.Should().Be(text);
         }
 
@@ -349,7 +343,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task TextFieldMultilineWithMask_CheckRendered()
+        public void TextFieldMultilineWithMask_CheckRendered()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(
                 Parameter(nameof(MudTextField<string>.Mask), new RegexMask(@"\d")),
@@ -358,7 +352,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task MultilineTextField_Should_UpdateTextOnInput()
+        public void MultilineTextField_Should_UpdateTextOnInput()
         {
             var comp = Context.RenderComponent<MudTextField<string>>();
             var textfield = comp.Instance;
@@ -378,7 +372,7 @@ namespace MudBlazor.UnitTests.Components
         /// <para>After editing the second (multi-line) tf it would not accept any updates from the first tf.</para>
         /// </summary>
         [Test]
-        public async Task MultiLineTextField_ShouldBe_TwoWayBindable()
+        public void MultiLineTextField_ShouldBe_TwoWayBindable()
         {
             var comp = Context.RenderComponent<MultilineTextfieldBindingTest>();
             // print the generated html
@@ -402,7 +396,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task AutoGrowTextField_Should_InvokeJavaScriptInitOnRender()
+        public void AutoGrowTextField_Should_InvokeJavaScriptInitOnRender()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(
                 Parameter(nameof(MudTextField<string>.AutoGrow), true),
@@ -425,7 +419,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextFieldClearableTest()
+        public void TextFieldClearableTest()
         {
             var comp = Context.RenderComponent<TextFieldClearableTest>();
             var textField = comp.FindComponent<MudTextField<string>>();
@@ -453,7 +447,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_ClearButton_TabIndex_Test()
+        public void TextField_ClearButton_TabIndex_Test()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(
                 Parameter(nameof(MudTextField<string>.Clearable), true),
@@ -674,7 +668,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_Should_UpdateOnBoundValueChange_WhenFocused_WithTextUpdateSuppressionOff()
+        public void TextField_Should_UpdateOnBoundValueChange_WhenFocused_WithTextUpdateSuppressionOff()
         {
             var comp = Context.RenderComponent<TextFieldUpdateViaBindingTest>();
             var input = comp.FindComponent<MudInput<string>>();
@@ -694,7 +688,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_ElementReferenceId_ShouldNot_BeEmpty()
+        public void TextField_ElementReferenceId_ShouldNot_BeEmpty()
         {
             var comp = Context.RenderComponent<MudTextField<string>>();
             var inputId = comp.Instance.InputReference.ElementReference.Id;
@@ -702,7 +696,7 @@ namespace MudBlazor.UnitTests.Components
             inputId.Should().NotBeEmpty();
         }
 
-        class TestDataAnnotationModel
+        private class TestDataAnnotationModel
         {
             [Required(ErrorMessage = "The {0} field is required.")]
             public string Foo1 { get; set; }
@@ -774,7 +768,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task InputMode_DefaultValue_IsText()
+        public void InputMode_DefaultValue_IsText()
         {
             var comp = Context.RenderComponent<MudTextField<string>>();
 
@@ -789,7 +783,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task InputMode_DefaultValueWithMask_IsText()
+        public void InputMode_DefaultValueWithMask_IsText()
         {
             var mask = new PatternMask("0000");
             var comp = Context.RenderComponent<MudTextField<string>>(
@@ -806,7 +800,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task InputMode_ChangedValue_IsPropagated()
+        public void InputMode_ChangedValue_IsPropagated()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(
                 x => x.Add(x => x.InputMode, InputMode.numeric));
@@ -822,7 +816,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task InputMode_ChangedValueWithMask_IsPropagated()
+        public void InputMode_ChangedValueWithMask_IsPropagated()
         {
             var mask = new PatternMask("0000");
             var comp = Context.RenderComponent<MudTextField<string>>(
@@ -933,7 +927,7 @@ namespace MudBlazor.UnitTests.Components
         /// ReadOnly TextFields should not validate when blurred
         /// </summary>
         [Test]
-        public async Task ReadOnlyTextFieldShouldNotValidate()
+        public void ReadOnlyTextFieldShouldNotValidate()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
             .Add(p => p.ReadOnly, true)
@@ -960,7 +954,7 @@ namespace MudBlazor.UnitTests.Components
         /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
         /// </summary>
         [Test]
-        public async Task OnBlurWithModifiedValueTriggerValidationOnce1()
+        public void OnBlurWithModifiedValueTriggerValidationOnce1()
         {
             var callCounter = 0;
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
@@ -976,7 +970,7 @@ namespace MudBlazor.UnitTests.Components
         /// Reproduce https://github.com/MudBlazor/MudBlazor/issues/7034
         /// </summary>
         [Test]
-        public async Task OnBlurWithModifiedValueTriggerValidationOnce2()
+        public void OnBlurWithModifiedValueTriggerValidationOnce2()
         {
             var callCounter = 0;
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
@@ -1063,7 +1057,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DebouncedTextField_Should_RenderDefaultValueTextOnFirstRender()
+        public void DebouncedTextField_Should_RenderDefaultValueTextOnFirstRender()
         {
             var defaultValue = "test";
             var comp = Context.RenderComponent<DebouncedTextFieldRerenderTest>(
@@ -1109,7 +1103,7 @@ namespace MudBlazor.UnitTests.Components
         /// A text field with AutoGrow enabled should contain a special class.
         /// </summary>
         [Test]
-        public async Task TextFieldAutoGrowHasClass()
+        public void TextFieldAutoGrowHasClass()
         {
             var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
             .Add(p => p.AutoGrow, true));

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -322,7 +322,11 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DebouncedTextField_ShouldNot_ThrowException()
         {
-            Context.RenderComponent<DebouncedTextFieldTest>();
+            // Arrange & Act
+            var renderComponent = () => Context.RenderComponent<DebouncedTextFieldTest>();
+
+            // Assert
+            renderComponent.Should().NotThrow();
         }
 
         [Test]


### PR DESCRIPTION
## Description
I have no idea why tests historically started using 'async Task' when it's not required, and why everyone seems to have copied this practice, but it's not normal.
No async code = void
Async code = async Task

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
