### PR TITLE
MudSnackbar: Move Icon configs to CommonSnackbarOptions

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarIconConfiguationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarIconConfiguationTest.razor
@@ -3,7 +3,7 @@
 <MudButton OnClick="@ShowDefault">Show default snackbar</MudButton>
 
 @code {
-    public static string __description__ = "Show snackbar that has custom custom configured icons";
+    public static string __description__ = "Show snackbar that has custom configured error icon";
 
     private const string MessageText = "All your base are belong to us";
     private const string ActionText = "I Surrender";

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarIconConfiguationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarIconConfiguationTest.razor
@@ -1,0 +1,30 @@
+﻿@inject ISnackbar SnackbarService
+
+<MudButton OnClick="@ShowDefault">Show default snackbar</MudButton>
+
+@code {
+    public static string __description__ = "Show snackbar that has custom custom configured icons";
+
+    private const string MessageText = "All your base are belong to us";
+    private const string ActionText = "I Surrender";
+
+    protected override void OnInitialized()
+    {
+        SnackbarService.Configuration.PositionClass = Defaults.Classes.Position.BottomEnd;
+        SnackbarService.Configuration.PreventDuplicates = false;
+        SnackbarService.Configuration.ShowCloseIcon = true;
+        SnackbarService.Configuration.RequireInteraction = true;
+        SnackbarService.Configuration.ErrorIcon = @Icons.Material.Filled.ReportGmailerrorred;
+        SnackbarService.Configuration.IconSize = Size.Large;
+
+        base.OnInitialized();
+    }
+
+    private void ShowDefault()
+    {
+        SnackbarService.Add(MessageText, Severity.Error, options =>
+        {
+            options.Action = ActionText;
+        });
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -251,7 +251,6 @@ namespace MudBlazor.UnitTests.Components
             );
 
             var svg = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild;
-            
             svg.ClassName.Should().Contain("mud-icon-size-large");
             svg.InnerHtml.Should().Contain("M15.73,3H8.27L3,8.27v7.46L8.27,21h7.46L21,15.73V8.27L15.73,3z M19,14.9L14.9,19H9.1L5,14.9V9.1L9.1,5h5.8L19,9.1V14.9z");
         }

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -240,6 +240,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void SnackbarIconConfigurationTest()
+        {
+            var testComponent = Context.RenderComponent<SnackbarIconConfiguationTest>();
+
+            testComponent.Find("button").Click();
+
+            _provider.WaitForAssertion(() =>
+                _provider.Find("div.mud-snackbar-content-message").Should().NotBe(null)
+            );
+
+            var svg = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild;
+            
+            svg.ClassName.Should().Contain("mud-icon-size-large");
+            svg.InnerHtml.Should().Contain("M15.73,3H8.27L3,8.27v7.46L8.27,21h7.46L21,15.73V8.27L15.73,3z M19,14.9L14.9,19H9.1L5,14.9V9.1L9.1,5h5.8L19,9.1V14.9z");
+        }
+
+        [Test]
         public async Task IconTest()
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -483,6 +483,8 @@ public class ServiceCollectionExtensionsTests
             options.SnackbarConfiguration.RequireInteraction = true;
             options.SnackbarConfiguration.BackgroundBlurred = true;
             options.SnackbarConfiguration.SnackbarVariant = Variant.Outlined;
+            options.SnackbarConfiguration.SuccessIcon = @Icons.Material.Outlined.CheckCircleOutline;
+            options.SnackbarConfiguration.WarningIcon = @Icons.Material.Outlined.WarningAmber;
 
             // ResizeOptions
             options.ResizeOptions.BreakpointDefinitions = new Dictionary<Breakpoint, int>
@@ -590,5 +592,11 @@ public class ServiceCollectionExtensionsTests
         actualSnackBarOptions.RequireInteraction.Should().Be(expectedOptions.SnackbarConfiguration.RequireInteraction);
         actualSnackBarOptions.BackgroundBlurred.Should().Be(expectedOptions.SnackbarConfiguration.BackgroundBlurred);
         actualSnackBarOptions.SnackbarVariant.Should().Be(expectedOptions.SnackbarConfiguration.SnackbarVariant);
+        actualSnackBarOptions.IconSize.Should().Be(expectedOptions.SnackbarConfiguration.IconSize);
+        actualSnackBarOptions.NormalIcon.Should().Be(expectedOptions.SnackbarConfiguration.NormalIcon);
+        actualSnackBarOptions.InfoIcon.Should().Be(expectedOptions.SnackbarConfiguration.InfoIcon);
+        actualSnackBarOptions.SuccessIcon.Should().Be(expectedOptions.SnackbarConfiguration.SuccessIcon);
+        actualSnackBarOptions.WarningIcon.Should().Be(expectedOptions.SnackbarConfiguration.WarningIcon);
+        actualSnackBarOptions.ErrorIcon.Should().Be(expectedOptions.SnackbarConfiguration.ErrorIcon);
     }
 }

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -22,6 +22,33 @@ public abstract class CommonSnackbarOptions
 
     public Variant SnackbarVariant { get; set; } = Variant.Filled;
 
