### PR TITLE
MudAutocomplete, MudSelect: Allow popover customization and add scroll events

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -90,7 +90,7 @@
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover"
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" Fixed="true"
                          AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -90,7 +90,7 @@
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" Fixed="true"
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" DropdownBehavior="@_dropdownBehavior"
                          AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -90,7 +90,7 @@
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" DropdownBehavior="@_dropdownBehavior"
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" DropDownSettings="@_dropdownBehavior"
                          AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -90,7 +90,7 @@
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" DropDownSettings="@_dropdownBehavior"
+        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" DropdownSettings="@_dropdownBehavior"
                          AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -21,7 +21,7 @@ public partial class Appbar
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
-    private DropdownBehavior _dropdownBehavior = new() { Fixed = true, OverflowBehavior = OverflowBehavior.FlipOnOpen };
+    private DropDownSettings _dropdownBehavior = new() { Fixed = true, OverflowBehavior = OverflowBehavior.FlipOnOpen };
     private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
     [
         new ApiLinkServiceEntry

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -21,6 +21,7 @@ public partial class Appbar
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
+    private DropdownBehavior _dropdownBehavior = new() { Fixed = true, OverflowBehavior = OverflowBehavior.FlipOnOpen };
     private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
     [
         new ApiLinkServiceEntry

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -21,7 +21,7 @@ public partial class Appbar
     private string _badgeTextSoon = "coming soon";
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
-    private DropDownSettings _dropdownBehavior = new() { Fixed = true, OverflowBehavior = OverflowBehavior.FlipOnOpen };
+    private DropdownSettings _dropdownBehavior = new() { Fixed = true, OverflowBehavior = OverflowBehavior.FlipOnOpen };
     private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
     [
         new ApiLinkServiceEntry

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectScrollDrawerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectScrollDrawerTest.razor
@@ -1,0 +1,36 @@
+﻿
+<MudPaper Height="200px" Style="overflow:hidden; position:relative;">
+    <MudDrawerContainer Class="mud-height-full">
+        <MudDrawer @bind-Open="@open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
+            <MudDrawerHeader>
+                <MudText Typo="Typo.h6">My App</MudText>
+            </MudDrawerHeader>
+            <MudPaper Height="2000px" Square="true">
+                <MudSelect Style="margin-top:100px;" T="string" Label="Coffee" AnchorOrigin="Origin.BottomLeft" Fixed="true">
+                    <MudSelectItem Value="@("Cappuccino")" />
+                    <MudSelectItem Value="@("Cafe Latte")" />
+                    <MudSelectItem Value="@("Espresso")" />
+                </MudSelect>
+                <MudNavMenu>
+                    <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Dashboard" IconColor="Color.Inherit">Dashboard</MudNavLink>
+                    <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.LocalLibrary" IconColor="Color.Inherit">Library</MudNavLink>
+                    <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.People" IconColor="Color.Inherit">Community</MudNavLink>
+                </MudNavMenu>
+            </MudPaper>
+        </MudDrawer>
+        <div class="d-flex justify-center align-center mud-height-full">
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="@ToggleDrawer">Persistent drawer</MudButton>
+        </div>
+    </MudDrawerContainer>
+</MudPaper>
+
+@code {
+    public static string __description__ = "A MudSelect inside a Drawer that stays fixed when scrolled";
+
+    bool open = false;
+
+    void ToggleDrawer()
+    {
+        open = !open;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectScrollDrawerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectScrollDrawerTest.razor
@@ -1,7 +1,7 @@
 ﻿
 <MudPaper Height="200px" Style="overflow:hidden; position:relative;">
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
+        <MudDrawer @bind-Open="@_open" Elevation="0" Variant="@DrawerVariant.Persistent" Color="Color.Primary">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">My App</MudText>
             </MudDrawerHeader>
@@ -27,10 +27,10 @@
 @code {
     public static string __description__ = "A MudSelect inside a Drawer that stays fixed when scrolled";
 
-    bool open = false;
+    private bool _open = false;
 
-    void ToggleDrawer()
+    private void ToggleDrawer()
     {
-        open = !open;
+        _open = !_open;
     }
 }

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -372,5 +372,32 @@ namespace MudBlazor.UnitTests.Components
                 await comp.Instance.Close();
             }
         }
+
+        [Test]
+        public void MudPopoverProvider_DropdownSettings_SetsDefaultValues()
+        {
+            var settings = new DropdownSettings();
+
+            settings.Fixed.Should().BeFalse();
+            settings.OverflowBehavior.Should().Be(OverflowBehavior.FlipOnOpen);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void MudPopoverProvider_DropdownSettings_Fixed_CanBeSetCorrectly(bool fixedValue)
+        {
+            var settings = new DropdownSettings { Fixed = fixedValue };
+
+            settings.Fixed.Should().Be(fixedValue);
+        }
+
+        [Test]
+        public void MudPopoverProvider_DropdownSettings_OverflowBehavior_CanBeSetCorrectly()
+        {
+            var settings = new DropdownSettings { OverflowBehavior = OverflowBehavior.FlipAlways };
+
+            settings.OverflowBehavior.Should().Be(OverflowBehavior.FlipAlways);
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -66,7 +66,7 @@
                     }
                 }
 
-                <MudPopover Fixed="@DropdownBehavior.Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@DropdownBehavior.OverflowBehavior">
+                <MudPopover Fixed="@DropDownSettings.Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@DropDownSettings.OverflowBehavior">
                     @if (ProgressIndicatorInPopoverTemplate is not null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -66,7 +66,7 @@
                     }
                 }
 
-                <MudPopover Fixed="@Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
+                <MudPopover Fixed="@Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@OverflowBehavior">
                     @if (ProgressIndicatorInPopoverTemplate is not null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -66,7 +66,7 @@
                     }
                 }
 
-                <MudPopover Fixed="@DropDownSettings.Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@DropDownSettings.OverflowBehavior">
+                <MudPopover Fixed="@DropdownSettings.Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@DropdownSettings.OverflowBehavior">
                     @if (ProgressIndicatorInPopoverTemplate is not null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -66,7 +66,7 @@
                     }
                 }
 
