### PR TITLE
[MudSelect] Control popover width

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -2,7 +2,7 @@
 
 <MudStack Row>
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" FullWidth Dense id="restricted-select" PopoverClass="restricted">
+        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" FullWidth Dense id="restricted-select" PopoverClass="restricted">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -22,7 +22,7 @@
 
 <MudStack>
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" FullWidth Dense id="select-fit-1" PopoverClass="fit1">
+        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" FullWidth Dense id="select-fit-1" PopoverClass="fit1">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -31,7 +31,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="select-fit-2" PopoverClass="fit2">
+        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" Dense id="select-fit-2" PopoverClass="fit2">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -45,7 +45,8 @@
                                               Row 2 & 3 - Oversized field - (1) Match parent & (2) Match parent";
 
     private string? selected;
-    private string[] _values = [
+    private readonly string[] _values =
+    [
         "Sun",
         "Moon",
         "Stars",

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -2,7 +2,7 @@
 
 <MudStack Row>
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" FullWidth Dense id="restricted-select" PopoverClass="restricted">
+        <MudSelect @bind-Value="@_selected" Variant="Variant.Outlined" FullWidth Dense id="restricted-select" PopoverClass="restricted">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -11,7 +11,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="expanded-select" PopoverClass="expanded">
+        <MudSelect @bind-Value=_selected Variant="Variant.Outlined" Dense id="expanded-select" PopoverClass="expanded">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -22,7 +22,7 @@
 
 <MudStack>
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" FullWidth Dense id="select-fit-1" PopoverClass="fit1">
+        <MudSelect @bind-Value="@_selected" Variant="Variant.Outlined" FullWidth Dense id="select-fit-1" PopoverClass="fit1">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -31,7 +31,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value="@selected" Variant="Variant.Outlined" Dense id="select-fit-2" PopoverClass="fit2">
+        <MudSelect @bind-Value="@_selected" Variant="Variant.Outlined" Dense id="select-fit-2" PopoverClass="fit2">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -44,7 +44,7 @@
     public static string __description__ =  @"Row 1 - limited size field - (1) Match parent & (2) Expanded |
                                               Row 2 & 3 - Oversized field - (1) Match parent & (2) Match parent";
 
-    private string? selected;
+    private string? _selected;
     private readonly string[] _values =
     [
         "Sun",

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -2,7 +2,7 @@
 
 <MudStack Row>
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth Dense id="restricted-select" PopoverClass="restricted">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" FullWidth Dense id="restricted-select" PopoverClass="restricted">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -11,7 +11,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth="false" Dense id="expanded-select" PopoverClass="expanded">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="expanded-select" PopoverClass="expanded">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -22,7 +22,7 @@
 
 <MudStack>
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth Dense id="select-fit-1" PopoverClass="fit1">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" FullWidth Dense id="select-fit-1" PopoverClass="fit1">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -31,7 +31,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth="false" Dense id="select-fit-2" PopoverClass="fit2">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="select-fit-2" PopoverClass="fit2">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -39,9 +39,6 @@
         </MudSelect>
     </div>
 </MudStack>
-
-
-
 
 @code {
     public static string __description__ =  @"Row 1 - limited size field - (1) Match parent & (2) Expanded |

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -1,0 +1,66 @@
+﻿<MudPopoverProvider />
+
+<MudStack Row>
+    <div class="pa-4 d-inline-block" style="width:125px;">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="restricted-select" PopoverClass="restricted">
+            @foreach (var value in _values)
+            {
+                <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
+            }
+        </MudSelect>
+    </div>
+
+    <div class="pa-4 d-inline-block" style="width:125px;">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth="false" Dense id="expanded-select" PopoverClass="expanded">
+            @foreach (var value in _values)
+            {
+                <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
+            }
+        </MudSelect>
+    </div>
+</MudStack>
+
+<MudStack Row>
+    <div class="pa-4 d-inline-block" style="width:400px;">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="select-fit-1" PopoverClass="fit1">
+            @foreach (var value in _values)
+            {
+                <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
+            }
+        </MudSelect>
+    </div>
+
+    <div class="pa-4 d-inline-block" style="width:400px;">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth="false" Dense id="select-fit-2" PopoverClass="fit2">
+            @foreach (var value in _values)
+            {
+                <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
+            }
+        </MudSelect>
+    </div>
+</MudStack>
+
+
+
+
+@code {
+    public static string __description__ =  @"Row 1 - limited size field - (1) Match parent & (2) Expanded |
+                                              Row 2 & 3 - Oversized field - (1) Match parent & (2) Match parent";
+
+    private string? selected;
+    private string[] _values = [
+        "Sun",
+        "Moon",
+        "Stars",
+        "Galaxy",
+        "Cometary",
+        "Nebulous",
+        "Planetary",
+        "Extraterrestrial",
+        "Constellate",
+        "Interstellar",
+        "Cosmic Dust Cloud",
+        "Gravitationally",
+        "Astrophotography"
+    ];
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -2,7 +2,7 @@
 
 <MudStack Row>
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="restricted-select" PopoverClass="restricted">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth Dense id="restricted-select" PopoverClass="restricted">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>
@@ -20,9 +20,9 @@
     </div>
 </MudStack>
 
-<MudStack Row>
+<MudStack>
     <div class="pa-4 d-inline-block" style="width:400px;">
-        <MudSelect @bind-Value=selected Variant="Variant.Outlined" Dense id="select-fit-1" PopoverClass="fit1">
+        <MudSelect @bind-Value=selected Variant="Variant.Outlined" RelativeWidth Dense id="select-fit-1" PopoverClass="fit1">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1378,25 +1378,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void SelectFullWidthTest()
+        public async Task SelectFullWidthTest()
         {
             var comp = Context.RenderComponent<SelectPopoverRelativeWidthTest>();
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open restricted popover
-            comp.Find("#restricted-select").PointerDown();
+            await comp.Find("#restricted-select").PointerDownAsync(new PointerEventArgs());
 
             //confirm relative width class
             comp.Find(".restricted").ClassList.Should().Contain("mud-popover-open").And.Contain("mud-popover-relative-width");
 
             //close popover
-            comp.Find("#restricted-select").PointerDown();
+            await comp.Find("#restricted-select").PointerDownAsync(new PointerEventArgs());
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open expanded popover
-            comp.Find("#expanded-select").PointerDown();
+            await comp.Find("#expanded-select").PointerDownAsync(new PointerEventArgs());
 
             //confirm relative width class not applied
             comp.Find(".expanded").ClassList.Should().Contain("mud-popover-open").And.NotContain("mud-popover-relative-width");

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1376,6 +1376,31 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
             comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
         }
+
+        [Test]
+        public void SelectTestRelativeWidth()
+        {
+            var comp = Context.RenderComponent<SelectPopoverRelativeWidthTest>();
+
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
+            //Open restricted popover
+            comp.Find("#restricted-select").PointerDown();
+
+            //confirm relative width class
+            comp.Find(".restricted").ClassList.Should().Contain("mud-popover-open").And.Contain("mud-popover-relative-width");
+
+            //close popover
+            comp.Find("#restricted-select").PointerDown();
+
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
+            //Open expanded popover
+            comp.Find("#expanded-select").PointerDown();
+
+            //confirm relative width class not applied
+            comp.Find(".expanded").ClassList.Should().Contain("mud-popover-open").And.NotContain("mud-popover-relative-width");
+        }
 #nullable disable
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1378,7 +1378,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void SelectTestRelativeWidth()
+        public void SelectFullWidthTest()
         {
             var comp = Context.RenderComponent<SelectPopoverRelativeWidthTest>();
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -62,7 +62,7 @@
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
                             Class="@PopoverClass"
-                            RelativeWidth="@RelativeWidth">
+                            RelativeWidth="@FullWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"
                                  Class="@ListClass"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -62,7 +62,7 @@
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
                             Class="@PopoverClass"
-                            RelativeWidth="true">
+                            RelativeWidth="@RelativeWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"
                                  Class="@ListClass"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -201,6 +201,16 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
+        /// Restricts the select items (popover) to have the same width as the parent container.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>. When <c>false</c>, the select items may extend beyond the parent container.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListAppearance)]
+        public bool RelativeWidth { get; set; } = true;
+
+        /// <summary>
         /// The Open Select Icon
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -201,14 +201,14 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Restricts the select items (popover) to have the same width as the parent container.
+        /// Determines the width of the select items popover, in relation to the parent container.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>. When <c>false</c>, the select items may extend beyond the parent container.
+        /// Defaults to <c>false</c>. When <c>true</c>, the select items are restricted to width of the parent container.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public bool RelativeWidth { get; set; } = true;
+        public bool RelativeWidth { get; set; }
 
         /// <summary>
         /// The Open Select Icon

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -201,16 +201,6 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Determines the width of the select items popover, in relation to the parent container.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>. When <c>true</c>, the select items are restricted to width of the parent container.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public bool RelativeWidth { get; set; }
-
-        /// <summary>
         /// The Open Select Icon
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -169,6 +169,9 @@ window.mudpopoverHelper = {
             if (classList.contains('mud-popover-relative-width')) {
                 popoverContentNode.style['max-width'] = (boundingRect.width) + 'px';
             }
+            else {
+                popoverContentNode.style['min-width'] = (boundingRect.width) + 'px';
+            }
 
             const selfRect = popoverContentNode.getBoundingClientRect();            
             const classListArray = Array.from(classList);


### PR DESCRIPTION
## Description
`MudSelect` hardcoded the `RelativeWidth` of the `MudPopover` to true. This ensures that the popover width matches the select field width. However, when items available for selection are longer than the width of the select field, they are cut off. This may not always be desirable. 

This change
- Utilizes the `FullWidth` parameter from `MudBaseInput`
  * Forwards that value to the `MudPopover` component
  * Defaults to `false` which is the opposite of the current behavior (current behavior is considered a bug)
- Updates `mudPopover.js` to set either min or max width based on the value of `RelativeWidth`

While a non `js` fix would be preferred, the current `js` is what enforces the `max-width` restriction and without setting `min-width`, the popover may render smaller than the select field, instead of matching its size, when `RelativeWidth` is `false` and the item list options are short in length.

Resolves #10195 , #825

## How Has This Been Tested?
Visually - unit test viewer 
Added a  unit test to confirm applied popover classes 

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
