### PR TITLE
Build: Always include CSS in build output

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -105,10 +105,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.72.0">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.80.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <!-- Always include MudBlazorDocs.min.css see https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/178-->
+  <Target Name="Include MudBlazorDocsCss" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+    <ItemGroup>
+      <None Remove="wwwroot\MudBlazorDocs.min.css" />
+      <!-- Fix to only include files that were newly generated as to not have duplicate Content items. -->
+      <_NewCompiledMudBlazorDocsCss Include="wwwroot\MudBlazorDocs.min.css" Exclude="@(Content)" />
+      <Content Include="@(_NewCompiledMudBlazorDocsCss)" />
+    </ItemGroup>
+  </Target>
 
   <!--Dont Include in build output-->
   <ItemGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -86,7 +86,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.72.0">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.80.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24415.1">
@@ -97,6 +97,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <!-- Always include MudBlazor.min.css see https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/178-->
+  <Target Name="Include MudBlazorCss" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+    <ItemGroup>
+      <None Remove="wwwroot\MudBlazor.min.css" />
+      <!-- Fix to only include files that were newly generated as to not have duplicate Content items. -->
+      <_NewCompiledMudBlazorCss Include="wwwroot\MudBlazor.min.css" Exclude="@(Content)" />
+      <Content Include="@(_NewCompiledMudBlazorCss)" />
+    </ItemGroup>
+  </Target>
   
   <ItemGroup>
     <ProjectReference Include="..\MudBlazor.Analyzers\MudBlazor.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="true" OutputItemType="Analyzer" />


### PR DESCRIPTION
## Description
Always add CSS output to MSBuild Content regardless of [SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler) output.
This is done in MudBlazor and MudBlazor.Docs projects.
See https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/178
This allows the current version of [SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler) to be used which avoids file contention which was causing some users builds to fail.
Following error reported by @ScarletKuro
```
Error running sass compiler: Error reading wwwroot\MudBlazor.min.css: Cannot open file.
```

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
`dotnet clean` multiple times
`Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }` to delete all `obj `and `bin` files.
`cd /src/MudBlazor.Docs.WasmHost`
`dotnet publish -c Release`
Check the `publish/wwwroot/_content` directory to check css files exist.

Does need further testing for NuGet publishing

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