-                <MudPopover Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
+                <MudPopover Fixed="@Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true">
                     @if (ProgressIndicatorInPopoverTemplate is not null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -66,7 +66,7 @@
                     }
                 }
 
-                <MudPopover Fixed="@Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@OverflowBehavior">
+                <MudPopover Fixed="@DropdownBehavior.Fixed" Open="@Open" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="true" OverflowBehavior="@DropdownBehavior.OverflowBehavior">
                     @if (ProgressIndicatorInPopoverTemplate is not null && IsLoading)
                     {
                         @ProgressIndicatorInPopoverTemplate

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -192,7 +192,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool ShowProgressIndicator { get; set; } = false;
+        public bool ShowProgressIndicator { get; set; }
 
         /// <summary>
         /// The color of the progress indicator.
@@ -393,7 +393,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool Fixed { get; set; } = false;
+        public bool Fixed { get; set; }
 
         /// <summary>
         /// The behavior applied when there is not enough space for this dropdown to be visible.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -389,11 +389,11 @@ namespace MudBlazor
         /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="DropdownBehavior.Fixed" /> false
-        /// Defaults to <see cref="DropdownBehavior.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
+        /// Defaults to <see cref="DropDownSettings.Fixed" /> false
+        /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Parameter]
-        public DropdownBehavior DropdownBehavior { get; set; }
+        public DropDownSettings DropDownSettings { get; set; }
 
         /// <summary>
         /// The function used to determine if an item should be disabled.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -386,6 +386,16 @@ namespace MudBlazor
         public bool CoerceValue { get; set; }
 
         /// <summary>
