### PR TITLE
MudTextField: With mask, setting parameter value updates the input text

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -13,6 +13,46 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class MaskTests : BunitTest
     {
+        public static object[] TextFieldWithMask_SetValueParameterUpdateText_Parameters = [
+    new object[] { "PatternMask", new PatternMask("""0000"""), "1111", "2222" },
+    new object[] { "RegexMask", new RegexMask("""^\d*$"""), "1111", "2222" },
+    new object[] { "MultiMask", new MultiMask("""0000"""), "1111", "2222" },
+    new object[] { "BlockMask", new BlockMask(new Block('0', 1, 4)), "1111", "2222" },
+    new object[] { "DateMask", new DateMask("""MM/dd/yyyy"""), "01/01/2024", "02/03/2025" }
+];
+
+        [TestCaseSource(nameof(TextFieldWithMask_SetValueParameterUpdateText_Parameters))]
+        public void TextFieldWithMask_SetValueParameterUpdateText(string testName, IMask mask, string initialValue, string setValue)
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudTextField<string>>(parameters =>
+            {
+                parameters.Add(m => m.Mask, mask);
+                parameters.Add(m => m.Value, initialValue);
+            });
+            var textField = comp.Instance;
+            var maskField = comp.FindComponent<MudMask>().Instance;
+
+            // Assert : Initial state
+
+            textField.Value.Should().Be(initialValue);
+            textField.Text.Should().Be(initialValue);
+            maskField.Value.Should().Be(initialValue);
+            maskField.Text.Should().Be(initialValue);
+
+            // Act
+
+            comp.SetParam(m => m.Value, setValue);
+
+            // Assert
+
+            textField.Value.Should().Be(setValue);
+            textField.Text.Should().Be(setValue);
+            maskField.Value.Should().Be(setValue);
+            maskField.Text.Should().Be(setValue);
+        }
+
         /// <summary>
         /// Test all IsMatch variants: letter, digit and symbols.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -14,12 +14,12 @@ namespace MudBlazor.UnitTests.Components
     public class MaskTests : BunitTest
     {
         public static object[] TextFieldWithMask_SetValueParameterUpdateText_Parameters = [
-    new object[] { "PatternMask", new PatternMask("""0000"""), "1111", "2222" },
-    new object[] { "RegexMask", new RegexMask("""^\d*$"""), "1111", "2222" },
-    new object[] { "MultiMask", new MultiMask("""0000"""), "1111", "2222" },
-    new object[] { "BlockMask", new BlockMask(new Block('0', 1, 4)), "1111", "2222" },
-    new object[] { "DateMask", new DateMask("""MM/dd/yyyy"""), "01/01/2024", "02/03/2025" }
-];
+            new object[] { "PatternMask", new PatternMask("""0000"""), "1111", "2222" },
+            new object[] { "RegexMask", new RegexMask("""^\d*$"""), "1111", "2222" },
+            new object[] { "MultiMask", new MultiMask("""0000"""), "1111", "2222" },
+            new object[] { "BlockMask", new BlockMask(new Block('0', 1, 4)), "1111", "2222" },
+            new object[] { "DateMask", new DateMask("""MM/dd/yyyy"""), "01/01/2024", "02/03/2025" }
+        ];
 
         [TestCaseSource(nameof(TextFieldWithMask_SetValueParameterUpdateText_Parameters))]
         public void TextFieldWithMask_SetValueParameterUpdateText(string testName, IMask mask, string initialValue, string setValue)

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -12,7 +12,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A text input which conforms user input to a specific format while typing. 
+    /// A text input which conforms user input to a specific format while typing.
     /// <remarks>
     /// Note that MudMask is recommended to be used in WASM projects only because it has known problems
     /// in BSS, especially with high network latency.
@@ -105,7 +105,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The type of the underlying input. 
+        /// The type of the underlying input.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="InputType.Text"/>.
@@ -282,13 +282,19 @@ namespace MudBlazor
                 return;
             var text = Converter.Set(Value);
             var cleanText = Mask.GetCleanText();
-            if (cleanText == text || string.IsNullOrEmpty(cleanText) && string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(cleanText) && string.IsNullOrEmpty(text))
                 return;
-            var maskText = Mask.Text;
-            Mask.SetText(text);
-            if (maskText == Mask.Text)
-                return; // no change, stop update loop
-            await UpdateAsync();
+
+            if (cleanText != text)
+            {
+                var maskText = Mask.Text;
+                Mask.SetText(text);
+                if (maskText == Mask.Text)
+                    return;
+            }
+
+            if (Text != Mask.Text)
+                await UpdateAsync();
         }
 
         protected override async Task UpdateValuePropertyAsync(bool updateText)
@@ -417,7 +423,7 @@ namespace MudBlazor
             }
         }
 
-        // from JS event     
+        // from JS event
         internal void OnCaretPositionChanged(int pos)
         {
             if (Mask.Selection != null)


### PR DESCRIPTION
## Description

Fixes #10252

When `MudTextField` has a mask of type `PatternMask`, set the parameter `MudTextField.Value` update the input text. But if the mask is of another type, then the input text isn't updated.

The reason is [the default mask in `MudMask` is a `PatternMask`](https://github.com/MudBlazor/MudBlazor/blob/7625925d37f66cfb8be87fb29258a1a8768c1e8e/src/MudBlazor/Components/Mask/MudMask.razor.cs#L30) :
```csharp
public partial class MudMask : MudBaseInput<string>
{
    ...
    private IMask _mask = new PatternMask("** **-** **");
```

So when `MudTextField` set the mask of type `PatternMask` to `MudMask`, they don't share the same instance :
```csharp
public partial class MudMask : MudBaseInput<string>
{
    private void SetMask(IMask? other)
    {
        if (_mask.GetType() == other.GetType())
        {
            // When type is the same, don't share the same instance
            _mask.UpdateFrom(other);
            return;
        }
        // When type is different, share the same instance
        _mask = other;
    }
```
And it's work fine. But when `MudTextField` set the mask of another type `PatternMask` to `MudMask`, they share the same instance.

`MudMask` update the inner text when `MudMask.Mask.Text` is different to `MudTextField.Mask.Text`. But like `MudMask.Mask` and `MudTextField.Mask` is the same instance, the condition is always false.

To fix the problem, I modified the condition to verrify if the `MudMask` inner text is different from `MudTextField.Mask.Text`.


## How Has This Been Tested?

I added tests for each `IMask` implementation.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.