### PR TITLE
MudTabs: Fix scrolling to active index

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsRenderTest.razor
@@ -1,0 +1,32 @@
+﻿<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="AlwaysShowScrollButtons" Position="Position">
+@foreach (var tab in _tabs)
+{
+    <MudTabPanel @key="tab" Text="@tab">
+        <MudText>@tab</MudText>
+    </MudTabPanel>
+}
+</MudTabs>
+
+@code
+{
+
+    public static string __description__ = "tabs should have scrolled after render";
+
+    private MudTabs _tabElement = null!;
+    private readonly List<string> _tabs = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
+
+    [Parameter]
+    public Position Position { get; set; } = Position.Top;
+
+    [Parameter]
+    public bool AlwaysShowScrollButtons { get; set; } = true;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if(firstRender)
+        {
+            _tabElement.ActivatePanel(3);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsRenderTest.razor
@@ -1,4 +1,4 @@
-﻿<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="AlwaysShowScrollButtons" Position="Position">
+﻿<MudTabs Elevation="1" ActivePanelIndex="8">
 @foreach (var tab in _tabs)
 {
     <MudTabPanel @key="tab" Text="@tab">
@@ -7,26 +7,8 @@
 }
 </MudTabs>
 
-@code
-{
-
+@code{
     public static string __description__ = "tabs should have scrolled after render";
 
-    private MudTabs _tabElement = null!;
     private readonly List<string> _tabs = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
-
-    [Parameter]
-    public Position Position { get; set; } = Position.Top;
-
-    [Parameter]
-    public bool AlwaysShowScrollButtons { get; set; } = true;
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        base.OnAfterRender(firstRender);
-        if(firstRender)
-        {
-            _tabElement.ActivatePanel(3);
-        }
-    }
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -215,19 +215,22 @@ namespace MudBlazor.UnitTests.Components
             };
 
             var factory = new MockResizeObserverFactory(observer);
-
-            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+            Context.Services.AddTransient<IResizeObserverFactory>(_ => factory);
 
             var comp = Context.RenderComponent<ScrollableTabsRenderTest>();
 
             var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
+            var tabs = comp.FindAll(".mud-tab");
 
             toolbarWrapper.Should().NotBeNull();
+            tabs.Count.Should().Be(11);
+            // Tab index starts from zero
+            tabs[8].ClassList.Should().Contain("mud-tab-active");
 
             toolbarWrapper.HasAttribute("style").Should().Be(true);
             var styleAttr = toolbarWrapper.GetAttribute("style");
 
-            styleAttr.Should().Be("transform:translateX(-300px);");
+            styleAttr.Should().Be("transform:translateX(-800px);");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -206,6 +206,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void ScrollToItem_BeforeRender()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 110,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.RenderComponent<ScrollableTabsRenderTest>();
+
+            var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
+
+            toolbarWrapper.Should().NotBeNull();
+
+            toolbarWrapper.HasAttribute("style").Should().Be(true);
+            var styleAttr = toolbarWrapper.GetAttribute("style");
+
+            styleAttr.Should().Be("transform:translateX(-300px);");
+        }
+
+        [Test]
         [TestCase(400.0, 100)]
         [TestCase(300.0, 100)]
         [TestCase(200.0, 200)]

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
@@ -1,9 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Interop;
 using MudBlazor.Services;
 
@@ -29,7 +24,7 @@ namespace MudBlazor.UnitTests.Mocks
 
     public class MockResizeObserver : IResizeObserver
     {
-        private Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
+        private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
 
         public bool IsVertical { get; set; } = false;
 
@@ -48,9 +43,7 @@ namespace MudBlazor.UnitTests.Mocks
                 entry.Value.Height = newSize;
             }
 
-            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
-                    { entry.Key, entry.Value  },
-                });
+            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> { { entry.Key, entry.Value }, });
         }
 
         public void UpdatePanelSize(int index, double newSize)
@@ -66,9 +59,7 @@ namespace MudBlazor.UnitTests.Mocks
                 entry.Value.Height = newSize;
             }
 
-            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
-                    { entry.Key, entry.Value  },
-                });
+            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> { { entry.Key, entry.Value }, });
         }
 
         public double PanelSize { get; set; } = 250;
@@ -115,12 +106,7 @@ namespace MudBlazor.UnitTests.Mocks
 
         public BoundingClientRect GetSizeInfo(ElementReference reference)
         {
-            if (_cachedValues.ContainsKey(reference) == false)
-            {
-                return null;
-            }
-
-            return _cachedValues[reference];
+            return _cachedValues.GetValueOrDefault(reference);
         }
         public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
         public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -347,6 +347,7 @@ namespace MudBlazor
 
                 Rerender();
                 StateHasChanged();
+                ActivatePanel(ActivePanelIndex);
 
                 _isRendered = true;
             }


### PR DESCRIPTION
## Description
Fixes: https://github.com/MudBlazor/MudBlazor/issues/6850 when index is set before rendering is complete

## How Has This Been Tested?
Visually + bUnit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.