### PR TITLE
MudTimeline: Fix item alignment in nested horizontal timeline (#9958)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Timeline/HorizontalTimelineInsideVerticalTimelineTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Timeline/HorizontalTimelineInsideVerticalTimelineTest.razor
@@ -1,0 +1,35 @@
+﻿
+<MudTimeline>
+    <MudTimelineItem Color="Color.Info">
+        <MudText Typo="Typo.button">Packaging Process Started</MudText>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 16:33</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem TimelineAlign="TimelineAlign.End">
+        <MudText Typo="Typo.body2">Packaging complete</MudText>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 17:10</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem TimelineAlign="TimelineAlign.End">
+        <MudText Typo="Typo.body2">Waiting for pickup</MudText>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">Yesterday: 17:15</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem>
+        <MudTimeline TimelineOrientation="TimelineOrientation.Horizontal">
+            <MudTimelineItem>
+                <MudText>Item A</MudText>
+            </MudTimelineItem>
+            <MudTimelineItem>
+                <MudText>Item B</MudText>
+            </MudTimelineItem>
+            <MudTimelineItem>
+                <MudText>Item C</MudText>
+            </MudTimelineItem>
+        </MudTimeline>
+    </MudTimelineItem>
+    <MudTimelineItem Color="Color.Success">
+        <MudText Typo="Typo.button">Package picked up by driver</MudText>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">Today: 17:00</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem TimelineAlign="TimelineAlign.End">
+        <MudText Typo="Typo.button">Package In Transit</MudText>
+    </MudTimelineItem>
+</MudTimeline>

--- a/src/MudBlazor.UnitTests/Components/TimelineTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimelineTests.cs
@@ -151,5 +151,22 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("div.mud-timeline-item-dot-inner").GetStyle()["background-color"].Should().Be("rgba(255, 0, 0, 1)");
         }
+
+        /// <summary>
+        /// Test horizontal timeline inside vertical timeline.
+        /// </summary>
+        [Test]
+        public void HorizontalTimelineInsideVerticalTimeline_Test()
+        {
+            var comp = Context.RenderComponent<HorizontalTimelineInsideVerticalTimelineTest>();
+            // select elements needed for the test
+            var timeline = comp.FindComponent<MudTimeline>().Instance;
+            // validating some renders
+            timeline.Should().NotBeNull();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-timeline").Count.Should().Be(2));
+            comp.FindAll("div.mud-timeline-item").Count.Should().Be(9);
+            var items = comp.FindComponents<MudTimelineItem>();
+            items.Count.Should().Be(9);
+        }
     }
 }

--- a/src/MudBlazor/Styles/components/_timeline.scss
+++ b/src/MudBlazor/Styles/components/_timeline.scss
@@ -50,8 +50,7 @@
   }
 
   .mud-timeline-item {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding: 0 24px;
     width: 100%;
     min-width: 0;
 


### PR DESCRIPTION
## Description
Close #9958

## How Has This Been Tested?
Added a test viewer page named HorizontalTimelineInsideVerticalTimelineTest

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Before:
![圖片](https://github.com/user-attachments/assets/b5fecec3-cd8d-42a1-a488-fb26ca8361b8)

After:
![圖片](https://github.com/user-attachments/assets/6dc19fc2-66cf-4899-b606-be4ee8a950d1)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
