### PR TITLE
MudMenuItem: Decouple from MudListItem and Change Icon Layout

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarMenuExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/Examples/AppBarMenuExample.razor
@@ -19,14 +19,14 @@
 
             <!-- Settings -->
             <ActivatorContent>
-                <MudMenuItem Icon=@Icons.Material.TwoTone.Settings IconColor=Color.Primary IconSize=Size.Medium AutoClose=@false>
+                <MudMenuItem Icon=@Icons.Material.TwoTone.Settings IconColor=Color.Primary AutoClose=@false>
                     <MudText Class="ml-n5" Color=Color.Default>Settings</MudText>
                 </MudMenuItem>
             </ActivatorContent>
 
             <!-- Theme -->
             <ChildContent>
-                <MudMenuItem Icon=@Icons.Material.TwoTone.DarkMode IconColor=Color.Secondary IconSize=Size.Medium>
+                <MudMenuItem Icon=@Icons.Material.TwoTone.DarkMode IconColor=Color.Secondary>
                     <MudText Class="ml-n5" Color=Color.Default>Dark Theme</MudText>
                 </MudMenuItem>
             </ChildContent>
@@ -35,11 +35,11 @@
         <MudDivider />
 
         <!-- Sign In -->
-        <MudMenuItem Href="/" ForceLoad Icon=@Icons.Material.TwoTone.Login IconColor=Color.Primary IconSize=Size.Medium>
+        <MudMenuItem Href="/" ForceLoad Icon=@Icons.Material.TwoTone.Login IconColor=Color.Primary>
             <MudText Class="ml-n5" Color=Color.Default>Sign In</MudText>
         </MudMenuItem>
         <!-- Sign Out -->
-        <MudMenuItem Href="/" ForceLoad Icon=@Icons.Material.TwoTone.Logout IconColor=Color.Primary IconSize=Size.Medium>
+        <MudMenuItem Href="/" ForceLoad Icon=@Icons.Material.TwoTone.Logout IconColor=Color.Primary>
             <MudText Class="ml-n5" Color=Color.Default>Sign Out</MudText>
         </MudMenuItem>
 

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuItemCustomizationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuItemCustomizationExample.razor
@@ -1,7 +1,13 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudMenu Label="Click to see icons">
-    <MudMenuItem IconSize="Size.Small" IconColor="Color.Primary" Disabled="true" Icon="@Icons.Material.Filled.Chair">Chair</MudMenuItem>
-    <MudMenuItem Icon="@Icons.Material.Filled.DoorFront">Door</MudMenuItem>
-    <MudMenuItem IconSize="Size.Large" IconColor="Color.Secondary" Icon="@Icons.Material.Filled.Window">Window</MudMenuItem>
+<MudMenu Label="Click to see normal icons">
+    <MudMenuItem Icon="@Icons.Material.Filled.Chair" Label="Chair" />
+    <MudMenuItem Icon="@Icons.Material.Filled.DoorFront" IconColor="Color.Secondary" Label="Door" />
+    <MudMenuItem Icon="@Icons.Material.Filled.Window" IconColor="Color.Tertiary" Label="Window" />
+</MudMenu>
+
+<MudMenu Label="Click to see dense icons" Dense>
+    <MudMenuItem Icon="@Icons.Material.Filled.Chair" Label="Chair" />
+    <MudMenuItem Icon="@Icons.Material.Filled.DoorFront" IconColor="Color.Secondary" Label="Door" />
+    <MudMenuItem Icon="@Icons.Material.Filled.Window" IconColor="Color.Tertiary" Label="Window" />
 </MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuItemCustomizationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuItemCustomizationExample.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudMenu Label="Click to see normal icons">
+<MudMenu Label="Click to see normal icons" FullWidth="false">
     <MudMenuItem Icon="@Icons.Material.Filled.Chair" Label="Chair" />
     <MudMenuItem Icon="@Icons.Material.Filled.DoorFront" IconColor="Color.Secondary" Label="Door" />
     <MudMenuItem Icon="@Icons.Material.Filled.Window" IconColor="Color.Tertiary" Label="Window" />
 </MudMenu>
 
-<MudMenu Label="Click to see dense icons" Dense>
+<MudMenu Label="Click to see dense icons" FullWidth="false" Dense>
     <MudMenuItem Icon="@Icons.Material.Filled.Chair" Label="Chair" />
     <MudMenuItem Icon="@Icons.Material.Filled.DoorFront" IconColor="Color.Secondary" Label="Door" />
     <MudMenuItem Icon="@Icons.Material.Filled.Window" IconColor="Color.Tertiary" Label="Window" />

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -40,8 +40,7 @@
                 <DocsPageSection>
                     <SectionHeader Title="Menu Items">
                         <Description>
