### PR TITLE
MudStepper: ResetAsync now sends correct StepAction arg

### DIFF
--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -615,14 +615,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ResetButton_ShouldTriggerResetStepAction()
+        public void ResetButton_ShouldTriggerResetStepActionOnAllStepsThenActivateFirstStep()
         {
             var cancel = false;
-            var action = StepAction.Reset;
+            var actions = new List<StepAction>();
             var index = -1;
             Task OnPreviewInteraction(StepperInteractionEventArgs args)
             {
-                action = args.Action;
+                actions.Add(args.Action);
                 index = args.StepIndex;
                 // ReSharper disable once AccessToModifiedClosure
                 args.Cancel = cancel;
@@ -642,16 +642,19 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();
             index.Should().Be(0);
-            action.Should().Be(StepAction.Complete);
+            actions[0].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
             stepper.Find(".mud-stepper-button-next").Click();
             index.Should().Be(1);
-            action.Should().Be(StepAction.Complete);
+            actions[1].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
 
             // check that clicking reset sends Reset StepAction
             stepper.Find(".mud-stepper-button-reset").Click();
-            action.Should().Be(StepAction.Reset);
+            actions[2].Should().Be(StepAction.Reset);
+            actions[3].Should().Be(StepAction.Reset);
+            actions[4].Should().Be(StepAction.Reset);
+            actions[5].Should().Be(StepAction.Activate);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
         }
 
@@ -730,11 +733,11 @@ namespace MudBlazor.UnitTests.Components
         public void Stepper_ControlledNavigationTest()
         {
             var cancel = false;
-            var action = StepAction.Reset;
+            var actions = new List<StepAction>();
             var index = -1;
             Task OnPreviewInteraction(StepperInteractionEventArgs args)
             {
-                action = args.Action;
+                actions.Add(args.Action);
                 index = args.StepIndex;
                 // ReSharper disable once AccessToModifiedClosure
                 args.Cancel = cancel;
@@ -754,45 +757,53 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();
             index.Should().Be(0);
-            action.Should().Be(StepAction.Complete);
+            actions[0].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
             stepper.Find(".mud-stepper-button-next").Click();
             index.Should().Be(1);
-            action.Should().Be(StepAction.Complete);
+            actions[1].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
             stepper.Find(".mud-stepper-button-complete").Click();
             index.Should().Be(2);
-            action.Should().Be(StepAction.Complete);
+            actions[2].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
 
             // cancel next
             stepper.Find(".mud-stepper-button-reset").Click();
+            actions[3].Should().Be(StepAction.Reset); // one reset for each step
+            actions[4].Should().Be(StepAction.Reset);
+            actions[5].Should().Be(StepAction.Reset);
+            actions[6].Should().Be(StepAction.Activate);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             cancel = true; // this should cancel the completion of step 1
             stepper.Find(".mud-stepper-button-next").Click();
+            actions[7].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
 
             // cancel previous
             cancel = false;
             stepper.Find(".mud-stepper-button-next").Click(); // go to step2
+            actions[8].Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
             cancel = true; // this should cancel the activation of step 1
             stepper.Find(".mud-stepper-button-previous").Click(); // try to go to step1
             index.Should().Be(0);
-            action.Should().Be(StepAction.Activate);
+            actions[9].Should().Be(StepAction.Activate);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
 
             // cancel jumping via header click
             cancel = false;
             stepper.Find(".mud-stepper-button-reset").Click();
-            action.Should().Be(StepAction.Reset);
+            actions[10].Should().Be(StepAction.Reset); // On reset for each step
+            actions[11].Should().Be(StepAction.Reset);
+            actions[12].Should().Be(StepAction.Reset);
+            actions[13].Should().Be(StepAction.Activate);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             cancel = true; // this should cancel the activation of step 3
             stepper.FindAll(".mud-step")[2].Click(); // try to go to step3
             index.Should().Be(2);
-            action.Should().Be(StepAction.Activate);
+            actions[14].Should().Be(StepAction.Activate);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
-
         }
 
         [TestCase(true, true)]

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -561,7 +561,7 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(0, "because the action content replaces them");
             stepper.Find(".mud-card-actions").InnerHtml?.Trim().Should().Be("je ne sais pas");
         }
-        
+
         [Test]
         public void ShowReset_ShouldControlResetButtonVisibilty()
         {
@@ -578,9 +578,9 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(2); // previous, next
             stepper.FindAll(".mud-card-actions .mud-stepper-button-reset").Count.Should().Be(0);
         }
-        
+
         [Test]
-		public void ResetButton_ShouldResetActiveStep()
+        public void ResetButton_ShouldResetActiveStep()
         {
             var stepper = Context.RenderComponent<MudStepper>(self =>
             {
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.Steps[0].GetState(x => x.Completed).Should().Be(false);
             stepper.Instance.GetState(x => x.ActiveIndex).Should().Be(0);
         }
-        
+
         [Test]
         public void ResetButton_ShouldTriggerResetStepAction()
         {
@@ -637,7 +637,7 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step => { });
                 self.AddChildContent<MudStep>(step => { });
             });
-        
+
             // clicking next sends Complete action requests to get us in a state that reset is a valid click
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();
@@ -648,13 +648,13 @@ namespace MudBlazor.UnitTests.Components
             index.Should().Be(1);
             action.Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
-            
+
             // check that clicking reset sends Reset StepAction
             stepper.Find(".mud-stepper-button-reset").Click();
             action.Should().Be(StepAction.Reset);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
         }