+        /// Displays the autocomplete popover in a fixed position, even through scrolling.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>False</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public bool Fixed { get; set; } = false;
+
+        /// <summary>
         /// The function used to determine if an item should be disabled.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -389,12 +389,12 @@ namespace MudBlazor
         /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="DropDownSettings.Fixed" /> false
-        /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
+        /// Defaults to <see cref="DropdownSettings.Fixed" /> false
+        /// Defaults to <see cref="DropdownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Category(CategoryTypes.Popover.Behavior)]
         [Parameter]
-        public DropDownSettings DropDownSettings { get; set; }
+        public DropdownSettings DropdownSettings { get; set; }
 
         /// <summary>
         /// The function used to determine if an item should be disabled.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -396,6 +396,16 @@ namespace MudBlazor
         public bool Fixed { get; set; } = false;
 
         /// <summary>
+        /// The behavior applied when there is not enough space for this dropdown to be visible.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Popover.Appearance)]
+        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+
+        /// <summary>
         /// The function used to determine if an item should be disabled.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -392,6 +392,7 @@ namespace MudBlazor
         /// Defaults to <see cref="DropDownSettings.Fixed" /> false
         /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
+        [Category(CategoryTypes.Popover.Behavior)]
         [Parameter]
         public DropDownSettings DropDownSettings { get; set; }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -386,24 +386,14 @@ namespace MudBlazor
         public bool CoerceValue { get; set; }
 
         /// <summary>
-        /// Displays the autocomplete popover in a fixed position, even through scrolling.
+        /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>False</c>.
+        /// Defaults to <see cref="DropdownBehavior.Fixed" /> false
+        /// Defaults to <see cref="DropdownBehavior.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Parameter]
-        [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool Fixed { get; set; }
-
-        /// <summary>
-        /// The behavior applied when there is not enough space for this dropdown to be visible.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Popover.Appearance)]
-        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+        public DropdownBehavior DropdownBehavior { get; set; }
 
         /// <summary>
         /// The function used to determine if an item should be disabled.

--- a/src/MudBlazor/Components/Popover/DropDownSettings.cs
+++ b/src/MudBlazor/Components/Popover/DropDownSettings.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
     /// <summary>
     /// Configures the behavior of a dropdown popover, specifically the Fixed and OverflowBehavior properties.  
     /// </summary>
-    public struct DropdownBehavior
+    public struct DropDownSettings
     {
         /// <summary>
         /// Displays the dropdown popover in a fixed position, even through scrolling.
@@ -36,6 +36,6 @@ namespace MudBlazor
         [Category(CategoryTypes.Popover.Appearance)]
         public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
 
-        public DropdownBehavior() { }
+        public DropDownSettings() { }
     }
 }

--- a/src/MudBlazor/Components/Popover/DropDownSettings.cs
+++ b/src/MudBlazor/Components/Popover/DropDownSettings.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
     /// <summary>
     /// Configures the behavior of a dropdown popover, specifically the Fixed and OverflowBehavior properties.  
     /// </summary>
-    public struct DropDownSettings
+    public struct DropdownSettings
     {
         /// <summary>
         /// Displays the dropdown popover in a fixed position, even through scrolling.
@@ -36,6 +36,6 @@ namespace MudBlazor
         [Category(CategoryTypes.Popover.Appearance)]
         public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
 
-        public DropDownSettings() { }
+        public DropdownSettings() { }
     }
 }

--- a/src/MudBlazor/Components/Popover/DropdownBehavior.cs
+++ b/src/MudBlazor/Components/Popover/DropdownBehavior.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    /// <summary>
+    /// Configures the behavior of a dropdown popover, specifically the Fixed and OverflowBehavior properties.  
+    /// </summary>
+    public struct DropdownBehavior
+    {
+        /// <summary>
+        /// Displays the dropdown popover in a fixed position, even through scrolling.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>False</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public bool Fixed { get; set; }
+
+        /// <summary>
+        /// The behavior applied when there is not enough space for this dropdown to be visible.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Popover.Appearance)]
+        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+
+        public DropdownBehavior() { }
+    }
+}

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -105,7 +105,7 @@ namespace MudBlazor
         public bool Square { get; set; }
 
         /// <summary>
