### PR TITLE
#10010: Menu overlay with css transforms (sections)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestCloseWithCssTransform.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestCloseWithCssTransform.razor
@@ -1,0 +1,19 @@
+@using Microsoft.AspNetCore.Components.Sections
+
+<MudPopoverProvider />
+
+<SectionOutlet SectionName="Overlay" />
+
+<div style="transform:translate(0px,0px);">
+    <MudMenu OverlaySection="Overlay">
+        <MudMenuItem>
+            Save
+        </MudMenuItem>
+        <MudMenuItem>
+            Export
+        </MudMenuItem>
+        <MudMenuItem>
+            Print
+        </MudMenuItem>
+    </MudMenu>
+</div>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -545,5 +545,29 @@ namespace MudBlazor.UnitTests.Components
 
             await Context.Renderer.Dispatcher.InvokeAsync(mudMenuContext.CloseMenuAsync);
         }
+
+        [Test]
+        public async Task CloseMenuWithCssTransform_Overlay()
+        {
+            var comp = Context.RenderComponent<MenuTestCloseWithCssTransform>();
+            var menuComponent = comp.FindComponent<MudMenu>();
+            var mudMenuContext = menuComponent.Instance;
+            mudMenuContext.Should().NotBeNull();
+
+            // open menu
+            await Context.Renderer.Dispatcher.InvokeAsync(() => mudMenuContext.OpenMenuAsync(new MouseEventArgs()));
+
+            // find mud-overlay
+            var overlay = comp.Find("div.mud-overlay");
+            var menuOverlay = menuComponent.FindAll("div.mud-overlay").FirstOrDefault();
+
+            // Assert
+            overlay.ClassList.Should().Contain("mud-overlay");
+            menuOverlay.Should().BeNull();
+
+            overlay.Click();
+            // menu shoud be closed
+            comp.WaitForAssertion(() => menuComponent.Instance.Open.Should().BeFalse());
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -1,4 +1,5 @@
 @namespace MudBlazor
+@using Microsoft.AspNetCore.Components.Sections
 @using MudBlazor.Interfaces
 @inherits MudComponentBase
 
@@ -69,5 +70,14 @@
         </CascadingValue>
     </MudPopover>
 
-    <MudOverlay Visible="Open && !_isTemporary" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
+    @if (string.IsNullOrWhiteSpace(OverlaySection))
+    {
+        <MudOverlay Visible="Open && !_isTemporary" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
+    }
+    else
+    {
+        <SectionContent SectionName="@OverlaySection">
+            <MudOverlay Visible="Open && !_isTemporary" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
+        </SectionContent>
+    }
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -38,6 +38,13 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
+        /// The style of the popover when <see cref="PositionAtCursor"/> is <c>true</c>.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Menu.PopupAppearance)]
+        public string? OverlaySection { get; set; }
+
+        /// <summary>
         /// The text shown for this menu.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fixes #10010.

As comented in previous issue, when using MudMenu with css transform,
inner overlay does not covers the entire page, so clicking outside menu does not close it.

This fix adds an optional parameter (OverlaySection) to MudMenu, to allow render overlay outside mud-menu div (when necessary, for example, when a css-transforms is needed like the one mentioned in the original issue).

<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
