### PR TITLE
MudDialog: Fix exception when closing a dialog while rendering

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/ComponentThatOpensAndClosesDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/ComponentThatOpensAndClosesDialog.razor
@@ -1,0 +1,18 @@
+<MudPopoverProvider/>
+<MudDialogProvider />
+
+<MudText>
+    Some content...
+</MudText>
+
+@code {
+    [Inject] IDialogService DialogService { get; set; } = default!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        var dialog = await DialogService.ShowAsync<SimpleDialog>();
+        await Task.Delay(TimeSpan.Zero);
+        dialog.Close();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/SimpleDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/SimpleDialog.razor
@@ -1,0 +1,11 @@
+<MudDialog>
+    <TitleContent>
+        Dialog Title
+    </TitleContent>
+    <DialogContent>
+        Dialog Content
+    </DialogContent>
+    <DialogActions>
+        Dialog Actions
+    </DialogActions>
+</MudDialog>

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -395,7 +395,7 @@ namespace MudBlazor.UnitTests.Components
             dialogReference.Should().NotBe(null);
             dialogReference.Should().BeAssignableTo(typeof(CustomDialogReference));
 
-            //After above checks have passed, we can safely cast the generic reference into our specific implementation  
+            //After above checks have passed, we can safely cast the generic reference into our specific implementation
             var customDialogReference = (CustomDialogReference)dialogReference;
             //The custom property should be false by default otherwise the rest of the test logic would be incorrect
             customDialogReference.AllowDismiss.Should().BeFalse();
@@ -584,6 +584,24 @@ namespace MudBlazor.UnitTests.Components
             DialogRender.OnInitializedCount.Should().Be(2);
             //Reset global value
             DialogRender.OnInitializedCount = 0;
+        }
+
+        /// <summary>
+        /// Reproduce bug from the GitHub issue #10180 :
+        /// https://github.com/MudBlazor/MudBlazor/issues/10180
+        /// </summary>
+        [Test]
+        public void OpenAndCloseImmediately()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<ComponentThatOpensAndClosesDialog>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            service.Should().NotBeNull();
+
+            // Act : Open and close immediately
+
+            comp.Render();
         }
 
         /// <summary>
@@ -776,7 +794,7 @@ namespace MudBlazor.UnitTests.Components
             dialogReference.Should().NotBe(null);
             dialogReference.Should().BeAssignableTo(typeof(CustomDialogReference));
 
-            //After above checks have passed, we can safely cast the generic reference into our specific implementation  
+            //After above checks have passed, we can safely cast the generic reference into our specific implementation
             var customDialogReference = (CustomDialogReference)dialogReference;
             //The custom property should be false by default otherwise the rest of the test logic would be incorrect
             customDialogReference.AllowDismiss.Should().BeFalse();
@@ -948,7 +966,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Show<DialogOkCancel>("Custom title"));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -972,7 +990,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Show<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -988,7 +1006,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel)));
 
             // Assert
@@ -1003,7 +1021,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel), "Custom title"));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1027,7 +1045,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Show(typeof(DialogOkCancel), "Custom title", new DialogOptions { CloseButton = true }));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1043,7 +1061,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() =>
                 service.Show(typeof(DialogWithActionsClass), "Custom title", new DialogParameters<DialogWithActionsClass> { { x => x.ActionsClass, "custom-class" } }));
 
@@ -1060,7 +1078,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.ShowAsync<DialogOkCancel>("Custom title"));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1083,7 +1101,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.ShowAsync<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1106,7 +1124,7 @@ namespace MudBlazor.UnitTests.Components
                 type = result.DataType;
             };
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.Close(reference));
 
             // Assert
@@ -1128,7 +1146,7 @@ namespace MudBlazor.UnitTests.Components
                 return Task.CompletedTask;
             };
 
-            // Act 
+            // Act
             await Task.Factory.StartNew(() => service.ShowAsync(typeof(DialogOkCancel))).ConfigureAwait(false);
 
             // Assert
