### PR TITLE
MudColor: Add IParsable and Deconstruct

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -956,6 +956,19 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
+        [TestCase("rgb(130,150,240, 63)")]
+        [TestCase("rgb(71,88,99, 63)")]
+        [TestCase("#8296f0ffff")]
+        public void ParseIncorrectFormatTest(string value)
+        {
+            // Act & Arrange
+            var act = () => MudColor.Parse(value);
+
+            // Assert
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Test]
         public void DeconstructTest()
         {
             // Arrange

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -934,6 +934,43 @@ namespace MudBlazor.UnitTests.Utilities
             mudColor.UInt32.Should().Be(mudColor.UInt32);
         }
 
+        [Test]
+        [TestCase("rgb(130,150,240)", 130, 150, 240, 255)]
+        [TestCase("rgb(71,88,99)", 71, 88, 99, 255)]
+        [TestCase("#8296f0ff", 130, 150, 240, 255)]
+        [TestCase( "#475863", 71, 88, 99, 255)]
+        public void ParseTest(string value, byte r, byte g, byte b, byte a)
+        {
+            // Arrange
+            var expected = new MudColor(r, g, b, a);
+
+            // Act
+            var result = MudColor.Parse(value);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void DeconstructTest()
+        {
+            // Arrange
+            var mudColor = new MudColor(255, 128, 64, 192);
+
+            // Act
+            var (r, g, b, a) = mudColor;
+            var (r2, g2, b2) = mudColor;
+
+            // Assert
+            r.Should().Be(255);
+            g.Should().Be(128);
+            b.Should().Be(64);
+            a.Should().Be(192);
+            r2.Should().Be(255);
+            g2.Should().Be(128);
+            b2.Should().Be(64);
+        }
+
         private static readonly object[] _multiGradientTestCases =
         [
             // Should return the same colors when list colors count is same as number of colors

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -210,12 +210,12 @@ namespace MudBlazor.UnitTests.Utilities
                 var darkenColor = color.ColorRgbDarken();
 
                 //use as reference
-                var colorFromRGB = new MudColor(color.R, color.G, color.B, color.A);
-                var darkenColorFromRGB = colorFromRGB.ColorRgbDarken();
+                var colorFromRgb = new MudColor(color.R, color.G, color.B, color.A);
+                var darkenColorFromRgb = colorFromRgb.ColorRgbDarken();
 
-                darkenColor.R.Should().Be(darkenColorFromRGB.R);
-                darkenColor.G.Should().Be(darkenColorFromRGB.G);
-                darkenColor.B.Should().Be(darkenColorFromRGB.B);
+                darkenColor.R.Should().Be(darkenColorFromRgb.R);
+                darkenColor.G.Should().Be(darkenColorFromRgb.G);
+                darkenColor.B.Should().Be(darkenColorFromRgb.B);
 
                 //MudColor implicitCasted = input;
 
@@ -837,8 +837,15 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         public void Equals_DifferentObjectType()
         {
+            // Arrange
             MudColor color1 = new(10, 20, 50, 255);
-            color1.Equals(124).Should().BeFalse();
+            object obj = 124;
+
+            // Act
+            var equals = color1.Equals(obj);
+
+            // Assert
+            equals.Should().BeFalse();
         }
 
         [Test]
@@ -990,6 +997,8 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("rgba(130,150,240,0.52,50)")]
         [TestCase("rgb(71,88,99, 63)")]
         [TestCase("#8296f0ffff")]
+        [TestCase("")]
+        [TestCase(null)]
         public void TryParseIncorrectFormatTest(string value)
         {
             // Act

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -969,6 +969,38 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
+        [TestCase("rgb(130,150,240)", 130, 150, 240, 255)]
+        [TestCase("rgb(71,88,99)", 71, 88, 99, 255)]
+        [TestCase("#8296f0ff", 130, 150, 240, 255)]
+        [TestCase("#475863", 71, 88, 99, 255)]
+        public void TryParseTest(string value, byte r, byte g, byte b, byte a)
+        {
+            // Arrange
+            var expected = new MudColor(r, g, b, a);
+
+            // Act
+            var success = MudColor.TryParse(value, out var result);
+
+            // Assert
+            success.Should().BeTrue();
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase("rgb(130,150,240, 63)")]
+        [TestCase("rgb(71,88,99, 63)")]
+        [TestCase("#8296f0ffff")]
+        public void TryParseIncorrectFormatTest(string value)
+        {
+            // Act
+            var success = MudColor.TryParse(value, out var result);
+
+            // Assert
+            success.Should().BeFalse();
+            result.Should().BeNull();
+        }
+
+        [Test]
         public void DeconstructTest()
         {
             // Arrange

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -939,7 +939,7 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        [TestCase("rgb(130,150,240)", 130, 150, 240, 255)]
+        [TestCase("rgba(130,150,240,0.52)", 130, 150, 240, 132)]
         [TestCase("rgb(71,88,99)", 71, 88, 99, 255)]
         [TestCase("#8296f0ff", 130, 150, 240, 255)]
         [TestCase("#475863", 71, 88, 99, 255)]
@@ -956,8 +956,8 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        [TestCase("rgb(130,150,240, 63)")]
-        [TestCase("rgb(71,88,99, 63)")]
+        [TestCase("rgba(130,150,240,0.52,50)")]
+        [TestCase("rgb(71,88,99,63)")]
         [TestCase("#8296f0ffff")]
         public void ParseIncorrectFormatTest(string value)
         {
@@ -969,7 +969,7 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        [TestCase("rgb(130,150,240)", 130, 150, 240, 255)]
+        [TestCase("rgba(130,150,240,0.52)", 130, 150, 240, 132)]
         [TestCase("rgb(71,88,99)", 71, 88, 99, 255)]
         [TestCase("#8296f0ff", 130, 150, 240, 255)]
         [TestCase("#475863", 71, 88, 99, 255)]
@@ -987,7 +987,7 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        [TestCase("rgb(130,150,240, 63)")]
+        [TestCase("rgba(130,150,240,0.52,50)")]
         [TestCase("rgb(71,88,99, 63)")]
         [TestCase("#8296f0ffff")]
         public void TryParseIncorrectFormatTest(string value)

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -842,13 +842,17 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        [TestCase(130, 150, 240, 255, 775)]
-        [TestCase(71, 88, 99, 100, 358)]
-        public void GetHashCode(byte r, byte g, byte b, byte a, int expectedValue)
+        public void GetHashCodeTest()
         {
-            MudColor color = new(r, g, b, a);
+            // Arrange
+            var color1 = new MudColor(130, 150, 240, 255);
+            var color2 = new MudColor(130, 150, 240, 255);
 
-            color.GetHashCode().Should().Be(expectedValue);
+            // Act
+            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
+
+            // Assert
+            areEqualGetHashCode.Should().BeTrue();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -938,7 +938,7 @@ namespace MudBlazor.UnitTests.Utilities
         [TestCase("rgb(130,150,240)", 130, 150, 240, 255)]
         [TestCase("rgb(71,88,99)", 71, 88, 99, 255)]
         [TestCase("#8296f0ff", 130, 150, 240, 255)]
-        [TestCase( "#475863", 71, 88, 99, 255)]
+        [TestCase("#475863", 71, 88, 99, 255)]
         public void ParseTest(string value, byte r, byte g, byte b, byte a)
         {
             // Arrange

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -216,13 +216,6 @@ namespace MudBlazor.UnitTests.Utilities
                 darkenColor.R.Should().Be(darkenColorFromRgb.R);
                 darkenColor.G.Should().Be(darkenColorFromRgb.G);
                 darkenColor.B.Should().Be(darkenColorFromRgb.B);
-
-                //MudColor implicitCasted = input;
-
-                //implicitCasted.R.Should().Be(r);
-                //implicitCasted.G.Should().Be(g);
-                //implicitCasted.B.Should().Be(b);
-                //implicitCasted.A.Should().Be(alpha);
             }
         }
 
@@ -1027,6 +1020,21 @@ namespace MudBlazor.UnitTests.Utilities
             r2.Should().Be(255);
             g2.Should().Be(128);
             b2.Should().Be(64);
+        }
+
+        [Test]
+        public void ExplicitMudColorToStringCastTest()
+        {
+            // Arrange
+            var mudColor1 = new MudColor(71, 88, 99, 1);
+
+            // Act
+            var result1 = (string)mudColor1;
+            var result2 = (string)(MudColor)null;
+
+            // Act & Assert
+            result1.Should().Be("#47586301");
+            result2.Should().Be(string.Empty);
         }
 
         private static readonly object[] _multiGradientTestCases =

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -152,50 +152,11 @@ namespace MudBlazor.Utilities
             l = Math.Round(l.EnsureRange(1), 2);
             a = a.EnsureRange(255);
 
-            // achromatic argb (gray scale)
-            if (Math.Abs(s) < Epsilon)
-            {
-                _valuesAsByte[0] = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255D)));
-                _valuesAsByte[1] = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255D)));
-                _valuesAsByte[2] = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255D)));
-                _valuesAsByte[3] = (byte)a;
-            }
-            else
-            {
-
-                var q = l < .5D
-                        ? l * (1D + s)
-                        : (l + s) - (l * s);
-                var p = (2D * l) - q;
-
-                var hk = h / 360D;
-                var t = new double[3];
-                t[0] = hk + (1D / 3D); // Tr
-                t[1] = hk; // Tb
-                t[2] = hk - (1D / 3D); // Tg
-
-                for (var i = 0; i < 3; i++)
-                {
-                    if (t[i] < 0D)
-                        t[i] += 1D;
-                    if (t[i] > 1D)
-                        t[i] -= 1D;
-
-                    if ((t[i] * 6D) < 1D)
-                        t[i] = p + ((q - p) * 6D * t[i]);
-                    else if ((t[i] * 2D) < 1)
-                        t[i] = q;
-                    else if ((t[i] * 3D) < 2)
-                        t[i] = p + ((q - p) * ((2D / 3D) - t[i]) * 6D);
-                    else
-                        t[i] = p;
-                }
-
-                _valuesAsByte[0] = ((int)Math.Round(t[0] * 255D)).EnsureRangeToByte();
-                _valuesAsByte[1] = ((int)Math.Round(t[1] * 255D)).EnsureRangeToByte();
-                _valuesAsByte[2] = ((int)Math.Round(t[2] * 255D)).EnsureRangeToByte();
-                _valuesAsByte[3] = (byte)a;
-            }
+            var (r, g, b) = HslToRgb(h, s, l);
+            _valuesAsByte[0] = r;
+            _valuesAsByte[1] = g;
+            _valuesAsByte[2] = b;
+            _valuesAsByte[3] = (byte)a;
 
             H = Math.Round(h, 0);
             S = Math.Round(s, 2);
