### PR TITLE
MudColor: Change Equals logic

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -775,41 +775,63 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         public void Equals_SameType()
         {
+            // Arrange
             MudColor color1 = new(10, 20, 50, 255);
             MudColor color2 = new(10, 20, 50, 255);
             MudColor color3 = null;
             MudColor color4 = null;
 
-            (color1 == color1).Should().BeTrue();
-            (color2 == color2).Should().BeTrue();
-            (color1 == color2).Should().BeTrue();
-            (color2 == color1).Should().BeTrue();
-            (color3 == color4).Should().BeTrue();
-
+            // Act & Assert
+            // Self-comparison
             color1.Equals(color1).Should().BeTrue();
             color2.Equals(color2).Should().BeTrue();
+
+            // Comparison with another instance with the same values
             color1.Equals(color2).Should().BeTrue();
             color2.Equals(color1).Should().BeTrue();
+
+            // Null comparisons
+            (color3 == color4).Should().BeTrue();
             Equals(color3, color4).Should().BeTrue();
+
+            // Operator overloads
+            (color1 == color2).Should().BeTrue();
+            (color2 == color1).Should().BeTrue();
+            (color1 != color3).Should().BeTrue();
+            (color3 != color1).Should().BeTrue();
         }
 
         [Test]
         public void NotEquals_SameType()
         {
+            // Arrange
             MudColor color1 = new(10, 20, 50, 255);
             MudColor color2 = new(10, 20, 50, 10);
             MudColor color3 = null;
 
-            (color1 != color2).Should().BeTrue();
-            (color2 != color1).Should().BeTrue();
-            (color2 != color3).Should().BeTrue();
-            (color3 != color2).Should().BeTrue();
+            // Act
+            var result1 = color1 != color2;
+            var result2 = color2 != color1;
+            var result3 = color2 != color3;
+            var result4 = color3 != color2;
 
-            color1.Equals(color2).Should().BeFalse();
-            color2.Equals(color1).Should().BeFalse();
-            color2.Equals(color3).Should().BeFalse();
-            Equals(color3, color2).Should().BeFalse();
-            Equals(color2, color3).Should().BeFalse();
+            var equalsResult1 = color1.Equals(color2);
+            var equalsResult2 = color2.Equals(color1);
+            var equalsResult3 = color2.Equals(color3);
+            var equalsResult4 = Equals(color3, color2);
+            var equalsResult5 = Equals(color2, color3);
+
+            // Assert
+            result1.Should().BeTrue();
+            result2.Should().BeTrue();
+            result3.Should().BeTrue();
+            result4.Should().BeTrue();
+
+            equalsResult1.Should().BeFalse();
+            equalsResult2.Should().BeFalse();
+            equalsResult3.Should().BeFalse();
+            equalsResult4.Should().BeFalse();
+            equalsResult5.Should().BeFalse();
         }
 
 #pragma warning restore CS1718 // Comparison made to same variable