@@ -1142,7 +1160,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel)));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1164,7 +1182,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel), "Custom title"));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1187,7 +1205,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() => service.ShowAsync(typeof(DialogOkCancel), "Custom title", new DialogOptions { CloseButton = true }));
             var dialogInstance = provider.FindComponent<MudDialogContainer>();
 
@@ -1202,7 +1220,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = Context.RenderComponent<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            // Act 
+            // Act
             await provider.InvokeAsync(() =>
                 service.ShowAsync(typeof(DialogWithActionsClass), "Custom title", new DialogParameters<DialogWithActionsClass> { { x => x.ActionsClass, "custom-class" } }));
 

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -2,7 +2,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
     <CascadingValue Value="_globalDialogOptions">
-        @foreach (var dialogReference in _dialogs.Values.Where(x => !x.Result.IsCompleted))
+        @foreach (var dialogReference in _dialogs.ToArray().Where(x => !x.Result.IsCompleted))
         {
             @dialogReference.RenderFragment
         }

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -2,7 +2,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
     <CascadingValue Value="_globalDialogOptions">
-        @foreach (var dialogReference in _dialogs.Where(x => !x.Result.IsCompleted))
+        @foreach (var dialogReference in _dialogs.Values.Where(x => !x.Result.IsCompleted))
         {
             @dialogReference.RenderFragment
         }

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -3,6 +3,7 @@
 // See https://github.com/Blazored
 // Copyright (c) 2020 - Adapted by MudBlazor Contributors
 
