### PR TITLE
MudColor: Add IFormattable

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -624,11 +624,58 @@ namespace MudBlazor.UnitTests.Utilities
             }
         }
 
+
+        [Test]
+        public void ToStringFormat()
+        {
+            // Arrange
+            var color = new MudColor(130, 150, 240, 170);
+
+            // Act
+            var rgb = color.ToString(MudColorOutputFormats.RGB);
+            var rgba = color.ToString(MudColorOutputFormats.RGBA);
+            var hex = color.ToString(MudColorOutputFormats.Hex);
+            var hexA = color.ToString(MudColorOutputFormats.HexA);
+            var colorElements = color.ToString(MudColorOutputFormats.ColorElements);
+            var unknown = color.ToString((MudColorOutputFormats)9999);
+
+            // Assert
+            rgb.Should().Be("rgb(130,150,240)");
+            rgba.Should().Be("rgba(130,150,240,0.6666666666666666)");
+            hex.Should().Be("#8296f0");
+            hexA.Should().Be("#8296f0aa");
+            colorElements.Should().Be("130,150,240");
+            unknown.Should().Be("#8296f0aa");
+        }
+
+        [Test]
+        public void ToStringFormatProvider()
+        {
+            // Arrange
+            var color = new MudColor(130, 150, 240, 170);
+
+            // Act
+            var rgb = $"{color:RGB}";
+            var rgba = $"{color:RGBA}";
+            var hex = $"{color:HEX}";
+            var hexA = $"{color:HEXA}";
+            var colorElements = $"{color:COLORELEMENTS}";
+            var unknown = $"{color:F2}";
+
+            // Assert
+            rgb.Should().Be("rgb(130,150,240)");
+            rgba.Should().Be("rgba(130,150,240,0.6666666666666666)");
+            hex.Should().Be("#8296f0");
+            hexA.Should().Be("#8296f0aa");
+            colorElements.Should().Be("130,150,240");
+            unknown.Should().Be("#8296f0aa");
+        }
+
         [Test]
         [TestCaseSource(nameof(_lerpTestCases))]
         public void Lerp_ShouldInterpolateCorrectly(MudColor colorStart, MudColor colorEnd, float t, MudColor expectedColor)
         {
-            // Act
+            // Arrange & Act
             var result = MudColor.Lerp(colorStart, colorEnd, t);
 
             // Assert

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -655,6 +655,7 @@ namespace MudBlazor.UnitTests.Utilities
             var color = new MudColor(130, 150, 240, 170);
 
             // Act
+            var normal = color.ToString(null, null);
             var rgb = $"{color:RGB}";
             var rgba = $"{color:RGBA}";
             var hex = $"{color:HEX}";
@@ -663,6 +664,7 @@ namespace MudBlazor.UnitTests.Utilities
             var unknown = $"{color:F2}";
 
             // Assert
+            normal.Should().Be("rgba(130,150,240,0.6666666666666666)");
             rgb.Should().Be("rgb(130,150,240)");
             rgba.Should().Be("rgba(130,150,240,0.6666666666666666)");
             hex.Should().Be("#8296f0");

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -530,6 +530,31 @@ namespace MudBlazor.Utilities
         };
 
         /// <inheritdoc />
+        /// <remarks>
+        /// The following formats are available:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>rgb</term>
+        /// <description>Outputs the color in the format "rgb(r,g,b)".</description>
+        /// </item>
+        /// <item>
+        /// <term>rgba</term>
+        /// <description>Outputs the color in the format "rgba(r,g,b,a)".</description>
+        /// </item>
+        /// <item>
+        /// <term>hex</term>
+        /// <description>Outputs the color in the hexadecimal format "#rrggbb".</description>
+        /// </item>
+        /// <item>
+        /// <term>hexa</term>
+        /// <description>Outputs the color in the hexadecimal format with alpha "#rrggbbaa".</description>
+        /// </item>
+        /// <item>
+        /// <term>colorelements</term>
+        /// <description>Outputs the color elements without any decorator "r,g,b".</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
             if (string.IsNullOrEmpty(format))

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.Utilities
     /// Represents a color with methods to manipulate color values.
     /// </summary>
     [Serializable]
-    public class MudColor : ISerializable, IEquatable<MudColor>
+    public class MudColor : ISerializable, IEquatable<MudColor>, IFormattable
     {
         private const double Epsilon = 0.000000000000001;
         private readonly byte[] _valuesAsByte;
@@ -528,6 +528,20 @@ namespace MudBlazor.Utilities
             MudColorOutputFormats.ColorElements => $"{R},{G},{B}",
             _ => Value,
         };
+
+        /// <inheritdoc />
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return format?.ToLowerInvariant() switch
+            {
+                "rgb" => ToString(MudColorOutputFormats.RGB),
+                "rgba" => ToString(MudColorOutputFormats.RGBA),
+                "hex" => ToString(MudColorOutputFormats.Hex),
+                "hexa" => ToString(MudColorOutputFormats.HexA),
+                "colorelements" => ToString(MudColorOutputFormats.ColorElements),
+                _ => Value
+            };
+        }
 
         /// <summary>
         /// Determines whether two <see cref="MudColor"/> instances are not equal.

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -532,7 +532,13 @@ namespace MudBlazor.Utilities
         /// <inheritdoc />
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return format?.ToLowerInvariant() switch
+            if (string.IsNullOrEmpty(format))
+            {
+                // Default to parameterless ToString, otherwise it will break as if the framework has choice between ToString(string) and ToString(string, IFormatProvider) it mostly choose the latter.
+                return ToString();
+            }
+
+            return format.ToLowerInvariant() switch
             {
                 "rgb" => ToString(MudColorOutputFormats.RGB),
                 "rgba" => ToString(MudColorOutputFormats.RGBA),

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -534,7 +534,8 @@ namespace MudBlazor.Utilities
         {
             if (string.IsNullOrEmpty(format))
             {
-                // Default to parameterless ToString, otherwise it will break as if the framework has choice between ToString(string) and ToString(string, IFormatProvider) it mostly choose the latter.
+                // Default to parameterless ToString behaviour, otherwise it will break and return incorrect format _ => Value
+                // if the framework has choice between ToString(string) and ToString(string, IFormatProvider) it will choose the latter.
                 return ToString();
             }
 


### PR DESCRIPTION
## Description
It can allow use to format string using the format provider
aka `"{color:hex}"` instead of `color.ToString(MudColorOutputFormats.Hex)`.

## How Has This Been Tested?
Unit tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
