### PR TITLE
MudDataGrid: Add AggregateTemplate render fragment

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAggregationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridAggregationExample.razor
@@ -4,20 +4,20 @@
 
 <MudDataGrid Items="@_items" Groupable="true" Filterable="true">
     <Columns>
-        <PropertyColumn Property="x => x.Name">
-            <FooterTemplate>
-                @{ int index = 1, count = @context.Items.Count(); }
-                People: 
-                @foreach (var person in @context.Items)
-                {
-                    <MudAvatar Color="@((Color)index)" Variant="Variant.Outlined" Size="Size.Small" Class="mr-1">@person.Name.First()</MudAvatar>@person.Name.Substring(1)
-                    if (index < count)
-                    {
-                        @(", ")
-                    }
-                    index++;
+        <PropertyColumn Property="x => x.Name" AggregateDefinition="@(new AggregateDefinition<Model>())">
+            <AggregateTemplate>
+                @{
+                    var names = context.Select(x => x.Name).ToArray();
+                    var index = 1;
                 }
-            </FooterTemplate>
+                @foreach (var name in names)
+                {
+                    <MudAvatar Color="@((Color)index++)" Variant="Variant.Outlined" Size="Size.Small" Class="ml-2 mr-1">
+                        @name.First()
+                    </MudAvatar>
+                    @name.Substring(1)
+                }
+            </AggregateTemplate>
         </PropertyColumn>
         <PropertyColumn Property="x => x.Age" AggregateDefinition="_ageAggregation" />
         <PropertyColumn Property="x => x.Status"></PropertyColumn>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridAggregationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridAggregationTest.razor
@@ -1,23 +1,20 @@
 ﻿<MudDataGrid Items="@_items" Groupable="true" Filterable="true" GroupExpanded="true">
     <Columns>
-        <TemplateColumn>
-            <FooterTemplate>
-                @{ int index = 1, count = context.Items.Count(); }
-                People: 
-                @foreach (var person in context.Items)
-                {
-                    <MudAvatar Color="@((Color)index)" Variant="Variant.Outlined" Size="Size.Small" Class="mr-1">
-                        @person?.Name.First()
-                    </MudAvatar>
-                    @person?.Name.Substring(1)
-                    if (index < count)
-                    {
-                        @(", ")
-                    }
-                    index++;
+        <PropertyColumn Property="x => x.Name" AggregateDefinition="@(new AggregateDefinition<Model>())">
+            <AggregateTemplate>
+                @{
+                    var names = context.Select(x => x.Name).ToArray();
+                    var index = 1;
                 }
-            </FooterTemplate>
-        </TemplateColumn>
+                @foreach (var name in names)
+                {
+                    <MudAvatar Color="@((Color)index++)" Variant="Variant.Outlined" Size="Size.Small" Class="ml-2 mr-1">
+                        @name.First()
+                    </MudAvatar>
+                    @name.Substring(1)
+                }
+            </AggregateTemplate>
+        </PropertyColumn>
         <PropertyColumn Property="x => x.Age" AggregateDefinition="_ageAggregation" />
         <PropertyColumn Property="x => x.Status" Grouping="true" />
         <PropertyColumn Property="x => x.Salary" AggregateDefinition="_salaryAggregation" />

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -104,6 +104,12 @@ namespace MudBlazor
         public RenderFragment<GroupDefinition<T>> GroupTemplate { get; set; }
 
         /// <summary>
+        /// The template used to display this column's aggregate.
+        /// </summary>
+        [Parameter]
+        public RenderFragment<IEnumerable<T>> AggregateTemplate { get; set; }
+
+        /// <summary>
         /// The function which groups values in this column.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor
@@ -7,7 +7,9 @@
     <td class="@Classname" style="@Stylename" colspan="@Column.FooterColSpan" @attributes="@UserAttributes">
         @if (Column.AggregateDefinition != null)
         {
-            @Column.AggregateDefinition?.GetValue(Column.PropertyExpression, items)
+            @(Column.AggregateTemplate is null 
+                ? builder => builder.AddContent(0, Column.AggregateDefinition?.GetValue(Column.PropertyExpression, items))
+                : Column.AggregateTemplate(items));
         }
         else if (Column.FooterTemplate != null)
         {

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor
@@ -9,7 +9,7 @@
         {
             @(Column.AggregateTemplate is null 
                 ? builder => builder.AddContent(0, Column.AggregateDefinition?.GetValue(Column.PropertyExpression, items))
-                : Column.AggregateTemplate(items));
+                : Column.AggregateTemplate(items))
         }
         else if (Column.FooterTemplate != null)
         {


### PR DESCRIPTION
## Description
Currently when using column aggregates, users are restricted to outputting `String` values. This changes adds a new `AggregateTemplate` render fragment similar to the `GroupTemplate` render fragment that's available for grouping. Using the `AggregateTemplate` instead of the `FooterTemplate` as previously demonstrated in the Docs, gives the user access to the aggregated items instead of all page items. 

Resolves #10410 

## How Has This Been Tested?
Visually

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
