### PR TITLE
MudGlobal: Add more defaults

### DIFF
--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -103,7 +103,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public bool DropShadow { get; set; } = true;
+        public bool DropShadow { get; set; } = MudGlobal.ButtonDefaults.DropShadow;
 
         /// <summary>
         /// Shows a ripple effect when the user clicks the button.
@@ -113,7 +113,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.ButtonDefaults.Ripple;
 
         /// <summary>
         /// Occurs when this button has been clicked.

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -96,21 +96,21 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.InputDefaults.Ripple;
 
         /// <summary>
         /// The Size of the component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size Size { get; set; } = MudGlobal.InputDefaults.Size;
 
         /// <summary>
         /// The color of the component. It supports the theme colors.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Color Color { get; set; } = Color.Default;
+        public Color Color { get; set; } = MudGlobal.PaginationDefaults.Color;
 
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -108,7 +108,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+        public Origin AnchorOrigin { get; set; } = MudGlobal.InputDefaults.AnchorOrigin;
 
         /// <summary>
         /// The transform origin point for the popover.
@@ -118,7 +118,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+        public Origin TransformOrigin { get; set; } = MudGlobal.InputDefaults.TransformOrigin;
 
         /// <summary>
         /// Uses compact padding.

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -49,7 +49,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Color Color { get; set; } = Color.Default;
+        public Color Color { get; set; } = MudGlobal.ButtonDefaults.Color;
 
         /// <summary>
         /// The size of the button.
@@ -59,7 +59,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size Size { get; set; } = MudGlobal.ButtonDefaults.Size;
 
         /// <summary>
         /// The amount of negative margin applied.
@@ -79,7 +79,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
+        public Variant Variant { get; set; } = MudGlobal.ButtonDefaults.Variant;
 
         /// <summary>
         /// The custom content within this button.

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -49,7 +49,7 @@ public partial class MudToggleIconButton : MudComponentBase
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Button.Appearance)]
-    public Color Color { get; set; } = Color.Default;
+    public Color Color { get; set; } = MudGlobal.ButtonDefaults.Color;
 
     /// <summary>
     /// An alternative color to use in the toggled state.
@@ -66,7 +66,7 @@ public partial class MudToggleIconButton : MudComponentBase
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Button.Appearance)]
-    public Size Size { get; set; } = Size.Medium;
+    public Size Size { get; set; } = MudGlobal.ButtonDefaults.Size;
 
     /// <summary>
     /// An alternative size to use in the toggled state.
@@ -83,7 +83,7 @@ public partial class MudToggleIconButton : MudComponentBase
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Button.Appearance)]
-    public Variant Variant { get; set; } = Variant.Text;
+    public Variant Variant { get; set; } = MudGlobal.ButtonDefaults.Variant;
 
     /// <summary>
     /// An alternative variant to use in the toggled state.
@@ -110,7 +110,7 @@ public partial class MudToggleIconButton : MudComponentBase
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Button.Appearance)]
-    public bool Ripple { get; set; } = true;
+    public bool Ripple { get; set; } = MudGlobal.ButtonDefaults.Ripple;
 
     /// <summary>
     /// Displays a shadow.
@@ -120,7 +120,7 @@ public partial class MudToggleIconButton : MudComponentBase
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Button.Appearance)]
-    public bool DropShadow { get; set; } = true;
+    public bool DropShadow { get; set; } = MudGlobal.ButtonDefaults.DropShadow;
 
     /// <summary>
     /// Disables interaction with the button.

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -63,7 +63,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
-        public bool DropShadow { get; set; } = true;
+        public bool DropShadow { get; set; } = MudGlobal.ButtonGroupDefaults.DropShadow;
 
         /// <summary>
         /// The color of all buttons in this group.
@@ -73,7 +73,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
-        public Color Color { get; set; } = Color.Default;
+        public Color Color { get; set; } = MudGlobal.ButtonGroupDefaults.Color;
 
         /// <summary>
         /// The size of all buttons in the group.
@@ -83,7 +83,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size Size { get; set; } = MudGlobal.ButtonGroupDefaults.Size;
 
         /// <summary>
         /// The display variant of all buttons in the group.
