### PR TITLE
MudMenu: Small optimization

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -349,8 +349,14 @@ namespace MudBlazor
                 await child.CloseMenuAsync();
             }
 
+            // Don't close if already closed.
+            if (!_openState.Value)
+            {
+                return;
+            }
+
             await _openState.SetValueAsync(false);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         /// <summary>
@@ -365,10 +371,8 @@ namespace MudBlazor
                 {
                     break;
                 }
-                else
-                {
-                    top = top.ParentMenu;
-                }
+
+                top = top.ParentMenu;
             }
 
             await top.CloseMenuAsync();
@@ -408,7 +412,7 @@ namespace MudBlazor
             }
 
             await _openState.SetValueAsync(true);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         /// <summary>
@@ -444,10 +448,12 @@ namespace MudBlazor
             _isPointerOver = true;
 
             // Cancel any existing mouse leave delay
+            // ReSharper disable MethodHasAsyncOverload
             _leaveCts?.Cancel();
 
             // Start a new hover delay
             _hoverCts?.Cancel();
+            // ReSharper restore MethodHasAsyncOverload
             _hoverCts = new();
 
             try
@@ -490,10 +496,12 @@ namespace MudBlazor
             }
 
             // Cancel any existing mouse hover delay
+            // ReSharper disable MethodHasAsyncOverload
             _hoverCts?.Cancel();
 
             // Start a new leave delay
             _leaveCts?.Cancel();
+            // ReSharper restore MethodHasAsyncOverload
             _leaveCts = new();
 
             try


### PR DESCRIPTION
## Description
1. A small optimization for `CloseMenuAsync`, similar to the one in `OpenMenuAsync`. Honestly, parameter state already contains this optimization, but we are saving a redundant `StateHasChanged` call. Maybe in future `SetValueAsync` should return `true` if updated the internal value and `false` if not.
2. It is always beneficial to wrap `StateHasChanged` inside `InvokeAsync`. Someone might call these methods, for example, from a timer or similar, which could result in an exception saying that `StateHasChanged` was not called from the UI thread. This wrap is always inexpensive, as it checks if it needs to queue the call to the UI thread.
3. Ignore resharper MethodHasAsyncOverload suggestion. Honestly, resharper should add this overload to exception as they have different behavior, the `CancelAsync` might cancel the task not immediately. Read https://github.com/dotnet/runtime/issues/23405 the difference.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant tests.
