### PR TITLE
MudSelect, MudMenu: Fix max height exceeds window

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuNoFlipScrollBarTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuNoFlipScrollBarTest.razor
@@ -40,5 +40,5 @@
 </MudMenu>
 
             @code {
-    public static string __description__ = "Covers various accessibility tests for MudMenu.";
+    public static string __description__ = "Test popovers using mudlist that exceed the height of the screen to show a scrollbar instead of causing the screen to scroll.";
             }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuNoFlipScrollBarTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuNoFlipScrollBarTest.razor
@@ -1,0 +1,44 @@
+﻿<MudMenu Label="Menu" AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopLeft" Dense=true>
+    <MudMenuItem>Chat</MudMenuItem>
+    <MudMenuItem>Phone</MudMenuItem>
+    <MudMenuItem>Chat</MudMenuItem>
+    <MudMenuItem>Phone</MudMenuItem>
+    <MudMenuItem>Chat</MudMenuItem>
+    <MudMenuItem>Phone</MudMenuItem>
+    <MudMenuItem>Chat</MudMenuItem>
+    <MudMenuItem>Phone</MudMenuItem>
+    <MudMenuItem>Chat</MudMenuItem>
+    <MudMenuItem>Phone</MudMenuItem>
+
+    <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopLeft" Dense=true
+             Class="mud-list-item mud-list-item-dense mud-list-item-gutters mud-list-item-clickable mud-ripple">
+        <ActivatorContent>
+            <div class="mud-list-item-text">Way more options...</div>
+        </ActivatorContent>
+
+        <ChildContent>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+            <MudMenuItem>Chat</MudMenuItem>
+            <MudMenuItem>Phone</MudMenuItem>
+        </ChildContent>
+    </MudMenu>
+</MudMenu>
+
+            @code {
+    public static string __description__ = "Covers various accessibility tests for MudMenu.";
+            }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -303,6 +303,13 @@ window.mudpopoverHelper = {
                         offsetY = 0;
                     }
 
+                    // if it contains a mud-list set that mud-list max-height to be the remaining size on screen
+                    const list = popoverContentNode.querySelector('.mud-list');
+                    const listMaxHeight = (window.innerHeight - top - offsetY);
+                    // is list defined and does the list calculated height exceed the listmaxheight
+                    if (list && list.offsetHeight > listMaxHeight) {
+                        list.style.maxHeight = listMaxHeight + 'px';
+                    }
                     popoverContentNode.removeAttribute('data-mudpopover-flip');
                 }
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -305,7 +305,8 @@ window.mudpopoverHelper = {
 
                     // if it contains a mud-list set that mud-list max-height to be the remaining size on screen
                     const list = popoverContentNode.querySelector('.mud-list');
-                    const listMaxHeight = (window.innerHeight - top - offsetY);
+                    const listPadding = 8;
+                    const listMaxHeight = (window.innerHeight - top - offsetY) - listPadding;
                     // is list defined and does the list calculated height exceed the listmaxheight
                     if (list && list.offsetHeight > listMaxHeight) {
                         list.style.maxHeight = listMaxHeight + 'px';

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -305,11 +305,11 @@ window.mudpopoverHelper = {
 
                     // if it contains a mud-list set that mud-list max-height to be the remaining size on screen
                     const list = popoverContentNode.querySelector('.mud-list');
-                    const listPadding = 8;
-                    const listMaxHeight = (window.innerHeight - top - offsetY) - listPadding;
+                    const listPadding = 24;
+                    const listMaxHeight = (window.innerHeight - top - offsetY);
                     // is list defined and does the list calculated height exceed the listmaxheight
                     if (list && list.offsetHeight > listMaxHeight) {
-                        list.style.maxHeight = listMaxHeight + 'px';
+                        list.style.maxHeight = (listMaxHeight - listPadding) + 'px';
                     }
                     popoverContentNode.removeAttribute('data-mudpopover-flip');
                 }


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Popover mud-list items create scrollbars in the main window when they exceed screen height. This can only happen if the flip function can't flip them without exceeding the top or left. (right in RTL) These changes add a max-height property if and ONLY if a mud-list in a popover would create a scrollbar outside of itself. 

Resolves #10204 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visual Tests Below

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