@@ -842,7 +864,7 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        public void GetHashCodeTest()
+        public void GetHashCode_SameRgba()
         {
             // Arrange
             var color1 = new MudColor(130, 150, 240, 255);
@@ -856,42 +878,77 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        public void HLSChanged_HChanged()
+        public void GetHasCode_DifferentRgba()
         {
+            // Arrange
+            var color1 = new MudColor(130, 150, 240, 255);
+            var color2 = new MudColor(131, 150, 240, 255);
+
+            // Act
+            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
+
+            // Assert
+            areEqualGetHashCode.Should().BeFalse();
+        }
+
+        [Test]
+        public void HslEquals_Hue()
+        {
+            // Arrange
             MudColor first = new(120, 0.5, 0.4, 1);
             MudColor second = new(121, 0.5, 0.4, 1);
 
-            first.HslChanged(second).Should().BeTrue();
-            second.HslChanged(first).Should().BeTrue();
+            // Act
+            var result1 = first.HslEquals(second);
+            var result2 = second.HslEquals(first);
+            var result3 = first.HslEquals(first);
+            var result4 = second.HslEquals(second);
 
-            first.HslChanged(first).Should().BeFalse();
-            second.HslChanged(second).Should().BeFalse();
+            // Assert
+            result1.Should().BeFalse();
+            result2.Should().BeFalse();
+            result3.Should().BeTrue();
+            result4.Should().BeTrue();
         }
 
         [Test]
-        public void HLSChanged_SChanged()
+        public void HslEquals_Saturation()
         {
+            // Arrange
             MudColor first = new(120, 0.5, 0.4, 1);
             MudColor second = new(120, 0.51, 0.4, 1);
 
-            first.HslChanged(second).Should().BeTrue();
-            second.HslChanged(first).Should().BeTrue();
+            // Act
+            var result1 = first.HslEquals(second);
+            var result2 = second.HslEquals(first);
+            var result3 = first.HslEquals(first);
+            var result4 = second.HslEquals(second);
 
-            first.HslChanged(first).Should().BeFalse();
-            second.HslChanged(second).Should().BeFalse();
+            // Assert
+            result1.Should().BeFalse();
+            result2.Should().BeFalse();
+            result3.Should().BeTrue();
+            result4.Should().BeTrue();
         }
 
         [Test]
-        public void HLSChanged_LChanged()
+        public void HslEquals_Lightness()
         {
+            // Arrange
             MudColor first = new(120, 0.5, 0.4, 1);
             MudColor second = new(120, 0.5, 0.41, 1);
 
-            first.HslChanged(second).Should().BeTrue();
-            second.HslChanged(first).Should().BeTrue();
+            // Act
+            var result1 = first.HslEquals(second);
+            var result2 = second.HslEquals(first);
+            var result3 = first.HslEquals(first);
+            var result4 = second.HslEquals(second);
 
-            first.HslChanged(first).Should().BeFalse();
-            second.HslChanged(second).Should().BeFalse();
+            // Assert
+            result1.Should().BeFalse();
+            result2.Should().BeFalse();
+            result3.Should().BeTrue();
+            result4.Should().BeTrue();
         }
 
         [Test]
@@ -1032,7 +1089,7 @@ namespace MudBlazor.UnitTests.Utilities
             var result1 = (string)mudColor1;
             var result2 = (string)(MudColor)null;
 
-            // Act & Assert
+            // Assert
             result1.Should().Be("#47586301");
             result2.Should().Be(string.Empty);
         }

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -374,7 +374,7 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         [TestCase(130, 150, 240, 130, 229, 0.79, 0.73)]
         [TestCase(71, 88, 99, 222, 204, 0.16, 0.33)]