+using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 
@@ -24,7 +25,7 @@ namespace MudBlazor
     public partial class MudDialogProvider : IDisposable
     {
         private DialogOptions _globalDialogOptions = new();
-        private readonly List<IDialogReference> _dialogs = [];
+        private readonly ConcurrentDictionary<Guid, IDialogReference> _dialogs = [];
 
         [Inject]
         private IDialogService DialogService { get; set; } = null!;
@@ -134,7 +135,7 @@ namespace MudBlazor
         {
             if (!firstRender)
             {
-                foreach (var dialogReference in _dialogs.Where(x => !x.Result.IsCompleted))
+                foreach (var dialogReference in _dialogs.Values.Where(x => !x.Result.IsCompleted))
                 {
                     dialogReference.RenderCompleteTaskCompletionSource.TrySetResult(true);
                 }
@@ -152,8 +153,8 @@ namespace MudBlazor
 
         private Task AddInstanceAsync(IDialogReference dialog)
         {
-            _dialogs.Add(dialog);
-
+            if (!_dialogs.TryAdd(dialog.Id, dialog))
+                throw new InvalidOperationException("Guid dialog already exists.");
             return InvokeAsync(StateHasChanged);
         }
 
@@ -162,7 +163,10 @@ namespace MudBlazor
         /// </summary>
         public void DismissAll()
         {
-            _dialogs.ToList().ForEach(r => DismissInstance(r, DialogResult.Cancel()));
+            foreach (var dialog in _dialogs.Values)
+            {
+                DismissInstance(dialog, DialogResult.Cancel());
+            }
             StateHasChanged();
         }
 
@@ -170,13 +174,13 @@ namespace MudBlazor
         {
             if (!dialog.Dismiss(result)) return;
 
-            _dialogs.Remove(dialog);
+            _dialogs.Remove(dialog.Id, out var _);
             StateHasChanged();
         }
 
         private IDialogReference? GetDialogReference(Guid id)
         {
-            return _dialogs.FirstOrDefault(x => x.Id == id);
+            return _dialogs.GetValueOrDefault(id);
         }
 
         private void LocationChanged(object? sender, LocationChangedEventArgs args)

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -154,7 +154,7 @@ namespace MudBlazor
         private Task AddInstanceAsync(IDialogReference dialog)
         {
             if (!_dialogs.TryAdd(dialog.Id, dialog))
-                throw new InvalidOperationException("Guid dialog already exists.");
+                throw new InvalidOperationException("A dialog with this id already exists");
             return InvokeAsync(StateHasChanged);
         }
 

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -3,7 +3,6 @@
 // See https://github.com/Blazored
 // Copyright (c) 2020 - Adapted by MudBlazor Contributors
 
-using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -27,8 +27,6 @@ namespace MudBlazor
         private DialogOptions _globalDialogOptions = new();
         private readonly List<IDialogReference> _dialogs = [];
 
-        public int DialogsCount => _dialogs.Count;
-
         [Inject]
         private IDialogService DialogService { get; set; } = null!;
 
@@ -164,7 +162,7 @@ namespace MudBlazor
         /// </summary>
         public void DismissAll()
         {
-            foreach (var dialog in _dialogs.ToList())
+            foreach (var dialog in _dialogs.ToArray())
             {
                 DismissInstance(dialog, DialogResult.Cancel());
             }

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -25,7 +25,9 @@ namespace MudBlazor
     public partial class MudDialogProvider : IDisposable
     {
         private DialogOptions _globalDialogOptions = new();
-        private readonly ConcurrentDictionary<Guid, IDialogReference> _dialogs = [];
+        private readonly List<IDialogReference> _dialogs = [];
+
+        public int DialogsCount => _dialogs.Count;
 
         [Inject]
         private IDialogService DialogService { get; set; } = null!;
@@ -135,7 +137,7 @@ namespace MudBlazor
         {
             if (!firstRender)
             {
-                foreach (var dialogReference in _dialogs.Values.Where(x => !x.Result.IsCompleted))
+                foreach (var dialogReference in _dialogs.ToArray().Where(x => !x.Result.IsCompleted))
                 {
                     dialogReference.RenderCompleteTaskCompletionSource.TrySetResult(true);
                 }
@@ -153,8 +155,7 @@ namespace MudBlazor
 
         private Task AddInstanceAsync(IDialogReference dialog)
         {
-            if (!_dialogs.TryAdd(dialog.Id, dialog))
-                throw new InvalidOperationException("A dialog with this id already exists");
+            _dialogs.Add(dialog);
             return InvokeAsync(StateHasChanged);
         }
 
@@ -163,7 +164,7 @@ namespace MudBlazor
         /// </summary>
         public void DismissAll()
         {
-            foreach (var dialog in _dialogs.Values)
+            foreach (var dialog in _dialogs.ToList())
             {
                 DismissInstance(dialog, DialogResult.Cancel());
             }
@@ -174,13 +175,13 @@ namespace MudBlazor
         {
             if (!dialog.Dismiss(result)) return;
 
-            _dialogs.Remove(dialog.Id, out var _);
+            _dialogs.Remove(dialog);
             StateHasChanged();
         }
 
         private IDialogReference? GetDialogReference(Guid id)
         {
-            return _dialogs.GetValueOrDefault(id);
+            return _dialogs.ToArray().FirstOrDefault(d => d.Id == id);
         }
 
         private void LocationChanged(object? sender, LocationChangedEventArgs args)


### PR DESCRIPTION
## Description

Fixes #10180
Fixes #8497

Closing a dialog while rendering throws the exception:
```txt
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at MudBlazor.MudDialogProvider.OnAfterRenderAsync(Boolean firstRender) in C:\repos\vernou\MudBlazor\src\MudBlazor\Components\Dialog\MudDialogProvider.razor.cs:line 137
   at Microsoft.AspNetCore.Components.ComponentBase.Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync()
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.NotifyRenderCompletedAsync()
```

The reason is that [rendering enumerate `MudDialogProvider._dialogs`](https://github.com/MudBlazor/MudBlazor/blob/a35edcbf7647f95cb9d3d8d4316ae4d4256b2eb5/src/MudBlazor/Components/Dialog/MudDialogProvider.razor#L5) and [closing remove a element in `MudDialogProvider._dialogs`](https://github.com/MudBlazor/MudBlazor/blob/a35edcbf7647f95cb9d3d8d4316ae4d4256b2eb5/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs#L173).

The solution is to use a concurrent collection.


## How Has This Been Tested?

I added a test to reproduce the bug.


## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)


## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