-                            Use the <CodeInline>Icon</CodeInline> property on a menu item to show an icon.
-                            The <CodeInline>IconSize</CodeInline> and <CodeInline>IconColor</CodeInline> can also be set.
+                            Use the <CodeInline>Icon</CodeInline> property on a menu item to show an icon and <CodeInline>IconColor</CodeInline> to change its color.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(MenuItemCustomizationExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemIconTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuItemIconTest.razor
@@ -1,7 +1,12 @@
 <MudPopoverProvider />
 
-<MudMenu Label="Menu with Icons">
-    <MudMenuItem IconSize="Size.Small" IconColor="Color.Primary" Icon="@Icons.Material.Filled.Chair">Chair</MudMenuItem>
-    <MudMenuItem Icon="@Icons.Material.Filled.DoorFront">Door</MudMenuItem>
-    <MudMenuItem IconSize="Size.Large" IconColor="Color.Secondary" Icon="@Icons.Material.Filled.Window">Window</MudMenuItem>
+<MudMenu Label="Click to see icons" Dense="Dense">
+    <MudMenuItem Icon="@Icons.Material.Filled.Chair" Label="Chair" />
+    <MudMenuItem Icon="@Icons.Material.Filled.DoorFront" IconColor="Color.Secondary" Label="Door" />
+    <MudMenuItem Icon="@Icons.Material.Filled.Window" IconColor="Color.Tertiary" Label="Window" />
 </MudMenu>
+
+@code {
+    [Parameter]
+    public bool Dense { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3073,7 +3073,7 @@ namespace MudBlazor.UnitTests.Components
                 var columnHamburger = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
                 columnHamburger[2].Click();
 
-                var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+                var listItems = popoverProvider.FindComponents<MudMenuItem>();
                 listItems.Count.Should().Be(2);
                 var clickablePopover = listItems[1].Find(".mud-menu-item");
                 clickablePopover.Click();
@@ -3088,7 +3088,7 @@ namespace MudBlazor.UnitTests.Components
                 columnsButton.Click();
 
                 popover.Instance.Open.Should().BeTrue("Should be open once clicked");
-                var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+                var listItems = popoverProvider.FindComponents<MudMenuItem>();
                 listItems.Count.Should().Be(1);
                 var clickablePopover = listItems[0].Find(".mud-menu-item");
                 clickablePopover.Click();
@@ -3136,7 +3136,7 @@ namespace MudBlazor.UnitTests.Components
             columnsButton.Click();
 
             popover.Instance.Open.Should().BeTrue("Should be open once clicked");
-            var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(1);
             var clickablePopover = listItems[0].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -3817,7 +3817,7 @@ namespace MudBlazor.UnitTests.Components
             var amountHeader = dataGrid.FindAll("th .mud-menu button")[2];
             amountHeader.Click();
 
-            var filterAmount = comp.FindAll(".mud-list-item")[1];
+            var filterAmount = comp.FindAll(".mud-menu-item")[1];
             filterAmount.Click();
 
             var filterField = comp.Find(".filters-panel .filter-field .mud-select-input");
@@ -3835,7 +3835,7 @@ namespace MudBlazor.UnitTests.Components
             // total with es-ES culture (decimals separated by comma)
             var totalHeader = dataGrid.FindAll("th .mud-menu button")[3];
             totalHeader.Click();
-            var filterTotal = comp.FindAll(".mud-list-item")[1];
+            var filterTotal = comp.FindAll(".mud-menu-item")[1];
             filterTotal.Click();
 
             var filterTotalField = comp.Find(".filters-panel .filter-field .mud-select-input");
@@ -4441,7 +4441,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Find all MudListItem components within the popoverProvider.
             // These list items represent the individual options within the grouping popover.
-            var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
 
             // Assert that there are exactly 2 list items (options) available in the popover.
             listItems.Count.Should().Be(2);
@@ -4520,7 +4520,7 @@ namespace MudBlazor.UnitTests.Components
             //click name grouping in grid
             var headerOption = comp.Find("th.name .mud-menu button");
             headerOption.Click();
-            var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(4);
             var clickablePopover = listItems[3].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4542,7 +4542,7 @@ namespace MudBlazor.UnitTests.Components
             //click name ungrouping in grid
             headerOption = comp.Find("th.name .mud-menu button");
             headerOption.Click();
-            listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(4);
             clickablePopover = listItems[3].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4618,7 +4618,7 @@ namespace MudBlazor.UnitTests.Components
             //click age grouping in grid
             var headerOption = comp.Find("th.age .mud-menu button");
             headerOption.Click();
-            var listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(2);
             var clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4630,7 +4630,7 @@ namespace MudBlazor.UnitTests.Components
             //click gender grouping in grid
             headerOption = comp.Find("th.gender .mud-menu button");
             headerOption.Click();
-            listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(2);
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4642,7 +4642,7 @@ namespace MudBlazor.UnitTests.Components
             //click Name grouping in grid
             headerOption = comp.Find("th.name .mud-menu button");
             headerOption.Click();
-            listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(2);
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4654,7 +4654,7 @@ namespace MudBlazor.UnitTests.Components
             //click profession grouping in grid
             headerOption = comp.Find("th.profession .mud-menu button");
             headerOption.Click();
-            listItems = popoverProvider.FindComponents<MudListItem<object>>();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
             listItems.Count.Should().Be(2);
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
@@ -4774,8 +4774,8 @@ namespace MudBlazor.UnitTests.Components
             columnMenu.Click();
 
             // Click on the menu item 'Hide'
-            comp.WaitForAssertion(() => comp.FindAll(".mud-list-item").ElementAt(1));
-            var hideMenuItem = comp.FindAll(".mud-list-item").ElementAt(1);
+            comp.WaitForAssertion(() => comp.FindAll(".mud-menu-item").ElementAt(1));
+            var hideMenuItem = comp.FindAll(".mud-menu-item").ElementAt(1);
             hideMenuItem.Click();
 
             // Mock mudElementRef.getBoundingClientRect for DataGrid and visible columns

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3075,7 +3075,7 @@ namespace MudBlazor.UnitTests.Components
 
                 var listItems = popoverProvider.FindComponents<MudListItem<object>>();
                 listItems.Count.Should().Be(2);
-                var clickablePopover = listItems[1].Find(".mud-list-item");
+                var clickablePopover = listItems[1].Find(".mud-menu-item");
                 clickablePopover.Click();
 
                 //dataGrid.Instance._columns[0].Hide();
@@ -3090,7 +3090,7 @@ namespace MudBlazor.UnitTests.Components
                 popover.Instance.Open.Should().BeTrue("Should be open once clicked");
                 var listItems = popoverProvider.FindComponents<MudListItem<object>>();
                 listItems.Count.Should().Be(1);
-                var clickablePopover = listItems[0].Find(".mud-list-item");
+                var clickablePopover = listItems[0].Find(".mud-menu-item");
                 clickablePopover.Click();
 
                 var switches = comp.FindComponents<MudSwitch<bool>>();
@@ -3138,7 +3138,7 @@ namespace MudBlazor.UnitTests.Components
             popover.Instance.Open.Should().BeTrue("Should be open once clicked");
             var listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(1);
-            var clickablePopover = listItems[0].Find(".mud-list-item");
+            var clickablePopover = listItems[0].Find(".mud-menu-item");
             clickablePopover.Click();
 
             // at this point, the column picker should be open
@@ -3226,7 +3226,7 @@ namespace MudBlazor.UnitTests.Components
         //    popover.Instance.Open.Should().BeTrue("Should be open once clicked");
         //    var listItems = popoverProvider.FindComponents<MudListItem>();
         //    listItems.Count.Should().Be(1);
-        //    var clickablePopover = listItems[0].Find(".mud-list-item");
+        //    var clickablePopover = listItems[0].Find(".mud-menu-item");
         //    clickablePopover.Click();
 
         //    // at this point, the column picker should be open
@@ -4447,7 +4447,7 @@ namespace MudBlazor.UnitTests.Components
             listItems.Count.Should().Be(2);
 
             // From the list items found, select the second one which is expected to be the clickable option for grouping.
-            var clickablePopover = listItems[1].Find(".mud-list-item");
+            var clickablePopover = listItems[1].Find(".mud-menu-item");
 
             // click on the grouping option to apply grouping to the data grid.
             clickablePopover.Click();
@@ -4522,7 +4522,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             var listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(4);
-            var clickablePopover = listItems[3].Find(".mud-list-item");
+            var clickablePopover = listItems[3].Find(".mud-menu-item");
             clickablePopover.Click();
             var cells = dataGrid.FindAll("td");
 
@@ -4544,7 +4544,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(4);
-            clickablePopover = listItems[3].Find(".mud-list-item");
+            clickablePopover = listItems[3].Find(".mud-menu-item");
             clickablePopover.Click();
             cells = dataGrid.FindAll("td");
             // We do not need check all 10 rows as it's clear that it's ungrouped if first row pass
@@ -4620,7 +4620,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             var listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(2);
-            var clickablePopover = listItems[1].Find(".mud-list-item");
+            var clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
             comp.Instance.IsAgeGrouped.Should().Be(true);
             comp.Instance.IsGenderGrouped.Should().Be(false);
@@ -4632,7 +4632,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(2);
-            clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
             comp.Instance.IsGenderGrouped.Should().Be(true);
             comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");
@@ -4644,7 +4644,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(2);
-            clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
             comp.Instance.IsGenderGrouped.Should().Be(false);
             comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");
@@ -4656,7 +4656,7 @@ namespace MudBlazor.UnitTests.Components
             headerOption.Click();
             listItems = popoverProvider.FindComponents<MudListItem<object>>();
             listItems.Count.Should().Be(2);
-            clickablePopover = listItems[1].Find(".mud-list-item");
+            clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
             comp.Instance.IsGenderGrouped.Should().Be(false);
             comp.Instance.IsAgeGrouped.Should().Be(true, because: "Age is not bound");

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -314,7 +314,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
 
-            comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-medium").Count.Should().Be(3);
+            if (dense)
+            {
+                comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-small").Count.Should().Be(3);
+            }
+            else
+            {
+                comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-medium").Count.Should().Be(3);
+            }
         }
 
         [Test]
@@ -330,9 +337,9 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-menu-item").Count.Should().Be(3);
             var items = comp.FindAll("div.mud-menu-item");
 
-            items[0].ClassList.Should().NotContainMatch("^mud-[a-z]+-text$");
-            items[1].ClassList.Should().Contain("mud-primary-text");
-            items[2].ClassList.Should().Contain("mud-secondary-text");
+            items[0].QuerySelector("svg").ClassList.Should().NotContainMatch("^mud-[a-z]+-text$");
+            items[1].QuerySelector("svg").ClassList.Should().Contain("mud-primary-text");
+            items[2].QuerySelector("svg").ClassList.Should().Contain("mud-secondary-text");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -305,40 +305,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void MenuItem_Should_SupportIcons()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void MenuItem_Should_RenderIcons(bool dense)
         {
             var comp = Context.RenderComponent<MenuItemIconTest>();
-            comp.FindAll("button.mud-button-root")[0].Click();
-            var listItems = comp.FindAll("div.mud-menu-item");
-            listItems.Count.Should().Be(3);
-            listItems[0].QuerySelector("div.mud-menu-item-icon").Should().NotBeNull();
-            listItems[0].QuerySelector("svg.mud-svg-icon").Should().NotBeNull();
+
+            comp.Find(".mud-menu-button-activator").Click();
+            comp.WaitForElement("div.mud-popover-open");
+
+            comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-medium").Count.Should().Be(3);
         }
 
         [Test]
-        public void MenuItem_IconAppearance_Test()
+        public void MenuItem_Should_RenderIconColors()
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>();
-            comp.FindAll("button.mud-button-root")[0].Click();
+            var comp = Context.RenderComponent<MenuItemIconTest>(parameters => parameters
+                .Add(p => p.Dense, false)
+            );
+
+            comp.Find(".mud-menu-button-activator").Click();
+            comp.WaitForElement("div.mud-popover-open");
+
             comp.FindAll("div.mud-menu-item").Count.Should().Be(3);
-            var listItems = comp.FindAll("div.mud-menu-item");
+            var items = comp.FindAll("div.mud-menu-item");
 
-            // 1st MenuItem
-            var svg = listItems[0].QuerySelector("svg");
-            svg.ClassList.Should().Contain("mud-icon-size-small");
-            svg.ClassList.Should().Contain("mud-primary-text");
-
-            // 2nd MenuItem
-            svg = listItems[1].QuerySelector("svg");
-            svg.ClassList.Should().Contain("mud-icon-size-medium");
-            // Ensure no color classes are present, like "mud-primary-text", "mud-error-text", etc.
-            foreach (var className in svg.ClassList)
-                Regex.IsMatch(className, "^mud-[a-z]+-text$", RegexOptions.IgnoreCase).Should().BeFalse();
-
-            // 3rd MenuItem
-            svg = listItems[2].QuerySelector("svg");
-            svg.ClassList.Should().Contain("mud-icon-size-large");
-            svg.ClassList.Should().Contain("mud-secondary-text");
+            items[0].ClassList.Should().NotContainMatch("^mud-[a-z]+-text$");
+            items[1].ClassList.Should().Contain("mud-primary-text");
+            items[2].ClassList.Should().Contain("mud-secondary-text");
         }
 
         /// <summary>
@@ -547,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Label()
+        public void ShouldRenderLabelOrChildContent()
         {
             var comp = Context.RenderComponent<MenuItemLabelTest>();
 

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -309,7 +309,9 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void MenuItem_Should_RenderIcons(bool dense)
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>();
+            var comp = Context.RenderComponent<MenuItemIconTest>(parameters => parameters
+                .Add(p => p.Dense, dense)
+            );
 
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
@@ -327,9 +329,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MenuItem_Should_RenderIconColors()
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>(parameters => parameters
-                .Add(p => p.Dense, false)
-            );
+            var comp = Context.RenderComponent<MenuItemIconTest>();
 
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
@@ -337,9 +337,9 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-menu-item").Count.Should().Be(3);
             var items = comp.FindAll("div.mud-menu-item");
 
-            items[0].QuerySelector("svg").ClassList.Should().NotContainMatch("^mud-[a-z]+-text$");
-            items[1].QuerySelector("svg").ClassList.Should().Contain("mud-primary-text");
-            items[2].QuerySelector("svg").ClassList.Should().Contain("mud-secondary-text");
+            items[0].QuerySelector("svg").ClassList.Should().NotContainMatch("mud-*-text");
+            items[1].QuerySelector("svg").ClassList.Should().Contain("mud-secondary-text");
+            items[2].QuerySelector("svg").ClassList.Should().Contain("mud-tertiary-text");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -25,20 +25,20 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.FindComponent<MudMenu>();
 
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
 
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
 
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
 
             //Disabled item's click ot touch should not close popover
@@ -49,7 +49,7 @@ namespace MudBlazor.UnitTests.Components
             menuItems[2].Instance.Disabled = true;
 #pragma warning restore BL0005 // Component parameter should not be set outside of its component.
 
-            comp.FindAll("a.mud-list-item")[1].Click();
+            comp.FindAll("a.mud-menu-item")[1].Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
             await comp.InvokeAsync(() => menu.Instance.ToggleMenuAsync(new TouchEventArgs()));
@@ -63,9 +63,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -74,9 +74,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item")[1].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item")[1].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -85,9 +85,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item.test-class").Count.Should().Be(1);
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item.test-class").Count.Should().Be(1);
         }
 
         [Test]