@@ -93,7 +93,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
+        public Variant Variant { get; set; } = MudGlobal.ButtonGroupDefaults.Variant;
 
         /// <summary>
         /// If true, the button group will take up 100% of available width.

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -29,11 +29,11 @@ namespace MudBlazor
         /// Overrides individual button styles with this group's style.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.  When <c>true</c>, the button styles are defined by this group.
+        /// Defaults to <c>true</c>. When <c>true</c>, the button styles are defined by this group.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ButtonGroup.Appearance)]
-        public bool OverrideStyles { get; set; } = true;
+        public bool OverrideStyles { get; set; } = MudGlobal.ButtonGroupDefaults.OverrideStyles;
 
         /// <summary>
         /// The custom content within this group.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -260,7 +260,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.MenuDefaults.Ripple;
 
         /// <summary>
         /// Displays a drop shadow under the activator button.
@@ -270,7 +270,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.Appearance)]
-        public bool DropShadow { get; set; } = true;
+        public bool DropShadow { get; set; } = MudGlobal.MenuDefaults.DropShadow;
 
         /// <summary>
         /// The <see cref="MudMenuItem" /> components within this menu.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -220,7 +220,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.PopupAppearance)]
-        public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+        public Origin AnchorOrigin { get; set; } = MudGlobal.MenuDefaults.AnchorOrigin;
 
         /// <summary>
         /// Sets the direction the menu will open from the anchor.
@@ -230,7 +230,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.PopupAppearance)]
-        public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+        public Origin TransformOrigin { get; set; } = MudGlobal.MenuDefaults.TransformOrigin;
 
         /// <summary>
         /// Prevents the page from scrolling while this menu is open.

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -111,7 +111,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
+        public Variant Variant { get; set; } = MudGlobal.PaginationDefaults.Variant;
 
         /// <summary>
         /// The color of the selected page button.
@@ -121,7 +121,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color Color { get; set; } = Color.Primary;
+        public Color Color { get; set; } = MudGlobal.PaginationDefaults.Color;
 
         /// <summary>
         /// Shows rectangular-shaped page buttons.
@@ -141,7 +141,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size Size { get; set; } = MudGlobal.PaginationDefaults.Size;
 
         /// <summary>
         /// Shows a drop shadow under each page button.
@@ -151,7 +151,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public bool DropShadow { get; set; } = true;
+        public bool DropShadow { get; set; } = MudGlobal.PaginationDefaults.DropShadow;
 
         /// <summary>
         /// Prevents the user from clicking page buttons.

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -297,7 +297,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
+        public Variant Variant { get; set; } = MudGlobal.PickerDefaults.Variant;
 
         /// <summary>
         /// The location of the <see cref="AdornmentIcon"/> for the input.
@@ -393,7 +393,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = MudGlobal.PickerDefaults.Margin;
 
         /// <summary>
         /// The mask to apply to input values when <see cref="Editable"/> is <c>true</c>.
@@ -414,7 +414,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+        public Origin AnchorOrigin { get; set; } = MudGlobal.PickerDefaults.AnchorOrigin;
 
         /// <summary>
         /// The direction the popover opens, relative to its container.
@@ -424,7 +424,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+        public Origin TransformOrigin { get; set; } = MudGlobal.PickerDefaults.TransformOrigin;
 
         /// <summary>
         /// The behavior of the popover when it overflows its container.
@@ -434,7 +434,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
+        public OverflowBehavior OverflowBehavior { get; set; } = MudGlobal.PickerDefaults.OverflowBehavior;
 
         protected IMask? _mask = null;
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -82,7 +82,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public bool DropShadow { get; set; } = true;
+        public bool DropShadow { get; set; } = MudGlobal.PopoverDefaults.DropShadow;
 
         /// <summary>
         /// The amount of drop shadow to apply.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -503,14 +503,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+        public Origin AnchorOrigin { get; set; } = MudGlobal.InputDefaults.AnchorOrigin;
 
         /// <summary>
         /// Sets the transform origin point for the popover.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+        public Origin TransformOrigin { get; set; } = MudGlobal.InputDefaults.TransformOrigin;
 
         /// <summary>
         /// If true, the Select's input will not show any values that are not defined in the dropdown.

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -170,7 +170,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Tabs.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.TabDefaults.Ripple;
 
         /// <summary>
         /// If true, displays slider animation

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -159,28 +159,28 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool Outlined { get; set; } = true;
+        public bool Outlined { get; set; } = MudGlobal.ToggleGroupDefaults.Outlined;
 
         /// <summary>
         /// If true, show a line delimiter between items. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool Delimiters { get; set; } = true;
