### PR TITLE
MudBaseDatePicker: Add CalendarFunc parameter for custom week calculations

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -4,7 +4,7 @@
 <MudDatePicker Label="Editable with Placeholder" Editable="true" @bind-Date="_date" Placeholder="Select Date" />
 <MudDatePicker Label="Only Calendar" @bind-Date="_date" ShowToolbar="false" />
 <MudDatePicker Label="Date Format" @bind-Date="_date" DateFormat="dd.MM.yyyy" />
-<MudDatePicker Label="Show week number" ShowWeekNumbers="true" @bind-Date="_date" />
+<MudDatePicker Label="Show week number" ShowWeekNumbers="true" @bind-Date="_date" ISOWeek="true" />
 <MudDatePicker Label="Display two months" DisplayMonths="2" TitleDateFormat="dddd, dd MMMM" @bind-Date="_date" />
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WeekNumberTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WeekNumberTest.razor
@@ -1,7 +1,11 @@
 ﻿<MudPopoverProvider />
-<MudDatePicker ISOWeek="IsoWeek" ShowWeekNumbers="true" />
+<MudDatePicker ISOWeek="IsoWeek" ShowWeekNumbers="true" FirstDayOfWeek="FirstDayOfWeek" />
 
 @code {
     [Parameter]
     public bool IsoWeek { get; set; }
+
+    [Parameter]
+    public DayOfWeek? FirstDayOfWeek { get; set; }
+    
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WeekNumberTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/WeekNumberTest.razor
@@ -1,0 +1,7 @@
+﻿<MudPopoverProvider />
+<MudDatePicker ISOWeek="IsoWeek" ShowWeekNumbers="true" />
+
+@code {
+    [Parameter]
+    public bool IsoWeek { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1569,43 +1569,69 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// .NET default week number implementation specifies January 2th 2016 as week number 53
+        /// .NET default week number implementation specifies 2025-12-30 as week number 53
         /// </summary>
         [Test]
-        [SetCulture("da-DK")]
         public void DatePicker_WeekNumberTest()
         {
-            var timeProvider = new FakeTimeProvider(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+            var timeProvider = new FakeTimeProvider(new DateTime(2025, 12, 30, 0, 0, 0, DateTimeKind.Utc));
 
             Context.Services.AddSingleton<TimeProvider>(timeProvider);
 
-            var comp = Context.RenderComponent<WeekNumberTest>();
+            var comp = Context.RenderComponent<WeekNumberTest>(
+                Parameter(nameof(WeekNumberTest.IsoWeek), false),
+                Parameter(nameof(WeekNumberTest.FirstDayOfWeek), DayOfWeek.Monday));
 
             // click to open menu
             comp.Find("input").Click();
 
-            // 2016-01-02 is week number 53 according to Calendar.GetWeekOfYear() which _is not_ ISO 8601 compliant
-            comp.FindAll(".mud-picker-calendar-week-text")[1].InnerHtml.Should().Contain("53");
+            // 2025-12-30 is week number 53 according to Calendar.GetWeekOfYear() which _is not_ ISO 8601 compliant
+            comp.FindAll(".mud-picker-calendar-week-text")[5].InnerHtml.Should().Contain("53");
         }
 
         /// <summary>
-        /// According to ISO-8601 January 2th 2016 is week number 1
+        /// IsoWeek parameter is ignored when FirstDayOfWeek is not monday
         /// </summary>
         [Test]
-        [SetCulture("da-DK")]
-        public void DatePicker_WeekNumberTestUseIsoWeek()
+        public void DatePicker_WeekNumberTestIgnoreUseIsoWeekWhenFirstWeekdaySunday()
         {
-            var timeProvider = new FakeTimeProvider(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+            var timeProvider = new FakeTimeProvider(new DateTime(2025, 12, 30, 0, 0, 0, DateTimeKind.Utc));
 
             Context.Services.AddSingleton<TimeProvider>(timeProvider);
 
-            var comp = Context.RenderComponent<WeekNumberTest>(Parameter(nameof(WeekNumberTest.IsoWeek), true));
+            var comp = Context.RenderComponent<WeekNumberTest>(
+                Parameter(nameof(WeekNumberTest.IsoWeek), true), // ignored when not monday
+                Parameter(nameof(WeekNumberTest.FirstDayOfWeek), DayOfWeek.Sunday)
+            );
 
             // click to open menu
             comp.Find("input").Click();
 
-            // 2016-01-02 is week number 1 according to ISOWeek.GetWeekOfYear() which _is_ ISO 8601 compliant
-            comp.FindAll(".mud-picker-calendar-week-text")[1].InnerHtml.Should().Contain("1");
+            // 2025-12-30 is week number 1 according to ISOWeek.GetWeekOfYear() which _is_ ISO 8601 compliant
+            // but we use en-US with first weekday set to sunday, so isoweek is ignored in this instance
+            comp.FindAll(".mud-picker-calendar-week-text")[5].InnerHtml.Should().Contain("53");
+        }
+
+        /// <summary>
+        /// According to ISO-8601 2025-12-30 is week number 1
+        /// </summary>
+        [Test]
+        public void DatePicker_WeekNumberTestUseIsoWeek()
+        {
+            var timeProvider = new FakeTimeProvider(new DateTime(2025, 12, 30, 0, 0, 0, DateTimeKind.Utc));
+
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+
+            var comp = Context.RenderComponent<WeekNumberTest>(
+                Parameter(nameof(WeekNumberTest.IsoWeek), true),
+                Parameter(nameof(WeekNumberTest.FirstDayOfWeek), DayOfWeek.Monday)
+                );
+
+            // click to open menu
+            comp.Find("input").Click();
+
+            // 2025-12-30 is week number 1 according to ISOWeek.GetWeekOfYear() which _is_ ISO 8601 compliant
+            comp.FindAll(".mud-picker-calendar-week-text")[5].InnerHtml.Should().Contain("1");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -32,6 +32,7 @@ namespace MudBlazor.UnitTests.Components
             picker.FirstDayOfWeek.Should().Be(null);
             picker.ClosingDelay.Should().Be(100);
             picker.DisplayMonths.Should().Be(1);
+            picker.ISOWeek.Should().BeFalse();
             picker.MaxMonthColumns.Should().Be(null);
             picker.StartMonth.Should().Be(null);
             picker.ShowWeekNumbers.Should().BeFalse();
@@ -1565,6 +1566,46 @@ namespace MudBlazor.UnitTests.Components
 
             picker.PickerReference.PickerMonth!.Value.Year.Should().Be(2025);
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
+        }
+
+        /// <summary>
+        /// .NET default week number implementation specifies January 2th 2016 as week number 53
+        /// </summary>
+        [Test]
+        [SetCulture("da-DK")]
+        public void DatePicker_WeekNumberTest()
+        {
+            var timeProvider = new FakeTimeProvider(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+
+            var comp = Context.RenderComponent<WeekNumberTest>();
+
+            // click to open menu
+            comp.Find("input").Click();
+
+            // 2016-01-02 is week number 53 according to Calendar.GetWeekOfYear() which _is not_ ISO 8601 compliant
+            comp.FindAll(".mud-picker-calendar-week-text")[1].InnerHtml.Should().Contain("53");
+        }
+
+        /// <summary>
+        /// According to ISO-8601 January 2th 2016 is week number 1
+        /// </summary>
+        [Test]
+        [SetCulture("da-DK")]
+        public void DatePicker_WeekNumberTestUseIsoWeek()
+        {
+            var timeProvider = new FakeTimeProvider(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+
+            var comp = Context.RenderComponent<WeekNumberTest>(Parameter(nameof(WeekNumberTest.IsoWeek), true));
+
+            // click to open menu
+            comp.Find("input").Click();
+
+            // 2016-01-02 is week number 1 according to ISOWeek.GetWeekOfYear() which _is_ ISO 8601 compliant
+            comp.FindAll(".mud-picker-calendar-week-text")[1].InnerHtml.Should().Contain("1");
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -171,6 +171,16 @@ namespace MudBlazor
         public int DisplayMonths { get; set; } = 1;
 
         /// <summary>
+        /// Use week numbering from ISOWeek.GetWeekOfYear
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c><br />
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerBehavior)]
+        public bool ISOWeek { get; set; }
+
+        /// <summary>
         /// The maximum number of months allowed in one row.
         /// </summary>
         /// <remarks>
@@ -390,6 +400,11 @@ namespace MudBlazor
 
             if (week_first.Month != month_first.Month && week_first.AddDays(6).Month != month_first.Month)
                 return "";
+
+            if (ISOWeek)
+            {
+                return System.Globalization.ISOWeek.GetWeekOfYear(week_first).ToString();
+            }
 
             return Culture.Calendar.GetWeekOfYear(week_first,
                 Culture.DateTimeFormat.CalendarWeekRule, FirstDayOfWeek ?? Culture.DateTimeFormat.FirstDayOfWeek).ToString();

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -171,7 +171,7 @@ namespace MudBlazor
         public int DisplayMonths { get; set; } = 1;
 
         /// <summary>
-        /// Use week numbering from ISOWeek.GetWeekOfYear
+        /// Use week numbering from ISOWeek.GetWeekOfYear. Requires first day of week to be monday.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c><br />
@@ -401,13 +401,18 @@ namespace MudBlazor
             if (week_first.Month != month_first.Month && week_first.AddDays(6).Month != month_first.Month)
                 return "";
 
-            if (ISOWeek)
+            // iso week requires first day to be monday
+            if (ISOWeek && GetFirstDayOfWeek() == DayOfWeek.Monday)
             {
-                return System.Globalization.ISOWeek.GetWeekOfYear(week_first).ToString();
+                var weeknumberIsoWeek = System.Globalization.ISOWeek.GetWeekOfYear(week_first).ToString();
+
+                return weeknumberIsoWeek;
             }
 
-            return Culture.Calendar.GetWeekOfYear(week_first,
+            var weeknumber = Culture.Calendar.GetWeekOfYear(week_first,
                 Culture.DateTimeFormat.CalendarWeekRule, FirstDayOfWeek ?? Culture.DateTimeFormat.FirstDayOfWeek).ToString();
+
+            return weeknumber;
         }
 
         protected virtual OpenTo? GetNextView()


### PR DESCRIPTION
Calendar.GetWeekOfYear() is not ISO 8601 compliant

https://learn.microsoft.com/en-us/archive/blogs/shawnste/iso-8601-week-of-year-format-in-microsoft-net

Example: 2024-12-31:
   Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday) -> 53
   ISOWeek.GetWeekOfYear(date) -> 1

## Description
Resolves #7360

Allows datepicker to usage ISOWeek.GetWeekOfYear and avoid Calendar.GetWeekOfYear which is not ISO 8601 compliant

## How Has This Been Tested?
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