-        public void TransformHLSFromRGB(byte r, byte g, byte b, byte a, double expectedH, double expectedS, double expectedL)
+        public void TransformHlsFromRgb(byte r, byte g, byte b, byte a, double expectedH, double expectedS, double expectedL)
         {
             MudColor color = new(r, g, b, a);
 
@@ -892,63 +892,65 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        public void HslEquals_Hue()
+        public void HslEquals_Null_Test()
         {
             // Arrange
-            MudColor first = new(120, 0.5, 0.4, 1);
-            MudColor second = new(121, 0.5, 0.4, 1);
+            MudColor color = new(120, 0.5, 0.4, 1);
 
             // Act
-            var result1 = first.HslEquals(second);
-            var result2 = second.HslEquals(first);
-            var result3 = first.HslEquals(first);
-            var result4 = second.HslEquals(second);
+            var equals = color.HslEquals(null);
 
             // Assert
-            result1.Should().BeFalse();
-            result2.Should().BeFalse();
-            result3.Should().BeTrue();
-            result4.Should().BeTrue();
+            equals.Should().BeFalse();
         }
 
         [Test]
-        public void HslEquals_Saturation()
+        [TestCase(120, 0.5, 0.4, 1, 121, 0.5, 0.4, 1, false)] // Hue differs
+        [TestCase(120, 0.5, 0.4, 1, 120, 0.51, 0.4, 1, false)] // Saturation differs
+        [TestCase(120, 0.5, 0.4, 1, 120, 0.5, 0.41, 1, false)] // Lightness differs
+        public void HslEquals_Test(double h1, double s1, double l1, double a1, double h2, double s2, double l2, double a2, bool expected)
         {
             // Arrange
-            MudColor first = new(120, 0.5, 0.4, 1);
-            MudColor second = new(120, 0.51, 0.4, 1);
+            MudColor first = new(h1, s1, l1, a1);
+            MudColor second = new(h2, s2, l2, a2);
 
             // Act
-            var result1 = first.HslEquals(second);
-            var result2 = second.HslEquals(first);
-            var result3 = first.HslEquals(first);
-            var result4 = second.HslEquals(second);
+            var result = first.HslEquals(second);
 
             // Assert
-            result1.Should().BeFalse();
-            result2.Should().BeFalse();
-            result3.Should().BeTrue();
-            result4.Should().BeTrue();
+            result.Should().Be(expected);
         }
 
         [Test]
-        public void HslEquals_Lightness()
+        public void RgbaEquals_Null_Test()
         {
             // Arrange
-            MudColor first = new(120, 0.5, 0.4, 1);
-            MudColor second = new(120, 0.5, 0.41, 1);
+            MudColor color = new(10, 20, 30, 255);
 
             // Act
-            var result1 = first.HslEquals(second);
-            var result2 = second.HslEquals(first);
-            var result3 = first.HslEquals(first);
-            var result4 = second.HslEquals(second);
+            var equals = color.RgbaEquals(null);
 
             // Assert
-            result1.Should().BeFalse();
-            result2.Should().BeFalse();
-            result3.Should().BeTrue();
-            result4.Should().BeTrue();
+            equals.Should().BeFalse();
+        }
+
+        [Test]
+        [TestCase(10, 20, 30, 255, 10, 20, 30, 254, false)] // Alpha differs
+        [TestCase(10, 20, 30, 255, 10, 20, 31, 255, false)] // Blue differs
+        [TestCase(10, 20, 30, 255, 10, 21, 30, 255, false)] // Green differs
+        [TestCase(10, 20, 30, 255, 11, 20, 30, 255, false)] // Red differs
+        [TestCase(10, 20, 30, 255, 10, 20, 30, 255, true)]  // All equal
+        public void RgbaEquals_Test(byte r1, byte g1, byte b1, byte a1, byte r2, byte g2, byte b2, byte a2, bool expected)
+        {
+            // Arrange
+            MudColor first = new(r1, g1, b1, a1);
+            MudColor second = new(r2, g2, b2, a2);
+
+            // Act
+            var result = first.RgbaEquals(second);
+
+            // Assert
+            result.Should().Be(expected);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs
@@ -837,7 +837,7 @@ namespace MudBlazor.UnitTests.Utilities
 #pragma warning restore CS1718 // Comparison made to same variable
 
         [Test]
-        public void Equals_null()
+        public void Equals_Null()
         {
             MudColor color1 = new(10, 20, 50, 255);
             (color1 == null).Should().BeFalse();
@@ -864,31 +864,21 @@ namespace MudBlazor.UnitTests.Utilities
         }
 
         [Test]
-        public void GetHashCode_SameRgba()
+        public void Equals_SameRgba_DifferentHsl()
         {
             // Arrange
-            var color1 = new MudColor(130, 150, 240, 255);
-            var color2 = new MudColor(130, 150, 240, 255);
+            var color1 = new MudColor(245, 0.34, 0.95, 1);
+            var color2 = new MudColor(245, 0.35, 0.95, 1);
 
             // Act
-            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
+            var equals = color1.Equals(color2);
+            var hslEquals = color1.HslEquals(color2);
+            var rgbaEquals = color1.RgbaEquals(color2);
 
             // Assert
-            areEqualGetHashCode.Should().BeTrue();
-        }
-
-        [Test]
-        public void GetHasCode_DifferentRgba()
-        {
-            // Arrange
-            var color1 = new MudColor(130, 150, 240, 255);
-            var color2 = new MudColor(131, 150, 240, 255);
-
-            // Act
-            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
-
-            // Assert
-            areEqualGetHashCode.Should().BeFalse();
+            equals.Should().BeFalse();
+            hslEquals.Should().BeFalse();
+            rgbaEquals.Should().BeTrue();
         }
 
         [Test]
@@ -951,6 +941,48 @@ namespace MudBlazor.UnitTests.Utilities
 
             // Assert
             result.Should().Be(expected);
+        }
+
+        [Test]
+        public void GetHashCode_SameRgba()
+        {
+            // Arrange
+            var color1 = new MudColor(130, 150, 240, 255);
+            var color2 = new MudColor(130, 150, 240, 255);
+
+            // Act
+            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
+
+            // Assert
+            areEqualGetHashCode.Should().BeTrue();
+        }
+
+        [Test]
+        public void GetHasCode_DifferentRgba()
+        {
+            // Arrange
+            var color1 = new MudColor(130, 150, 240, 255);
+            var color2 = new MudColor(131, 150, 240, 255);
+
+            // Act
+            var areEqualGetHashCode = color1.GetHashCode() == color2.GetHashCode();
+
+            // Assert
+            areEqualGetHashCode.Should().BeFalse();
+        }
+
+        [Test]
+        public void GetHasCode_SameRgba_DifferentHsl()
+        {
+            // Arrange
+            var color1 = new MudColor(245, 0.34, 0.95, 1);
+            var color2 = new MudColor(245, 0.35, 0.95, 1);
+
+            // Act
+            var getHashCodeEquals = color1.GetHashCode() == color2.GetHashCode();
+
+            // Assert
+            getHashCodeEquals.Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -370,8 +370,8 @@ namespace MudBlazor
                 return;
             }
 
-            var rgbChanged = value != _value;
-            var hslChanged = _value != null && value.HslChanged(_value);
+            var rgbChanged = !value.Equals(_value);
+            var hslChanged = !value.HslEquals(_value);
             var shouldUpdateBinding = _value != null
                                       && (rgbChanged || (UpdateBindingIfOnlyHSLChanged && hslChanged));
             _value = value;

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -370,13 +370,13 @@ namespace MudBlazor
                 return;
             }
 
