### PR TITLE
MudDataGrid: Don't remove `Is Not Empty` filter definition on filter close

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2477,6 +2477,114 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridCloseFiltersTest()
+        {
+            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+            IElement FilterButton() => dataGrid.FindAll(".filter-button")[0];
+
+            // click on the filter button
+            FilterButton().Click();
+
+            // check the number of filters displayed in the filters panel is 1
+            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(1);
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            //set operator to CONTAINS
+            comp.FindAll(".mud-list .mud-list-item")[0].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to NOT CONTAINS
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[1].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to EQUALS
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[2].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to NOT EQUALS
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[3].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to STARTS WITH
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[4].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to ENDS WITH
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[5].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should be removed since no value is provided
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(0);
+
+            //set operator to IS EMPTY
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[6].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should maintain filter, no value is required
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+
+            //set operator to IS NOT EMPTY
+            FilterButton().Click();
+
+            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+
+            comp.FindAll(".mud-list .mud-list-item")[7].Click();
+            comp.Find(".mud-overlay").Click();
+            comp.Render();
+
+            //should maintain filter, no value is required
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+        }
+
+        [Test]
         public async Task DataGridFiltersTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1883,11 +1883,13 @@ namespace MudBlazor
 
         internal void CloseFilters()
         {
-            FilterDefinitions.RemoveAll(p =>
-                p.Value == null
-                && (p.Operator != FilterOperator.String.Empty || p.Operator != FilterOperator.Number.Empty || p.Operator != FilterOperator.DateTime.Empty)
-            );
+            FilterDefinitions.RemoveAll(p => p.Value == null && ValueRequired(p));
         }
+
+        private static bool ValueRequired(IFilterDefinition<T> filterDefinition) => filterDefinition.Operator is not
+            FilterOperator.String.Empty and not FilterOperator.String.NotEmpty and not
+            FilterOperator.Number.Empty and not FilterOperator.Number.NotEmpty and not
+            FilterOperator.DateTime.Empty and not FilterOperator.DateTime.NotEmpty;
 
         internal async Task HideAllColumnsAsync()
         {


### PR DESCRIPTION
## Description
Filtering for `Is Empty` and `Is Not Empty` does not require a filter value to be set along with the operator. As such, these filters should not be removed when value is null and the filter popup is closed.

Resolves #10435 

## How Has This Been Tested?
Visually and Unit Tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
