### PR TITLE
Build: Better sasscompiler workaround

### DIFF
--- a/src/MudBlazor.Docs.Compiler/sasscompiler.json
+++ b/src/MudBlazor.Docs.Compiler/sasscompiler.json
@@ -1,5 +1,0 @@
-{
-    "SourceFolder": "Styles/MudBlazor.scss",
-    "Target": "../MudBlazor.Docs.Compiler/MudBlazor.min.css",
-    "Arguments": "--style=compressed --no-source-map --silence-deprecation=import --silence-deprecation=global-builtin"
-}

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -17,19 +17,12 @@
     <MudIllegalParameters>V7IgnoreCase</MudIllegalParameters>
     <MudDebugAnalyzer>false</MudDebugAnalyzer>
   </PropertyGroup>
-  
-  <!--Project path for code generator-->
-  <PropertyGroup>
-    <BinDocsCompiler>$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/net9.0/MudBlazor.Docs.Compiler.dll</BinDocsCompiler>
-    <ProjectDocsCompiler>dotnet run --configuration Release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj" -p:SassCompilerSassCompilerJson="$(SolutionDir)MudBlazor.Docs.Compiler/sasscompiler.json"</ProjectDocsCompiler>
-  </PropertyGroup>
 
   <!--Execute the code generator-->
-  <Target Name="CompileDocs" BeforeTargets="BeforeBuild">
+  <Target Name="CompileDocs" AfterTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
     <!--Command-line for the code generator-->
     <Message Text="Generating Docs and Tests" Importance="high" />
-    <Exec Command="dotnet &quot;$(BinDocsCompiler)&quot;" Condition="Exists('$(BinDocsCompiler)')" />
-    <Exec Command="$(ProjectDocsCompiler)" Condition="!Exists('$(BinDocsCompiler)')" />
+    <Exec Command="dotnet run --configuration Release --project '$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj'" />
   </Target>
 
   <!--This file contains any ExampleCode that is new and needs including in the build -->
@@ -44,7 +37,7 @@
 
   <!--Add Content that is being generated as part of the build cycle-->
   <!--We need to do this because the project is not yet aware of files that were generated after the build started-->
-  <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild" DependsOnTargets="CompileDocs;ReadFromFile">
+  <Target Name="IncludeGeneratedFiles" AfterTargets="ResolveProjectReferences" DependsOnTargets="CompileDocs;ReadFromFile">
     <ItemGroup>
       <!--Include without duplication-->
       <_NewCompiledSnippets Include="Models\Snippets.generated.cs" Exclude="@(Compile)" />

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -22,7 +22,7 @@
   <Target Name="CompileDocs" AfterTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
     <!--Command-line for the code generator-->
     <Message Text="Generating Docs and Tests" Importance="high" />
-    <Exec Command="dotnet run --configuration Release --project '$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj'" />
+    <Exec Command="dotnet run --configuration Release --project &quot;$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj&quot;" />
   </Target>
 
   <!--Add Content that is being generated as part of the build cycle-->

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -25,33 +25,20 @@
     <Exec Command="dotnet run --configuration Release --project '$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj'" />
   </Target>
 
-  <!--This file contains any ExampleCode that is new and needs including in the build -->
-  <Target Name="ReadFromFile" DependsOnTargets="CompileDocs">
-    <ItemGroup>
-      <NewFiles Include="NewFilesToBuild.txt" />
-    </ItemGroup>
-    <ReadLinesFromFile File="@(NewFiles)">
-      <Output TaskParameter="Lines" ItemName="NewExampleCodeToBuild" />
-    </ReadLinesFromFile>
-  </Target>
-
   <!--Add Content that is being generated as part of the build cycle-->
   <!--We need to do this because the project is not yet aware of files that were generated after the build started-->
-  <Target Name="IncludeGeneratedFiles" AfterTargets="ResolveProjectReferences" DependsOnTargets="CompileDocs;ReadFromFile">
+  <Target Name="IncludeGeneratedFiles" AfterTargets="ResolveProjectReferences" DependsOnTargets="CompileDocs">
     <ItemGroup>
-      <!--Include without duplication-->
-      <_NewCompiledSnippets Include="Models\Snippets.generated.cs" Exclude="@(Compile)" />
-      <_NewCompiledDocsStrings Include="Models\Generated\ApiDocumentation.generated.cs" Exclude="@(Compile)" />
-      <Compile Include="@(_NewCompiledSnippets)" />
-      <Compile Include="@(_NewCompiledDocsStrings)" />
-      <EmbeddedResource Include="@(NewExampleCodeToBuild)" Condition="@(NewExampleCodeToBuild-&gt;Count()) != 0" />
+      <!--Include without duplication (always at the end so that _GenerateCompileDependencyCache gives consistent results)-->
+      <!--This avoids full recompile after adding generated files-->
+      <!--See https://github.com/dotnet/msbuild/issues/6401-->
+      <Compile Remove="Models\Snippets.generated.cs" />
+      <Compile Include="Models\Snippets.generated.cs" />
+      <Compile Remove="Models\Generated\ApiDocumentation.generated.cs" />
+      <Compile Include="Models\Generated\ApiDocumentation.generated.cs" />
+      <EmbeddedResource Include="Pages\**\*.html" />
     </ItemGroup>
   </Target>