-            var rgbChanged = !value.Equals(_value);
+            var changed = !value.Equals(_value);
             var hslChanged = !value.HslEquals(_value);
             var shouldUpdateBinding = _value != null
-                                      && (rgbChanged || (UpdateBindingIfOnlyHSLChanged && hslChanged));
+                                      && (changed || (UpdateBindingIfOnlyHSLChanged && hslChanged));
             _value = value;
 
-            if (rgbChanged && _skipFeedback == false)
+            if (changed && _skipFeedback == false)
             {
                 UpdateBaseColor();
                 UpdateColorSelectorBasedOnRgb();

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -44,8 +44,12 @@ namespace MudBlazor.Utilities
     [Serializable]
     public partial class MudColor : ISerializable, IEquatable<MudColor>, IParsable<MudColor>, IFormattable
     {
+        private readonly record struct HSL(double H, double S, double L);
+        private readonly record struct RGBA(byte R, byte G, byte B, byte A);
+
         private const double Epsilon = 0.000000000000001;
-        private readonly byte[] _valuesAsByte;
+        private readonly HSL _hsl;
+        private readonly RGBA _rgba;
 
         /// <summary>
         /// Gets the hexadecimal representation of the color.
@@ -62,22 +66,22 @@ namespace MudBlazor.Utilities
         /// <summary>
         /// Gets the red component value of the color.
         /// </summary>
-        public byte R => _valuesAsByte[0];
+        public byte R => _rgba.R;
 
         /// <summary>
         /// Gets the green component value of the color.
         /// </summary>
-        public byte G => _valuesAsByte[1];
+        public byte G => _rgba.G;
 
         /// <summary>
         /// Gets the blue component value of the color.
         /// </summary>
-        public byte B => _valuesAsByte[2];
+        public byte B => _rgba.B;
 
         /// <summary>
         /// Gets the alpha component value of the color.
         /// </summary>
-        public byte A => _valuesAsByte[3];
+        public byte A => _rgba.A;
 
         /// <summary>
         /// Gets the alpha component value as a percentage (0.0 to 1.0) of the color.
@@ -89,19 +93,19 @@ namespace MudBlazor.Utilities
         /// Gets the hue component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double H { get; }
+        public double H => _hsl.H;
 
         /// <summary>
         /// Gets the lightness component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double L { get; }
+        public double L => _hsl.L;
 
         /// <summary>
         /// Gets the saturation component value of the color.
         /// </summary>
         [JsonIgnore]
-        public double S { get; }
+        public double S => _hsl.S;
 
         /// <summary>
         /// Deserialization constructor for <see cref="MudColor"/>.
@@ -118,11 +122,7 @@ namespace MudBlazor.Utilities
         /// </summary>
         public MudColor()
         {
-            _valuesAsByte = new byte[4];
-            _valuesAsByte[0] = 0;
-            _valuesAsByte[1] = 0;
-            _valuesAsByte[2] = 0;
-            _valuesAsByte[3] = 255;
+            _rgba = new RGBA(0, 0, 0, 255);
         }
 
         /// <summary>
@@ -146,22 +146,17 @@ namespace MudBlazor.Utilities
         /// <param name="a">The alpha component value (0 to 255).</param>
         public MudColor(double h, double s, double l, int a)
         {
-            _valuesAsByte = new byte[4];
+            //_valuesAsByte = new byte[4];
 
             h = Math.Round(h.EnsureRange(360), 0);
             s = Math.Round(s.EnsureRange(1), 2);
             l = Math.Round(l.EnsureRange(1), 2);
             a = a.EnsureRange(255);
 
-            var (r, g, b) = HslToRgb(h, s, l);
-            _valuesAsByte[0] = r;
-            _valuesAsByte[1] = g;
-            _valuesAsByte[2] = b;
-            _valuesAsByte[3] = (byte)a;
+            var (r, g, b) = HslToRgb(new HSL(h, s, l));
+            _rgba = new RGBA(r, g, b, (byte)a);
 
-            H = Math.Round(h, 0);
-            S = Math.Round(s, 2);
-            L = Math.Round(l, 2);
+            _hsl = new HSL(Math.Round(h, 0), Math.Round(s, 2), Math.Round(l, 2));
         }
 
         /// <summary>
@@ -174,17 +169,8 @@ namespace MudBlazor.Utilities
         [JsonConstructor]
         public MudColor(byte r, byte g, byte b, byte a)
         {
-            _valuesAsByte = new byte[4];
-
-            _valuesAsByte[0] = r;
-            _valuesAsByte[1] = g;
-            _valuesAsByte[2] = b;
-            _valuesAsByte[3] = a;
-
-            var (h, s, l) = RgbToHsl(r, g, b);
-            H = h;
-            S = s;
-            L = l;
+            _rgba = new RGBA(r, g, b, a);
+            _hsl = RgbToHsl(r, g, b);
         }
 
         /// <summary>
@@ -205,7 +191,7 @@ namespace MudBlazor.Utilities
         /// <param name="color">The existing color to copy the hue value from.</param>
         public MudColor(byte r, byte g, byte b, MudColor color) : this(r, g, b, color.A)
         {
-            H = color.H;
+            _hsl = _hsl with { H = color.H };
         }
 
         /// <summary>
@@ -248,11 +234,8 @@ namespace MudBlazor.Utilities
             ArgumentException.ThrowIfNullOrEmpty(value);
 
             var (r, g, b, a) = ParseStringColorCore(value);
-            var (h, s, l) = RgbToHsl(r, g, b);
-            _valuesAsByte = [r, g, b, a];
-            H = h;
-            S = s;
-            L = l;
+            _rgba = new RGBA(r, g, b, a);
+            _hsl = RgbToHsl(r, g, b);
         }
 
         /// <summary>
@@ -345,16 +328,18 @@ namespace MudBlazor.Utilities
         public MudColor ColorRgbDarken() => ColorDarken(0.075);
 
         /// <summary>
-        /// Checks whether the HSL (Hue, Saturation, lightness) values of this <see cref="MudColor"/> instance have changed compared to another <see cref="MudColor"/> instance.
+        /// Checks whether the HSL (Hue, Saturation, Lightness) values of this <see cref="MudColor"/> instance are equal compared to another <see cref="MudColor"/> instance.
         /// </summary>
-        /// <param name="value">The <see cref="MudColor"/> instance to compare HSL values with.</param>
-        /// <returns>True if the HSL values have changed; otherwise, false.</returns>
-        public bool HslChanged(MudColor value)
-        {
-            var comparer = DoubleEpsilonEqualityComparer.Default;
+        /// <param name="other">The <see cref="MudColor"/> instance to compare HSL values with.</param>
+        /// <returns>True if the HSL are equal; otherwise, false.</returns>
+        public bool HslEquals(MudColor? other) => other is not null && _hsl.Equals(other._hsl);
 
-            return !comparer.Equals(H, value.H) || !comparer.Equals(S, value.S) || !comparer.Equals(L, value.L);
-        }
+        /// <summary>
+        /// Checks whether the RGBA (Red, Green, Blue, Alpha) values of this <see cref="MudColor"/> instance are equal compared to another <see cref="MudColor"/> instance.
+        /// </summary>
+        /// <param name="other">The <see cref="MudColor"/> instance to compare HSL values with.</param>
+        /// <returns>True if the RGBA are equal; otherwise, false.</returns>
+        public bool RgbaEquals(MudColor? other) => other is not null && _rgba.Equals(other._rgba);
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is MudColor color && Equals(color);
@@ -371,15 +356,11 @@ namespace MudBlazor.Utilities
                 return false;
             }
 