+        public bool Delimiters { get; set; } = MudGlobal.ToggleGroupDefaults.Delimiters;
 
         /// <summary>
         /// Gets or sets whether to show a ripple effect when the user clicks the button. Default is true.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.ToggleGroupDefaults.Ripple;
 
         /// <summary>
         /// The size of the items in the toggle group.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size Size { get; set; } = MudGlobal.ToggleGroupDefaults.Size;
 
         /// <summary>
         /// The selection behavior of the group. SingleSelection (the default) is a radio-button like exclusive collection.
@@ -196,7 +196,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
-        public Color Color { get; set; } = Color.Primary;
+        public Color Color { get; set; } = MudGlobal.ToggleGroupDefaults.Color;
 
         /// <summary>
         /// If true, the items show a check mark next to the text or render fragment. Customize the check mark by setting

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -57,17 +57,17 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Tooltip.Appearance)]
-        public bool Arrow { get; set; } = false;
+        public bool Arrow { get; set; } = MudGlobal.TooltipDefaults.Arrow;
 
         /// <summary>
         /// Sets the length of time that the opening transition takes to complete.
         /// </summary>
         /// <remarks>
-        /// Set globally via <see cref="MudGlobal.TransitionDefaults.Duration"/>.
+        /// Set globally via <see cref="MudGlobal.TooltipDefaults.Duration"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Tooltip.Appearance)]
-        public double Duration { get; set; } = MudGlobal.TransitionDefaults.Duration.TotalMilliseconds;
+        public double Duration { get; set; } = MudGlobal.TooltipDefaults.Duration.TotalMilliseconds;
 
         /// <summary>
         /// Sets the amount of time in milliseconds to wait from opening the popover before beginning to perform the transition. 

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -75,7 +75,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Selecting)]
-        public Color Color { get; set; } = Color.Primary;
+        public Color Color { get; set; } = MudGlobal.TreeViewDefaults.Color;
 
         /// <summary>
         /// Check box color if multiselection is used.
@@ -187,7 +187,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.TreeView.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = MudGlobal.TreeViewDefaults.Ripple;
 
         /// <summary>
         /// Tree items that will be rendered using the Item

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -91,6 +91,15 @@ public static class MudGlobal
         /// Defaults to <c>true</c>
         /// </remarks>
         public static bool DropShadow { get; set; } = true;
+
+        /// <summary>
+        /// Override individual button styles with a <see cref="MudButtonGroup"/> style. 
+        /// When <c>true</c>, the button styles are defined by the group.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool OverrideStyles { get; set; } = true;
     }
 
     /// <summary>

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -212,6 +212,22 @@ public static class MudGlobal
         /// Defaults to <see cref="Margin.None"/>.
         /// </remarks>
         public static Margin Margin { get; set; } = Margin.None;
+
+        /// <summary>
+        /// The default AnchorOrigin for <see cref="MudSelect{T}"/> and <see cref="MudAutocomplete{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.BottomLeft"/>.
+        /// </remarks>
+        public static Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+
+        /// <summary>
+        /// The default TransformOrigin for <see cref="MudSelect{T}"/> and <see cref="MudAutocomplete{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.TopLeft"/>.
+        /// </remarks>
+        public static Origin TransformOrigin { get; set; } = Origin.TopLeft;
     }
 
     /// <summary>
@@ -259,6 +275,22 @@ public static class MudGlobal
         /// Indicate the default waiting time to prevent closing if a mouse enter event occurs.
         /// </summary>
         public static int PreventCloseWaitingTime { get; set; } = 50;
