### PR TITLE
MudDataGrid: Add CurrentPageChanged EventHandler to enable binding

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCurrentPageParameterTwoWayBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCurrentPageParameterTwoWayBindingTest.razor
@@ -1,0 +1,15 @@
+﻿<MudDataGrid Items="_items" @bind-CurrentPage="_currentPage">
+    <Columns>
+        <PropertyColumn Property="x => x" Title="Item" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="int" PageSizeOptions="[1]" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "CurrentPage parameter should be two-way bindable.";
+
+    private readonly int[] _items = [1, 2, 3];
+    private int _currentPage;
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4919,7 +4919,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeFalse();
         }
-        
+
         /// <summary>
         /// Tests two-way binding on the CurrentPage parameter.
         /// The table should re-render with the newly provided value as the CurrentPage.

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4919,5 +4919,30 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeFalse();
         }
+        
+        /// <summary>
+        /// Tests two-way binding on the CurrentPage parameter.
+        /// The table should re-render with the newly provided value as the CurrentPage.
+        /// </summary>
+        [Test]
+        public async Task TestCurrentPageParameterTwoWayBinding()
+        {
+            var comp = Context.RenderComponent<DataGridCurrentPageParameterTwoWayBindingTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<int>>().Instance;
+
+            // Assert starting page index is 0 (default).
+            comp.WaitForAssertion(() => dataGrid.CurrentPage.Should().Be(0));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("1"));
+
+            // Assert modification via code correctly renders the corresponding page.
+            await comp.InvokeAsync(() => dataGrid.CurrentPage = 1);
+            comp.WaitForAssertion(() => dataGrid.CurrentPage.Should().Be(1));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("2"));
+
+            // Assert user input correctly updates the CurrentPage parameter value by clicking the "Next Page" button in the pager.
+            comp.FindAll(".mud-table-pagination-actions .mud-button-root")[2].Click();
+            comp.WaitForAssertion(() => dataGrid.CurrentPage.Should().Be(2));
+            comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("3"));
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -920,11 +920,18 @@ namespace MudBlazor
                     return;
                 _currentPage = value;
                 InvokeAsync(StateHasChanged);
+                CurrentPageChanged.InvokeAsync(_currentPage);
 
                 if (_isFirstRendered)
                     InvokeAsync(InvokeServerLoadFunc);
             }
         }
+
+        /// <summary>
+        /// Occurs when <see cref="CurrentPage"/> has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<int> CurrentPageChanged { get; set; }
 
         /// <summary>
         /// Prevents values from being edited.
@@ -1670,7 +1677,12 @@ namespace MudBlazor
             _rowsPerPage = size;
 
             if (resetPage)
+            {
+                var currentPageHasChanged = _currentPage != 0;
                 _currentPage = 0;
+                if (currentPageHasChanged)
+                    await CurrentPageChanged.InvokeAsync(_currentPage);
+            }
 
             await RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
 


### PR DESCRIPTION
## Description

Just like #10458 this simply adds an `EventHandler` matching the `CurrentPage` property of `MudDataGrid`. The previous PR did this for `MudTable`, this is simply a follow-up to match that functionality in `MudDataGrid` since their setup in this regard is practically identical.

Similarly to before, I opted not to refactor the setter of `CurrentPage` (it breaks the auto-property guideline) and keep changes to a minimum.

Related issues were already linked in the other PR, should that be repeated here or does that interfere with how GitHub links/autoresolves them?

## How Has This Been Tested?
A new unit test has been added.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