@@ -609,6 +570,46 @@ namespace MudBlazor.Utilities
         private static double NormalizeAlpha(int a, int digit = 2) => Math.Round(a / 255.0, digit);
 
         private static byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
+
+        private static (byte r, byte g, byte b) HslToRgb(double h, double s, double l)
+        {
+            // Achromatic (gray scale)
+            if (Math.Abs(s) < Epsilon)
+            {
+                var gray = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255d)));
+                return (gray, gray, gray);
+            }
+
+            var hNormalized = h / 360d;
+            var t2 = l <= 0.5d
+                ? l * (1.0d + s)
+                : l + s - l * s;
+            var t1 = 2.0d * l - t2;
+
+            var tr = HueToRgb(t1, t2, hNormalized + 1.0d / 3.0d);
+            var tg = HueToRgb(t1, t2, hNormalized);
+            var tb = HueToRgb(t1, t2, hNormalized - 1.0d / 3.0d);
+
+                
+            var r = ((int)Math.Round(tr * 255d)).EnsureRangeToByte();
+            var g = ((int)Math.Round(tg * 255d)).EnsureRangeToByte();
+            var b = ((int)Math.Round(tb * 255d)).EnsureRangeToByte();
+                
+            return (r, g, b);
+        }
+
+        private static double HueToRgb(double t1, double t2, double hueNormalized)
+        {
+            if (hueNormalized < 0.0d) hueNormalized += 1.0d;
+            if (hueNormalized > 1.0d) hueNormalized -= 1.0d;
+            return hueNormalized switch
+            {
+                < 1.0d / 6.0d => t1 + (t2 - t1) * 6.0d * hueNormalized,
+                < 1.0d / 2.0d => t2,
+                < 2.0d / 3.0d => t1 + (t2 - t1) * (2.0d / 3.0d - hueNormalized) * 6.0d,
+                _ => t1
+            };
+        }
 
         private static string[] SplitInputIntoParts(string value)
         {

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -625,11 +625,10 @@ namespace MudBlazor.Utilities
             var tg = HueToRgb(t1, t2, hNormalized);
             var tb = HueToRgb(t1, t2, hNormalized - 1.0d / 3.0d);
 
-                
             var r = ((int)Math.Round(tr * 255d)).EnsureRangeToByte();
             var g = ((int)Math.Round(tg * 255d)).EnsureRangeToByte();
             var b = ((int)Math.Round(tb * 255d)).EnsureRangeToByte();
-                
+
             return (r, g, b);
         }
 

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -379,7 +379,7 @@ namespace MudBlazor.Utilities
         }
 
         /// <inheritdoc />
