### PR TITLE
MudTextField: Add note in docs about TextUpdateSuppression

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -166,6 +166,7 @@
                 <Description>
                     The following text fields are bound against the properties of a POCO (Plain old C-Sharp Object). Edit them to see the model change. Reset the model and see the textfields change.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with textfields.</MudAlert>
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: only on BSS, the parameter <CodeInline>TextUpdateSuppression</CodeInline> prevents the text from being updated via a bound value. Defaults to <CodeInline>true</CodeInline>. When <CodeInline>false</CodeInline>, the input's text can be updated programmatically while the input has focus.</MudAlert>
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">
@@ -260,22 +261,22 @@
 <DocsPageSection>
     <SectionHeader Title="Mask">
         <Description>
-            If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly 
-            while the user is typing.             
+            If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly
+            while the user is typing.
 
             <MudAlert  Class="my-3" Severity="Severity.Info">
-                Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples. 
+                Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples.
             </MudAlert>
 
-            In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of 
-            <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and 
+            In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of
+            <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and
             refusing invalid input. Note how the cursor automatically
             jumps over delimiters so you don't have to type them. You can also try pasting the test credit card number <i>4543474002249996</i>.
         </Description>
     </SectionHeader>
     <SectionContent FullWidth="true" Outlined="true" Code="@nameof(PatternMaskExample)" ShowCode="false">
         <PatternMaskExample />
-    </SectionContent>          
+    </SectionContent>
 </DocsPageSection>
 
 </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -166,7 +166,7 @@
                 <Description>
                     The following text fields are bound against the properties of a POCO (Plain old C-Sharp Object). Edit them to see the model change. Reset the model and see the textfields change.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with textfields.</MudAlert>
-                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: only on BSS, the parameter <CodeInline>TextUpdateSuppression</CodeInline> prevents the text from being updated via a bound value. Defaults to <CodeInline>true</CodeInline>. When <CodeInline>false</CodeInline>, the input's text can be updated programmatically while the input has focus.</MudAlert>
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: only on BSS, the parameter <CodeInline>TextUpdateSuppression</CodeInline> prevents the text from being updated via a bound value while the input is focused. Defaults to <CodeInline>true</CodeInline>.</MudAlert>
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">


### PR DESCRIPTION
## Description

From #10337.

The property `MudTextField.TextUpdateSuppression` [doc](https://mudblazor.com/api/MudTextField%601) is explicite about it, but the information is missing in the main `MudTextField` [documentation](https://mudblazor.com/components/MudTextField%601).

So I added a note in the doc to help about this special behavior.

## How Has This Been Tested?

I open in debug the doc to check the visual of the page.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
