### PR TITLE
Docs: Fix error on Icons and Typography pages after #10262

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Typography.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Typography.razor
@@ -1,7 +1,7 @@
 ﻿@page "/customization/typography"
 
 <DocsPage>
-    <DocsPageHeader Title="Typography" SubTitle="Typography controls the text throughout the theme, like font-family, size, and other settings." DisableApiHeader="true" />
+    <DocsPageHeader Title="Typography" SubTitle="Typography controls the text throughout the theme, like font-family, size, and other settings." />
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader Title="How it works">

--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 
 <DocsPage>
-    <DocsPageHeader Title="MudBlazor Icons" DisableApiHeader="true" SubTitle="Over 1800 Material Design icons and a few custom ones." />
+    <DocsPageHeader Title="MudBlazor Icons" SubTitle="Over 1800 Material Design icons and a few custom ones." />
     <DocsPageContent>
 
         <DocsPageSection>


### PR DESCRIPTION
## Description

Resolves #10288

The release of #10262 introduced a regression where the Icons and Typography pages throw an error due to the now-deprecated `DisableApiHeader` parameter.  These parameters are no longer needed and were removed in two places.

## How Has This Been Tested?

1. Visit the Icon Reference page (Local URL: https://localhost:7128/features/icons)
2. Visit the Typography page (Local URL: https://localhost:7128/customization/typography)

## Type of Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