-        public override int GetHashCode() => _valuesAsByte[0] + _valuesAsByte[1] + _valuesAsByte[2] + _valuesAsByte[3];
+        public override int GetHashCode() => HashCode.Combine(R, G, B, A);
 
         /// <inheritdoc />
         public override string ToString() => ToString(MudColorOutputFormats.RGBA);

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -2,6 +2,7 @@
 //// https://stackoverflow.com/questions/4087581/creating-a-c-sharp-color-from-hsl-values/4087601#4087601
 //// Stripped and adapted by Meinrad Recheis and Benjamin Kappel for MudBlazor
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
@@ -41,7 +42,7 @@ namespace MudBlazor.Utilities
     /// Represents a color with methods to manipulate color values.
     /// </summary>
     [Serializable]
-    public partial class MudColor : ISerializable, IEquatable<MudColor>, IFormattable
+    public partial class MudColor : ISerializable, IEquatable<MudColor>, IParsable<MudColor>, IFormattable
     {
         private const double Epsilon = 0.000000000000001;
         private readonly byte[] _valuesAsByte;
@@ -180,7 +181,7 @@ namespace MudBlazor.Utilities
             _valuesAsByte[2] = b;
             _valuesAsByte[3] = a;
 
-            var (h, s, l) = CalculateHsl();
+            var (h, s, l) = RgbToHsl(r, g, b);
             H = h;
             S = s;
             L = l;
@@ -246,75 +247,9 @@ namespace MudBlazor.Utilities
         {
             ArgumentException.ThrowIfNullOrEmpty(value);
 
-            value = value.Trim().ToLowerInvariant();
-
-            if (value.StartsWith("rgba"))
-            {
-                var parts = SplitInputIntoParts(value);
-                if (parts.Length != 4)
-                {
-                    throw new ArgumentException("Invalid color format.");
-                }
-
-                _valuesAsByte = new[]
-                {
-                    byte.Parse(parts[0], CultureInfo.InvariantCulture),
-                    byte.Parse(parts[1], CultureInfo.InvariantCulture),
-                    byte.Parse(parts[2], CultureInfo.InvariantCulture),
-                    (byte)Math.Max(0, Math.Min(255, 255 * double.Parse(parts[3], CultureInfo.InvariantCulture))),
-                };
-            }
-            else if (value.StartsWith("rgb"))
-            {
-                var parts = SplitInputIntoParts(value);
-                if (parts.Length != 3)
-                {
-                    throw new ArgumentException("Invalid color format.");
-                }
-
-                _valuesAsByte = new[]
-                {
-                    byte.Parse(parts[0], CultureInfo.InvariantCulture),
-                    byte.Parse(parts[1], CultureInfo.InvariantCulture),
-                    byte.Parse(parts[2], CultureInfo.InvariantCulture),
-                    byte.MaxValue
-                };
-            }
-            else
-            {
-
-                if (value.StartsWith('#'))
-                {
-                    value = value.Substring(1);
-                }
-
-                switch (value.Length)
-                {
-                    case 3:
-                        value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], 'F', 'F' });
-                        break;
-                    case 4:
-                        value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], value[3], value[3] });
-                        break;
-                    case 6:
-                        value += "FF";
-                        break;
-                    case 8:
-                        break;
-                    default:
-                        throw new ArgumentException(@"Not a valid color.", nameof(value));
-                }
-
-                _valuesAsByte = new[]
-                {
-                    GetByteFromValuePart(value,0),
-                    GetByteFromValuePart(value,2),
-                    GetByteFromValuePart(value,4),
-                    GetByteFromValuePart(value,6),
-                };
-            }
-
-            var (h, s, l) = CalculateHsl();
+            var (r, g, b, a) = ParseStringColorCore(value);
+            var (h, s, l) = RgbToHsl(r, g, b);
+            _valuesAsByte = [r, g, b, a];
             H = h;
             S = s;
             L = l;