-            return
-                _valuesAsByte[0] == other._valuesAsByte[0] &&
-                _valuesAsByte[1] == other._valuesAsByte[1] &&
-                _valuesAsByte[2] == other._valuesAsByte[2] &&
-                _valuesAsByte[3] == other._valuesAsByte[3];
+            return RgbaEquals(other) && HslEquals(other);
         }
 
         /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(R, G, B, A);
+        public override int GetHashCode() => HashCode.Combine(_rgba, _hsl);
 
         /// <inheritdoc />
         public override string ToString() => ToString(MudColorOutputFormats.RGBA);
@@ -606,20 +587,20 @@ namespace MudBlazor.Utilities
 
         private static byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 
-        private static (byte r, byte g, byte b) HslToRgb(double h, double s, double l)
+        private static (byte r, byte g, byte b) HslToRgb(HSL hsl)
         {
             // Achromatic (gray scale)
-            if (Math.Abs(s) < Epsilon)
+            if (Math.Abs(hsl.S) < Epsilon)
             {
-                var gray = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(l * 255d)));
+                var gray = (byte)Math.Max(0, Math.Min(255, (int)Math.Ceiling(hsl.L * 255d)));
                 return (gray, gray, gray);
             }
 
-            var hNormalized = h / 360d;
-            var t2 = l <= 0.5d
-                ? l * (1.0d + s)
-                : l + s - l * s;
-            var t1 = 2.0d * l - t2;
+            var hNormalized = hsl.H / 360d;
+            var t2 = hsl.L <= 0.5d
+                ? hsl.L * (1.0d + hsl.S)
+                : hsl.L + hsl.S - hsl.L * hsl.S;
+            var t1 = 2.0d * hsl.L - t2;
 
             var tr = HueToRgb(t1, t2, hNormalized + 1.0d / 3.0d);
             var tg = HueToRgb(t1, t2, hNormalized);