+    public Size IconSize { get; set; } = Size.Medium;
+
+    /// <summary>
+    /// Custom normal icon.
+    /// </summary>
+    public string NormalIcon { get; set; } = Icons.Material.Outlined.EventNote;
+
+    /// <summary>
+    /// Custom info icon.
+    /// </summary>
+    public string InfoIcon { get; set; } = Icons.Material.Outlined.Info;
+
+    /// <summary>
+    /// Custom success icon.
+    /// </summary>
+    public string SuccessIcon { get; set; } = Icons.Custom.Uncategorized.AlertSuccess;
+
+    /// <summary>
+    /// Custom warning icon.
+    /// </summary>
+    public string WarningIcon { get; set; } = Icons.Material.Outlined.ReportProblem;
+
+    /// <summary>
+    /// Custom error icon.
+    /// </summary>
+    public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
+
     protected CommonSnackbarOptions() { }
 
     protected CommonSnackbarOptions(CommonSnackbarOptions options)
@@ -34,5 +61,11 @@ public abstract class CommonSnackbarOptions
         RequireInteraction = options.RequireInteraction;
         BackgroundBlurred = options.BackgroundBlurred;
         SnackbarVariant = options.SnackbarVariant;
+        IconSize = options.IconSize;
+        NormalIcon = options.NormalIcon;
+        InfoIcon = options.InfoIcon;
+        SuccessIcon = options.SuccessIcon;
+        WarningIcon = options.WarningIcon;
+        ErrorIcon = options.ErrorIcon;
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -26,34 +26,7 @@ namespace MudBlazor
 
         public Color IconColor { get; set; } = Color.Inherit;
 
-        public Size IconSize { get; set; } = Size.Medium;
-
         public SnackbarDuplicatesBehavior DuplicatesBehavior { get; set; } = SnackbarDuplicatesBehavior.GlobalDefault;
-
-        /// <summary>
-        /// Custom normal icon.
-        /// </summary>
-        public string NormalIcon { get; set; } = Icons.Material.Outlined.EventNote;
-
-        /// <summary>
-        /// Custom info icon.
-        /// </summary>
-        public string InfoIcon { get; set; } = Icons.Material.Outlined.Info;
-
-        /// <summary>
-        /// Custom success icon.
-        /// </summary>
-        public string SuccessIcon { get; set; } = Icons.Custom.Uncategorized.AlertSuccess;
-
-        /// <summary>
-        /// Custom warning icon.
-        /// </summary>
-        public string WarningIcon { get; set; } = Icons.Material.Outlined.ReportProblem;
-
-        /// <summary>
-        /// Custom error icon.
-        /// </summary>
-        public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
 
         public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -358,6 +358,12 @@ namespace MudBlazor.Services
                     snackBarConfiguration.RequireInteraction = options.SnackbarConfiguration.RequireInteraction;
                     snackBarConfiguration.BackgroundBlurred = options.SnackbarConfiguration.BackgroundBlurred;
                     snackBarConfiguration.SnackbarVariant = options.SnackbarConfiguration.SnackbarVariant;
+                    snackBarConfiguration.IconSize = options.SnackbarConfiguration.IconSize;
+                    snackBarConfiguration.NormalIcon = options.SnackbarConfiguration.NormalIcon;
+                    snackBarConfiguration.InfoIcon = options.SnackbarConfiguration.InfoIcon;
+                    snackBarConfiguration.SuccessIcon = options.SnackbarConfiguration.SuccessIcon;
+                    snackBarConfiguration.WarningIcon = options.SnackbarConfiguration.WarningIcon;
+                    snackBarConfiguration.ErrorIcon = options.SnackbarConfiguration.ErrorIcon;
                 })
                 .AddMudBlazorResizeListener(resizeOptions =>
                 {


### PR DESCRIPTION
## Description
Move Icon configs from `SnackbarOptions` to `CommonSnackbarOptions`.  
This allows the Icons to be set globally via `SnackbarConfigurations` 

Resolves #10284

## How Has This Been Tested?
Unit tests and visually

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