@@ -251,54 +251,54 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MenuTestVariants>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[0].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Standart button menu -- right click
             comp.FindAll("button.mud-button-root")[1].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[1].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Icon button menu -- left click
             comp.FindAll("button.mud-button-root")[2].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[2].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Icon button menu -- right click
             comp.FindAll("button.mud-button-root")[3].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[3].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Activator content menu -- left click
             comp.FindAll("button.mud-button-root")[4].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[4].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Activator content menu -- right click
             comp.FindAll("button.mud-button-root")[5].Click(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[0].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             comp.FindAll("button.mud-button-root")[5].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
@@ -309,9 +309,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuItemIconTest>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            var listItems = comp.FindAll("div.mud-list-item");
+            var listItems = comp.FindAll("div.mud-menu-item");
             listItems.Count.Should().Be(3);
-            listItems[0].QuerySelector("div.mud-list-item-icon").Should().NotBeNull();
+            listItems[0].QuerySelector("div.mud-menu-item-icon").Should().NotBeNull();
             listItems[0].QuerySelector("svg.mud-svg-icon").Should().NotBeNull();
         }
 
@@ -320,8 +320,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuItemIconTest>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(3);
-            var listItems = comp.FindAll("div.mud-list-item");
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(3);
+            var listItems = comp.FindAll("div.mud-menu-item");
 
             // 1st MenuItem
             var svg = listItems[0].QuerySelector("svg");