-        /// Displays this popover in a fixed position.
+        /// Displays this popover in a fixed position, even through scrolling.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>False</c>.

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,9 +61,9 @@
                             MaxHeight="@MaxHeight"
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
-                            OverflowBehavior="@OverflowBehavior"
+                            OverflowBehavior="@DropdownBehavior.OverflowBehavior"
                             Class="@PopoverClass"
-                            Fixed="@Fixed"
+                            Fixed="@DropdownBehavior.Fixed"
                             RelativeWidth="@FullWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,9 +61,9 @@
                             MaxHeight="@MaxHeight"
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
-                            OverflowBehavior="@DropDownSettings.OverflowBehavior"
+                            OverflowBehavior="@DropdownSettings.OverflowBehavior"
                             Class="@PopoverClass"
-                            Fixed="@DropDownSettings.Fixed"
+                            Fixed="@DropdownSettings.Fixed"
                             RelativeWidth="@FullWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,9 +61,9 @@
                             MaxHeight="@MaxHeight"
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
-                            OverflowBehavior="@DropdownBehavior.OverflowBehavior"
+                            OverflowBehavior="@DropDownSettings.OverflowBehavior"
                             Class="@PopoverClass"
-                            Fixed="@DropdownBehavior.Fixed"
+                            Fixed="@DropDownSettings.Fixed"
                             RelativeWidth="@FullWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,6 +61,7 @@
                             MaxHeight="@MaxHeight"
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
+                            OverflowBehavior="@OverflowBehavior"
                             Class="@PopoverClass"
                             Fixed="@Fixed"
                             RelativeWidth="@FullWidth">

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -62,6 +62,7 @@
                             AnchorOrigin="@AnchorOrigin"
                             TransformOrigin="@TransformOrigin"
                             Class="@PopoverClass"
+                            Fixed="@Fixed"
                             RelativeWidth="@FullWidth">
                     <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                         <MudList T="string"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -155,6 +155,16 @@ namespace MudBlazor
         public bool Fixed { get; set; } = false;
 
         /// <summary>
+        /// The behavior applied when there is not enough space for this dropdown to be visible.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Popover.Appearance)]
+        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+
+        /// <summary>
         /// The outer div's classnames, separated by space.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Appearance)]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -145,24 +145,14 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Displays this selectitems in a fixed position, even through scrolling.
+        /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>False</c>.
-        /// </remarks>
-        [Category(CategoryTypes.FormComponent.Appearance)]
-        [Parameter]
-        public bool Fixed { get; set; }
-
-        /// <summary>
-        /// The behavior applied when there is not enough space for this dropdown to be visible.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// Defaults to <see cref="DropdownBehavior.Fixed" /> false
+        /// Defaults to <see cref="DropdownBehavior.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Parameter]
-        [Category(CategoryTypes.Popover.Appearance)]
-        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+        public DropdownBehavior DropdownBehavior { get; set; }
 
         /// <summary>
         /// The outer div's classnames, separated by space.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -145,6 +145,16 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Displays this selectitems in a fixed position, even through scrolling.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>False</c>.
+        /// </remarks>
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        [Parameter]
+        public bool Fixed { get; set; } = false;
+
+        /// <summary>
         /// The outer div's classnames, separated by space.
         /// </summary>
         [Category(CategoryTypes.FormComponent.Appearance)]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -151,6 +151,7 @@ namespace MudBlazor
         /// Defaults to <see cref="DropDownSettings.Fixed" /> false
         /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
+        [Category(CategoryTypes.Popover.Behavior)]
         [Parameter]
         public DropDownSettings DropDownSettings { get; set; }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -148,12 +148,12 @@ namespace MudBlazor
         /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="DropDownSettings.Fixed" /> false