+
+        /// <summary>
+        /// The default AnchorOrigin for <see cref="MudMenu"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.BottomLeft"/>.
+        /// </remarks>
+        public static Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+
+        /// <summary>
+        /// The default TransformOrigin for <see cref="MudMenu"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.TopLeft"/>.
+        /// </remarks>
+        public static Origin TransformOrigin { get; set; } = Origin.TopLeft;
     }
 
     /// <summary>
@@ -303,6 +335,46 @@ public static class MudGlobal
         /// Defaults to <see cref="TransitionDefaults.Duration"/>.
         /// </remarks>
         public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
+
+        /// <summary>
+        /// The default variant for <see cref="MudPicker{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text"/>.
+        /// </remarks>
+        public static Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// The default margin for <see cref="MudPicker{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Margin.None"/>.
+        /// </remarks>
+        public static Margin Margin { get; set; } = Margin.None;
+
+        /// <summary>
+        /// The default AnchorOrigin for <see cref="MudPicker{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.BottomLeft"/>.
+        /// </remarks>
+        public static Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+
+        /// <summary>
+        /// The default TransformOrigin for <see cref="MudPicker{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Origin.TopLeft"/>.
+        /// </remarks>
+        public static Origin TransformOrigin { get; set; } = Origin.TopLeft;
+
+        /// <summary>
+        /// The default OverflowBehavior for <see cref="MudPicker{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OverflowBehavior.FlipOnOpen"/>.
+        /// </remarks>
+        public static OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipOnOpen;
     }
 
     /// <summary>

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -37,6 +37,60 @@ public static class MudGlobal
         /// Defaults to <see cref="Variant.Text"/>.
         /// </remarks>
         public static Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Display a shadow for <see cref="MudBaseButton"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool DropShadow { get; set; } = true;
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks a <see cref="MudBaseButton"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Ripple { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Defaults for the <see cref="MudButtonGroup"/> component.
+    /// </summary>
+    public static class ButtonGroupDefaults
+    {
+        /// <summary>
+        /// The default color for <see cref="MudButtonGroup"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
+        public static Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The default size for <see cref="MudButtonGroup"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
+        public static Size Size { get; set; } = Size.Medium;
+
+        /// <summary>
+        /// The default variant for <see cref="MudButtonGroup"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text"/>.
+        /// </remarks>
+        public static Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Display a shadow for <see cref="MudButtonGroup"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool DropShadow { get; set; } = true;
     }
 
     /// <summary>
@@ -206,6 +260,14 @@ public static class MudGlobal
         public static Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
+        /// The default size for <see cref="MudBooleanInput{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
+        public static Size Size { get; set; } = Size.Medium;
+
+        /// <summary>
         /// The default margin for <see cref="MudBaseInput{T}"/>.
         /// </summary>
         /// <remarks>
@@ -228,6 +290,14 @@ public static class MudGlobal
         /// Defaults to <see cref="Origin.TopLeft"/>.
         /// </remarks>
         public static Origin TransformOrigin { get; set; } = Origin.TopLeft;
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks a <see cref="MudBooleanInput{T}"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Ripple { get; set; } = true;
     }
 
     /// <summary>
@@ -291,6 +361,22 @@ public static class MudGlobal
         /// Defaults to <see cref="Origin.TopLeft"/>.
         /// </remarks>
         public static Origin TransformOrigin { get; set; } = Origin.TopLeft;
+
+        /// <summary>
+        /// Display a shadow for <see cref="MudMenu"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool DropShadow { get; set; } = true;
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks a <see cref="MudMenu"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Ripple { get; set; } = true;
     }
 
     /// <summary>
@@ -313,6 +399,44 @@ public static class MudGlobal
         /// Defaults to <see cref="TransitionDefaults.Duration"/>.
         /// </remarks>
         public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
