### PR TITLE
Build: Refactor docs compiler to be fully reflective

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "C#: Docs Compiler Debug",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/MudBlazor.Docs.Compiler/bin/Debug/net9.0/MudBlazor.Docs.Compiler.dll",
+            "args": ["${workspaceFolder}/src/MudBlazor/obj/Debug/net9.0/MudBlazor.dll"],
+            "cwd": "${workspaceFolder}/src/MudBlazor.Docs",
+        },
+        {
             "name": "unit test viewer (wasm)",
             "type": "blazorwasm",
             "request": "launch",

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -29,7 +29,7 @@ public class ApiDocumentationBuilder
     /// <summary>
     /// The assembly to document.
     /// </summary>
-    public List<Assembly> Assemblies { get; } = [typeof(_Imports).Assembly];
+    public List<Assembly> Assemblies { get; } = [];
 
     /// <summary>
     /// The types in the assembly.
@@ -173,8 +173,10 @@ public class ApiDocumentationBuilder
     /// <summary>
     /// Generates documentation for all types.
     /// </summary>
-    public bool Execute()
+    public bool Execute(string mudBlazorDllPath)
     {
+        var assembly = Assembly.LoadFrom(mudBlazorDllPath);
+        Assemblies.Add(assembly);
         AddTypesToDocument();
         ResolveSeeAlsoLinks();
         FindDeclaringTypes();
@@ -293,7 +295,7 @@ public class ApiDocumentationBuilder
         // Go through each property
         foreach (var property in properties)
         {
-            var category = property.GetCustomAttribute<CategoryAttribute>();
+            var (categoryName, categoryOrder) = property.GetCategoryAttribute();
             var blazorParameter = property.GetCustomAttribute<ParameterAttribute>();
             var key = GetPropertyFullName(property);
 
@@ -314,13 +316,13 @@ public class ApiDocumentationBuilder
                     // Record this event
                     documentedEvent = new DocumentedEvent
                     {
-                        Category = category?.Name,
+                        Category = categoryName,
                         DeclaringType = property.DeclaringType,
                         IsProtected = property.GetMethod?.IsFamily ?? false,
                         IsParameter = blazorParameter != null,
                         Key = key,
                         Name = property.Name,
-                        Order = category?.Order ?? int.MaxValue,
+                        Order = categoryOrder ?? int.MaxValue,
                         Remarks = xmlDocs.Remarks?.Replace("\r\n", "").Trim(),
                         Summary = xmlDocs.Summary?.Replace("\r\n", "").Trim(),
                         Type = property.PropertyType,
@@ -341,13 +343,13 @@ public class ApiDocumentationBuilder
                     // Record this property                
                     documentedProperty = new DocumentedProperty()
                     {
-                        Category = category?.Name,
+                        Category = categoryName,
                         DeclaringType = property.DeclaringType,
                         IsProtected = property.GetMethod?.IsFamily ?? false,
                         IsParameter = blazorParameter is not null,
                         Key = key,
                         Name = property.Name,
-                        Order = category?.Order ?? int.MaxValue,
+                        Order = categoryOrder ?? int.MaxValue,
                         Remarks = xmlDocs.Remarks?.Replace("\r\n", "").Trim(),
                         Summary = xmlDocs.Summary?.Replace("\r\n", "").Trim(),
                         Type = property.PropertyType,
@@ -385,7 +387,7 @@ public class ApiDocumentationBuilder
         // Go through each property
         foreach (var field in fields)
         {
-            var category = field.GetCustomAttribute<CategoryAttribute>();
+            var (categoryName, categoryOrder) = field.GetCategoryAttribute();
             var key = GetFieldFullName(field);
 
             if (string.IsNullOrEmpty(key))
@@ -402,12 +404,12 @@ public class ApiDocumentationBuilder
                 // Record this property
                 documentedField = new DocumentedField
                 {
-                    Category = category?.Name,
+                    Category = categoryName,
                     DeclaringType = field.DeclaringType,
                     IsProtected = field.IsFamily,
                     Key = key,
                     Name = field.Name,
-                    Order = category?.Order ?? int.MaxValue,
+                    Order = categoryOrder ?? int.MaxValue,
                     Remarks = xmlDocs.Remarks?.Replace("\r\n", "").Trim(),
                     Summary = xmlDocs.Summary?.Replace("\r\n", "").Trim(),
                     Type = field.FieldType,
@@ -441,7 +443,7 @@ public class ApiDocumentationBuilder
         // Go through each property
         foreach (var eventItem in events)
         {
-            var category = eventItem.GetCustomAttribute<CategoryAttribute>();
+            var (categoryName, categoryOrder) = eventItem.GetCategoryAttribute();
             var blazorParameter = eventItem.GetCustomAttribute<ParameterAttribute>();
             var key = $"{eventItem.DeclaringType?.FullName}.{eventItem.Name}";
 
@@ -451,11 +453,11 @@ public class ApiDocumentationBuilder
                 // No.
                 documentedEvent = new DocumentedEvent
                 {
-                    Category = category?.Name,
+                    Category = categoryName,
                     DeclaringType = eventItem.DeclaringType,
                     Key = key,
                     Name = eventItem.Name,
-                    Order = category?.Order ?? int.MaxValue,
+                    Order = categoryOrder ?? int.MaxValue,
                     Type = eventItem.EventHandlerType,
                 };
                 Events.Add(key, documentedEvent);

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
@@ -432,7 +432,7 @@ public class ApiDocumentationWriter : StringWriter
         WriteLineIndented($"Name = \"{type.Name}\", ");
         WriteLineIndented($"NameFriendly = \"{type.Type.GetFriendlyName()}\", ");
         WriteBaseTypeIndented(type.BaseType);
-        WriteIsComponentIndented(type.Type.IsSubclassOf(typeof(MudComponentBase)));
+        WriteIsComponentIndented(type.Type.IsComponent());
         WriteSummaryIndented(type.Summary);
         WriteRemarksIndented(type.Remarks);
         WriteProperties(type);

--- a/src/MudBlazor.Docs.Compiler/MemberInfoExtensions.cs
+++ b/src/MudBlazor.Docs.Compiler/MemberInfoExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace MudBlazor.Docs.Compiler;
+
+#nullable enable
+/// <summary>
+/// Methods added to the <see cref="MemberInfo"/> class.
+/// </summary>
+public static class MemberInfoExtensions
+{
+    public static (string? name, int? order) GetCategoryAttribute(this MemberInfo property)
+    {
+        string? categoryName = null;
+        int? categoryOrder = null;
+
+        var propertyAttributes = property.GetCustomAttributes();
+        foreach (var attribute in propertyAttributes)
+        {
+            if (attribute.ToString() == "MudBlazor.CategoryAttribute")
+            {
+                var props = attribute.GetType().GetProperties();
+                foreach (var prop in props)
+                {
+                    switch (prop.Name)
+                    {
+                        case "Name":
+                            categoryName = prop.GetValue(attribute)?.ToString();
+                            break;
+                        case "Order":
+                            categoryOrder = (int?)prop.GetValue(attribute);
+                            break;
+                    }
+                }
+            }
+        }
+        return (categoryName, categoryOrder);
+    }
+}

--- a/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
+++ b/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
@@ -9,10 +9,9 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
     <PackageReference Include="LoxSmoke.DocXml" Version="3.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.Docs.Compiler/Program.cs
+++ b/src/MudBlazor.Docs.Compiler/Program.cs
@@ -4,12 +4,19 @@ namespace MudBlazor.Docs.Compiler;
 
 public class Program
 {
-    public static int Main()
+    public static int Main(string[] args)
     {
+        if (args.Length < 1)
+        {
+            Console.WriteLine("Please supply the path to MudBlazor.dll for documentation");
+            return 1;
+        }
+
+        var mudBlazorDllPath = args[0];
         var stopWatch = Stopwatch.StartNew();
         var success =
             new CodeSnippets().Execute()
-            && new ApiDocumentationBuilder().Execute()
+            && new ApiDocumentationBuilder().Execute(mudBlazorDllPath)
             && new ExamplesMarkup().Execute();
 
         Console.WriteLine(@$"Docs.Compiler completed in {stopWatch.ElapsedMilliseconds} milliseconds.");

--- a/src/MudBlazor.Docs.Compiler/TypeExtensions.cs
+++ b/src/MudBlazor.Docs.Compiler/TypeExtensions.cs
@@ -70,6 +70,21 @@ public static partial class TypeExtensions
         return name;
     }
 
+
+    public static bool IsComponent(this Type type)
+    {
+        Type? p = type;
+        if (p.Name == "MudComponentBase")
+            return false;
+        while (p is not null && p.Name != null)
+        {
+            if (p.Name == "MudComponentBase")
+                return true;
+            p = p.BaseType;
+        }
+        return false;
+    }
+
     /// <summary>
     /// The regular expression for <see cref="Nullable{T}"/>
     /// </summary>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -22,7 +22,7 @@
   <Target Name="GenerateDocs" AfterTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
     <!--Command-line for the code generator-->
     <Message Text="Generating Docs" Importance="high" />
-    <Exec Command="dotnet run --configuration Release --project &quot;$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj&quot;" />
+    <Exec Command="dotnet run --configuration Release --project &quot;$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj&quot; -- &quot;$(SolutionDir)MudBlazor/bin/$(Configuration)/net9.0//MudBlazor.dll&quot;" />
   </Target>
 
   <!--Add Content that is being generated as part of the build cycle-->


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
A fully reflective `MudBlazor.Docs.Compiler` that doesn't need to reference `MudBlazor`
This allows a cleaner build since we don't build `MudBlazor` in the separate process `MudBlazorDocs.Compiler`.
Instead we depend on the build of `MudBlazor` that `MudBlazor.Docs` initiated through its project reference.
This problem has caused us file contention and timing threading issues that have been very hard to fix since having 2 builds of `MudBlazor` happening concurrently means any tools used in the `MudBlazor` build need to be completely thread safe which we have workarounds for but IMO this is cleaner.

This would also allow us to put the generation logic into a MSBuildTask.
In addition I would like to use the same method to split the docs tests generation out and only have them run in `MudBlazor.UnitTests.Docs`.  In this project we could also reflect on the docs `MenuService` to build the docs tests rather than rely on hard coded copy.

See https://github.com/MudBlazor/MudBlazor/pull/10314#discussion_r1867037396

Note this PR is behind @jperson2000 PR for `<seealso/>` as its just for discussion for now

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Running the build

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
