### PR TITLE
MudSelect: Change Visibility of "_currentIcon" to Internal

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -640,7 +640,7 @@ namespace MudBlazor
         /// <remarks>
         /// If an <c>AdornmentIcon</c> is set, it is returned.  Otherwise, either <see cref="OpenIcon"/> or <see cref="CloseIcon"/> is returned depending on whether the drop-down is open.
         /// </remarks>
-        public string? _currentIcon { get; set; }
+        internal string? _currentIcon { get; set; }
 
         /// <summary>
         /// Selects the item at the specified index.


### PR DESCRIPTION
## Description

This breaking change is proposed for V8, to change the visibility of `MudSelect._currentIcon` from `public` to `internal`.  This member appears to be for internal use by the component.

## How Has This Been Tested?

This was tested by running all unit tests to ensure they still complete properly after the change.  Also, the "Select All" MudSelect example was tested, which exercises the `_currentIcon` property (for the "Select All" icon).

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
