### PR TITLE
Revert "Popover: Hide all element overflow"

### DIFF
--- a/src/MudBlazor/Styles/components/_popover.scss
+++ b/src/MudBlazor/Styles/components/_popover.scss
@@ -3,7 +3,6 @@
   z-index: calc(var(--mud-zindex-popover) + 1);
   position: absolute;
   opacity: 0;
-  overflow: hidden;
 
   &.mud-popover-fixed {
     position: fixed;


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#9993

Resolves #10306. Certain elements (tooltip arrow) use `::after` which is not included in the popover overflow.

Hiding the overflow in a sweeping way like this doesn't seem common in other libraries either.

Instead I'll focus on clipping it in the source itself, like the shadow from a button in the original instance, instead of applying a band aid over it by hiding all overflow when there are legitimate uses for it.