@@ -443,32 +378,6 @@ namespace MudBlazor.Utilities
                 _valuesAsByte[3] == other._valuesAsByte[3];
         }
 
-        /// <summary>
-        /// Determines whether two <see cref="MudColor"/> instances are equal.
-        /// </summary>
-        /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
-        /// <param name="rhs">The second <see cref="MudColor"/> instance to compare.</param>
-        /// <returns>True if the instances are equal; otherwise, false.</returns>
-        public static bool operator ==(MudColor? lhs, MudColor? rhs)
-        {
-            if (lhs is null && rhs is null)
-            {
-                return true;
-            }
-
-            if (ReferenceEquals(lhs, rhs))
-            {
-                return true;
-            }
-
-            if (lhs is null || rhs is null)
-            {
-                return false;
-            }
-
-            return lhs.Equals(rhs);
-        }
-
         /// <inheritdoc />
         public override int GetHashCode() => _valuesAsByte[0] + _valuesAsByte[1] + _valuesAsByte[2] + _valuesAsByte[3];
 
@@ -537,6 +446,34 @@ namespace MudBlazor.Utilities
         }
 
         /// <summary>
+        /// Deconstructs the <see cref="MudColor"/> into its red, green, and blue components.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        public void Deconstruct(out byte r, out byte g, out byte b)
+        {
+            r = R;
+            g = G;
+            b = B;
+        }
+
+        /// <summary>
+        /// Deconstructs the <see cref="MudColor"/> into its red, green, blue, and alpha components.
+        /// </summary>
+        /// <param name="r">The red component value (0 to 255).</param>
+        /// <param name="g">The green component value (0 to 255).</param>
+        /// <param name="b">The blue component value (0 to 255).</param>
+        /// <param name="a">The alpha component value (0 to 255).</param>
+        public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
+        {
+            r = R;
+            g = G;
+            b = B;
+            a = A;
+        }
+
+        /// <summary>
         /// Determines whether two <see cref="MudColor"/> instances are not equal.
         /// </summary>
         /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
