### PR TITLE
MudDrawer: Set `display:none` when drawer is closed

### DIFF
--- a/src/MudBlazor/Styles/layout/_drawer.scss
+++ b/src/MudBlazor/Styles/layout/_drawer.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-drawer {
   display: flex;
@@ -60,7 +60,11 @@
         left: calc(-1 * var(--mud-drawer-width, var(--mud-drawer-width-left)));
 
         &:not(.mud-drawer--initial) {
-          animation: mud-drawer-slide-out-left 225ms cubic-bezier(0, 0, 0.2, 1);
+          animation: mud-drawer-slide-out-left 225ms cubic-bezier(0, 0, 0.2, 1) forwards;
+        }
+
+        &.mud-drawer--initial {
+          display: none !important;
         }
       }
     }
@@ -82,7 +86,11 @@
         right: calc(-1 * var(--mud-drawer-width, var(--mud-drawer-width-right)));
 
         &:not(.mud-drawer--initial) {
-          animation: mud-drawer-slide-out-right 225ms cubic-bezier(0, 0, 0.2, 1);
+          animation: mud-drawer-slide-out-right 225ms cubic-bezier(0, 0, 0.2, 1) forwards;
+        }
+
+        &.mud-drawer--initial {
+          display: none !important;
         }
       }
     }
@@ -167,6 +175,10 @@
         &:not(.mud-drawer--initial) {
           animation: mud-drawer-slide-out-right 225ms cubic-bezier(0, 0, 0.2, 1)forwards;
         }
+
+        &.mud-drawer--initial {
+          display: none !important;
+        }
       }
     }
 
@@ -187,7 +199,11 @@
         bottom: calc(-1 * var(--mud-drawer-content-height));
 
         &:not(.mud-drawer--initial) {
-          animation: mud-drawer-slide-out-bottom 225ms cubic-bezier(0, 0, 0.2, 1) 0ms 1;
+          animation: mud-drawer-slide-out-bottom 225ms cubic-bezier(0, 0, 0.2, 1) 0ms 1 forwards;
+        }
+
+        &.mud-drawer--initial {
+          display: none !important;
         }
       }
     }
@@ -209,7 +225,7 @@
         top: calc(-1 * var(--mud-drawer-content-height));
 
         &:not(.mud-drawer--initial) {
-          animation: mud-drawer-slide-out-top 225ms cubic-bezier(0, 0, 0.2, 1) 0ms 1;
+          animation: mud-drawer-slide-out-top 225ms cubic-bezier(0, 0, 0.2, 1) 0ms 1 forwards;
         }
       }
     }
@@ -350,6 +366,9 @@
   from {
     left: 0;
   }
+  to {
+    display: none;
+  }
 }
 
 @keyframes mud-drawer-slide-in-right {
@@ -361,6 +380,9 @@
 @keyframes mud-drawer-slide-out-right {
   from {
     right: 0;
+  }
+  to {
+    display: none;
   }
 }
 
@@ -374,6 +396,9 @@
   from {
     bottom: 0;
   }
+  to {
+    display: none;
+  }
 }
 
 @keyframes mud-drawer-slide-in-top {
@@ -385,6 +410,9 @@
 @keyframes mud-drawer-slide-out-top {
   from {
     top: 0;
+  }
+  to {
+    display: none;
   }
 }
 /*#endregion*/


### PR DESCRIPTION
## Description
When `MudDrawer` closes it's actually just positioned "off-screen". Based on how an app/page is setup, this can sometimes lead to right and bottom draws still being visible when scrolling.

Resolves #10175

`This image represents the closed drawer being shifted off-screen`
![visible offscreen](https://github.com/user-attachments/assets/78b3dc50-f9da-4d2d-9a49-3eb1397fc734)

## How Has This Been Tested?
Tested with the sample app provided in issue #10175 
Unable to replicate in test viewer as components are property wrapped in a `MudLayout`. Also, the markeup remains in the document so unable to confirm via bunit tests. 

**Any ides for testing are welcomed.**

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
