### PR TITLE
MudDataGrid: Fix regression ServerData + Virtualize flag (#10495) & Footer columns (#10501)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataWithVirtualizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataWithVirtualizeTest.razor
@@ -1,4 +1,4 @@
-﻿<MudDataGrid ServerData="@Search" Virtualize T="Item">
+﻿<MudDataGrid T="Item" ServerData="@ServerData" Virtualize="true">
     <NoRecordsContent>No records</NoRecordsContent>
     <PagerContent><MudDataGridPager PageSizeOptions="new []{ 10, 25, 50}" /></PagerContent>
     <Columns>
@@ -6,24 +6,21 @@
     </Columns>
 </MudDataGrid>
 
-
 @code {
     public static string __description__ = @"The data grid should load data correctly when using ServerData with Virtualize flag";
-
-    public record Item(string Text);
 
     private readonly List<Item> _items = Enumerable.Range(0, 5)
         .Select(i => new Item($"Value_{i}"))
         .ToList();
 
-    private async Task<GridData<Item>> Search(GridState<Item> arg)
+    private Task<GridData<Item>> ServerData(GridState<Item> arg)
     {
-        await Task.Delay(2000);
-
-        return new GridData<Item>()
-            {
-                TotalItems = _items.Count,
-                Items = _items
-            };
+        return Task.FromResult(new GridData<Item>
+        {
+            TotalItems = _items.Count,
+            Items = _items
+        });
     }
+
+    public record Item(string Text);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataWithVirtualizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridServerDataWithVirtualizeTest.razor
@@ -1,0 +1,29 @@
+﻿<MudDataGrid ServerData="@Search" Virtualize T="Item">
+    <NoRecordsContent>No records</NoRecordsContent>
+    <PagerContent><MudDataGridPager PageSizeOptions="new []{ 10, 25, 50}" /></PagerContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Text" Title="test" />
+    </Columns>
+</MudDataGrid>
+
+
+@code {
+    public static string __description__ = @"The data grid should load data correctly when using ServerData with Virtualize flag";
+
+    public record Item(string Text);
+
+    private readonly List<Item> _items = Enumerable.Range(0, 5)
+        .Select(i => new Item($"Value_{i}"))
+        .ToList();
+
+    private async Task<GridData<Item>> Search(GridState<Item> arg)
+    {
+        await Task.Delay(2000);
+
+        return new GridData<Item>()
+            {
+                TotalItems = _items.Count,
+                Items = _items
+            };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -155,6 +155,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGirdWithServerDataAndVirtualize()
+        {
+            var comp = Context.RenderComponent<DataGridServerDataWithVirtualizeTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataWithVirtualizeTest.Item>>();
+
+            // Count the number of rows including header.
+            var rows = dataGrid.FindAll("tr");
+            rows.Count.Should().Be(7, because: "1 header row + 5 data rows + 1 footer row");
+
+            var cells = dataGrid.FindAll("td");
+            cells.Count.Should().Be(5, because: "We have 5 data rows with one column");
+
+            cells[0].TextContent.Should().Be("Value_0");
+            cells[1].TextContent.Should().Be("Value_1");
+            cells[2].TextContent.Should().Be("Value_2");
+            cells[3].TextContent.Should().Be("Value_3");
+            cells[4].TextContent.Should().Be("Value_4");
+        }
+
+        [Test]
         public async Task DataGridSortableVirtualizeServerDataTest()
         {
             var comp = Context.RenderComponent<DataGridSortableVirtualizeServerDataTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -205,7 +205,7 @@
                         @{
                             var resolvedPageItems = new List<IndexBag<T>>(0);
                             // resolve the page items only when used
-                            if (!Virtualize || !HasServerData || HasFooter)
+                            if (!Virtualize || VirtualizeServerData == null || HasFooter)
                             {
                                 resolvedPageItems = CurrentPageItems.Select((item, index) => new IndexBag<T>(index, item))
                                     .ToList();
@@ -440,9 +440,15 @@
         @<text>
             @if (currentItems is not null)
             {
-                foreach (var column in RenderedColumns.Where(IsFooterCellDisplayable))
+                foreach (var column in RenderedColumns)
                 {
-                    <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
+                    if (!column.HiddenState.Value)
+                    {
+                        if (column.AggregateDefinition is not null || column.FooterTemplate is not null || HasFooter)
+                        {
+                            <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
+                        }
+                    }
                 }
             }
          </text>;


### PR DESCRIPTION
I hope there is no more other regressions... i'm sorry for this, it's very hard to cover all Datagrid usage will testing, some unit test are missing. i'll check if i can add some relevants test later

## Description
fix: regression usage of ServerData with Virtualize flag (#10495)
fix: restore original filter on footer column display (#10501)

## How Has This Been Tested?
`DataGridServerDataWithVirtualizeTest.razor` created
tested visually (docs & unitTest viewer)

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