-        
+
         [Test]
         public void NextButton_ShouldTriggerCompleteStepAction()
         {
@@ -678,7 +678,7 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step => { });
                 self.AddChildContent<MudStep>(step => { });
             });
-            
+
             // clicking next sends Complete action requests
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -561,7 +561,7 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(0, "because the action content replaces them");
             stepper.Find(".mud-card-actions").InnerHtml?.Trim().Should().Be("je ne sais pas");
         }
-
+        
         [Test]
         public void ShowReset_ShouldControlResetButtonVisibilty()
         {
@@ -578,9 +578,9 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(2); // previous, next
             stepper.FindAll(".mud-card-actions .mud-stepper-button-reset").Count.Should().Be(0);
         }
-
+        
         [Test]
-        public void ResetButton_ShouldResetActiveStep()
+		public void ResetButton_ShouldResetActiveStep()
         {
             var stepper = Context.RenderComponent<MudStepper>(self =>
             {
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.Steps[0].GetState(x => x.Completed).Should().Be(false);
             stepper.Instance.GetState(x => x.ActiveIndex).Should().Be(0);
         }
-
+        
         [Test]
         public void ResetButton_ShouldTriggerResetStepAction()
         {
@@ -648,13 +648,13 @@ namespace MudBlazor.UnitTests.Components
             index.Should().Be(1);
             action.Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
-        
+            
             // check that clicking reset sends Reset StepAction
             stepper.Find(".mud-stepper-button-reset").Click();
             action.Should().Be(StepAction.Reset);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
         }
-
+        
         [Test]
         public void NextButton_ShouldTriggerCompleteStepAction()
         {
@@ -678,7 +678,7 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step => { });
                 self.AddChildContent<MudStep>(step => { });
             });
-        
+            
             // clicking next sends Complete action requests
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();
@@ -686,7 +686,7 @@ namespace MudBlazor.UnitTests.Components
             action.Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
         }
-        
+
         [Test]
         public void BackButton_ShouldTriggerActivateStepAction()
         {
@@ -710,14 +710,14 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step => { });
                 self.AddChildContent<MudStep>(step => { });
             });
-        
+
             // clicking next sends Complete action requests to get us in a state that back is a valid click
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             stepper.Find(".mud-stepper-button-next").Click();
             index.Should().Be(0);
             action.Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
-        
+
             // check that clicking reset sends Reset StepAction
             stepper.Find(".mud-stepper-button-previous").Click();
             index.Should().Be(0);

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -614,6 +614,117 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.GetState(x => x.ActiveIndex).Should().Be(0);
         }
 