@@ -545,11 +482,37 @@ namespace MudBlazor.Utilities
         public static bool operator !=(MudColor? lhs, MudColor? rhs) => !(lhs == rhs);
 
         /// <summary>
+        /// Determines whether two <see cref="MudColor"/> instances are equal.
+        /// </summary>
+        /// <param name="lhs">The first <see cref="MudColor"/> instance to compare.</param>
+        /// <param name="rhs">The second <see cref="MudColor"/> instance to compare.</param>
+        /// <returns>True if the instances are equal; otherwise, false.</returns>
+        public static bool operator ==(MudColor? lhs, MudColor? rhs)
+        {
+            if (lhs is null && rhs is null)
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(lhs, rhs))
+            {
+                return true;
+            }
+
+            if (lhs is null || rhs is null)
+            {
+                return false;
+            }
+
+            return lhs.Equals(rhs);
+        }
+
+        /// <summary>
         /// Converts a string representation of a color to a <see cref="MudColor"/> instance.
         /// </summary>
         /// <param name="input">The string representation of the color.</param>
         /// <returns>A new <see cref="MudColor"/> instance representing the color.</returns>
-        public static implicit operator MudColor(string input) => new(input);
+        public static implicit operator MudColor(string input) => Parse(input);
 
         /// <summary>
         /// Converts a <see cref="MudColor"/> instance to its string representation.
@@ -564,6 +527,78 @@ namespace MudBlazor.Utilities
         /// <param name="mudColor">The MudColor instance to convert.</param>
         /// <returns>The 32-bit unsigned integer representation of the color.</returns>
         public static explicit operator uint(MudColor mudColor) => mudColor.UInt32;