@@ -350,8 +350,8 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MenuErrorContenCaughtException>();
             await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs());
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            await comp.FindAll("div.mud-list-item")[0].ClickAsync(new MouseEventArgs());
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            await comp.FindAll("div.mud-menu-item")[0].ClickAsync(new MouseEventArgs());
             var mudAlert = comp.FindComponent<MudAlert>();
             var text = mudAlert.Find("div.mud-alert-message");
             text.InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
@@ -362,9 +362,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(2);
-            comp.FindAll("div.mud-list-item")[1].Click();
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
+            comp.FindAll("div.mud-menu-item")[1].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
         }
 
@@ -392,13 +392,13 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MenuHrefTest>();
             comp.FindAll("button.mud-button-root")[0].Click();
-            comp.FindAll("div.mud-list-item").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item").Count.Should().Be(3);
-            comp.FindAll("a.mud-list-item")[0].Attributes["href"].TextContent.Should().Be("https://www.test.com/1");
-            comp.FindAll("a.mud-list-item")[1].Attributes["href"].TextContent.Should().Be("https://www.test.com/2");
-            comp.FindAll("a.mud-list-item")[2].Click(); // disabled
+            comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
+            comp.FindAll("a.mud-menu-item").Count.Should().Be(3);
+            comp.FindAll("a.mud-menu-item")[0].Attributes["href"].TextContent.Should().Be("https://www.test.com/1");
+            comp.FindAll("a.mud-menu-item")[1].Attributes["href"].TextContent.Should().Be("https://www.test.com/2");
+            comp.FindAll("a.mud-menu-item")[2].Click(); // disabled
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
-            comp.FindAll("a.mud-list-item")[1].Click(); // enabled
+            comp.FindAll("a.mud-menu-item")[1].Click(); // enabled
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -57,7 +57,6 @@ namespace MudBlazor
         /// </summary>
         protected string ListClassname =>
             new CssBuilder("mud-menu-list")
