### PR TITLE
MudDataGrid: Fix virtualization regression (#10343)

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -205,7 +205,7 @@
                         @{
                             var resolvedPageItems = new List<IndexBag<T>>(0);
                             // resolve the page items only when used
-                            if (!Virtualize || HasFooter)
+                            if (!Virtualize || !HasServerData || HasFooter)
                             {
                                 resolvedPageItems = CurrentPageItems.Select((item, index) => new IndexBag<T>(index, item))
                                     .ToList();


### PR DESCRIPTION
## Description
Fix: #10343 introduced by #10218, revert from #10361 can be cancelled
Fix: #10338

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.

## Additionnal notes :
If there is any other related bug, you can try to remove this optimisation
```cs
                        @{
                            var resolvedPageItems = new List<IndexBag<T>>(0);
                            // resolve the page items only when used
                            if (!Virtualize || !HasServerData || HasFooter)
                            {
                                resolvedPageItems = CurrentPageItems.Select((item, index) => new IndexBag<T>(index, item))
                                    .ToList();
                            }
                        }
```
with
```cs
                        @{ 
                            var resolvedPageItems = CurrentPageItems.Select((item, index) => new IndexBag<T>(index, item))
                                .ToList();
                        }
```