### PR TITLE
MudAutocomplete: Fix OnAdornmentClick regression #10446

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1896,7 +1896,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.AdornmentIcon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.AdornmentAriaLabel, ariaLabel));
 
-            comp.Find(".mud-input-adornment-icon").Attributes.GetNamedItem("aria-label")!.Value.Should().Be(ariaLabel);
+            comp.Find(".mud-input-adornment-icon-button").Attributes.GetNamedItem("aria-label")!.Value.Should().Be(ariaLabel);
         }
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1423,7 +1423,7 @@ namespace MudBlazor.UnitTests.Components
             first.SetCanceled();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ToMarkup().Should().NotContain("Foo"));
 
-            second.SetResult(new List<string> { "Bar" });
+            second.SetResult(["Bar"]);
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ToMarkup().Should().Contain("Bar"));
         }
 
@@ -2072,6 +2072,36 @@ namespace MudBlazor.UnitTests.Components
             await autocompleteComponent.Find("input").KeyDownAsync(arrowUpKeyboardEventArgs);
             var noWrapToLastIndex = (int)selectedItemIndexPropertyInfo.GetValue(autocompleteInstance);
             component.WaitForAssertion(() => noWrapToLastIndex.Should().Be(0, "ArrowUp should not wrap around past the first item"));
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task AutoComplete_ShouldHaveOnAdornmentClickBehavior(bool attachDelegate)
+        {
+            var eventCallbackFactory = new EventCallbackFactory();
+            var _delegate = attachDelegate ?
+                eventCallbackFactory.Create<MouseEventArgs>(this, (e) => { }) : default;
+
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+                .Add(p => p.OnAdornmentClick, _delegate));
+
+            var autocompleteInstance = comp.Instance;
+            autocompleteInstance.OnAdornmentClick.HasDelegate.Should().Be(attachDelegate);
+            await comp.InvokeAsync(async () => await autocompleteInstance.AdornmentClickHandlerAsync());
+            autocompleteInstance.Open.Should().Be(!attachDelegate);
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Autocomplete_OpenOnFocusShouldWork(bool openOnFocus)
+        {
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+                .Add(p => p.OpenOnFocus, openOnFocus));
+            comp.Find("input").Focus();
+
+            comp.WaitForAssertion(() => comp.Instance.Open.Should().Be(openOnFocus, $"OpenOnFocus should set Open to {openOnFocus} after input Focus"));
         }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -46,6 +46,7 @@
                           @attributes="UserAttributes"
                           TextChanged="OnTextChangedAsync"
                           OnBlur="OnInputBlurredAsync"
+                          @onfocus="@OnInputFocusedAsync"
                           OnKeyDown="@OnInputKeyDownAsync"
                           OnKeyUp="@OnInputKeyUpAsync" KeyUpPreventDefault="KeyUpPreventDefault"
                           Placeholder="@Placeholder" Immediate="true"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -36,6 +36,7 @@
                           HelperId="@GetHelperId()"
                           HelperText="@HelperText"
                           AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize" AdornmentText="@AdornmentText"
+                          OnAdornmentClick="@AdornmentClickHandlerAsync"
                           AdornmentAriaLabel="@AdornmentAriaLabel"
                           Clearable="@(Clearable && !GetReadOnlyState())"
                           OnClearButtonClick="@OnClearButtonClick"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -951,7 +951,7 @@ namespace MudBlazor
             }
         }
 
-        private async Task AdornmentClickHandlerAsync()
+        internal async Task AdornmentClickHandlerAsync()
         {
             if (OnAdornmentClick.HasDelegate)
             {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -953,9 +953,15 @@ namespace MudBlazor
 
         private async Task AdornmentClickHandlerAsync()
         {
-            await ToggleMenuAsync();
-
-            await OnAdornmentClick.InvokeAsync();
+            if (OnAdornmentClick.HasDelegate)
+            {
+                await FocusAsync();
+                await OnAdornmentClick.InvokeAsync();
+            }
+            else
+            {
+                await ToggleMenuAsync();
+            }
         }
 
         private Task OnInputBlurredAsync(FocusEventArgs args)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -951,6 +951,13 @@ namespace MudBlazor
             }
         }
 
+        private async Task AdornmentClickHandlerAsync()
+        {
+            await ToggleMenuAsync();
+
+            await OnAdornmentClick.InvokeAsync();
+        }
+
         private Task OnInputBlurredAsync(FocusEventArgs args)
         {
             _isFocused = false;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Re-enable Autocomplete OnAdornmentClick functionality

Regression
 - Resolves #10497 
 - Original PR #10446 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