@@ -645,7 +626,7 @@ namespace MudBlazor.Utilities
             };
         }
 
-        private static (byte r, byte g, byte b, byte a) ParseStringColorCore(string value)
+        private static RGBA ParseStringColorCore(string value)
         {
             value = value.Trim().ToLowerInvariant();
 
@@ -657,7 +638,7 @@ namespace MudBlazor.Utilities
             };
         }
 
-        private static (byte r, byte g, byte b, byte a) ParseStringRgbaToRgba(string value)
+        private static RGBA ParseStringRgbaToRgba(string value)
         {
             var parts = SplitInputIntoParts(value);
             if (parts.Length != 4)
@@ -670,10 +651,10 @@ namespace MudBlazor.Utilities
             var b = byte.Parse(parts[2], CultureInfo.InvariantCulture);
             var a = (byte)Math.Max(0, Math.Min(255, 255 * double.Parse(parts[3], CultureInfo.InvariantCulture)));
 
-            return (r, g, b, a);
+            return new RGBA(r, g, b, a);
         }
 
-        private static (byte r, byte g, byte b, byte a) ParseStringRgbToRgba(string value)
+        private static RGBA ParseStringRgbToRgba(string value)
         {
             var parts = SplitInputIntoParts(value);
             if (parts.Length != 3)
@@ -684,10 +665,10 @@ namespace MudBlazor.Utilities
             var r = byte.Parse(parts[0], CultureInfo.InvariantCulture);
             var g = byte.Parse(parts[1], CultureInfo.InvariantCulture);
             var b = byte.Parse(parts[2], CultureInfo.InvariantCulture);
-            return (r, g, b, byte.MaxValue);
+            return new RGBA(r, g, b, byte.MaxValue);
         }
 