-                .AddClass("mud-menu-list-dense", Dense)
                 .AddClass(ListClass)
                 .Build();
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -57,7 +57,7 @@ namespace MudBlazor
         /// </summary>
         protected string ListClassname =>
             new CssBuilder("mud-menu-list")
-                .AddClass("mud-menu-dense", Dense)
+                .AddClass("mud-menu-list-dense", Dense)
                 .AddClass(ListClass)
                 .Build();
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -57,6 +57,7 @@ namespace MudBlazor
         /// </summary>
         protected string ListClassname =>
             new CssBuilder("mud-menu-list")
+                .AddClass("mud-menu-dense", Dense)
                 .AddClass(ListClass)
                 .Build();
 

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -1,23 +1,34 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<MudListItem T="object"
-             @attributes="UserAttributes"
-             @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandlerAsync)"
-             Href="@Href"
-             Target="@Target"
-             ForceLoad="@ForceLoad"
-             Disabled="@Disabled"
-             Class="@Classname"
-             Style="@Style"
-             Icon="@Icon"
-             IconColor="@IconColor">
-    @if(ChildContent is null)
+<MudElement HtmlTag="@GetHtmlTag()"
+            Class="@Classname"
+            Style="@Style"
+            tabindex="0"
+            href="@Href"
+            target="@Target"
+            PreventDefault="GetDisabled()"
+            ClickPropagation="false"
+            @attributes="UserAttributes"
+            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandlerAsync)">
+
+    @if (!string.IsNullOrWhiteSpace(Icon))
     {
-        @Label
+        <MudIcon Class="mud-menu-item-icon"
+                 Icon="@Icon"
+                 Color="IconColor"
+                 Disabled="GetDisabled()" />
+    }
+
+    @if (ChildContent is null)
+    {
+        <MudText Class="mud-menu-item-text"
+                 Typo="GetTypo()">
+            @Label
+        </MudText>
     }
     else
     {
         @ChildContent
     }
