### PR TITLE
AppBar: Fix `--mud-appbar-height` not matching actual height

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-drawer-width-right: 240px;",
                 "--mud-drawer-width-mini-left: 56px;",
                 "--mud-drawer-width-mini-right: 56px;",
-                "--mud-appbar-height: 64px;",
+                "--mud-appbar-base-height: 64px;",
                 "--mud-typography-default-family: 'Roboto','Helvetica','Arial','sans-serif';",
                 "--mud-typography-default-size: .875rem;",
                 "--mud-typography-default-weight: 400;",

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -330,7 +330,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
             $"--{LayoutProperties}-drawer-width-mini-left: {_theme.LayoutProperties.DrawerMiniWidthLeft};");
         theme.AppendLine(
             $"--{LayoutProperties}-drawer-width-mini-right: {_theme.LayoutProperties.DrawerMiniWidthRight};");
-        theme.AppendLine($"--{LayoutProperties}-appbar-height: {_theme.LayoutProperties.AppbarHeight};");
+        theme.AppendLine($"--{LayoutProperties}-appbar-base-height: {_theme.LayoutProperties.AppbarBaseHeight};");
 
         //Breakpoint
         //theme.AppendLine($"--{Breakpoint}-xs: {Theme.Breakpoints.xs};");

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -330,7 +330,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
             $"--{LayoutProperties}-drawer-width-mini-left: {_theme.LayoutProperties.DrawerMiniWidthLeft};");
         theme.AppendLine(
             $"--{LayoutProperties}-drawer-width-mini-right: {_theme.LayoutProperties.DrawerMiniWidthRight};");
-        theme.AppendLine($"--{LayoutProperties}-appbar-base-height: {_theme.LayoutProperties.AppbarBaseHeight};");
+        theme.AppendLine($"--{LayoutProperties}-appbar-base-height: {_theme.LayoutProperties.AppBarBaseHeight};");
 
         //Breakpoint
         //theme.AppendLine($"--{Breakpoint}-xs: {Theme.Breakpoints.xs};");

--- a/src/MudBlazor/Styles/abstracts/_variables.scss
+++ b/src/MudBlazor/Styles/abstracts/_variables.scss
@@ -1,4 +1,4 @@
-﻿$mud-palette-colors: primary, secondary, tertiary, info, success, warning, error, dark;
+$mud-palette-colors: primary, secondary, tertiary, info, success, warning, error, dark;
 
 $mud-sizes: small, medium, large;
 
