### PR TITLE
MudColor: Add Palette algorithms

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
@@ -1,17 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 @using MudBlazor.Utilities
 
-<MudColorPicker PickerVariant="PickerVariant.Static" ColorPickerView="ColorPickerView.Palette" Palette="CustomPalette" />
+<MudColorPicker PickerVariant="PickerVariant.Static" ColorPickerView="ColorPickerView.Palette" Palette="_customPalette" />
 
 @code {
-    public IEnumerable<MudColor> CustomPalette { get; set; } = new MudColor[]
+    private readonly IEnumerable<MudColor> _customPalette = new List<IEnumerable<MudColor>>
     {
-        "#F44336", "#E91E63", "#9C27B0", "#673AB7", "#3F51B5",
-        "#FFEBEE", "#FCE4EC", "#F3E5F5", "#EDE7F6", "#E8EAF6",
-        "#FFCDD2", "#F8BBD0", "#E1BEE7", "#D1C4E9", "#C5CAE9",
-        "#EF9A9A", "#F48FB1", "#CE93D8", "#B39DDB", "#9FA8DA",
-        "#E57373", "#F06292", "#BA68C8", "#9575CD", "#7986CB",
-        "#EF5350", "#EC407A", "#AB47BC", "#7E57C2", "#5C6BC0",
-        "#E53935", "#D81B60", "#8E24AA", "#5E35B1", "#3949AB"
-    };
+        MudColor.GenerateTintShadePalette("#DC143C", shadeStep: 0),
+        MudColor.GenerateTintShadePalette("#1E90FF", tintStep: 0),
+        MudColor.GenerateTintShadePalette("#8E24AA"),
+        MudColor.GenerateAnalogousPalette("#40E0D0"),
+        MudColor.GenerateGradientPalette("#1E90FF", "#32CD32"),
+    }.SelectMany(palette => palette);
 }

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -674,6 +674,75 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
+        public void GenerateGradientPalette_ShouldGenerateCorrectGradient()
+        {
+            // Arrange
+            var startColor = new MudColor("#FF0000FF"); // Red
+            var endColor = new MudColor("#0000FFFF"); // Blue
+            IReadOnlyList<MudColor> expectedColors = ["#FF0000FF", "#BF003FFF", "#7F007FFF", "#3F00BFFF", "#0000FFFF"];
+
+            // Act
+            var gradientPalette = MudColor.GenerateGradientPalette(startColor, endColor).ToList();
+
+            // Assert
+            gradientPalette.Should().HaveCount(5);
+            gradientPalette.Should().Equal(expectedColors);
+        }
+
+        [Test]
+        public void GenerateAnalogousPalette_ShouldGenerateCorrectAnalogousColors()
+        {
+            // Arrange
+            var baseColor = new MudColor("#FF0000FF"); // Red
+            IReadOnlyList<MudColor> expectedColors = ["#FF0000FF", "#FFFF00FF", "#00FF00FF", "#00FFFFFF", "#0000FFFF"];
+
+            // Act
+            var analogousPalette = MudColor.GenerateAnalogousPalette(baseColor, angle: 60).ToList();
+
+            // Assert
+            analogousPalette.Should().HaveCount(5);
+            analogousPalette.Should().Equal(expectedColors);
+        }
+
+        [Test]
+        public void GenerateTintShadePalette_ShouldGenerateCorrectTintsAndShades()
+        {
+            // Arrange
+            var baseColor = new MudColor("#808080FF"); // Gray
+
+            // Only tints
+            IReadOnlyList<MudColor> expectedTints = ["#808080FF", "#999999FF", "#B3B3B3FF", "#CCCCCCFF", "#E6E6E6FF"];
+
+            // Only shades
+            IReadOnlyList<MudColor> expectedShades = ["#808080FF", "#666666FF", "#4D4D4DFF", "#333333FF", "#1A1A1AFF"];
+
+            // Both tints and shades (odd number of colors)
+            IReadOnlyList<MudColor> expectedBothOdd = ["#CCCCCCFF", "#B3B3B3FF", "#999999FF", "#808080FF", "#666666FF", "#4D4D4DFF", "#333333FF"];
+
+            // Both tints and shades (even number of colors)
+            IReadOnlyList<MudColor> expectedBothEven = ["#CCCCCCFF", "#B3B3B3FF", "#999999FF", "#808080FF", "#666666FF", "#4D4D4DFF"];
+
+            // Act
+            var tintsPalette = MudColor.GenerateTintShadePalette(baseColor, tintStep: 0.1, shadeStep: 0).ToList();
+            var shadesPalette = MudColor.GenerateTintShadePalette(baseColor, tintStep: 0, shadeStep: 0.1).ToList();
+            var bothPaletteOdd = MudColor.GenerateTintShadePalette(baseColor, 7, tintStep: 0.1, shadeStep: 0.1).ToList();
+            var bothPaletteEven = MudColor.GenerateTintShadePalette(baseColor, 6, tintStep: 0.1, shadeStep: 0.1).ToList();
+
+            // Assert
+            tintsPalette.Should().HaveCount(5);
+            tintsPalette.Should().Equal(expectedTints);
+
+            shadesPalette.Should().HaveCount(5);
+            shadesPalette.Should().Equal(expectedShades);
+
+            bothPaletteOdd.Should().HaveCount(7);
+            bothPaletteOdd.Should().Equal(expectedBothOdd);
+
+            bothPaletteEven.Should().HaveCount(6);
+            bothPaletteEven.Should().Equal(expectedBothEven);
+        }
+
+        [Test]
         [TestCaseSource(nameof(_lerpTestCases))]
         public void Lerp_ShouldInterpolateCorrectly(MudColor colorStart, MudColor colorEnd, float t, MudColor expectedColor)
         {

--- a/src/MudBlazor/Utilities/MudColor.Algorithms.cs
+++ b/src/MudBlazor/Utilities/MudColor.Algorithms.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Utilities;
+
+public partial class MudColor
+{
+    /// <summary>
+    /// Linearly interpolates between two <see cref="MudColor"/> instances.
+    /// </summary>
+    /// <param name="colorStart">The starting <see cref="MudColor"/> instance.</param>
+    /// <param name="colorEnd">The ending <see cref="MudColor"/> instance.</param>
+    /// <param name="t">The interpolation factor (0.0 to 1.0).</param>
+    /// <returns>A new <see cref="MudColor"/> instance that is the result of the interpolation.</returns>
+    public static MudColor Lerp(MudColor colorStart, MudColor colorEnd, float t)
+    {
+        t = Math.Clamp(t, 0.0f, 1.0f);
+        var r = InterpolateValue(colorStart.R, colorEnd.R);
+        var g = InterpolateValue(colorStart.G, colorEnd.G);
+        var b = InterpolateValue(colorStart.B, colorEnd.B);
+        var a = InterpolateValue(colorStart.A, colorEnd.A);
+        var aPercentage = NormalizeAlpha(a, 3);
+        // Using alpha as a percentage ensures more accurate alpha blending. 
+        // Creating a MudColor from an alpha byte or integer can result in fractional alpha values (e.g., 0.996078431372549), 
+        // which makes it difficult to compare two colors accurately in real-world scenarios.
+        return new MudColor(r, g, b, alpha: aPercentage);
+
+        int InterpolateValue(byte start, byte end) => (int)(start * (1.0f - t) + end * t);
+    }
+
+    /// <summary>
+    /// Generates a gradient palette of colors between two specified colors.
+    /// </summary>
+    /// <param name="startColor">The starting color of the gradient.</param>
+    /// <param name="endColor">The ending color of the gradient.</param>
+    /// <param name="numberOfColors">The total number of colors in the gradient palette.</param>
+    /// <returns>An enumerable collection of <see cref="MudColor"/> representing the gradient palette.</returns>
+    public static IEnumerable<MudColor> GenerateGradientPalette(MudColor startColor, MudColor endColor, int numberOfColors = 5)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfColors);
+        for (var i = 0; i < numberOfColors; i++)
+        {
+            var t = i / (float)(numberOfColors - 1);
+            yield return Lerp(startColor, endColor, t);
+        }
+    }
+
+    /// <summary>
+    /// Generates an analogous palette of colors based on a specified base color.
+    /// </summary>
+    /// <param name="baseColor">The base color to generate the analogous palette from.</param>
+    /// <param name="numberOfColors">The total number of colors in the analogous palette.</param>
+    /// <param name="angle">The angle between each color in the analogous palette.</param>
+    /// <returns>An enumerable collection of <see cref="MudColor"/> representing the analogous palette.</returns>
+    public static IEnumerable<MudColor> GenerateAnalogousPalette(MudColor baseColor, int numberOfColors = 5, double angle = 30)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfColors);
+        yield return baseColor;
+        for (var i = 1; i < numberOfColors; i++)
+        {
+            yield return baseColor.SetH((baseColor.H + i * angle) % 360);
+        }
+    }
+
+    /// <summary>
+    /// Generates a palette of colors by lightening and darkening the base color.
+    /// </summary>
+    /// <param name="baseColor">The base color to generate the palette from.</param>
+    /// <param name="numberOfColors">The total number of colors in the palette.</param>
+    /// <param name="tintStep">The step value for lightening the color. If <paramref name="tintStep"/> is <c>0</c>, no lighter colors will be added to the palette.</param>
+    /// <param name="shadeStep">The step value for darkening the color. If <paramref name="shadeStep"/> is <c>0</c>, no darker colors will be added to the palette.</param>
+    /// <returns>A read-only list of <see cref="MudColor"/> representing the generated palette.</returns>
+    public static IEnumerable<MudColor> GenerateTintShadePalette(MudColor baseColor, int numberOfColors = 5, double tintStep = 0.075, double shadeStep = 0.075)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfColors);
+        ArgumentOutOfRangeException.ThrowIfNegative(tintStep);
+        ArgumentOutOfRangeException.ThrowIfNegative(shadeStep);
+
+        if (tintStep > 0 && shadeStep > 0)
+        {
+            var halfColors = (numberOfColors - 1) / 2;
+            var lighterColors = halfColors + (numberOfColors % 2 == 0 ? 1 : 0);
+            var darkerColors = halfColors;
+
+            // lighter colors
+            for (var i = lighterColors; i > 0; i--)
+            {
+                yield return baseColor.ColorLighten(i * tintStep);
+            }
+
+            // Yield the base color
+            yield return baseColor;
+
+            // darker colors
+            for (var i = 1; i <= darkerColors; i++)
+            {
+                yield return baseColor.ColorDarken(i * shadeStep);
+            }
+        }
+        else if (tintStep > 0) // Only lighter colors
+        {
+            yield return baseColor;
+            for (var i = 1; i < numberOfColors; i++)
+            {
+                yield return baseColor.ColorLighten(i * tintStep);
+            }
+        }
+        else if (shadeStep > 0) // Only darker colors
+        {
+            yield return baseColor;
+            for (var i = 1; i < numberOfColors; i++)
+            {
+                yield return baseColor.ColorDarken(i * shadeStep);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.Utilities
     /// Represents a color with methods to manipulate color values.
     /// </summary>
     [Serializable]
-    public class MudColor : ISerializable, IEquatable<MudColor>, IFormattable
+    public partial class MudColor : ISerializable, IEquatable<MudColor>, IFormattable
     {
         private const double Epsilon = 0.000000000000001;
         private readonly byte[] _valuesAsByte;
@@ -603,28 +603,6 @@ namespace MudBlazor.Utilities
         /// <param name="mudColor">The MudColor instance to convert.</param>
         /// <returns>The 32-bit unsigned integer representation of the color.</returns>
         public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
-
-        /// <summary>
-        /// Linearly interpolates between two <see cref="MudColor"/> instances.
-        /// </summary>
-        /// <param name="colorStart">The starting <see cref="MudColor"/> instance.</param>
-        /// <param name="colorEnd">The ending <see cref="MudColor"/> instance.</param>
-        /// <param name="t">The interpolation factor (0.0 to 1.0).</param>
-        /// <returns>A new <see cref="MudColor"/> instance that is the result of the interpolation.</returns>
-        public static MudColor Lerp(MudColor colorStart, MudColor colorEnd, float t)
-        {
-            var r = InterpolateValue(colorStart.R, colorEnd.R);
-            var g = InterpolateValue(colorStart.G, colorEnd.G);
-            var b = InterpolateValue(colorStart.B, colorEnd.B);
-            var a = InterpolateValue(colorStart.A, colorEnd.A);
-            var aPercentage = NormalizeAlpha(a, 3);
-            // Using alpha as a percentage ensures more accurate alpha blending. 
-            // Creating a MudColor from an alpha byte or integer can result in fractional alpha values (e.g., 0.996078431372549), 
-            // which makes it difficult to compare two colors accurately in real-world scenarios.
-            return new MudColor(r, g, b, alpha: aPercentage);
-
-            int InterpolateValue(byte start, byte end) => (int)(start * (1.0f - t) + end * t);
-        }
 
         private static double NormalizeAlpha(byte a, int digit = 2) => Math.Round(a / 255.0, digit);
 


### PR DESCRIPTION
## Description
Since we already have the Lerp algorithm (https://github.com/MudBlazor/MudBlazor/pull/10275) and MudColor implements `HSL` information, `ColorLighten`, and `ColorDarken`, I thought it would make sense to add palette algorithms.
**NB!**: These algorithms are very simple, generic and most common ones. They do not allocate any additional memory, as I only use `IEnumerable` and `yield return`.

I replaced the statically generated palette in `ColorPickerPaletteExample` with our algorithms:

![palette](https://github.com/user-attachments/assets/7b153399-3f32-495a-8fa7-b43640d56ac1)


- The first line shows the tint palette.
- The second line shows the shades palette.
- The third line shows both the tint and shades palettes at the same time (reverted sequence).
- The fourth line shows the analogous palette.
- The fifth line shows the gradient palette between two colors.
- The sixth line shows the multi gradient between three(it can be more) colors. (**new**: added in #10318)

## How Has This Been Tested?
Unit tests added, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