-</MudListItem>
+</MudElement>

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -10,7 +10,7 @@
             PreventDefault="GetDisabled()"
             ClickPropagation="false"
             @attributes="UserAttributes"
-            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandlerAsync)">
+            @onclick="OnClickHandlerAsync">
 
     @if (!string.IsNullOrWhiteSpace(Icon))
     {

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -17,7 +17,8 @@
         <MudIcon Class="mud-menu-item-icon"
                  Icon="@Icon"
                  Color="IconColor"
-                 Disabled="GetDisabled()" />
+                 Disabled="GetDisabled()"
+                 Size="GetIconSize()" />
     }
 
     <MudText Class="mud-menu-item-text"

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -20,15 +20,15 @@
                  Disabled="GetDisabled()" />
     }
 
-    @if (ChildContent is null)
-    {
-        <MudText Class="mud-menu-item-text"
-                 Typo="GetTypo()">
+    <MudText Class="mud-menu-item-text"
+             Typo="GetTypo()">
+        @if (ChildContent is null)
+        {
             @Label
-        </MudText>
-    }
-    else
-    {
-        @ChildContent
-    }
+        }
+        else
+        {
+            @ChildContent
+        }
+    </MudText>
 </MudElement>

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -11,8 +11,7 @@
              Class="@Classname"
              Style="@Style"
              Icon="@Icon"