+    }
+
+    /// <summary>
+    /// Defaults for the <see cref="MudPagination"/> component.
+    /// </summary>
+    public static class PaginationDefaults
+    {
+        /// <summary>
+        /// The default color for <see cref="MudPagination"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
+        public static Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The default size for <see cref="MudPagination"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
+        public static Size Size { get; set; } = Size.Medium;
+
+        /// <summary>
+        /// The default variant for <see cref="MudPagination"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text"/>.
+        /// </remarks>
+        public static Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Display a shadow for <see cref="MudPagination"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool DropShadow { get; set; } = true;
     }
 
     /// <summary>
@@ -389,6 +513,14 @@ public static class MudGlobal
         /// Defaults to <c>8</c>.
         /// </remarks>
         public static int Elevation { get; set; } = 8;
+
+        /// <summary>
+        /// Display a shadow for <see cref="MudPopover"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool DropShadow { get; set; } = true;
     }
 
     /// <summary>
@@ -530,6 +662,60 @@ public static class MudGlobal
         /// Defaults to <c>false</c>. When <c>true</c>, the effects will be applied to the container as well.
         /// </remarks>
         public static bool ApplyEffectsToContainer { get; set; }
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks <see cref="MudTabs"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Ripple { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Defaults for the <see cref="MudToggleGroup{T}"/> component.
+    /// </summary>
+    public static class ToggleGroupDefaults
+    {
+        /// <summary>
+        /// The default color for <see cref="MudToggleGroup{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
+        public static Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The default size for <see cref="MudToggleGroup{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="InputDefaults.Size"/>.
+        /// </remarks>
+        public static Size Size { get; set; } = InputDefaults.Size;
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks a <see cref="MudToggleGroup{T}"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="InputDefaults.Ripple"/>
+        /// </remarks>
+        public static bool Ripple { get; set; } = InputDefaults.Ripple;
+
+        /// <summary>
+        /// Show an outline border around a <see cref="MudToggleGroup{T}"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Outlined { get; set; } = true;
+
+        /// <summary>
+        /// Show a line delimiter between <see cref="MudToggleGroup{T}"/> items
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Delimiters { get; set; } = true;
     }
 
     /// <summary>
@@ -546,6 +732,14 @@ public static class MudGlobal
         /// The default transition time for <see cref="MudTooltip"/>.
         /// </summary>
         public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
+
+        /// <summary>
+        /// The default Arrow value for <see cref="MudTooltip"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>, when <c>true</c> an arrow will be displayed pointing towards the content from the tooltip.
+        /// </remarks>
+        public static bool Arrow { get; set; } = false;
     }
 
     /// <summary>
@@ -562,6 +756,28 @@ public static class MudGlobal
         /// The default transition time for components like <see cref="MudOverlay"/>, <see cref="MudPicker{T}"/>, <see cref="MudPopover"/>, and <see cref="MudTooltip"/>.
         /// </summary>
         public static TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
+    }
+
+    /// <summary>
+    /// Defaults for the <see cref="MudTreeView{T}"/> component.
+    /// </summary>
+    public static class TreeViewDefaults
+    {
+        /// <summary>
+        /// The default color for <see cref="MudTreeView{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
+        public static Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// Display a ripple effect when the user clicks a <see cref="MudTreeView{T}"/>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>
+        /// </remarks>
+        public static bool Ripple { get; set; } = true;
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Added more MudGlobal defaults:
- **Autocomplete**: AnchorOrigin, TransformOrigin
- **Menu**: AnchorOrigin, TransformOrigin, DropShadow, Ripple
- **Select**: AnchorOrigin, TransformOrigin
- **Pickers**: AnchorOrigin, TransformOrigin, Variant, Margin, OverflowBehavior
- **Buttons**: DropShadow, Ripple
- **IconButton**: Color, Size, Variant
- **ToggleIconButtons**: Color, Size, Variant, DropShadow, Ripple
- **ButtonGroup**: Color, Size, Variant, DropShadow
- **Input/BooleanInput**: Ripple, Size, Color
- **Pagination**: Color, Size, Variant, DropShadow
- **Popover**: DropShadow
- **Tabs**: Ripple
- **ToggleGroup**: Size, Color, Ripple, Delimiters, Outlined
- **Tooltip**: Arrow, fixed Duration default
- **TreeView**: Color, Ripple

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
