### PR TITLE
MudColor: Fix special case in GenerateGradientPalette

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
@@ -8,7 +8,8 @@
     {
         MudColor.GenerateTintShadePalette("#DC143C", shadeStep: 0),
         MudColor.GenerateTintShadePalette("#1E90FF", tintStep: 0),
-        MudColor.GenerateTintShadePalette("#8E24AA"),
+        // Reverse for illustrative purposes
+        MudColor.GenerateTintShadePalette("#8E24AA").Reverse(),
         MudColor.GenerateAnalogousPalette("#40E0D0"),
         MudColor.GenerateGradientPalette("#1E90FF", "#32CD32"),
     }.SelectMany(palette => palette);

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -674,18 +674,14 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        public void GenerateGradientPalette_ShouldGenerateCorrectGradient()
+        [TestCaseSource(nameof(_gradientTestCases))]
+        public void GenerateGradientPalette_ShouldGenerateCorrectGradient(MudColor startColor, MudColor endColor, int numberOfColors, MudColor[] expectedColors)
         {
-            // Arrange
-            var startColor = new MudColor("#FF0000FF"); // Red
-            var endColor = new MudColor("#0000FFFF"); // Blue
-            IReadOnlyList<MudColor> expectedColors = ["#FF0000FF", "#BF003FFF", "#7F007FFF", "#3F00BFFF", "#0000FFFF"];
-
-            // Act
-            var gradientPalette = MudColor.GenerateGradientPalette(startColor, endColor).ToList();
+            // Arrange & Act
+            var gradientPalette = MudColor.GenerateGradientPalette(startColor, endColor, numberOfColors).ToList();
 
             // Assert
-            gradientPalette.Should().HaveCount(5);
+            gradientPalette.Should().HaveCount(numberOfColors);
             gradientPalette.Should().Equal(expectedColors);
         }
 
@@ -910,6 +906,15 @@ namespace MudBlazor.UnitTests.Utilities
             mudColor.UInt32.Should().Be(mudColor.UInt32);
         }
 
+        private static readonly object[] _gradientTestCases =
+        [
+            // Should just lerp between two colors when numbers of colors is 1
+            new object[] { new MudColor("#FF0000FF"), new MudColor("#0000FFFF"), 1, new MudColor[] { "#7F007FFF" } },
+            // Should return start and end colors when numbers of colors is 2
+            new object[] { new MudColor("#FF0000FF"), new MudColor("#0000FFFF"), 2, new MudColor[] { "#FF0000FF", "#0000FFFF" }},
+            // Should return start, then evenly lerped colors, and end color when numbers of colors are more than 3
+            new object[] { new MudColor("#FF0000FF"), new MudColor("#0000FFFF"), 5, new MudColor[] { "#FF0000FF", "#BF003FFF", "#7F007FFF", "#3F00BFFF", "#0000FFFF" }},
+        ];
 
         private static readonly object[] _lerpTestCases =
         [

--- a/src/MudBlazor/Utilities/MudColor.Algorithms.cs
+++ b/src/MudBlazor/Utilities/MudColor.Algorithms.cs
@@ -39,6 +39,14 @@ public partial class MudColor
     public static IEnumerable<MudColor> GenerateGradientPalette(MudColor startColor, MudColor endColor, int numberOfColors = 5)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfColors);
+
+        // Special case for a single numberOfColors, otherwise "t" will be NaN, so we just lerp between the two colors
+        if (numberOfColors == 1)
+        {
+            yield return Lerp(startColor, endColor, 0.5f);
+            yield break;
+        }
+
         for (var i = 0; i < numberOfColors; i++)
         {
             var t = i / (float)(numberOfColors - 1);
@@ -83,7 +91,7 @@ public partial class MudColor
             var lighterColors = halfColors + (numberOfColors % 2 == 0 ? 1 : 0);
             var darkerColors = halfColors;
 
-            // lighter colors
+            // Lighter colors
             for (var i = lighterColors; i > 0; i--)
             {
                 yield return baseColor.ColorLighten(i * tintStep);
@@ -92,7 +100,7 @@ public partial class MudColor
             // Yield the base color
             yield return baseColor;
 
-            // darker colors
+            // Darker colors
             for (var i = 1; i <= darkerColors; i++)
             {
                 yield return baseColor.ColorDarken(i * shadeStep);


### PR DESCRIPTION
## Description
Follow-up PR for: https://github.com/MudBlazor/MudBlazor/pull/10313

This fixes an issue where setting `numberOfColors = 1` in `GenerateGradientPalette` causes the following line:
```
var t = i / (float)(numberOfColors - 1);
```
to return `NaN`, resulting in the end color being white. 

The fix adds a special case to handle the situation when `numberOfColors = 1`. An alternative approach would be to throw an exception when `numberOfColors` is less than two, but I believe this approach is better. If someone wants to create a multi-gradient palette, `GenerateGradientPalette` could be reused, and there could be scenarios where the number of colors per segment is equal to one, which would cause the same problem again.

## How Has This Been Tested?
Unit tests, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