+        [Test]
+        public void ResetButton_ShouldTriggerResetStepAction()
+        {
+            var cancel = false;
+            var action = StepAction.Reset;
+            var index = -1;
+            Task OnPreviewInteraction(StepperInteractionEventArgs args)
+            {
+                action = args.Action;
+                index = args.StepIndex;
+                // ReSharper disable once AccessToModifiedClosure
+                args.Cancel = cancel;
+                return Task.CompletedTask;
+            }
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
+                self.Add(x => x.ShowResetButton, true);
+                self.Add(x => x.NonLinear, true);
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+            });
+        
+            // clicking next sends Complete action requests to get us in a state that reset is a valid click
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+            stepper.Find(".mud-stepper-button-next").Click();
+            index.Should().Be(0);
+            action.Should().Be(StepAction.Complete);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
+            stepper.Find(".mud-stepper-button-next").Click();
+            index.Should().Be(1);
+            action.Should().Be(StepAction.Complete);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
+        
+            // check that clicking reset sends Reset StepAction
+            stepper.Find(".mud-stepper-button-reset").Click();
+            action.Should().Be(StepAction.Reset);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+        }
+
+        [Test]
+        public void NextButton_ShouldTriggerCompleteStepAction()
+        {
+            var cancel = false;
+            var action = StepAction.Reset;
+            var index = -1;
+            Task OnPreviewInteraction(StepperInteractionEventArgs args)
+            {
+                action = args.Action;
+                index = args.StepIndex;
+                // ReSharper disable once AccessToModifiedClosure
+                args.Cancel = cancel;
+                return Task.CompletedTask;
+            }
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
+                self.Add(x => x.ShowResetButton, true);
+                self.Add(x => x.NonLinear, true);
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+            });
+        
+            // clicking next sends Complete action requests
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+            stepper.Find(".mud-stepper-button-next").Click();
+            index.Should().Be(0);
+            action.Should().Be(StepAction.Complete);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
+        }
+        
+        [Test]
+        public void BackButton_ShouldTriggerActivateStepAction()
+        {
+            var cancel = false;
+            var action = StepAction.Reset;
+            var index = -1;
+            Task OnPreviewInteraction(StepperInteractionEventArgs args)
+            {
+                action = args.Action;
+                index = args.StepIndex;
+                // ReSharper disable once AccessToModifiedClosure
+                args.Cancel = cancel;
+                return Task.CompletedTask;
+            }
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
+                self.Add(x => x.ShowResetButton, true);
+                self.Add(x => x.NonLinear, true);
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+                self.AddChildContent<MudStep>(step => { });
+            });
+        
+            // clicking next sends Complete action requests to get us in a state that back is a valid click
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+            stepper.Find(".mud-stepper-button-next").Click();
+            index.Should().Be(0);
+            action.Should().Be(StepAction.Complete);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
+        
+            // check that clicking reset sends Reset StepAction
+            stepper.Find(".mud-stepper-button-previous").Click();
+            index.Should().Be(0);
+            action.Should().Be(StepAction.Activate);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+        }
+
 
         [Test]
         public void Stepper_ControlledNavigationTest()
@@ -674,6 +785,7 @@ namespace MudBlazor.UnitTests.Components
             // cancel jumping via header click
             cancel = false;
             stepper.Find(".mud-stepper-button-reset").Click();
+            action.Should().Be(StepAction.Reset);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
             cancel = true; // this should cancel the activation of step 3
             stepper.FindAll(".mud-step")[2].Click(); // try to go to step3

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -457,7 +457,7 @@ public partial class MudStepper : MudComponentBase
             }
         }
 
-        await UpdateStepAsync(_steps[0], new MouseEventArgs(), StepAction.Activate);
+        await UpdateStepAsync(_steps[0], new MouseEventArgs(), StepAction.Reset);
     }
 
     private Task OnStepClickAsync(MudStep step, MouseEventArgs e)

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -330,6 +330,7 @@ public partial class MudStepper : MudComponentBase
                     var nextStep = GetNextStep(index);
                     if (nextStep is not null)
                         index = _steps.IndexOf(nextStep);
+                    await SetActiveIndexAsync(index);
                     break;
                 }
             case StepAction.Skip:
@@ -337,11 +338,17 @@ public partial class MudStepper : MudComponentBase
                     var nextStep = GetNextStep(index);
                     if (nextStep is not null)
                         index = _steps.IndexOf(nextStep);
+                    await SetActiveIndexAsync(index);
                 }
                 break;
+            case StepAction.Reset:
+                break;
+            default:
+                {
+                    await SetActiveIndexAsync(index);
+                    break;
+                }
         }
-
-        await SetActiveIndexAsync(index);
 
         await (ActiveStep?.OnClick.InvokeAsync(ev) ?? Task.CompletedTask);
     }
@@ -455,9 +462,10 @@ public partial class MudStepper : MudComponentBase
             {
                 await step.SetHasErrorAsync(false, refreshParent: false);
             }
+            await UpdateStepAsync(step, new MouseEventArgs(), StepAction.Reset);
         }
 
-        await UpdateStepAsync(_steps[0], new MouseEventArgs(), StepAction.Reset);
+        await UpdateStepAsync(_steps[0], new MouseEventArgs(), StepAction.Activate);
     }
 
     private Task OnStepClickAsync(MudStep step, MouseEventArgs e)


### PR DESCRIPTION
## Description
Resolves bug where pressing reset in Stepper component pushed StepAction.Activate rather than StepAction.Reset

## How Has This Been Tested?
Using the library at work and this bug was causing a lot of grief. Cloned repo, fixed bug and tested in our codebase. Now sending the correct action.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
