### PR TITLE
Docs: Fixed Missing Link to API Documentation Page

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor
@@ -30,6 +30,32 @@ else
     </div>
 }
 
+@if (!IsApi && DocumentedType != null)
+{
+    <DocsPageSection api-link-section>
+        <SectionHeader Title="API" />
+        <div class="docs-page-apilinks">
+            <ul class="my-2">
+                <li>
+                    <MudLink Href="@(DocumentedType.ApiUrl)">
+                        <CodeInline>@($"<{Component}>")</CodeInline>
+                    </MudLink>
+                </li>
+                @if (Example != null && Example.ChildTypes != null)
+                {
+                    @foreach (var childType in Example.ChildTypes)
+                    {
+                        <li>
+                            <MudLink Href="@($"api/{childType.Name}")" Class="ms-1">
+                                - <CodeInline>@($"<{childType.Name.Replace("`1", "")}>")</CodeInline>
+                            </MudLink>
+                        </li>
+                    }
+                }
+            </ul>
+        </div>
+    </DocsPageSection>
+}
 @if (IsApi && Example != null)
 {
     <DocsPageSection api-link-section>


### PR DESCRIPTION
## Description

This update fixes an issue introduced by #10314 where the link to API documentation disappeared.  This issue was caused when an attempt to standardize links between example/API pages was rolled back, but code was deleted which should have been kept.

![image](https://github.com/user-attachments/assets/8bc6210c-0f8f-414c-af19-c4bcbabe616e)

Thanks to @mikes-gh for reporting this issue.

## How Has This Been Tested?

This was tested by clicking every Example page under the **Component** menu, then clicking the link back to the Example page for each component.

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