-
-  <!--Update ExampleCode-->
-  <ItemGroup>
-    <EmbeddedResource Include="Pages\**\*.html" />
-  </ItemGroup>
 
   <!--Is this a rebuild - Dont clean generated files as this breaks rebuild behaviour-->
   <Target Name="ShouldCleanGeneratedFiles" BeforeTargets="BeforeRebuild">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Inspired by https://github.com/MudBlazor/MudBlazor/pull/10404
Rather than giving `MudBlazor.Docs.Compiler` a dummy `sasscompiler.json` in order to redirect css output this PR simply runs `MudBlazor.Docs.Compiler` after `MudBlazor` has been built.
This is acheived by using the `ResolveProjectReferences` target.
This ensures `MudBlazor` is the first to run the sasscompiler and hence avoid being second and receiving no output.

This solution is preferable and also puts the `MudBlazor.Docs.Compiler` in a more logical order of events when building `MudBlazor.Docs`.

The output of `dotnet publish - c Release` (for `MudBlazor.Docs.WasmHost`)

Before
```
  Determining projects to restore...
  All projects are up-to-date for restore.
  Generating Docs and Tests
  MudBlazor.Examples.Data -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Examples.Data/bin/Release/net9.0/MudBlazor.Examples.Data.dll
  XML Documentation Coverage for MudBlazor:
  
  Types:      325 of 415 (78%) types
  Properties: 2236 of 2744 (81%) properties
  Methods:    439 of 748 (59%) methods
  Fields:     268 of 392 (68%) fields
  Events:     166 of 180 (92%) events/EventCallback
  
  Docs.Compiler updated 0 generated files
  Docs.Compiler generated 671 new files
  Docs.Compiler completed in 3131 milliseconds.
  MudBlazor.Analyzers -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Analyzers/bin/Release/netstandard2.0/MudBlazor.Analyzers.dll
  MudBlazor.SourceGenerator -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.SourceGenerator/bin/Release/netstandard2.0/MudBlazor.SourceGenerator.dll
  wwwroot/MudBlazor.min.js UpToDate
  MudBlazor -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor/bin/Release/net9.0/MudBlazor.dll
  MudBlazor.Docs -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs/bin/Release/net9.0/MudBlazor.Docs.dll
  MudBlazor.Docs.Wasm -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.Wasm/bin/Release/net9.0/MudBlazor.Docs.Wasm.dll
  MudBlazor.Docs.Wasm (Blazor output) -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.Wasm/bin/Release/net9.0/wwwroot
  MudBlazor.Docs.WasmHost -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.WasmHost/bin/Release/net9.0/MudBlazor.Docs.WasmHost.dll
  wwwroot/MudBlazor.min.js UpToDate
  Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  Optimizing assemblies for size. This process might take a while.
  MudBlazor.Docs.WasmHost -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.WasmHost/bin/Release/net9.0/publish/

```
After
```
   Determining projects to restore...
  All projects are up-to-date for restore.
  MudBlazor.Analyzers -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Analyzers/bin/Release/netstandard2.0/MudBlazor.Analyzers.dll
  MudBlazor.SourceGenerator -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.SourceGenerator/bin/Release/netstandard2.0/MudBlazor.SourceGenerator.dll
  wwwroot/MudBlazor.min.js UpToDate
  MudBlazor.Examples.Data -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Examples.Data/bin/Release/net9.0/MudBlazor.Examples.Data.dll
  MudBlazor -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor/bin/Release/net9.0/MudBlazor.dll
  Generating Docs and Tests
  XML Documentation Coverage for MudBlazor:
  
  Types:      325 of 415 (78%) types
  Properties: 2236 of 2744 (81%) properties
  Methods:    439 of 748 (59%) methods
  Fields:     268 of 392 (68%) fields
  Events:     166 of 180 (92%) events/EventCallback
  
  Docs.Compiler updated 0 generated files
  Docs.Compiler generated 671 new files
  Docs.Compiler completed in 2329 milliseconds.
  MudBlazor.Docs -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs/bin/Release/net9.0/MudBlazor.Docs.dll
  MudBlazor.Docs.Wasm -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.Wasm/bin/Release/net9.0/MudBlazor.Docs.Wasm.dll
  MudBlazor.Docs.Wasm (Blazor output) -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.Wasm/bin/Release/net9.0/wwwroot
  MudBlazor.Docs.WasmHost -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.WasmHost/bin/Release/net9.0/MudBlazor.Docs.WasmHost.dll
  wwwroot/MudBlazor.min.js UpToDate
  Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  Optimizing assemblies for size. This process might take a while.
  MudBlazor.Docs.WasmHost -> /Users/mike/Documents/Repos/MudBlazor/src/MudBlazor.Docs.WasmHost/bin/Release/net9.0/publish/
```
In the course of this PR I also finally understood why `MudBlazor.min.js` is appearing magically.
This is caused by a design-time build.
I will change the JSCompiler to only run for normal builds as I believe its more deterministic and in line with the sass compiler. edit DONE

I also noticed that this `MudBlazor.Docs` project file did a full rebuild for a second time after code generation.
This was due to https://github.com/dotnet/msbuild/issues/6401 so I fixed that.

In addition it was noted that EmbeddedResource was more complex than it needed to be so I also fixed that.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
`git clean . -Xdf` (for a clean repo)
`dotnet build`
and
`dotnet publish`

repeat check etc

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
