### PR TITLE
Build:  Update SASS compiler

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -21,7 +21,7 @@
   <!--Project path for code generator-->
   <PropertyGroup>
     <BinDocsCompiler>$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/net9.0/MudBlazor.Docs.Compiler.dll</BinDocsCompiler>
-    <ProjectDocsCompiler>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"</ProjectDocsCompiler>
+    <ProjectDocsCompiler>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj" -p:SassCompilerSassCompilerJson=''</ProjectDocsCompiler>
   </PropertyGroup>
 
   <!--Execute the code generator-->
@@ -105,7 +105,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.72.0">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.80.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -66,6 +66,7 @@
       <FilesToClean Include="./wwwroot/MudBlazor.min.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.css" />
       <FilesToClean Include="./wwwroot/MudBlazor.css" />
+      <FilesToClean Include="./wwwroot/css/MudBlazor.css" />
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>
@@ -86,7 +87,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.72.0">
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.80.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24415.1">
@@ -121,6 +122,7 @@
     <Content Remove="compilerconfig.json" />
     <Content Remove="sasscompiler.json" />
     <Content Remove="wwwroot/DoNotRemove.txt" />
+    <Content Remove="wwwroot/css/MudBlazor.css" />
     <!--macOS hidden file (causes problems with dotnet pack)-->
     <Content Remove="**/*/.DS_Store" />
   </ItemGroup>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
See https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/178

TLDR
During a website publish from a fresh repo e.g. CI/CD publish `MudBlazor.DocsCompiler` is causing a transitive build of `MudBlazor` lib before `MudBlazor.Docs.WasmHost`
The result is that `MudBlazor.Docs.WasmHost` doesnt add `MudBlazor.min.css` to its output as it sees it as uptodate.

This PR allows the current version of [SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler) to be used which in turn avoids file contention which was causing some users' builds to fail.
Following error reported by @ScarletKuro
```
Error running sass compiler: Error reading wwwroot\MudBlazor.min.css: Cannot open file.
```
The solution is a bit of a workaround.
It uses an MSBuild prop to override the normal sasscompiler configuration file which allows `MudBlazor.DocsCompiler` to avoid compiling `MudBlazor.min.css` to `wwwroot` by using a null configuration file which results in defaults for the sasscompiler.  This has the effect of compiling to `wwwroot/css/MudBlazor.css`.
This allows subsequent builds using the `sasscompiler.json` configuration file to succeed since they are then considered a fresh build and are added to publish or NUGET output as expected.
It is a workaround but the result is we dont need a custom sasscompiler which would require knowledge and maintenance.



**Note** now we update the Sasscompiler we should deal with the depreciation warnings.
This is for another PR.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
For publish

`dotnet clean` multiple times
`Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }` to delete all `obj `and `bin` files.
`cd /src/MudBlazor.Docs.WasmHost`
`dotnet publish -c Release`
Check the `publish/wwwroot/_content` directory to check css files exist.

For pack

`dotnet clean` multiple times
`Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }` to delete all `obj `and `bin` files.
`cd /src/MudBlazor`
`dotnet pack`
Open resulting NUGET and check `staticwebassets` folder

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
