### PR TITLE
MudTable: Allow greater control of the inline edit and icon sizes

### DIFF
--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -481,7 +481,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
-        public Size? InlineEditButtonSize { get; set; } = Size.Small;
+        public Size InlineEditButtonSize { get; set; } = Size.Small;
 
         /// <summary>
         /// Shows the cancel button during inline editing.

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -474,16 +474,6 @@ namespace MudBlazor
         public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
 
         /// <summary>
-        /// The size of the inline edit button.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Size.Small"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.Table.Editing)]
-        public Size InlineEditButtonSize { get; set; } = Size.Small;
-
-        /// <summary>
         /// Shows the cancel button during inline editing.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -479,11 +479,11 @@ namespace MudBlazor
         /// The size of the inline edit button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Size.Medium"/>.
+        /// Defaults to <see cref="Size.Small"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
-        public Size InlineEditButtonSize { get; set; } = Size.Medium;
+        public Size InlineEditButtonSize { get; set; } = Size.Small;
 
         /// <summary>
         /// Shows the cancel button during inline editing.

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,6 +1,4 @@
-﻿﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -483,7 +481,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
-        public Size InlineEditButtonSize { get; set; } = Size.Small;
+        public Size? InlineEditButtonSize { get; set; } = Size.Small;
 
         /// <summary>
         /// Shows the cancel button during inline editing.

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -476,6 +474,16 @@ namespace MudBlazor
         public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
 
         /// <summary>
+        /// The size of the inline edit button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Editing)]
+        public Size InlineEditButtonSize { get; set; } = Size.Medium;
+
+        /// <summary>
         /// Shows the cancel button during inline editing.
         /// </summary>
         /// <remarks>
@@ -524,6 +532,27 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Table.Editing)]
         public RenderFragment<EditButtonContext>? EditButtonContent { get; set; }
+
+        /// <summary>
+        /// The content of the Commit button which commits the inline edit.
+        /// </summary>
+        /// <remarks>
+        /// Requires <see cref="Editable"/> to be <c>true</c> and <see cref="ReadOnly"/> to be <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Editing)]
+        public RenderFragment? CommitButtonContext { get; set; }
+
+
+        /// <summary>
+        /// The content of the Cancel button which cancels the inline edit.
+        /// </summary>
+        /// <remarks>
+        /// Requires <see cref="Editable"/> to be <c>true</c> and <see cref="ReadOnly"/> to be <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Editing)]
+        public RenderFragment? CancelButtonContext { get; set; }
 
         /// <summary>
         /// Occurs before inline editing begins for a row.

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -15,7 +15,7 @@
                 }
                 else
                 {
-                    <MudIconButton Size="@Context?.Table?.InlineEditButtonSize" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item) ?? false" />
+                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item) ?? false" />
                 }
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true)
@@ -28,7 +28,7 @@
                     else
                     {
                         <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
-                            <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Context?.Table?.InlineEditButtonSize" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
+                            <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
                         </MudTooltip>
                     }
 
@@ -41,7 +41,7 @@
                         else
                         {
                             <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
-                                <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Context?.Table?.InlineEditButtonSize" />
+                                <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="Size.Small" />
                             </MudTooltip>
                         }
                     }
