### PR TITLE
Revert "Fix`--mud-appbar-height` not always match `MudAppBar`'s actual height"

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -152,7 +152,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-drawer-width-right: 240px;",
                 "--mud-drawer-width-mini-left: 56px;",
                 "--mud-drawer-width-mini-right: 56px;",
-                "--mud-appbar-base-height: 64px;",
+                "--mud-appbar-height: 64px;",
                 "--mud-typography-default-family: 'Roboto','Helvetica','Arial','sans-serif';",
                 "--mud-typography-default-size: .875rem;",
                 "--mud-typography-default-weight: 400;",

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -330,7 +330,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
             $"--{LayoutProperties}-drawer-width-mini-left: {_theme.LayoutProperties.DrawerMiniWidthLeft};");
         theme.AppendLine(
             $"--{LayoutProperties}-drawer-width-mini-right: {_theme.LayoutProperties.DrawerMiniWidthRight};");
-        theme.AppendLine($"--{LayoutProperties}-appbar-base-height: {_theme.LayoutProperties.AppbarBaseHeight};");
+        theme.AppendLine($"--{LayoutProperties}-appbar-height: {_theme.LayoutProperties.AppbarHeight};");
 
         //Breakpoint
         //theme.AppendLine($"--{Breakpoint}-xs: {Theme.Breakpoints.xs};");

--- a/src/MudBlazor/Styles/abstracts/_variables.scss
+++ b/src/MudBlazor/Styles/abstracts/_variables.scss
@@ -1,4 +1,4 @@
-$mud-palette-colors: primary, secondary, tertiary, info, success, warning, error, dark;
+﻿$mud-palette-colors: primary, secondary, tertiary, info, success, warning, error, dark;
 
 $mud-sizes: small, medium, large;
 
@@ -11,20 +11,3 @@ $breakpoint-xxl: 2560px;
 
 $breakpoints: ( xs: $breakpoint-xs, sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
 $breakpoints-css-utilities-only: ( sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
-
-:root {
-  --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 8);
-  --mud-appbar-dense-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
-}
-
-@media (min-width:$breakpoint-xs) and (orientation: landscape) {
-  :root {
-    --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
-  }
-}
-
-@media (min-width:$breakpoint-sm) {
-  :root {
-    --mud-appbar-height: var(--mud-appbar-base-height);
-  }
-}

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -1,5 +1,3 @@
-@import '../abstracts/variables';
-
 .mud-dialog-container {
   display: flex;
   position: fixed;

--- a/src/MudBlazor/Styles/layout/_appbar.scss
+++ b/src/MudBlazor/Styles/layout/_appbar.scss
@@ -1,4 +1,4 @@
-@import '../abstracts/variables';
+﻿@import '../abstracts/variables';
 
 .mud-appbar {
   width: 100%;
@@ -35,12 +35,24 @@
   }
 
   .mud-toolbar-appbar {
-    height: var(--mud-appbar-height);
+    height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
+  }
+
+  @media (min-width:$breakpoint-xs) and (orientation: landscape) {
+    .mud-toolbar-appbar {
+      height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+    }
+  }
+
+  @media (min-width:$breakpoint-sm) {
+    .mud-toolbar-appbar {
+      height: var(--mud-appbar-height);
+    }
   }
 
   &.mud-appbar-dense {
     .mud-toolbar-appbar {
-      height: var(--mud-appbar-dense-height);
+      height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
     }
   }
 }

--- a/src/MudBlazor/Styles/layout/_drawer.scss
+++ b/src/MudBlazor/Styles/layout/_drawer.scss
@@ -1,4 +1,4 @@
-@import '../abstracts/variables';
+﻿@import '../abstracts/variables';
 
 .mud-drawer {
   display: flex;
@@ -247,7 +247,7 @@
   padding: 12px 24px 12px 24px;
 
   &.mud-drawer-header-dense {
-    min-height: var(--mud-appbar-dense-height);
+    min-height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
     padding: 8px 24px 8px 24px;
   }
 }
@@ -259,6 +259,16 @@
   &.mud-drawer-temporary.mud-drawer-clipped-always {
     top: var(--mud-appbar-height);
     height: calc(100% - var(--mud-appbar-height));
+
+    @media (max-width:$breakpoint-sm - 1px) and (orientation: landscape) {
+      top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+      height: calc(100% - calc(var(--mud-appbar-height) - var(--mud-appbar-height)/4));
+    }
+
+    @media (max-width:$breakpoint-sm - 1px) and (orientation: portrait) {
+      top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
+      height: calc(100% - calc(var(--mud-appbar-height) - var(--mud-appbar-height)/8));
+    }
   }
 
   @each $breakpoint in map-keys($breakpoints) {
@@ -267,6 +277,16 @@
       @media (min-width: map-get($breakpoints, $breakpoint)) {
         top: var(--mud-appbar-height);
         height: calc(100% - var(--mud-appbar-height));
+
+        @media (max-width:$breakpoint-sm - 1px) and (orientation: landscape) {
+          top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+          height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+        }
+
+        @media (max-width:$breakpoint-sm - 1px) and (orientation: portrait) {
+          top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
+          height: calc(100% - var(--mud-appbar-height) / 8);
+        }
       }
     }
   }