-        /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
+        /// Defaults to <see cref="DropdownSettings.Fixed" /> false
+        /// Defaults to <see cref="DropdownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Category(CategoryTypes.Popover.Behavior)]
         [Parameter]
-        public DropDownSettings DropDownSettings { get; set; }
+        public DropdownSettings DropdownSettings { get; set; }
 
         /// <summary>
         /// The outer div's classnames, separated by space.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -148,11 +148,11 @@ namespace MudBlazor
         /// The behavior of the dropdown popover menu
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="DropdownBehavior.Fixed" /> false
-        /// Defaults to <see cref="DropdownBehavior.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
+        /// Defaults to <see cref="DropDownSettings.Fixed" /> false
+        /// Defaults to <see cref="DropDownSettings.OverflowBehavior" /> <see cref="OverflowBehavior.FlipOnOpen" />
         /// </remarks>
         [Parameter]
-        public DropdownBehavior DropdownBehavior { get; set; }
+        public DropDownSettings DropDownSettings { get; set; }
 
         /// <summary>
         /// The outer div's classnames, separated by space.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -152,7 +152,7 @@ namespace MudBlazor
         /// </remarks>
         [Category(CategoryTypes.FormComponent.Appearance)]
         [Parameter]
-        public bool Fixed { get; set; } = false;
+        public bool Fixed { get; set; }
 
         /// <summary>
         /// The behavior applied when there is not enough space for this dropdown to be visible.

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -145,7 +145,7 @@ window.mudpopoverHelper = {
     placePopover: function (popoverNode, classSelector) {
         // parentNode is the calling element, mudmenu/tooltip/etc not the parent popover if it's a child popover
         // this happens at page load unless it's popover inside a popover, then it happens when you activate the parent
-        
+
         if (popoverNode && popoverNode.parentNode) {
             const id = popoverNode.id.substr(8);
             const popoverContentNode = document.getElementById('popovercontent-' + id);
@@ -173,7 +173,7 @@ window.mudpopoverHelper = {
                 popoverContentNode.style['min-width'] = (boundingRect.width) + 'px';
             }
 
-            const selfRect = popoverContentNode.getBoundingClientRect();            
+            const selfRect = popoverContentNode.getBoundingClientRect();
             const classListArray = Array.from(classList);
 
             const postion = window.mudpopoverHelper.calculatePopoverPosition(classListArray, boundingRect, selfRect);
@@ -299,8 +299,8 @@ window.mudpopoverHelper = {
                         //console.log(`top: ${top} | offsetY: ${offsetY} | total: ${top + offsetY} | appBarOffset: ${appBarOffset}`);
                     }
 
-                        if (top + offsetY < 0 && // it's starting above the screen
-                            Math.abs(top + offsetY) < selfRect.height) { // it's not starting so far above the entire box would be hidden
+                    if (top + offsetY < 0 && // it's starting above the screen
+                        Math.abs(top + offsetY) < selfRect.height) { // it's not starting so far above the entire box would be hidden
                         top = Math.max(0, top + offsetY);
                         // set offsetY to 0 to avoid double offset
                         offsetY = 0;
@@ -324,12 +324,10 @@ window.mudpopoverHelper = {
                 }
             }
 
-            if (classList.contains('mud-popover-fixed')) {                
-            }
-            else if (window.getComputedStyle(popoverNode).position == 'fixed') {
+            if (window.getComputedStyle(popoverNode).position == 'fixed') {
                 popoverContentNode.style['position'] = 'fixed';
             }
-            else {
+            else if (!classList.contains('mud-popover-fixed')) {
                 offsetX += window.scrollX;
                 offsetY += window.scrollY
             }
@@ -362,7 +360,7 @@ window.mudpopoverHelper = {
         let currentNode = node.parentNode;
         while (currentNode) {
             //console.log(currentNode);
-            const isScrollable = 
+            const isScrollable =
                 (currentNode.scrollHeight > currentNode.clientHeight) || // Vertical scroll
                 (currentNode.scrollWidth > currentNode.clientWidth);    // Horizontal scroll
             if (isScrollable) {
@@ -402,7 +400,7 @@ window.mudpopoverHelper = {
 
     updatePopoverZIndex: function (popoverContentNode, parentNode) {
         // find the first parent mud-popover if it exists
-        const parentPopover = parentNode.closest('.mud-popover'); 
+        const parentPopover = parentNode.closest('.mud-popover');
         const parentOfPopover = popoverContentNode.parentNode;
         // get --mud-zindex-popover from root
         let newZIndex = window.mudpopoverHelper.basePopoverZIndex + 1;
@@ -464,7 +462,7 @@ class MudPopover {
         this.contentObserver = null;
         this.mainContainerClass = null;
     }
-    
+
     callback(id, mutationsList, observer) {
         for (const mutation of mutationsList) {
             if (mutation.type === 'attributes') {

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -324,7 +324,7 @@ window.mudpopoverHelper = {
                 }
             }
 
-            if (classList.contains('mud-popover-fixed')) {
+            if (classList.contains('mud-popover-fixed')) {                
             }
             else if (window.getComputedStyle(popoverNode).position == 'fixed') {
                 popoverContentNode.style['position'] = 'fixed';
@@ -355,6 +355,29 @@ window.mudpopoverHelper = {
         }
         else {
             //console.log(`popoverNode: ${popoverNode} ${popoverNode ? popoverNode.parentNode : ""}`);
+        }
+    },
+
+    popoverScrollListener: function (node) {
+        let currentNode = node.parentNode;
+        while (currentNode) {
+            console.log(currentNode);
+            const isScrollable = 
+                (currentNode.scrollHeight > currentNode.clientHeight) || // Vertical scroll
+                (currentNode.scrollWidth > currentNode.clientWidth);    // Horizontal scroll
+            if (isScrollable) {
+                console.log("scrollable");
+                currentNode.addEventListener('scroll', () => {
+                    console.log("scrolled");
+                    window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-fixed');
+                    window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-overflow-flip-always');
+                });
+            }
+            // Stop if we reach the body, or head
+            if (currentNode.tagName === "BODY") {
+                break;
+            }
+            currentNode = currentNode.parentNode;
         }
     },
 
@@ -538,6 +561,7 @@ class MudPopover {
         this.initialize(this.mainContainerClass);
 
         const popoverNode = document.getElementById('popover-' + id);
+        mudpopoverHelper.popoverScrollListener(popoverNode);
         const popoverContentNode = document.getElementById('popovercontent-' + id);
         if (popoverNode && popoverNode.parentNode && popoverContentNode) {
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -361,14 +361,14 @@ window.mudpopoverHelper = {
     popoverScrollListener: function (node) {
         let currentNode = node.parentNode;
         while (currentNode) {
-            console.log(currentNode);
+            //console.log(currentNode);
             const isScrollable = 
                 (currentNode.scrollHeight > currentNode.clientHeight) || // Vertical scroll
                 (currentNode.scrollWidth > currentNode.clientWidth);    // Horizontal scroll
             if (isScrollable) {
-                console.log("scrollable");
+                //console.log("scrollable");
                 currentNode.addEventListener('scroll', () => {
-                    console.log("scrolled");
+                    //console.log("scrolled");
                     window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-fixed');
                     window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-overflow-flip-always');
                 });


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Allow MudSelect and MudAutocomplete to pass Fixed and OverflowBehavior to the contained popover. Defaults are the same as before, just now it can be overridden if need be.

Additionally, add scroll events on connect for parents with scrollable containers

Resolves #8656 
Resolves #10325 
Resolves doc page where there is a floating component containing a popover by setting the AutoComplete to Fixed="true"

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visual Tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