@@ -11,3 +11,20 @@ $breakpoint-xxl: 2560px;
 
 $breakpoints: ( xs: $breakpoint-xs, sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
 $breakpoints-css-utilities-only: ( sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
+
+:root {
+  --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 8);
+  --mud-appbar-dense-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
+}
+
+@media (min-width:$breakpoint-xs) and (orientation: landscape) {
+  :root {
+    --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
+  }
+}
+
+@media (min-width:$breakpoint-sm) {
+  :root {
+    --mud-appbar-height: var(--mud-appbar-base-height);
+  }
+}

--- a/src/MudBlazor/Styles/abstracts/_variables.scss
+++ b/src/MudBlazor/Styles/abstracts/_variables.scss
@@ -11,20 +11,3 @@ $breakpoint-xxl: 2560px;
 
 $breakpoints: ( xs: $breakpoint-xs, sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
 $breakpoints-css-utilities-only: ( sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );
-
-:root {
-  --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 8);
-  --mud-appbar-dense-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
-}
-
-@media (min-width:$breakpoint-xs) and (orientation: landscape) {
-  :root {
-    --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
-  }
-}
-
-@media (min-width:$breakpoint-sm) {
-  :root {
-    --mud-appbar-height: var(--mud-appbar-base-height);
-  }
-}

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -1,5 +1,3 @@
-@import '../abstracts/variables';
-
 .mud-dialog-container {
   display: flex;
   position: fixed;

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -1,3 +1,5 @@
+@import '../abstracts/variables';
+
 .mud-dialog-container {
   display: flex;
   position: fixed;

--- a/src/MudBlazor/Styles/core/_base.scss
+++ b/src/MudBlazor/Styles/core/_base.scss
@@ -1,3 +1,5 @@
+@import '../abstracts/variables';
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -32,4 +34,21 @@ a {
   height: 100%;
   width: 100%;
   position: relative;
+}
+
+:root {
+  --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 8);
+  --mud-appbar-dense-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
+}
+
+@media (min-width:$breakpoint-xs) and (orientation: landscape) {
+  :root {
+    --mud-appbar-height: calc(var(--mud-appbar-base-height) - var(--mud-appbar-base-height) / 4);
+  }
+}
+
+@media (min-width:$breakpoint-sm) {
+  :root {
+    --mud-appbar-height: var(--mud-appbar-base-height);
+  }
 }

--- a/src/MudBlazor/Styles/layout/_appbar.scss
+++ b/src/MudBlazor/Styles/layout/_appbar.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-appbar {
   width: 100%;
@@ -35,24 +35,12 @@
   }
 
   .mud-toolbar-appbar {
-    height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
-  }
-
-  @media (min-width:$breakpoint-xs) and (orientation: landscape) {
-    .mud-toolbar-appbar {
-      height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-    }
-  }
-
-  @media (min-width:$breakpoint-sm) {
-    .mud-toolbar-appbar {
-      height: var(--mud-appbar-height);
-    }
+    height: var(--mud-appbar-height);
   }
 
   &.mud-appbar-dense {
     .mud-toolbar-appbar {
-      height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+      height: var(--mud-appbar-dense-height);
     }
   }
 }

--- a/src/MudBlazor/Styles/layout/_drawer.scss
+++ b/src/MudBlazor/Styles/layout/_drawer.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-drawer {
   display: flex;
@@ -247,7 +247,7 @@
   padding: 12px 24px 12px 24px;
 
   &.mud-drawer-header-dense {
-    min-height: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+    min-height: var(--mud-appbar-dense-height);
     padding: 8px 24px 8px 24px;
   }
 }
@@ -259,16 +259,6 @@
   &.mud-drawer-temporary.mud-drawer-clipped-always {
     top: var(--mud-appbar-height);
     height: calc(100% - var(--mud-appbar-height));
-
-    @media (max-width:$breakpoint-sm - 1px) and (orientation: landscape) {
-      top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-      height: calc(100% - calc(var(--mud-appbar-height) - var(--mud-appbar-height)/4));
-    }
-
-    @media (max-width:$breakpoint-sm - 1px) and (orientation: portrait) {
-      top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
-      height: calc(100% - calc(var(--mud-appbar-height) - var(--mud-appbar-height)/8));
-    }
   }
 
   @each $breakpoint in map-keys($breakpoints) {
@@ -277,16 +267,6 @@
       @media (min-width: map-get($breakpoints, $breakpoint)) {
         top: var(--mud-appbar-height);
         height: calc(100% - var(--mud-appbar-height));
-
-        @media (max-width:$breakpoint-sm - 1px) and (orientation: landscape) {
-          top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-          height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-        }
-
-        @media (max-width:$breakpoint-sm - 1px) and (orientation: portrait) {
-          top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
-          height: calc(100% - var(--mud-appbar-height) / 8);
-        }
       }
     }
   }
@@ -297,15 +277,15 @@
   &.mud-drawer-persistent:not(.mud-drawer-clipped-never),
   &.mud-drawer-responsive.mud-drawer-clipped-always,
   &.mud-drawer-temporary.mud-drawer-clipped-always {
-    top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-    height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) / 4);
+    top: var(--mud-appbar-dense-height);
+    height: calc(100% - var(--mud-appbar-dense-height));
   }
 
   @each $breakpoint in map-keys($breakpoints) {
     @media (min-width: map-get($breakpoints, $breakpoint)) {
       &.mud-drawer-responsive.mud-drawer-clipped-docked.mud-drawer-#{$breakpoint} {
-        top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-        height: calc(100% - var(--mud-appbar-height) + var(--mud-appbar-height) / 4);
+        top: var(--mud-appbar-dense-height);
+        height: calc(100% - var(--mud-appbar-dense-height));
       }
     }
   }

