### PR TITLE
IJSRuntimeExtensions: Fix InvokeVoidAsyncIgnoreErrors to catch JSException

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
@@ -166,7 +166,7 @@ namespace MudBlazor.UnitTests
             result2.success.Should().BeFalse();
             result2.value.Should().Be("fallback2");
         }
-        
+
 #if DEBUG
         [Test]
         public async Task InvokeAsyncIgnoreErrors_ShouldThrow_WhenDebugJSException()
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests
             await act1.Should().ThrowAsync<JSException>();
             await act2.Should().ThrowAsync<JSException>();
         }
-#else        
+#else
         [Test]
         public async Task InvokeAsyncIgnoreErrors_ShouldSucceed_WhenReleaseJSException()
         {

--- a/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
@@ -166,5 +166,37 @@ namespace MudBlazor.UnitTests
             result2.success.Should().BeFalse();
             result2.value.Should().Be("fallback2");
         }
+        
+#if DEBUG
+        [Test]
+        public async Task InvokeAsyncIgnoreErrors_ShouldThrow_WhenDebugJSException()
+        {
+            // Arrange
+            var jsRuntime1 = new ExceptionJavascriptRuntime();
+
+            // Act
+            var act1 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod");
+            var act2 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod", CancellationToken.None);
+
+            // Assert
+            await act1.Should().ThrowAsync<JSException>();
+            await act2.Should().ThrowAsync<JSException>();
+        }
+#else        
+        [Test]
+        public async Task InvokeAsyncIgnoreErrors_ShouldSucceed_WhenReleaseJSException()
+        {
+            // Arrange
+            var jsRuntime1 = new ExceptionJavascriptRuntime();
+
+            // Act
+            var act1 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod");
+            var act2 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod", CancellationToken.None);
+
+            // Assert
+            await act1.Should().NotThrowAsync();
+            await act2.Should().NotThrowAsync();
+        }
+#endif
     }
 }

--- a/src/MudBlazor.UnitTests/Mocks/ExceptionJavascriptRuntime.cs
+++ b/src/MudBlazor.UnitTests/Mocks/ExceptionJavascriptRuntime.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.JSInterop;
+
+namespace MudBlazor.UnitTests.Mocks;
+
+public class ExceptionJavascriptRuntime : IJSRuntime
+{
+    public Func<Exception> ExceptionFactory { get; set; } = () => new JSException("An error occurred when invoking JavaScript function.");
+    
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
+    {
+        throw ExceptionFactory();
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object[] args)
+    {
+        throw ExceptionFactory();
+    }
+}

--- a/src/MudBlazor.UnitTests/Mocks/ExceptionJavascriptRuntime.cs
+++ b/src/MudBlazor.UnitTests/Mocks/ExceptionJavascriptRuntime.cs
@@ -9,7 +9,7 @@ namespace MudBlazor.UnitTests.Mocks;
 public class ExceptionJavascriptRuntime : IJSRuntime
 {
     public Func<Exception> ExceptionFactory { get; set; } = () => new JSException("An error occurred when invoking JavaScript function.");
-    
+
     public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
     {
         throw ExceptionFactory();

--- a/src/MudBlazor/Extensions/IJSRuntimeExtensions.cs
+++ b/src/MudBlazor/Extensions/IJSRuntimeExtensions.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
             {
                 await jsRuntime.InvokeVoidAsync(identifier, args);
             }
-#if DEBUG
+#if !DEBUG
             catch (JSException)
             {
             }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

After upgrading my app to version 8.0.0-preview4, it crashed when invoking a non-existing JavaScript function.

The method `IJSRuntimeExtensions.InvokeVoidAsyncIgnoreErrors` is supposed to catch `JSException`. Only the overload taking a `CancellationToken` would work as expected. A debug condition seem to be inverted.

I believe this is a regression from #9997.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
New unit test

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