-             IconColor="@IconColor"
-             IconSize="@IconSize">
+             IconColor="@IconColor">
     @if(ChildContent is null)
     {
         @Label

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -115,9 +115,6 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when this menu item is clicked.
         /// </summary>
-        /// <remarks>
-        /// This event will only fire if <see cref="Href"/> is not set.
-        /// </remarks>
         [Parameter]
         public EventCallback<MouseEventArgs> OnClick { get; set; }
 
@@ -148,7 +145,8 @@ namespace MudBlazor
             {
                 UriHelper.NavigateTo(Href, forceLoad: ForceLoad);
             }
-            else if (OnClick.HasDelegate)
+
+            if (OnClick.HasDelegate)
             {
                 await OnClick.InvokeAsync(ev);
             }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -80,11 +80,8 @@ namespace MudBlazor
         public bool ForceLoad { get; set; }
 
         /// <summary>
-        /// The icon displayed for this menu item.
+        /// The icon displayed at the start of this menu item.  The size depends on whether or not the menu is using the dense variant.
         /// </summary>
-        /// <remarks>
-        /// When set, this menu will display a <see cref="MudIconButton" />.
-        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.List.Behavior)]
         public string? Icon { get; set; }
@@ -98,16 +95,6 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public Color IconColor { get; set; } = Color.Inherit;
-
-        /// <summary>
-        /// The size of the icon when <see cref="Icon"/> is set.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Size.Medium"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.List.Appearance)]
-        public Size IconSize { get; set; } = Size.Medium;
 
         /// <summary>
         /// Closes the menu when this item is clicked.

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -126,6 +126,8 @@ namespace MudBlazor
 
         protected Typo GetTypo() => GetDense() ? Typo.body2 : Typo.body1;
 
+        protected Size GetIconSize() => GetDense() ? Size.Small : Size.Medium;
+
         protected async Task OnClickHandlerAsync(MouseEventArgs ev)
         {
             if (GetDisabled())

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -23,8 +23,6 @@ namespace MudBlazor
                 .AddClass("mud-ripple", !GetDisabled())
                 .AddClass("mud-list-item-clickable", !GetDisabled())
                 .AddClass("mud-menu-item-dense", GetDense())
-                //.AddClass($"mud-selected-item mud-{MudList?.Color.ToDescriptionString()}-text", !MultiSelection && _selected && !GetDisabled())
-                //.AddClass($"mud-{MudList?.Color.ToDescriptionString()}-hover", !MultiSelection && _selected && !GetDisabled())
                 .AddClass(Class)
                 .Build();
 
@@ -140,9 +138,8 @@ namespace MudBlazor
                 await ParentMenu.CloseAllMenusAsync();
             }
 
