### PR TITLE
MudTable: Add CurrentPageChanged fot two-way binding (#3563 #6260)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterTwoWayBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterTwoWayBindingTest.razor
@@ -1,0 +1,18 @@
+﻿<MudTable Items="_items" @bind-CurrentPage="_currentPage">
+    <HeaderContent>
+        <MudTh>Item</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Item">@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager PageSizeOptions="[1]"/>
+    </PagerContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "CurrentPage parameter should be two-way bindable.";
+    
+    private readonly int[] _items = [1, 2, 3];
+    private int _currentPage;
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2504,16 +2504,16 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TableCurrentPageParameterTwoWayBindingTest>();
             var table = comp.FindComponent<MudTable<int>>().Instance;
-            
+
             // Assert starting page index is 0 (default).
             comp.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
             comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("1"));
-            
+
             // Assert modification via code correctly renders the corresponding page.
             await comp.InvokeAsync(() => table.CurrentPage = 1);
             comp.WaitForAssertion(() => table.CurrentPage.Should().Be(1));
             comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("2"));
-            
+
             // Assert user input correctly updates the CurrentPage parameter value by clicking the "Next Page" button in the pager.
             comp.FindAll(".mud-table-pagination-actions .mud-button-root")[2].Click();
             comp.WaitForAssertion(() => table.CurrentPage.Should().Be(2));

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2493,5 +2493,31 @@ namespace MudBlazor.UnitTests.Components
             selectAllCheckbox.Change(true);
             comp.Find("#counter").TextContent.Should().Be("1");
         }
+
+        /// <summary>
+        /// Issue #3563, Issue #6260
+        /// Tests two-way binding on the CurrentPage parameter.
+        /// The table should re-render with the newly provided value as the CurrentPage.
+        /// </summary>
+        [Test]
+        public async Task TestCurrentPageParameterTwoWayBinding()
+        {
+            var comp = Context.RenderComponent<TableCurrentPageParameterTwoWayBindingTest>();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            
+            // Assert starting page index is 0 (default).
+            comp.WaitForAssertion(() => table.CurrentPage.Should().Be(0));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("1"));
+            
+            // Assert modification via code correctly renders the corresponding page.
+            await comp.InvokeAsync(() => table.CurrentPage = 1);
+            comp.WaitForAssertion(() => table.CurrentPage.Should().Be(1));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("2"));
+            
+            // Assert user input correctly updates the CurrentPage parameter value by clicking the "Next Page" button in the pager.
+            comp.FindAll(".mud-table-pagination-actions .mud-button-root")[2].Click();
+            comp.WaitForAssertion(() => table.CurrentPage.Should().Be(2));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("3"));
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -238,7 +238,7 @@ namespace MudBlazor
                 }
             }
         }
-        
+
         /// <summary>
         /// Occurs when <see cref="CurrentPage"/> has changed.
         /// </summary>
@@ -678,7 +678,7 @@ namespace MudBlazor
             {
                 CurrentPageChanged.InvokeAsync(_currentPage);
             }
-            
+
             if (_isFirstRendered)
             {
                 InvokeServerLoadFunc();

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -231,12 +231,19 @@ namespace MudBlazor
 
                 _currentPage = value;
                 InvokeAsync(StateHasChanged);
+                CurrentPageChanged.InvokeAsync(_currentPage);
                 if (_isFirstRendered)
                 {
                     InvokeServerLoadFunc();
                 }
             }
         }
+        
+        /// <summary>
+        /// Occurs when <see cref="CurrentPage"/> has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<int> CurrentPageChanged { get; set; }
 
         /// <summary>
         /// Allows multiple rows to be selected with checkboxes.
@@ -661,10 +668,17 @@ namespace MudBlazor
                 return;
             }
 
+            var currentPageHasChanged = _currentPage != 0;
             _rowsPerPage = size;
             _currentPage = 0;
             StateHasChanged();
             RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
+
+            if (currentPageHasChanged)
+            {
+                CurrentPageChanged.InvokeAsync(_currentPage);
+            }
+            
             if (_isFirstRendered)
             {
                 InvokeServerLoadFunc();


### PR DESCRIPTION
## Description
Quite simply just adds an `EventHandler` matching the `CurrentPage` property of `MudTableBase` so it can be bound to. A personal use case for this is more easily retaining the last shown page of a table during navigation, but others have expressed desire for this too as seen in the issues below.

There is a similar property available in the `MudDataGrid` component, but I opted to keep the PR limited to just `MudTable` for now as I assumed this is more in line with your guidelines regarding "one topic". Likewise I opted not to refactor the `CurrentPage` setter because this is both my first PR here and I'm not sure what else that could affect right now without looking more into the workings of MudBlazor first. If this is desired then let me know and I will take a look at it, in which case we can mark this PR as draft instead.

Resolves #3563, resolves #6260

## How Has This Been Tested?
A new unit test has been added.

Aside from the unit test, I compared behavior to the current non-bindable handling of `CurrentPage`. There appears to be different behavior between tables with `ServerData` versus `Items` when setting negative values and values higher than the maximum available pages. I considered handling these cases in the setter of `CurrentPage`, but opted not to because that might be an unexpected behavioral change if I do so.

Currently negative page values simply show the `NoRecordsContent` with the pager adjusted to a negative page value. With serverside data it instead defaults the `TableState.Page` property to 0, causing the first page to load instead if this is blindly passed on as a query parameter.

When setting the page to `int.MaxValue` it defaults to the last available page and when using serverside data it once again loads back to the first page. How this is handled exactly on the serverside implementation depends on user implementation of passing the page as a query parameter so this shouldn't be an issue. In my test I simply passed the value on as is.

I wanted to share this finding just in case there are differing opinions about handling these edge cases. It currently doesn't break anything nor do my changes modify how it currently behaves. I just figured I should point this out.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.