### PR TITLE
MudInput : When the bound value is modfiied  on ValueChanged then the modification is replicated on the input text

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputToUpperTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputToUpperTest.razor
@@ -1,0 +1,13 @@
+﻿<MudInput T="string" Value="@Value" ValueChanged="OnValueChanged" Immediate="@Immediate" />
+
+@code {
+    [Parameter]
+    public bool Immediate { get; set; }
+
+    public string? Value { get; private set; }
+
+    private void OnValueChanged(string newValue)
+    {
+        Value = newValue.ToUpper();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -1,5 +1,7 @@
 ﻿using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.UnitTests.TestComponents.Input;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components;
@@ -21,5 +23,49 @@ public class InputTests : BunitTest
         comp.SetParametersAndRender(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
         comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
     }
-#nullable disable
+
+    [Test]
+    public async Task WithImmediate_BindValueModifiedOnChange_SoTextUpdated()
+    {
+        // Arrange
+
+        var comp = Context.RenderComponent<InputToUpperTest>(parameters => parameters
+            .Add(i => i.Immediate, true)
+        );
+        var stu = comp.Instance;
+        var input = comp.FindComponent<MudInput<string>>().Instance;
+
+        // Act
+
+        await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "AbCdEfGhI" });
+
+        // Assert
+
+        stu.Value.Should().Be("ABCDEFGHI");
+        input.Value.Should().Be("ABCDEFGHI");
+        input.Text.Should().Be("ABCDEFGHI");
+    }
+
+    [Test]
+    public async Task WithoutImmediate_BindValueModifiedOnChange_SoTextUpdated()
+    {
+        // Arrange
+
+        var comp = Context.RenderComponent<InputToUpperTest>(parameters => parameters
+            .Add(i => i.Immediate, false)
+        );
+        var stu = comp.Instance;
+        var input = comp.FindComponent<MudInput<string>>().Instance;
+
+        // Act
+
+        comp.Find("input").KeyDown("a"); // Trick to force the focus on input
+        await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "AbCdEfGhI" });
+
+        // Assert
+
+        stu.Value.Should().Be("ABCDEFGHI");
+        input.Value.Should().Be("ABCDEFGHI");
+        input.Text.Should().Be("ABCDEFGHI");
+    }
 }


### PR DESCRIPTION
## Description

Fixes #10337

With WASM, when a bound value to `MudInput.Value` is modified on the event `MudInput.ValueChanged`, the input text is also modified. For example :
```razor
<MudInput T="string" Value="@currentValue" ValueChanged="OnValueChanged" />

@code {
    public string currentValue;

    private void OnValueChanged(string newValue)
    {
        currentValue= newValue.ToUpper();
    }
}
```

But with Server, the modification isn't replicated on input text.

This PR fix this problem, so the Server behavior is similar to WASM behavior.

## How Has This Been Tested?

I added tests.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