@@ -73,19 +73,19 @@
                 }
                 else
                 {
-                    <MudIconButton Size="@Context?.Table?.InlineEditButtonSize" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item)?? false" />
+                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item)?? false" />
                 }
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd() == true)
             {
                 <div style="display: flex;">
                     <MudTooltip Text="@Context.Table.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Context?.Table?.InlineEditButtonSize" Disabled="@(!(Context?.Table.Validator?.IsValid ?? false))" />
+                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="Size.Small" Disabled="@(!(Context?.Table.Validator?.IsValid ?? false))" />
                     </MudTooltip>
                     @if (Context.Table.CanCancelEdit)
                     {
                         <MudTooltip Text="@Context.Table.CancelEditTooltip">
-                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Context?.Table?.InlineEditButtonSize" />
+                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="Size.Small" />
                         </MudTooltip>
                     }
                 </div>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -20,32 +20,32 @@
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true)
             {
-        <div style="display: flex;">
-            @if (Context?.Table.CommitButtonContext != null)
-            {
-                @Context?.Table.CommitButtonContext;
-            }
-            else
-            {
-                <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
-                    <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
-                </MudTooltip>
-            }
+                <div style="display: flex;">
+                    @if (Context?.Table.CommitButtonContext != null)
+                    {
+                        @Context?.Table.CommitButtonContext;
+                    }
+                    else
+                    {
+                        <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
+                            <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
+                        </MudTooltip>
+                    }
 
-            @if (Context?.Table?.CanCancelEdit ?? false)
-            {
-                @if (Context?.Table.CancelButtonContext != null)
-                {
-                    @Context?.Table.CancelButtonContext;
-                }
-                else
-                {
-                    <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
-                        <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
-                    </MudTooltip>
-                }
-            }
-        </div>
+                    @if (Context?.Table?.CanCancelEdit ?? false)
+                    {
+                        @if (Context?.Table.CancelButtonContext != null)
+                        {
+                            @Context?.Table.CancelButtonContext;
+                        }
+                        else
+                        {
+                            <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
+                                <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                            </MudTooltip>
+                        }
+                    }
+                </div>
             }
         </MudTd>
     }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -15,7 +15,7 @@
                 }
                 else
                 {
-                    <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item) ?? false" />
+                    <MudIconButton Size="@Context?.Table?.InlineEditButtonSize" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item) ?? false" />
                 }
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true)
@@ -28,7 +28,7 @@
                     else
                     {
                         <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
-                            <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
+                            <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Context?.Table?.InlineEditButtonSize" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
                         </MudTooltip>
                     }
 
@@ -41,7 +41,7 @@
                         else
                         {
                             <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
-                                <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                                <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Context?.Table?.InlineEditButtonSize" />
                             </MudTooltip>
                         }
                     }
@@ -73,19 +73,19 @@
                 }
                 else
                 {
-                    <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item)?? false" />
+                    <MudIconButton Size="@Context?.Table?.InlineEditButtonSize" Icon="@Icons.Material.Outlined.Edit" Class="pa-0" OnClick="StartEditingItem" Disabled="Context?.EditButtonDisabled(Item)?? false" />
                 }
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd() == true)
             {
                 <div style="display: flex;">
                     <MudTooltip Text="@Context.Table.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table.Validator?.IsValid ?? false))" />
+                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Context?.Table?.InlineEditButtonSize" Disabled="@(!(Context?.Table.Validator?.IsValid ?? false))" />
                     </MudTooltip>
                     @if (Context.Table.CanCancelEdit)
                     {
                         <MudTooltip Text="@Context.Table.CancelEditTooltip">
-                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Context?.Table?.InlineEditButtonSize" />
                         </MudTooltip>
                     }
                 </div>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -20,17 +20,32 @@
             }
             else if (ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false) && Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true)
             {
-                <div style="display: flex;">
-                    <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
+        <div style="display: flex;">
+            @if (Context?.Table.CommitButtonContext != null)
+            {
+                @Context?.Table.CommitButtonContext;
+            }
+            else
+            {
+                <MudTooltip Text="@Context?.Table?.CommitEditTooltip">
+                    <MudIconButton Class="pa-0" Icon="@Context?.Table?.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!(Context?.Table?.Validator?.IsValid ?? false))" />
+                </MudTooltip>
+            }
+
+            @if (Context?.Table?.CanCancelEdit ?? false)
+            {
+                @if (Context?.Table.CancelButtonContext != null)
+                {
+                    @Context?.Table.CancelButtonContext;
+                }
+                else
+                {
+                    <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
+                        <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
                     </MudTooltip>
-                    @if (Context?.Table?.CanCancelEdit ?? false)
-                    {
-                        <MudTooltip Text="@Context?.Table?.CancelEditTooltip">
-                            <MudIconButton Class="pa-0 ml-4" Icon="@Context?.Table?.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
-                        </MudTooltip>
-                    }
-                </div>
+                }
+            }
+        </div>
             }
         </MudTd>
     }


### PR DESCRIPTION
## Description
Extended Commit Icon and Cancel Icon to be more similar to the Edit Icon where you are able to pass in your own render fragment. 

## How Has This Been Tested?
Currently only tested via running locally, as the change is to include a RenderFragment to either the EditButton or CommitButton if provided.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
