### PR TITLE
Pickers: Fix popover elevation and gap

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/ColorPickerPage.razor
@@ -97,7 +97,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Elevation">
-                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default value is 0 for static and 8 for inline.</Description>
+                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default level is 8 for Inline, and 0 for Static or Dialog.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Class="demo-datetime-margin" Code="@nameof(ColorPickerElevationExample)">
                 <ColorPickerElevationExample />

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -121,7 +121,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Elevation">
-                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default value is 0 for static and 8 for inline.</Description>
+                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default level is 8 for Inline, and 0 for Static or Dialog.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DatePickerElevationExample)">
                 <DatePickerElevationExample/>

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -83,7 +83,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Elevation">
-                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default value is 0 for static and 8 for inline.</Description>
+                <Description>You can change the elevation with the <CodeInline>Elevation</CodeInline> parameter. The default level is 8 for Inline, and 0 for Static or Dialog.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Class="demo-datetime-margin" Code="@nameof(TimePickerElevationExample)" ShowCode="false">
                 <TimePickerElevationExample />

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1145,6 +1145,8 @@ namespace MudBlazor.UnitTests.Components
                 "mud-popover-top-left",
                 "mud-popover-anchor-bottom-left",
                 "mud-popover-overflow-flip-onopen",
+                "mud-picker-popover",
+                "mud-elevation-8",
             ]);
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -60,9 +60,9 @@
                 }
                 @if (PickerVariant == PickerVariant.Inline)
                 {
-                    <MudPopover Open="@Open" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" OverflowBehavior="@(OverflowBehavior)" Paper="false">
+                    <MudPopover Class="@PopoverClassname" Open="@Open" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" OverflowBehavior="@(OverflowBehavior)" Paper="false">
                         <div @ref="_pickerInlineRef" class="@PickerInlineClassname">
-                            <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                            <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                                 <div class="@PickerContainerClassname">
                                     @if (PickerContent != null)
                                     {
@@ -81,7 +81,7 @@
                 }
                 else if (PickerVariant == PickerVariant.Static)
                 {
-                    <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                    <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                         <div class="@PickerContainerClassname">
                             @if (PickerContent != null)
                             {
@@ -99,7 +99,7 @@
                 else if (Open && PickerVariant == PickerVariant.Dialog)
                 {
                     <MudOverlay Visible="@Open" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
-                        <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                        <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                             <div class="@PickerContainerClassname">
                                 @if (PickerContent != null)
                                 {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -20,7 +20,6 @@ namespace MudBlazor
     {
         private string? _text;
         private bool _pickerSquare;
-        private int _pickerElevation;
         private ElementReference _pickerInlineRef;
         private bool _keyInterceptorObserving = false;
         private string _elementId = Identifier.Create("picker");
@@ -37,7 +36,7 @@ namespace MudBlazor
                 .AddClass("mud-picker-inline", PickerVariant != PickerVariant.Static)
                 .AddClass("mud-picker-static", PickerVariant == PickerVariant.Static)
                 .AddClass("mud-rounded", PickerVariant == PickerVariant.Static && !_pickerSquare)
-                .AddClass($"mud-elevation-{_pickerElevation}", PickerVariant == PickerVariant.Static)
+                .AddClass($"mud-elevation-{Elevation ?? 0}", PickerVariant == PickerVariant.Static)
                 .AddClass("mud-picker-input-button", !Editable && PickerVariant != PickerVariant.Static)
                 .AddClass("mud-picker-input-text", Editable && PickerVariant != PickerVariant.Static)
                 .AddClass("mud-disabled", GetDisabledState() && PickerVariant != PickerVariant.Static)
@@ -74,6 +73,12 @@ namespace MudBlazor
         protected string PickerInputClassname =>
             new CssBuilder("mud-input-input-control")
                 .AddClass(Class)
+                .Build();
+
+        protected string PopoverClassname =>
+            new CssBuilder("mud-picker-popover")
+                // We can't use the Elevation parameter because it requires Paper=true; Instead we define the class explicitly.
+                .AddClass($"mud-elevation-{Elevation ?? MudGlobal.PopoverDefaults.Elevation}")
                 .Build();
 
         protected string ActionsClassname =>
@@ -143,12 +148,12 @@ namespace MudBlazor
         /// The size of the drop shadow.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>8</c>.<br />
+        /// Defaults to <c>8</c> for inline pickers; otherwise <c>0</c>.<br />
         /// A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerAppearance)]
-        public int Elevation { set; get; } = 8;
+        public int? Elevation { set; get; }
 
         /// <summary>
         /// Disables rounded corners.
@@ -552,14 +557,6 @@ namespace MudBlazor
             if (PickerVariant == PickerVariant.Static)
             {
                 Open = true;
-                if (Elevation == 8)
-                {
-                    _pickerElevation = 0;
-                }
-                else
-                {
-                    _pickerElevation = Elevation;
-                }
 
                 if (!Rounded)
                 {
@@ -569,7 +566,6 @@ namespace MudBlazor
             else
             {
                 _pickerSquare = Square;
-                _pickerElevation = Elevation;
             }
 
             if (Label == null && For != null)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
                 .AddClass("mud-picker-inline", PickerVariant != PickerVariant.Static)
                 .AddClass("mud-picker-static", PickerVariant == PickerVariant.Static)
                 .AddClass("mud-rounded", PickerVariant == PickerVariant.Static && !_pickerSquare)
-                .AddClass($"mud-elevation-{Elevation ?? 0}", PickerVariant == PickerVariant.Static)
+                .AddClass($"mud-elevation-{Elevation ?? 0}", PickerVariant != PickerVariant.Inline)
                 .AddClass("mud-picker-input-button", !Editable && PickerVariant != PickerVariant.Static)
                 .AddClass("mud-picker-input-text", Editable && PickerVariant != PickerVariant.Static)
                 .AddClass("mud-disabled", GetDisabledState() && PickerVariant != PickerVariant.Static)

--- a/src/MudBlazor/Styles/components/_picker.scss
+++ b/src/MudBlazor/Styles/components/_picker.scss
@@ -87,7 +87,6 @@
 
 .mud-picker-view {
   display: none;
-  margin-top: 20px;
 
   &.mud-picker-open {
     display: block;


### PR DESCRIPTION

## Description
Regression by: https://github.com/MudBlazor/MudBlazor/pull/9993
Resolves #10235

- Moves the drop shadow for inline pickers up to the popover itself and up to the picker element for others
- Adds a `mud-picker-popover` class to the popover
- `MudPicker.Elevation` is now nullable
  - Defaults to `MudGlobal.PopoverDefaults.Elevation` for inline pickers
  - Defaults to `0` for other variants
  - This avoids the hardcoded logic around the default of `8`; you couldn't use that number to add an elevation for other variants

Additionally resolves issue caused by #10071 where there was a (now no longer needed) margin between the picker input and the picker itself:

![image](https://github.com/user-attachments/assets/bc0aba8b-538a-4727-96ad-00ad8de4c8f3)

This PR may or may not be considered a breaking change.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
