### PR TITLE
MudDataGrid: Fix SelectOnRowClick when MultiSelection is false

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSingleSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSingleSelectionTest.razor
@@ -1,4 +1,4 @@
-﻿<MudDataGrid Items="_listItems" MultiSelection="false" SelectOnRowClick="true" @bind-SelectedItems="_selectionList">
+﻿<MudDataGrid Items="_listItems" MultiSelection="false" @bind-SelectedItems="_selectionList">
     <Columns>
         <SelectColumn />
         <PropertyColumn Property="x => x.Name"/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSingleSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSingleSelectionTest.razor
@@ -1,4 +1,4 @@
-﻿<MudDataGrid Items="_listItems" MultiSelection="false" @bind-SelectedItems="_selectionList">
+﻿<MudDataGrid Items="_listItems" MultiSelection="false" SelectOnRowClick="true" @bind-SelectedItems="_selectionList">
     <Columns>
         <SelectColumn />
         <PropertyColumn Property="x => x.Name"/>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4139,7 +4139,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridSelectOnRowClickTest()
+        public async Task DataGridMultiSelectOnRowClickTest()
         {
             var comp = Context.RenderComponent<DataGridMultiSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultiSelectionTest.Item>>();
@@ -4148,9 +4148,57 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
             dataGrid.FindAll("tbody.mud-table-body td")[1].Click();
             dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(1); //ensure selection is rendered
+
+            // click on the second row
+            dataGrid.FindAll("tbody.mud-table-body td")[2].Click();
+            dataGrid.Instance.SelectedItems.Count.Should().Be(2);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(2);
 
             var parameters = new List<ComponentParameter>();
             parameters.Add(ComponentParameter.CreateParameter(nameof(dataGrid.Instance.SelectOnRowClick), false));
+            dataGrid.SetParametersAndRender(parameters.ToArray());
+
+            // deselect all programmatically
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetSelectAllAsync(false));
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(0);
+
+            // click on the first row
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll("tbody.mud-table-body td")[1].Click();
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(0);
+        }
+
+        [Test]
+        public async Task DataGridSingleSelectOnRowClickTest()
+        {
+            var comp = Context.RenderComponent<DataGridSingleSelectionTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSingleSelectionTest.Item>>();
+
+            // click on the first row
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll("tbody.mud-table-body td")[1].Click();
+            dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(1); //ensure selection is rendered
+
+            // click on the second row
+            dataGrid.FindAll("tbody.mud-table-body td")[2].Click();
+            dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(1);
+
+
+            // click on the second row
+            dataGrid.FindAll("tbody.mud-table-body td")[2].Click();
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(0);
+
+            var parameters = new List<ComponentParameter>
+            {
+                ComponentParameter.CreateParameter(nameof(dataGrid.Instance.SelectOnRowClick), false)
+            };
+
             dataGrid.SetParametersAndRender(parameters.ToArray());
 
             // deselect all programmatically
@@ -4161,6 +4209,7 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
             dataGrid.FindAll("tbody.mud-table-body td")[1].Click();
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+            dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(0);
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1801,19 +1801,27 @@ namespace MudBlazor
         /// </remarks>
         public async Task SetSelectedItemAsync(T item)
         {
-            if (MultiSelection && SelectOnRowClick)
-            {
-                if (Selection.Contains(item))
-                {
-                    Selection.Remove(item);
-                }
-                else
-                {
-                    Selection.Add(item);
-                }
+            if (!SelectOnRowClick)
+                return;
 
+            if (!Selection.Remove(item))
+            {
+                Selection.Add(item);
+            }
+            else if (!MultiSelection)
+            {
+                SelectedItem = default;
+                return;
+            }
+
+            if (MultiSelection)
+            {
                 SelectedItemsChangedEvent?.Invoke(SelectedItems);
                 await SelectedItemsChanged.InvokeAsync(SelectedItems);
+            }
+            else
+            {
+                Selection.Remove(SelectedItem);
             }
 
             SelectedItem = item;


### PR DESCRIPTION
## Description
When MultiSelection is false, SelectOnRowClick updates the selected item property, but does not update the selection checkbox.
 
Resolves #10381

## How Has This Been Tested?
Visually + unit tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