+
+        /// <summary>
+        /// Parses a string representation of a color to a <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="s">The string representation of the color.</param>
+        /// <param name="provider">An optional format provider.</param>
+        /// <remarks>
+        /// The color can be represented in various formats, including hexadecimal (with or without alpha), RGB, and RGBA.
+        /// Examples of valid color strings:
+        /// - Hexadecimal format: "#ab2a3d", "#ab2a3dff"
+        /// - RGB format: "rgb(12,15,40)"
+        /// - RGBA format: "rgba(12,15,40,0.42)"
+        /// </remarks>
+        /// <returns>A new <see cref="MudColor"/> instance representing the color.</returns>
+        /// <exception cref="ArgumentException">Thrown when the input string is null, empty or invalid color format.</exception>
+        public static MudColor Parse(string s, IFormatProvider? provider = null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(s);
+            var (r, g, b, a) = ParseStringColorCore(s);
+
+            return new MudColor(r, g, b, a);
+        }
+
+        /// <summary>
+        /// Tries to parse a string representation of a color to a <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="s">The string representation of the color.</param>
+        /// <param name="provider">An optional format provider.</param>
+        /// <param name="result">When this method returns, contains the <see cref="MudColor"/> instance equivalent to the color contained in <paramref name="s"/>, if the conversion succeeded, or <c>null</c> if the conversion failed.</param>
+        /// <remarks>
+        /// The color can be represented in various formats, including hexadecimal (with or without alpha), RGB, and RGBA.
+        /// Examples of valid color strings:
+        /// - Hexadecimal format: "#ab2a3d", "#ab2a3dff"
+        /// - RGB format: "rgb(12,15,40)"
+        /// - RGBA format: "rgba(12,15,40,0.42)"
+        /// </remarks>
+        /// <returns><c>true</c> if the string was successfully parsed; otherwise, <c>false</c>.</returns>
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out MudColor result)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                result = null;
+                return false;
+            }
+
+            try
+            {
+                var mudColor = Parse(s, provider);
+                result = mudColor;
+                return true;
+            }
+            catch (Exception)
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Tries to parse a string representation of a color to a <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="s">The string representation of the color.</param>
+        /// <param name="result">When this method returns, contains the <see cref="MudColor"/> instance equivalent to the color contained in <paramref name="s"/>, if the conversion succeeded, or <c>null</c> if the conversion failed.</param>
+        /// <remarks>
+        /// The color can be represented in various formats, including hexadecimal (with or without alpha), RGB, and RGBA.
+        /// Examples of valid color strings:
+        /// - Hexadecimal format: "#ab2a3d", "#ab2a3dff"
+        /// - RGB format: "rgb(12,15,40)"
+        /// - RGBA format: "rgba(12,15,40,0.42)"
+        /// </remarks>
+        /// <returns><c>true</c> if the string was successfully parsed; otherwise, <c>false</c>.</returns>
+        public static bool TryParse([NotNullWhen(true)] string? s, [MaybeNullWhen(false)] out MudColor result) => TryParse(s, null, out result);
 
         private static double NormalizeAlpha(byte a, int digit = 2) => Math.Round(a / 255.0, digit);
 
@@ -611,6 +646,73 @@ namespace MudBlazor.Utilities
             };
         }
 