-            // the only case a manual Navigation is required, is when
-            // the target is empty, but a force reload is desired, all other cases are handled
-            // by the html anchor
+            // Manual navigation is only required when the target is empty and a
+            // forced reload is necessary; all other scenarios are managed by the HTML anchor.
             if (ForceLoad && !string.IsNullOrEmpty(Href) && string.IsNullOrEmpty(Target))
             {
                 UriHelper.NavigateTo(Href, forceLoad: ForceLoad);

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -19,6 +19,12 @@ namespace MudBlazor
 
         protected string Classname =>
             new CssBuilder("mud-menu-item")
+                .AddClass("mud-disabled", GetDisabled())
+                .AddClass("mud-ripple", !GetDisabled())
+                .AddClass("mud-list-item-clickable", !GetDisabled())
+                .AddClass("mud-menu-item-dense", GetDense())
+                //.AddClass($"mud-selected-item mud-{MudList?.Color.ToDescriptionString()}-text", !MultiSelection && _selected && !GetDisabled())
+                //.AddClass($"mud-{MudList?.Color.ToDescriptionString()}-hover", !MultiSelection && _selected && !GetDisabled())
                 .AddClass(Class)
                 .Build();
 
@@ -26,7 +32,7 @@ namespace MudBlazor
         /// The <see cref="MudMenu"/> which contains this item.
         /// </summary>
         [CascadingParameter]
-        public MudMenu? MudMenu { get; set; }
+        public MudMenu? ParentMenu { get; set; }
 
         /// <summary>
         /// The text shown on this menu item if <see cref="ChildContent"/> is not set.
@@ -110,24 +116,39 @@ namespace MudBlazor
         /// Occurs when this menu item is clicked.
         /// </summary>
         /// <remarks>
-        /// This event only occurs if <see cref="Href"/> is not set.
+        /// This event will only fire if <see cref="Href"/> is not set.
         /// </remarks>
         [Parameter]
         public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+        protected string GetHtmlTag() => string.IsNullOrEmpty(Href) ? "div" : "a";
+
+        protected bool GetDisabled() => Disabled || ParentMenu?.Disabled == true;
+
+        protected bool GetDense() => ParentMenu?.Dense == true;
+
+        protected Typo GetTypo() => GetDense() ? Typo.body2 : Typo.body1;
+
         protected async Task OnClickHandlerAsync(MouseEventArgs ev)
         {
-            if (Disabled)
+            if (GetDisabled())
             {
                 return;
             }
 
-            if (AutoClose && MudMenu is not null)
+            if (AutoClose && ParentMenu is not null)
             {
-                await MudMenu.CloseAllMenusAsync();
+                await ParentMenu.CloseAllMenusAsync();
             }
 
-            if (OnClick.HasDelegate)
+            // the only case a manual Navigation is required, is when
+            // the target is empty, but a force reload is desired, all other cases are handled
+            // by the html anchor
+            if (ForceLoad && !string.IsNullOrEmpty(Href) && string.IsNullOrEmpty(Target))
+            {
+                UriHelper.NavigateTo(Href, forceLoad: ForceLoad);
+            }
+            else if (OnClick.HasDelegate)
             {
                 await OnClick.InvokeAsync(ev);
             }

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -26,7 +26,50 @@
   position: absolute;
 }
 
+.mud-menu-list {
+  padding: 8px 0;
 
-.mud-menu-list > .mud-menu {
+  > .mud-menu {
+    width: 100%;
+  }
+}
+
+.mud-menu-item {
   width: 100%;
+  display: flex;
+  position: relative;
+  box-sizing: border-box;
+  text-align: start;
+  align-items: center;
+  padding: 8px 16px;
+  justify-content: flex-start;
+  text-decoration: none;
+
+  .mud-menu-item-icon {
+    color: var(--mud-palette-action-default);
+    display: inline-flex;
+    flex-shrink: 0;
+    margin: 0 20px 0 8px;
+  }
+
+  .mud-menu-item-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+
+  &.mud-menu-item-dense {
+    padding: 4px 16px;
+  }
+
+  &.mud-disabled {
+    color: var(--mud-palette-action-disabled) !important;
+    cursor: default !important;
+    pointer-events: none !important;
+
+    .mud-menu-item-icon {
+      color: var(--mud-palette-action-disabled) !important;
+    }
+  }
 }

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -27,7 +27,11 @@
 }
 
 .mud-menu-list {
-  padding: 8px 0;
+  /*padding: 8px 0;*/
+
+  &.mud-menu-list-dense {
+    /*padding: 0;*/
+  }
 
   > .mud-menu {
     width: 100%;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

MenuItem is no longer based on ListItem internally to allow greater control over behaviour and style. Any dependencies on the list item classes will likely break.

The icon size is now chosen based on whether or not the Dense variant is used. The style is based loosely on the [MD2 spec](https://m2.material.io/components/menus#specs) and lays the groundwork for further refinements under #10077.

Resolves #9097

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before, no icons

![image](https://github.com/user-attachments/assets/f796e66a-0eab-4c31-8b9f-77b42b8b4fc9)


![image](https://github.com/user-attachments/assets/d9c61191-26a3-44d3-ab32-16cec6ab4cbb)


After, no icons (no change which is intended)

![image](https://github.com/user-attachments/assets/9a29f06e-2bfd-4abb-9dda-4f3bd3aa65f4)

![image](https://github.com/user-attachments/assets/11fd77f3-56d4-4ffe-b4a8-090f3096dc6f)

.

Before, mixed icons sizes:

![image](https://github.com/user-attachments/assets/92e83a43-a4f9-4cf9-a525-ae77406cdfea)

![image](https://github.com/user-attachments/assets/c6190f99-d6fe-487d-8771-8844140291a0)


After, can no longer be customized:

![image](https://github.com/user-attachments/assets/2deec4e4-1ef5-45e6-8c06-864e4d772bc1)

![image](https://github.com/user-attachments/assets/2838f789-f4c1-461e-b6d4-c0f1173eac7a)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
