### PR TITLE
MudAppBar: Add contextual action bar implementation

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
@@ -55,5 +55,16 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Contextual App Bar">
+                <Description>
+                    <MudText>You can conditionally transform the app bar into a contextual action bar with page specific action buttons.</MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(AppBarContextualExample)" ShowCode="false">
+                <AppBarContextualExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
@@ -8,7 +8,7 @@
     </MudAppBar>
     <MudMainContent Class="pt-4">
         <div class="d-flex flex-wrap gap-4">
-            @for(int i = 0; i < _images.Length; i++) 
+            @for (int i = 0; i < _images.Length; i++)
             {
                 var index = i;
 
@@ -17,7 +17,7 @@
                 <MudPaper Width="200px" Height="150px" Elevation="0" Class="d-flex align-center justify-center" Style="background-color:inherit">
                     <MudImage Src="@($"images/{_images[index].Title}.jpg")" Width="@_images[index].Width" Height="@_images[index].Height"
                               Elevation="25" ObjectFit="ObjectFit.Cover" Class="rounded-lg"
-                              @onclick="@(() => SelectImage(index))" />
+                              @onclick="@(() => SelectImage(index))"/>
                 </MudPaper>
             }
         </div>
@@ -38,7 +38,7 @@
 
     private readonly HashSet<Image> _selected = [];
     private int Deleted => _images.Count(x => x.IsDeleted);