@@ -277,15 +297,15 @@
   &.mud-drawer-persistent:not(.mud-drawer-clipped-never),
   &.mud-drawer-responsive.mud-drawer-clipped-always,
   &.mud-drawer-temporary.mud-drawer-clipped-always {
-    top: var(--mud-appbar-dense-height);
-    height: calc(100% - var(--mud-appbar-dense-height));
+    top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+    height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) / 4);
   }
 
   @each $breakpoint in map-keys($breakpoints) {
     @media (min-width: map-get($breakpoints, $breakpoint)) {
       &.mud-drawer-responsive.mud-drawer-clipped-docked.mud-drawer-#{$breakpoint} {
-        top: var(--mud-appbar-dense-height);
-        height: calc(100% - var(--mud-appbar-dense-height));
+        top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+        height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) / 4);
       }
     }
   }

--- a/src/MudBlazor/Styles/layout/_main.scss
+++ b/src/MudBlazor/Styles/layout/_main.scss
@@ -1,15 +1,27 @@
-@import '../abstracts/variables';
+﻿@import '../abstracts/variables';
 
 .mud-main-content {
   margin: 0;
   flex: 1 1 auto;
-  padding-top: var(--mud-appbar-height);
+  padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
   transition: margin 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+@media (min-width:$breakpoint-xs) and (orientation: landscape) {
+  .mud-main-content {
+    padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+  }
+}
+
+@media (min-width:$breakpoint-sm) {
+  .mud-main-content {
+    padding-top: var(--mud-appbar-height);
+  }
 }
 
 .mud-appbar-dense {
   ~ .mud-main-content {
-    padding-top: var(--mud-appbar-dense-height);
+    padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
   }
 }
 

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -32,9 +32,8 @@
         public string DrawerWidthRight { get; set; } = "240px";
 
         /// <summary>
-        /// Gets or sets the base height of the appbar. <br/>
-        /// The actual height of the appbar is relative to this value, and it also depends on the current <see cref="Breakpoint"/>, or <see cref="MudAppBar.Dense"/>.
+        /// Gets or sets the height of the appbar.
         /// </summary>
-        public string AppbarBaseHeight { get; set; } = "64px";
+        public string AppbarHeight { get; set; } = "64px";
     }
 }


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#10097

Need to re-review.

@Garderoben Found a large number of duplicate CSS variables applied

[whatjpg.webm](https://github.com/user-attachments/assets/b6bd6c39-a7ce-4f54-9e0c-04f646341c9e)

And unsure about the root definitions

![image](https://github.com/user-attachments/assets/b1261578-5aaa-4bf6-b5f1-493ca63eaab0)
