### PR TITLE
MudDataGrid: Fix Resizable property behavior 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
@@ -4,22 +4,22 @@
         <PropertyColumn Property="x => x.Column2" />
         <PropertyColumn Property="x => x.Column3" />
         <PropertyColumn Property="x => x.Column4" />
-        <PropertyColumn Property="x => x.Column5" />
+        <PropertyColumn Property="x => x.Column5" Resizable="true" />
         <PropertyColumn Property="x => x.Column6" />
         <PropertyColumn Property="x => x.Column7" />
         <PropertyColumn Property="x => x.Column8" />
         <PropertyColumn Property="x => x.Column9" />
-        <PropertyColumn Property="x => x.Column10" />
+        <PropertyColumn Property="x => x.Column10" Resizable="false" />
         <PropertyColumn Property="x => x.Column11" />
         <PropertyColumn Property="x => x.Column12" />
         <PropertyColumn Property="x => x.Column13" />
         <PropertyColumn Property="x => x.Column14" />
-        <PropertyColumn Property="x => x.Column15" />
+        <PropertyColumn Property="x => x.Column15" Resizable="true"/>
         <PropertyColumn Property="x => x.Column16" />
         <PropertyColumn Property="x => x.Column17" />
         <PropertyColumn Property="x => x.Column18" />
         <PropertyColumn Property="x => x.Column19" />
-        <PropertyColumn Property="x => x.Column20" />
+        <PropertyColumn Property="x => x.Column20" Resizable="false" />
         <PropertyColumn Property="x => x.Column21" />
         <PropertyColumn Property="x => x.Column22" />
         <PropertyColumn Property="x => x.Column23" />
@@ -31,6 +31,8 @@
 </MudDataGrid>
 
 @code {
+    public static string __description__ = "Columns 5 & 15 Resizable=true | Columns 10 & 20 Resizable=false | All others null (resizable by default)";
+
     private readonly IEnumerable<Model> _items = new List<Model>
     {
         new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",

--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -33,9 +33,9 @@ namespace MudBlazor
         }
 
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX, IList<Column<T>> columns,
-            ResizeMode columnResizeMode, bool rightToLeft)
+                                                    ResizeMode columnResizeMode, bool rightToLeft)
         {
-            if ((headerCell.Column?.Resizable ?? false) || columnResizeMode == ResizeMode.None ||
+            if (headerCell.Column?.Resizable is false || columnResizeMode == ResizeMode.None ||
                 _pointerMoveSubscriptionId != default || _pointerUpSubscriptionId != default)
                 return false;
 


### PR DESCRIPTION
## Description
Currently, setting Resizable to `true` on a column enables the drag indicators, however users are unable to resize the column.

Resolves #10430 

## How Has This Been Tested?
Visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
