### PR TITLE
MudInput: Remove `@onmousewheel`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -426,38 +426,38 @@ namespace MudBlazor.UnitTests.Components
             var numericField = comp.Instance;
 
             //MouseWheel up
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1235.56));
 
             //MouseWheel down
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
 
             //Invert MouseWheel
             numericField.InvertMouseWheel = true;
 
             //MouseWheel up
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1233.56));
 
             //MouseWheel down
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
 
             //Try with different step
             numericField.Step = 0.5;
 
             //MouseWheel up
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.06));
 
             //MouseWheel down
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
 
             //MouseWheel without Shift doesn't do anything
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
-            comp.Find("input").MouseWheel(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
+            comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
             comp.WaitForAssertion(() => numericField.Value.Should().Be(1234.56));
         }
 

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -40,7 +40,6 @@
                 maxlength="@MaxLength"
                 @onkeydown:preventDefault="@KeyDownPreventDefault"
                 @onkeyup:preventDefault="@KeyUpPreventDefault"
-                @onmousewheel="@OnMouseWheel"
                 @onwheel="@OnMouseWheel"
                 aria-describedby="@GetAriaDescribedByString()"
                 aria-invalid="@Error.ToString().ToLowerInvariant()"
@@ -48,7 +47,6 @@
                 aria-required="@Required.ToString().ToLowerInvariant()">
             @Text
         </textarea>
-        @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
         @*note: the value="@_internalText" is absolutely essential here. the inner html @Text is needed by tests checking it*@
     }
     else
@@ -72,14 +70,11 @@
                 maxlength="@MaxLength"
                 @onkeydown:preventDefault="KeyDownPreventDefault"
                 @onkeyup:preventDefault="@KeyUpPreventDefault"
-                @onmousewheel="@OnMouseWheel"
                 @onwheel="@OnMouseWheel"
                 aria-describedby="@GetAriaDescribedByString()"
                 aria-invalid="@Error.ToString().ToLowerInvariant()"
                 required="@Required"
                 aria-required="@Required.ToString().ToLowerInvariant()">
-
-        @*Note: double mouse wheel handlers needed for Firefox because it doesn't know onmousewheel*@
 
          @if (GetDisabledState()) {
              @*Note: this div must always be there to avoid crashes in WASM, but it is hidden most of the time except if ChildContent should be shown.


### PR DESCRIPTION
## Description
As discussed in discord and in discussion https://github.com/MudBlazor/MudBlazor/discussions/9946#discussioncomment-10903265

The `onmousewheel` should be removed as it's deprecated API and `onwheel` should be used instead.
See: 
https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event
https://www.w3schools.com/tags/att_onmousewheel.asp

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