-    private readonly Image[] _images = [ new Image("sweden"), new Image("iceland"), new Image("castle"), new Image("tractor"), new Image("door"), new Image("pilars") ];
+    private readonly Image[] _images = [ new Image("sweden"), new Image("iceland"), new Image("castle"), new Image("tractor"), new Image("door"), new Image("pillars") ];
 
     private void SelectImage(int index)
     {

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
@@ -38,7 +38,7 @@
 
     private readonly HashSet<Image> _selected = [];
     private int Deleted => _images.Count(x => x.IsDeleted);
-    private readonly Image[] _images = [ new Image("sweden"), new Image("iceland"), new Image("castle"), new Image("tractor"), new Image("door"), new Image("pillars") ];
+    private readonly Image[] _images = [ new Image("sweden"), new Image("iceland"), new Image("castle"), new Image("tractor"), new Image("door"), new Image("pilars") ];
 
     private void SelectImage(int index)
     {

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudLayout>
-    <MudAppBar Color="Color.Primary" Fixed="false" Contextual Bottom>
+    <MudAppBar Color="Color.Primary" Fixed="false" Contextual>
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         <MudSpacer />
         <MudIconButton Icon="@(Deleted > 0 ? @Icons.Material.Filled.FlipToBack : @Icons.Material.Filled.FlipToFront)" Color="Color.Inherit" OnClick="ResetItems" />

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
@@ -1,0 +1,85 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Fixed="false" Contextual Bottom>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+        <MudSpacer />
+        <MudIconButton Icon="@(Deleted > 0 ? @Icons.Material.Filled.FlipToBack : @Icons.Material.Filled.FlipToFront)" Color="Color.Inherit" OnClick="ResetItems" />
+    </MudAppBar>
+    <MudMainContent Class="pt-4">
+        <div class="d-flex flex-wrap gap-4">
+            @for(int i = 0; i < _images.Length; i++) 
+            {
+                var index = i;
+
+                if (_images[index].IsDeleted) continue;
+
+                <MudPaper Width="200px" Height="150px" Elevation="0" Class="d-flex align-center justify-center" Style="background-color:inherit">
+                    <MudImage Src="@($"images/{_images[index].Title}.jpg")" Width="@_images[index].Width" Height="@_images[index].Height"
+                              Elevation="25" ObjectFit="ObjectFit.Cover" Class="rounded-lg"
+                              @onclick="@(() => SelectImage(index))" />
+                </MudPaper>
+            }
+        </div>
+    </MudMainContent>
+</MudLayout>
+
+<MudContextualActionBar Color="Color.Tertiary" Fixed="false" Visible="ShowContext">
+    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(() => _selected.Clear())" />
+    <MudText Class="pl-8" Typo="Typo.h6">@($"{_selected.Count} Selected") </MudText>
+    <MudSpacer />
+    <MudIconButton Icon="@Icons.Material.Filled.Share" Color="Color.Inherit" />
+    <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Inherit" />
+    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Inherit" OnClick="DeleteSelectedItems" />
+</MudContextualActionBar>
+
+@code {
+    private bool ShowContext => _selected.Count > 0;
+
+    private readonly HashSet<Image> _selected = [];
+    private int Deleted => _images.Count(x => x.IsDeleted);
+    private readonly Image[] _images = [ new Image("sweden"), new Image("iceland"), new Image("castle"), new Image("tractor"), new Image("door"), new Image("pilars") ];
+
+    private void SelectImage(int index)
+    {
+        var image = _images[index];
+        bool isSelected = _selected.Contains(image);
+
+        _images[index] = image with { Width = isSelected ? 200 : 100, Height = isSelected ? 150 : 75 };
+
+        if (isSelected)
+            _selected.Remove(image);
+        else
+            _selected.Add(_images[index]);
+    }
+
+    private void DeleteSelectedItems()
+    {
+        for (int index = 0; index < _images.Length; index++)
+        {
+            var image = _images[index];
+
+            if(_selected.Contains(image))
+            {
+                _images[index] = image with { Width = 200, Height = 150, IsDeleted = true };
+            }
+        }
+
+        _selected.Clear();
+    }
+
+    private void ResetItems()
+    {
+        for (int index = 0; index < _images.Length; index++)
+        {
+            var image = _images[index];
+
+            if (image.IsDeleted)
+            {
+                _images[index] = image with { IsDeleted = false };
+            }
+        }
+    }
+
+    private record Image(string Title, int Width = 200, int Height = 150, bool IsDeleted = false);
+}

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarContextualExample.razor
@@ -25,7 +25,7 @@
 </MudLayout>
 
 <MudContextualActionBar Color="Color.Tertiary" Fixed="false" Visible="ShowContext">
-    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(() => _selected.Clear())" />
+    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Edge="Edge.Start" OnClick="UnselectItems" />
     <MudText Class="pl-8" Typo="Typo.h6">@($"{_selected.Count} Selected") </MudText>
     <MudSpacer />
     <MudIconButton Icon="@Icons.Material.Filled.Share" Color="Color.Inherit" />
@@ -51,6 +51,21 @@
             _selected.Remove(image);
         else
             _selected.Add(_images[index]);
+    }
+
+    private void UnselectItems()
+    {
+        for (int index = 0; index < _images.Length; index++)
+        {
+            var image = _images[index];
+
+            if (_selected.Contains(image))
+            {
+                _images[index] = image with { Width = 200, Height = 150 };
+            }
+        }
+
+        _selected.Clear();
     }
 
     private void DeleteSelectedItems()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/AppBar/ContextualAppBarTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/AppBar/ContextualAppBarTest.razor
@@ -1,0 +1,27 @@
+﻿<MudAppBar Color="Color.Primary" Fixed="false" Contextual="IsContextual" id="regular-app-bar">
+    <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+    <MudSpacer />
+    <MudText Typo="Typo.h6">Regular</MudText>
+    <MudSpacer />
+    <MudIconButton Icon="@Icons.Material.Filled.DarkMode" Color="Color.Inherit"/>
+</MudAppBar>
+
+<MudContextualActionBar Color="Color.Tertiary" Fixed="false" Visible="_visible" id="contextual-app-bar">
+    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(() => _visible = false)" />
+    <MudSpacer />
+    <MudText Class="pl-8" Typo="Typo.h6">Contextual</MudText>
+    <MudSpacer />
+    <MudIconButton Icon="@Icons.Material.Filled.LightMode" Color="Color.Inherit" />
+</MudContextualActionBar>
+
+<MudSwitch Class="pt-8" @bind-Value="_visible" />
+
+@code
+{
+    public static string __description__ = "App bar should change when toggled";
+
+    [Parameter]
+    public bool IsContextual { get; set; } = true;
+
+    private bool _visible;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/AppBar/ContextualAppBarTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/AppBar/ContextualAppBarTest.razor
@@ -16,12 +16,11 @@
 
 <MudSwitch Class="pt-8" @bind-Value="_visible" />
 
-@code
-{
+@code {
     public static string __description__ = "App bar should change when toggled";
+
+    private bool _visible;
 
     [Parameter]
     public bool IsContextual { get; set; } = true;
-
-    private bool _visible;
 }

--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -4,6 +4,7 @@
 
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents.AppBar;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
@@ -78,5 +79,30 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudToolBar>().Instance.WrapContent.Should().Be(false);
         }
 
+        [Test]
+        public void AppBarWithContextualSetTrue()
+        {
+            var comp = Context.RenderComponent<ContextualAppBarTest>();
+            var bar = comp.FindComponent<MudAppBar>();
+
+            bar.Markup.Should().Contain("regular-app-bar").And.Contain("mud-theme-primary");
+
+            comp.Find(".mud-switch-input").Change(true);
+
+            bar.Markup.Should().Contain("contextual-app-bar").And.Contain("mud-theme-tertiary");
+        }
+
+        [Test]
+        public void AppBarWithContextualSetFalse()
+        {
+            var comp = Context.RenderComponent<ContextualAppBarTest>(Parameter(nameof(ContextualAppBarTest.IsContextual), false));
+            var bar = comp.FindComponent<MudAppBar>();
+
+            bar.Markup.Should().Contain("regular-app-bar").And.Contain("mud-theme-primary");
+
+            comp.Find(".mud-switch-input").Change(true);
+
+            bar.Markup.Should().Contain("regular-app-bar").And.Contain("mud-theme-primary");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -49,7 +49,7 @@ namespace MudBlazor.UnitTests.UserAttributes
             // these components do not need to have user attributes
             var excludedComponents = new HashSet<string>()
             {
-                nameof(MudPopover), nameof(MudStep),
+                nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar),
                 "Column`1", "FooterCell`1", "HeaderCell`1", "FilterHeaderCell`1", "SelectColumn`1",
                 "HierarchyColumn`1", "PropertyColumn`2", "TemplateColumn`1",
             };

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -7,8 +7,8 @@
 {
     @if (Contextual)
     {
-        <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
-        <SectionContent SectionId="MudAppBar.ContextualActionBar">
+        <SectionOutlet SectionId="@ContextualActionBar" />
+        <SectionContent SectionId="@ContextualActionBar">
             @Footer
         </SectionContent>
     }
@@ -21,8 +21,8 @@ else
 {
     @if (Contextual)
     {
-        <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
-        <SectionContent SectionId="MudAppBar.ContextualActionBar">
+        <SectionOutlet SectionId="@ContextualActionBar" />
+        <SectionContent SectionId="@ContextualActionBar">
             @Header
         </SectionContent>
     }

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -3,33 +3,16 @@
 @namespace MudBlazor
 @inherits MudComponentBase
 
-@if (Bottom)
+@if (Contextual)
 {
-    @if (Contextual)
-    {
-        <SectionOutlet SectionId="@ContextualActionBar" />
-        <SectionContent SectionId="@ContextualActionBar">
-            @Footer
-        </SectionContent>
-    }
-    else
-    {
-        @Footer
-    }
+    <SectionOutlet SectionId="@ContextualActionBar" />
+    <SectionContent SectionId="@ContextualActionBar">
+        @(Bottom ? Footer : Header)
+    </SectionContent>
 }
 else
 {
-    @if (Contextual)
-    {
-        <SectionOutlet SectionId="@ContextualActionBar" />
-        <SectionContent SectionId="@ContextualActionBar">
-            @Header
-        </SectionContent>
-    }
-    else
-    {
-        @Header
-    }
+    @(Bottom ? Footer : Header)
 }
 
 @code {

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -1,18 +1,49 @@
+@using Microsoft.AspNetCore.Components.Sections;
+
 @namespace MudBlazor
 @inherits MudComponentBase
+
 @if (Bottom)
 {
-<footer @attributes="UserAttributes" class="@Classname" style="@Style">
-    <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
-        @ChildContent
-    </MudToolBar>
-</footer>
+    @if(Contextual)
+    {
+        <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
+        <SectionContent SectionId="MudAppBar.ContextualActionBar">
+            <footer @attributes="UserAttributes" class="@Classname" style="@Style">
+                <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+                    @ChildContent
+                </MudToolBar>
+            </footer>    
+        </SectionContent>
+    }
+    else
+    {
+        <footer @attributes="UserAttributes" class="@Classname" style="@Style">
+            <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+                @ChildContent
+            </MudToolBar>
+        </footer>  
+    }
 }
 else
 {
-<header @attributes="UserAttributes" class="@Classname" style="@Style">
-    <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
-        @ChildContent
-    </MudToolBar>
-</header>
+    @if(Contextual)
+    {
+        <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
+        <SectionContent SectionId="MudAppBar.ContextualActionBar">
+            <header @attributes="UserAttributes" class="@Classname" style="@Style">
+                <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+                    @ChildContent
+                </MudToolBar>
+            </header>    
+        </SectionContent>
+    }
+    else
+    {
+        <header @attributes="UserAttributes" class="@Classname" style="@Style">
+            <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+                @ChildContent
+            </MudToolBar>
+        </header>  
+    }
 }

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -5,45 +5,45 @@
 
 @if (Bottom)
 {
-    @if(Contextual)
+    @if (Contextual)
     {
         <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
         <SectionContent SectionId="MudAppBar.ContextualActionBar">
-            <footer @attributes="UserAttributes" class="@Classname" style="@Style">
-                <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
-                    @ChildContent
-                </MudToolBar>
-            </footer>    
+            @Footer
         </SectionContent>
     }
     else
     {
-        <footer @attributes="UserAttributes" class="@Classname" style="@Style">
-            <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
-                @ChildContent
-            </MudToolBar>
-        </footer>  
+        @Footer
     }
 }
 else
 {
-    @if(Contextual)
+    @if (Contextual)
     {
         <SectionOutlet SectionId="MudAppBar.ContextualActionBar" />
         <SectionContent SectionId="MudAppBar.ContextualActionBar">
-            <header @attributes="UserAttributes" class="@Classname" style="@Style">
-                <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
-                    @ChildContent
-                </MudToolBar>
-            </header>    
+            @Header
         </SectionContent>
     }
     else
     {
-        <header @attributes="UserAttributes" class="@Classname" style="@Style">
+        @Header
+    }
+}
+
+@code {
+    private RenderFragment Header =>
+        @<header @attributes="@UserAttributes" class="@Classname" style="@Style">
             <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
                 @ChildContent
             </MudToolBar>
-        </header>  
-    }
+        </header>;
+
+    private RenderFragment Footer =>
+        @<footer @attributes="@UserAttributes" class="@Classname" style="@Style">
+            <MudToolBar Dense="@Dense" Gutters="@Gutters" Class="@ToolBarClassname" WrapContent="@WrapContent">
+                @ChildContent
+            </MudToolBar>
+        </footer>;
 }

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -1,114 +1,127 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Sections;
 using MudBlazor.Utilities;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+#nullable enable
+
+/// <summary>
+/// Represents a bar used to display actions, branding, navigation and screen titles.
+/// </summary>
+/// <remarks>
+/// This component is often used to keep important information persistent while browsing different pages to ease navigation and access to actions for users.
+/// </remarks>
+public partial class MudAppBar : MudComponentBase
 {
+    internal static SectionOutlet ContextualActionBar = new();
+
+    protected string Classname =>
+        new CssBuilder("mud-appbar")
+            .AddClass($"mud-appbar-dense", Dense)
+            .AddClass($"mud-appbar-fixed-top", Fixed && !Bottom)
+            .AddClass($"mud-appbar-fixed-bottom", Fixed && Bottom)
+            .AddClass($"mud-elevation-{Elevation}")
+            .AddClass($"mud-theme-{Color.ToDescriptionString()}", Color != Color.Default)
+            .AddClass(Class)
+            .Build();
+
+    protected string ToolBarClassname =>
+        new CssBuilder("mud-toolbar-appbar")
+            .AddClass(ToolBarClass)
+            .Build();
+
     /// <summary>
-    /// Represents a bar used to display actions, branding, navigation and screen titles.
+    /// Places the appbar at the bottom of the screen instead of the top.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Behavior)]
+    public bool Bottom { get; set; }
+
+    /// <summary>
+    /// Allows the app bar to be overridden with page specific actions
     /// </summary>
     /// <remarks>
-    /// This component is often used to keep important information persistent while browsing different pages to ease navigation and access to actions for users.
+    /// Defaults to <c>false</c>. When <c>true</c>, can be overridden by <see cref="MudContextualActionBar"/>
     /// </remarks>
-    public partial class MudAppBar : MudComponentBase
-    {
-#nullable enable
-        protected string Classname =>
-            new CssBuilder("mud-appbar")
-                .AddClass($"mud-appbar-dense", Dense)
-                .AddClass($"mud-appbar-fixed-top", Fixed && !Bottom)
-                .AddClass($"mud-appbar-fixed-bottom", Fixed && Bottom)
-                .AddClass($"mud-elevation-{Elevation}")
-                .AddClass($"mud-theme-{Color.ToDescriptionString()}", Color != Color.Default)
-                .AddClass(Class)
-                .Build();
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Behavior)]
+    public bool Contextual { get; set; } = false;
 
-        protected string ToolBarClassname =>
-            new CssBuilder("mud-toolbar-appbar")
-                .AddClass(ToolBarClass)
-                .Build();
+    /// <summary>
+    /// The size of the drop shadow.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>4</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Appearance)]
+    public int Elevation { set; get; } = 4;
 
-        /// <summary>
-        /// Places the appbar at the bottom of the screen instead of the top.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Behavior)]
-        public bool Bottom { get; set; }
+    /// <summary>
+    /// Uses compact padding.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Appearance)]
+    public bool Dense { get; set; }
 
-        /// <summary>
-        /// The size of the drop shadow.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>4</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Appearance)]
-        public int Elevation { set; get; } = 4;
+    /// <summary>
+    /// Adds left and right padding to this appbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Appearance)]
+    public bool Gutters { get; set; } = true;
 
-        /// <summary>
-        /// Uses compact padding.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Appearance)]
-        public bool Dense { get; set; }
+    /// <summary>
+    /// The color of this appbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Appearance)]
+    public Color Color { get; set; } = Color.Default;
 
-        /// <summary>
-        /// Adds left and right padding to this appbar.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>true</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Appearance)]
-        public bool Gutters { get; set; } = true;
+    /// <summary>
+    /// Fixes this appbar in place as the page is scrolled.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.  When <c>false</c>, the appbar will scroll with other page content.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Behavior)]
+    public bool Fixed { get; set; } = true;
 
-        /// <summary>
-        /// The color of this appbar.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Color.Default"/>.  Theme colors are supported.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Appearance)]
-        public Color Color { get; set; } = Color.Default;
+    /// <summary>
+    /// Allows appbar content to wrap.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Behavior)]
+    public bool WrapContent { get; set; } = false;
 
-        /// <summary>
-        /// Fixes this appbar in place as the page is scrolled.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>true</c>.  When <c>false</c>, the appbar will scroll with other page content.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Behavior)]
-        public bool Fixed { get; set; } = true;
+    /// <summary>
+    /// The CSS classes applied to the nested toolbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Appearance)]
+    public string? ToolBarClass { get; set; }
 
-        /// <summary>
-        /// Allows appbar content to wrap.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Behavior)]
-        public bool WrapContent { get; set; } = false;
-
-        /// <summary>
-        /// The CSS classes applied to the nested toolbar.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Appearance)]
-        public string? ToolBarClass { get; set; }
-
-        /// <summary>
-        /// The content within this component.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.AppBar.Behavior)]
-        public RenderFragment? ChildContent { get; set; }
-    }
+    /// <summary>
+    /// The content within this component.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.AppBar.Behavior)]
+    public RenderFragment? ChildContent { get; set; }
 }

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor;
 /// </remarks>
 public partial class MudAppBar : MudComponentBase
 {
-    internal static SectionOutlet ContextualActionBar = new();
+    internal static SectionOutlet ContextualActionBar { get; } = new();
 
     protected string Classname =>
         new CssBuilder("mud-appbar")

--- a/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Components.Sections
 @inherits MudAppBar
 
-@if(_visibleState.Value)
+@if(Visible)
 {
     <SectionContent SectionId="@MudAppBar.ContextualActionBar">
         @ContextualContent

--- a/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
@@ -1,0 +1,10 @@
+﻿@namespace MudBlazor
+@using Microsoft.AspNetCore.Components.Sections
+@inherits MudAppBar
+
+@if(_visibleState.Value)
+{
+    <SectionContent SectionId="@MudAppBar.ContextualActionBar">
+        @ContextualContent
+    </SectionContent>    
+}

--- a/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor
@@ -2,9 +2,9 @@
 @using Microsoft.AspNetCore.Components.Sections
 @inherits MudAppBar
 
-@if(Visible)
+@if (Visible)
 {
-    <SectionContent SectionId="@MudAppBar.ContextualActionBar">
+    <SectionContent SectionId="@ContextualActionBar">
         @ContextualContent
-    </SectionContent>    
+    </SectionContent>
 }

--- a/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+
+namespace MudBlazor;
+
+#nullable enable
+
+public partial class MudContextualActionBar : MudAppBar
+{
+    private readonly ParameterState<bool> _visibleState;
+
+    private new bool Contextual { get; set; }
+
+    private RenderFragment ContextualContent => base.BuildRenderTree;
+
+    /// <summary>
+    /// Determines if the action bar is visible.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [EditorRequired]
+    [Category(CategoryTypes.Overlay.Behavior)]
+    public bool Visible { get; set; }
+
+    /// <summary>
+    /// Occurs when <see cref="Visible"/> changes.
+    /// </summary>
+    /// <remarks>
+    /// This event is triggered when the visibility of the action bar changes.
+    /// </remarks>
+    [Parameter]
+    public EventCallback<bool> VisibleChanged { get; set; }
+
+    public MudContextualActionBar()
+    {
+        using var registerScope = CreateRegisterScope();
+        _visibleState = registerScope.RegisterParameter<bool>(nameof(Visible))
+            .WithParameter(() => Visible)
+            .WithEventCallback(() => VisibleChanged);
+    }
+}

--- a/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudContextualActionBar.razor.cs
@@ -11,8 +11,6 @@ namespace MudBlazor;
 
 public partial class MudContextualActionBar : MudAppBar
 {
-    private readonly ParameterState<bool> _visibleState;
-
     private new bool Contextual { get; set; }
 
     private RenderFragment ContextualContent => base.BuildRenderTree;
@@ -27,21 +25,4 @@ public partial class MudContextualActionBar : MudAppBar
     [EditorRequired]
     [Category(CategoryTypes.Overlay.Behavior)]
     public bool Visible { get; set; }
-
-    /// <summary>
-    /// Occurs when <see cref="Visible"/> changes.
-    /// </summary>
-    /// <remarks>
-    /// This event is triggered when the visibility of the action bar changes.
-    /// </remarks>
-    [Parameter]
-    public EventCallback<bool> VisibleChanged { get; set; }
-
-    public MudContextualActionBar()
-    {
-        using var registerScope = CreateRegisterScope();
-        _visibleState = registerScope.RegisterParameter<bool>(nameof(Visible))
-            .WithParameter(() => Visible)
-            .WithEventCallback(() => VisibleChanged);
-    }
 }


### PR DESCRIPTION
## Description
Adds a possible contextual action bar implementation using [Blazor Sections](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/sections).

- Adds a new parameter **`Contextual`** to `MudAppBar` 
  * This determines if the app bar should be rendered with a `SectionOutlet` or not. 
- Adds a new component - **MudContextualActionBar**
  * The alternate app bar to be displayed
- Adds a new `Contextual App Bar` section (with working example) in the `App Bar` documentation page
- Requires the main App Bar and the Contextual Action Bar to be interactive
- Excluded from `UserAttributesTests` as nothing is rendered until the specified `Visible` condition is met.
  * Confirmed that the `UserAttributes` inherited from `MudAppBar` function as expected

Resolves #104

## How Has This Been Tested?
- Unit tests
- Test viewer component
- Test projects (Global Interactive Server, Per Page Interactive Server, Global WASM, Per Page Interactive WASM)

https://github.com/user-attachments/assets/37fedaa6-ca88-4f31-89c1-149b268ab8e3

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
