### PR TITLE
Cookie Consent CSS: Fixes the Cookie Consent Popup from Blocking the UI

### DIFF
--- a/src/MudBlazor.Docs/Styles/components/_consent.scss
+++ b/src/MudBlazor.Docs/Styles/components/_consent.scss
@@ -4,6 +4,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
+  pointer-events: none;
   width: 100%;
   z-index: var(--mud-zindex-popover);
 }
@@ -14,6 +15,7 @@
   padding: 1em;
   gap: 0.5rem;
   max-width: 48rem;
+  pointer-events: all;
   border-radius: 0.25rem;
 }
 


### PR DESCRIPTION
The Cookie Consent Dialog Container blocks the ui from being interacted with even though the content of the dialog is restricted to a max width of `48rem;`

## Description
I have updated the following file `MudBlocks.Docs/Styles/components/_consent.scss` to do the following

```css
.cookie-consent-container {
  pointer-events: none;
}
.cookie-consent {
  pointer-events: all;
}
```
This will allow users to click though the area of `.cookie-consent-container` but still interact with `.cookie-consent` content.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

The content to the sides of the cookie consent are now able to be interacted with.
![image](https://github.com/user-attachments/assets/bffdbad2-d87b-4d50-9138-6d2d6e40f2f7)

## Checklist
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