--- a/src/MudBlazor/Styles/layout/_main.scss
+++ b/src/MudBlazor/Styles/layout/_main.scss
@@ -1,27 +1,15 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-main-content {
   margin: 0;
   flex: 1 1 auto;
-  padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 8);
+  padding-top: var(--mud-appbar-height);
   transition: margin 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-}
-
-@media (min-width:$breakpoint-xs) and (orientation: landscape) {
-  .mud-main-content {
-    padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
-  }
-}
-
-@media (min-width:$breakpoint-sm) {
-  .mud-main-content {
-    padding-top: var(--mud-appbar-height);
-  }
 }
 
 .mud-appbar-dense {
   ~ .mud-main-content {
-    padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4);
+    padding-top: var(--mud-appbar-dense-height);
   }
 }
 

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -41,7 +41,8 @@
             set => AppbarBaseHeight = value;
         }
         /// <summary>
-        /// Gets or sets the base height of the appbar.
+        /// Gets or sets the base height of the appbar. <br/>
+        /// The actual height of the appbar is relative to this value, and it also depends on the current <see cref="Breakpoint"/>, or <see cref="MudAppBar.Dense"/>.
         /// </summary>
         public string AppbarBaseHeight { get; set; } = "64px";
     }

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -32,15 +32,6 @@
         public string DrawerWidthRight { get; set; } = "240px";
 
         /// <summary>
-        /// Gets or sets the height of the appbar.
-        /// </summary>
-        [Obsolete($"Use {nameof(AppbarBaseHeight)} instead.")]
-        public string AppbarHeight
-        {
-            get => AppbarBaseHeight;
-            set => AppbarBaseHeight = value;
-        }
-        /// <summary>
         /// Gets or sets the base height of the appbar. <br/>
         /// The actual height of the appbar is relative to this value, and it also depends on the current <see cref="Breakpoint"/>, or <see cref="MudAppBar.Dense"/>.
         /// </summary>

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -35,6 +35,6 @@
         /// Gets or sets the base height of the appbar. <br/>
         /// The actual height of the appbar is relative to this value, and it also depends on the current <see cref="Breakpoint"/>, or <see cref="MudAppBar.Dense"/>.
         /// </summary>
-        public string AppbarBaseHeight { get; set; } = "64px";
+        public string AppBarBaseHeight { get; set; } = "64px";
     }
 }

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -34,6 +34,15 @@
         /// <summary>
         /// Gets or sets the height of the appbar.
         /// </summary>
-        public string AppbarHeight { get; set; } = "64px";
+        [Obsolete($"Use {nameof(AppbarBaseHeight)} instead.")]
+        public string AppbarHeight
+        {
+            get => AppbarBaseHeight;
+            set => AppbarBaseHeight = value;
+        }
+        /// <summary>
+        /// Gets or sets the base height of the appbar.
+        /// </summary>
+        public string AppbarBaseHeight { get; set; } = "64px";
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Fixes #10083.
This also includes the fix for the issue of duplicated CSS variables reported in #10214.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

- Run Unit tests and confirmed that this PR do not make newly failed test.
(`DateRangePickerTests.FormatFirst_Should_RenderCorrectly` and `DateRangePickerTests.FormatLast_Should_RenderCorrectly` fail even before this PR)
- Visually confirmed that AppBar's responsive height works properly in`MudBlazor.Docs.Server`.
## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - `LayoutProperties.AppbarHeight` is now obsoleted and renamed to `LayoutProperties.AppBarBaseHeight` as its current naming is confusing
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
