### PR TITLE
DataGridTests: Fix test failure by using Invariant Culture

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -38,20 +38,21 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridPropertyColumnNullCheckTest>();
             var cells = comp.FindAll("td").ToArray();
+            const char Nnbsp = '\u202F';
 
             // First Row
-            cells[0].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[0].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
             cells[1].TextContent.Should().BeEmpty();
-            cells[2].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[2].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
             cells[3].TextContent.Should().BeEmpty();
             cells[4].TextContent.Should().BeEmpty();
             cells[5].TextContent.Should().BeEmpty();
 
             // Second Row
-            cells[6].TextContent.Should().Be("1/1/0001 12:00:00 AM");
-            cells[7].TextContent.Should().Be("1/1/0001 12:00:00 AM +00:00");
-            cells[8].TextContent.Should().Be("1/1/0001 12:00:00 AM");
-            cells[9].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[6].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
+            cells[7].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM +00:00");
+            cells[8].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
+            cells[9].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
             cells[10].TextContent.Should().Be("some text");
             cells[11].TextContent.Should().BeEmpty();
         }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -32,27 +32,26 @@ namespace MudBlazor.UnitTests.Components
     public class DataGridTests : BunitTest
     {
         [Test]
-        [SetCulture("en-US")]
-        [SetUICulture("en-US")]
+        [SetCulture("")]
+        [SetUICulture("")]
         public void DataGridPropertyNullCheck()
         {
             var comp = Context.RenderComponent<DataGridPropertyColumnNullCheckTest>();
             var cells = comp.FindAll("td").ToArray();
-            const char Nnbsp = '\u202F';
 
             // First Row
-            cells[0].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
+            cells[0].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[1].TextContent.Should().BeEmpty();
-            cells[2].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
+            cells[2].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[3].TextContent.Should().BeEmpty();
             cells[4].TextContent.Should().BeEmpty();
             cells[5].TextContent.Should().BeEmpty();
 
             // Second Row
-            cells[6].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
-            cells[7].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM +00:00");
-            cells[8].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
-            cells[9].TextContent.Replace(Nnbsp, ' ').Should().Be("1/1/0001 12:00:00 AM");
+            cells[6].TextContent.Should().Be("01/01/0001 00:00:00");
+            cells[7].TextContent.Should().Be("01/01/0001 00:00:00 +00:00");
+            cells[8].TextContent.Should().Be("01/01/0001 00:00:00");
+            cells[9].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[10].TextContent.Should().Be("some text");
             cells[11].TextContent.Should().BeEmpty();
         }

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -266,7 +266,6 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.ListGutters, listGutters)
                 .Add(x => x.ItemGutters, itemGutters)
             );
-            Console.WriteLine(comp.Markup);
             (comp.FindAll("div.mud-list-item-gutters").Count > 0).Should().Be(resultingGutters);
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description

On my machine this test was always failing because for some reason a `NNBSP` char instead of a whitespace is added:

```cs
string actual   = "1/1/0001 12:00:00\u202FAM"
string expected = "1/1/0001 12:00:00 AM"
```

Because the type of whitespace does not actually matter I've just replaced it with a normal whitespace to make the assertion happy.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
n/a

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