-        private static (byte r, byte g, byte b, byte a) ParseStringHexToRgba(string value)
+        private static RGBA ParseStringHexToRgba(string value)
         {
             if (value.StartsWith('#'))
             {
@@ -709,7 +690,7 @@ namespace MudBlazor.Utilities
                 default:
                     throw new ArgumentException(@"Not a valid color.", nameof(value));
             }
-            return (GetByteFromValuePart(value, 0), GetByteFromValuePart(value, 2), GetByteFromValuePart(value, 4), GetByteFromValuePart(value, 6));
+            return new RGBA(GetByteFromValuePart(value, 0), GetByteFromValuePart(value, 2), GetByteFromValuePart(value, 4), GetByteFromValuePart(value, 6));
         }
 
         private static string[] SplitInputIntoParts(string value)
@@ -726,7 +707,7 @@ namespace MudBlazor.Utilities
             return parts;
         }
 
-        private static (double h, double s, double l) RgbToHsl(byte r, byte g, byte b)
+        private static HSL RgbToHsl(byte r, byte g, byte b)
         {
             var h = 0D;
             var s = 0D;
@@ -778,7 +759,7 @@ namespace MudBlazor.Utilities
                 s = (max - min) / (2D - (max + min)); //(max-min > 0)?
             }
 
-            return (Math.Round(h.EnsureRange(360), 0), Math.Round(s.EnsureRange(1), 2), Math.Round(l.EnsureRange(1), 2));
+            return new HSL(Math.Round(h.EnsureRange(360), 0), Math.Round(s.EnsureRange(1), 2), Math.Round(l.EnsureRange(1), 2));
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -146,17 +146,15 @@ namespace MudBlazor.Utilities
         /// <param name="a">The alpha component value (0 to 255).</param>
         public MudColor(double h, double s, double l, int a)
         {
-            //_valuesAsByte = new byte[4];
-
             h = Math.Round(h.EnsureRange(360), 0);
             s = Math.Round(s.EnsureRange(1), 2);
             l = Math.Round(l.EnsureRange(1), 2);
             a = a.EnsureRange(255);
 
-            var (r, g, b) = HslToRgb(new HSL(h, s, l));
+            var hsl = new HSL(h, s, l);
+            var (r, g, b) = HslToRgb(in hsl);
             _rgba = new RGBA(r, g, b, (byte)a);
-
-            _hsl = new HSL(Math.Round(h, 0), Math.Round(s, 2), Math.Round(l, 2));
+            _hsl = hsl;
         }
 
         /// <summary>
@@ -587,7 +585,7 @@ namespace MudBlazor.Utilities
 
         private static byte GetByteFromValuePart(string input, int index) => byte.Parse(new string(new[] { input[index], input[index + 1] }), NumberStyles.HexNumber);
 
-        private static (byte r, byte g, byte b) HslToRgb(HSL hsl)
+        private static (byte r, byte g, byte b) HslToRgb(in HSL hsl)
         {
             // Achromatic (gray scale)
             if (Math.Abs(hsl.S) < Epsilon)


### PR DESCRIPTION
## Description
I need this for my other future PRs (for the ColorPicker, there will be 2 or more).  
The problem is that the old `Equals` only checks for RGBA equality, but there are cases where the HSL values might be different, even though the RGBA values are the same.  
Below is an example of such a case:  
![hsl](https://github.com/user-attachments/assets/f252d482-b4c1-41a8-98a7-1d6614e261d8)


In this example, the saturation is different by 1% (0.01), but the RGBA values are the same.  
The key issue is that the ColorPicker operates in multiple modes, including RGBA and HSL.  
There are tests, such as `SetHLS_NotChangeRGB_ButCallbackFired`, that check these edge cases—where the RGBA remains the same, but the HSL changes. If the HSL is altered, the new value should be pushed to the `Value` binding.  
If we use `ParameterState`, it will use the built-in `Equals`, and if the HSL changes but the RGBA does not, the new value will not be pushed to the binding as expected because of that (of course we can add own `IEqualityComparer` and pass it to `ParameterState`, but I feel like it's weird to have an special case comparer just for that and it won't be used anywhere else).  

Therefore, I believe the default `Equals` should check both HSL and RGBA. If someone doesn't need that, they can use `RgbaEquals` or `HslEquals`. For collections like `HashSet` or `Dictionary`, they can implement their own `IEqualityComparer` (and perhaps we could provide our own implementation if it's seen as essential).

## How Has This Been Tested?
Unit tests, including the edge case.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