+        private static (byte r, byte g, byte b, byte a) ParseStringColorCore(string value)
+        {
+            value = value.Trim().ToLowerInvariant();
+
+            return value switch
+            {
+                _ when value.StartsWith("rgba") => ParseStringRgbaToRgba(value),
+                _ when value.StartsWith("rgb") => ParseStringRgbToRgba(value),
+                _ => ParseStringHexToRgba(value),
+            };
+        }
+
+        private static (byte r, byte g, byte b, byte a) ParseStringRgbaToRgba(string value)
+        {
+            var parts = SplitInputIntoParts(value);
+            if (parts.Length != 4)
+            {
+                throw new ArgumentException("Invalid color format.");
+            }
+
+            var r = byte.Parse(parts[0], CultureInfo.InvariantCulture);
+            var g = byte.Parse(parts[1], CultureInfo.InvariantCulture);
+            var b = byte.Parse(parts[2], CultureInfo.InvariantCulture);
+            var a = (byte)Math.Max(0, Math.Min(255, 255 * double.Parse(parts[3], CultureInfo.InvariantCulture)));
+
+            return (r, g, b, a);
+        }
+
+        private static (byte r, byte g, byte b, byte a) ParseStringRgbToRgba(string value)
+        {
+            var parts = SplitInputIntoParts(value);
+            if (parts.Length != 3)
+            {
+                throw new ArgumentException("Invalid color format.");
+            }
+
+            var r = byte.Parse(parts[0], CultureInfo.InvariantCulture);
+            var g = byte.Parse(parts[1], CultureInfo.InvariantCulture);
+            var b = byte.Parse(parts[2], CultureInfo.InvariantCulture);
+            return (r, g, b, byte.MaxValue);
+        }
+
+        private static (byte r, byte g, byte b, byte a) ParseStringHexToRgba(string value)
+        {
+            if (value.StartsWith('#'))
+            {
+                value = value.Substring(1);
+            }
+            switch (value.Length)
+            {
+                case 3:
+                    value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], 'F', 'F' });
+                    break;
+                case 4:
+                    value = new string(new[] { value[0], value[0], value[1], value[1], value[2], value[2], value[3], value[3] });
+                    break;
+                case 6:
+                    value += "FF";
+                    break;
+                case 8:
+                    break;
+                default:
+                    throw new ArgumentException(@"Not a valid color.", nameof(value));
+            }
+            return (GetByteFromValuePart(value, 0), GetByteFromValuePart(value, 2), GetByteFromValuePart(value, 4), GetByteFromValuePart(value, 6));
+        }
+
         private static string[] SplitInputIntoParts(string value)
         {
             var startIndex = value.IndexOf('(');
@@ -625,39 +727,39 @@ namespace MudBlazor.Utilities
             return parts;
         }
 
-        private (double h, double s, double l) CalculateHsl()
+        private static (double h, double s, double l) RgbToHsl(byte r, byte g, byte b)
         {
             var h = 0D;
             var s = 0D;
 
             // normalize red, green, blue values
-            var r = R / 255D;
-            var g = G / 255D;
-            var b = B / 255D;
+            var rNormalized = r / 255D;
+            var gNormalized = g / 255D;
+            var bNormalized = b / 255D;
 
-            var max = Math.Max(r, Math.Max(g, b));
-            var min = Math.Min(r, Math.Min(g, b));
+            var max = Math.Max(rNormalized, Math.Max(gNormalized, bNormalized));
+            var min = Math.Min(rNormalized, Math.Min(gNormalized, bNormalized));
 
             // hue
             if (Math.Abs(max - min) < Epsilon)
             {
                 h = 0D; // undefined
             }
-            else if ((Math.Abs(max - r) < Epsilon) && (g >= b))
+            else if ((Math.Abs(max - rNormalized) < Epsilon) && (gNormalized >= bNormalized))
             {
-                h = (60D * (g - b)) / (max - min);
+                h = (60D * (gNormalized - bNormalized)) / (max - min);
             }
-            else if ((Math.Abs(max - r) < Epsilon) && (g < b))
+            else if ((Math.Abs(max - rNormalized) < Epsilon) && (gNormalized < bNormalized))
             {
-                h = ((60D * (g - b)) / (max - min)) + 360D;
+                h = ((60D * (gNormalized - bNormalized)) / (max - min)) + 360D;
             }
-            else if (Math.Abs(max - g) < Epsilon)
+            else if (Math.Abs(max - gNormalized) < Epsilon)
             {
-                h = ((60D * (b - r)) / (max - min)) + 120D;
+                h = ((60D * (bNormalized - rNormalized)) / (max - min)) + 120D;
             }
-            else if (Math.Abs(max - b) < Epsilon)
+            else if (Math.Abs(max - bNormalized) < Epsilon)
             {
-                h = ((60D * (r - g)) / (max - min)) + 240D;
+                h = ((60D * (rNormalized - gNormalized)) / (max - min)) + 240D;
             }
 
             // lightness


### PR DESCRIPTION
## Description
Adds `IParsable` and `Deconstruct` to `MudColor`.
In future I want to obsolete MudColor(string) constructor, as parse logic shouldn't be done via constructor.
Optimized HSL to RGB logic that doesn't require a for loop.

## How Has This Been Tested?
New unit tests.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
