### PR TITLE
RegexMask: Add note to specify the regex must start with ^ and end with $

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
@@ -80,7 +80,12 @@
                     Instead it lets you define the allowed input with a single C# regular expression. The advantage of RegexMask is that it 
                     can allow input of variable length. The disadvantage is that it can be applied only in very specific use-cases. The problem
                     is that the Regex needs to match <b>all incomplete versions of the input value</b> which can be very challenging for non-trivial 
-                    use-cases.<br/><br/> 
+                    use-cases.
+                    <br/>
+                    <MudAlert Class="my-3" Severity="Severity.Warning">
+                        The regex must begin with <b>^</b> and end with <b>$</b>.
+                    </MudAlert>
+                    <br/>
                     The following example restricts user input to digits only on the left and restricts input to Russian postal codes 
                     (first digit between 1 and 6, total of 6 digits) on the right. 
                 </Description>


### PR DESCRIPTION
## Description

To work, the regex pattern must start with `^` and end with `$`, but this detail isn't in the doc.
So this PR is to add a note about it in the documentation to avoid some confusion like #10252.

This is the result :
![image](https://github.com/user-attachments/assets/6caa5b5e-1298-4aea-8eac-ebbfdad681db)


## How Has This Been Tested?

I opened the doc in debug to check.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
