### PR TITLE
MudMenuItem: Add chevrons to submenus and automatically choose anchor origin

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
@@ -4,24 +4,24 @@
     <MudMenuItem Label="Add reaction" />
     <MudMenuItem Label="Add bookmark" />
 
-    <MudMenu Label="Format" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
-        <MudMenu Label="Text" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenu Label="Format" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Text" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bold" />
             <MudMenuItem Label="Italic" />
             <MudMenuItem Label="Underline" />
 
-            <MudMenu Label="Size" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+            <MudMenu Label="Size" ActivationEvent="@MouseEvent.MouseOver">
                 <MudMenuItem Label="Increase font size" />
                 <MudMenuItem Label="Decrease font size" />
             </MudMenu>
         </MudMenu>
 
-        <MudMenu Label="Points" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Points" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bullet" />
             <MudMenuItem Label="Number" />
         </MudMenu>
 
-        <MudMenu Label="Alignment" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Alignment" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Left" />
             <MudMenuItem Label="Right" />
         </MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
@@ -4,24 +4,24 @@
     <MudMenuItem Label="Add reaction" />
     <MudMenuItem Label="Add bookmark" />
 
-    <MudMenu Label="Format >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
-        <MudMenu Label="Text >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenu Label="Format" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Text" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bold" />
             <MudMenuItem Label="Italic" />
             <MudMenuItem Label="Underline" />
 
-            <MudMenu Label="Size >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+            <MudMenu Label="Size" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
                 <MudMenuItem Label="Increase font size" />
                 <MudMenuItem Label="Decrease font size" />
             </MudMenu>
         </MudMenu>
 
-        <MudMenu Label="Points >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Points" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bullet" />
             <MudMenuItem Label="Number" />
         </MudMenu>
 
-        <MudMenu Label="Alignment >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Alignment" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Left" />
             <MudMenuItem Label="Right" />
         </MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -88,7 +88,7 @@
                 <Description>
                     Cascading menus, also known as nested menus, allow users to navigate through a wide range of options by presenting multiple levels of hierarchical menus.
                     Using the pattern shown below, multiple menus can be nested.
-                    Hover your mouse over submenus (marked with a <CodeInline>></CodeInline>) to open them.
+                    Hover your mouse over submenus (indicated by a chevron) to open them.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(MenuWithNestingExample)" ShowCode="true">

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -88,7 +88,7 @@
                 <Description>
                     Cascading menus, also known as nested menus, allow users to navigate through a wide range of options by presenting multiple levels of hierarchical menus.
                     Using the pattern shown below, multiple menus can be nested.
-                    Hover your mouse over submenus (indicated by a chevron) to open them.
+                    Hover your mouse over submenus (denoted by an arrow) to open them.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(MenuWithNestingExample)" ShowCode="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuWithNestingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuWithNestingTest.razor
@@ -4,24 +4,24 @@
     <MudMenuItem Label="Add reaction" />
     <MudMenuItem Label="Add bookmark" />
 
-    <MudMenu Label="Format >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
-        <MudMenu Label="Text >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenu Label="Format" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Text" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bold" />
             <MudMenuItem Label="Italic" />
             <MudMenuItem Label="Underline" />
 
-            <MudMenu Label="Size >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+            <MudMenu Label="Size" ActivationEvent="@MouseEvent.MouseOver">
                 <MudMenuItem Label="Increase font size" />
                 <MudMenuItem Label="Decrease font size" />
             </MudMenu>
         </MudMenu>
 
-        <MudMenu Label="Points >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Points" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Bullet" />
             <MudMenuItem Label="Number" />
         </MudMenu>
 
-        <MudMenu Label="Alignment >" AnchorOrigin="Origin.TopRight" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Alignment" ActivationEvent="@MouseEvent.MouseOver">
             <MudMenuItem Label="Left" />
             <MudMenuItem Label="Right" />
         </MudMenu>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -70,7 +70,7 @@
                 Class="@PopoverClassname"
                 Style="@Stylename"
                 MaxHeight="@MaxHeight"
-                AnchorOrigin="@(PositionAtCursor ? Origin.TopLeft : AnchorOrigin)"
+                AnchorOrigin="@GetAnchorOrigin()"
                 TransformOrigin="@TransformOrigin"
                 RelativeWidth="@FullWidth"
                 DropShadow="@DropShadow">

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -249,7 +249,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.PopupAppearance)]
-        public Origin AnchorOrigin { get; set; } = Origin.BottomLeft;
+        public Origin? AnchorOrigin { get; set; }
 
         /// <summary>
         /// Sets the direction the menu will open from the anchor.
@@ -330,6 +330,25 @@ namespace MudBlazor
         public IReadOnlyList<MudMenu> GetChildren() => _children.AsReadOnly();
 
         protected bool GetActivatorHidden() => ActivatorContent is null && string.IsNullOrWhiteSpace(Label) && string.IsNullOrWhiteSpace(Icon);
+
+        protected Origin GetAnchorOrigin()
+        {
+            if (AnchorOrigin is not null)
+            {
+                return AnchorOrigin.Value;
+            }
+
+            if (ParentMenu is not null)
+            {
+                return Origin.TopRight;
+            }
+            else if (PositionAtCursor)
+            {
+                return Origin.TopLeft;
+            }
+
+            return Origin.BottomLeft;
+        }
 
         protected void RegisterChild(MudMenu child)
         {

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -32,4 +32,12 @@
             @ChildContent
         }
     </MudText>
+
+    @if (ActivatesSubMenu)
+    {
+        <MudIcon Class="mud-menu-item-chevron"
+                 Icon="@Icons.Material.Filled.ChevronRight"
+                 Disabled="GetDisabled()"
+                 Size="GetIconSize()" />
+    }
 </MudElement>

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -36,7 +36,7 @@
     @if (ActivatesSubMenu)
     {
         <MudIcon Class="mud-menu-item-chevron"
-                 Icon="@Icons.Material.Filled.ChevronRight"
+                 Icon="@Icons.Material.Filled.ArrowRight"
                  Disabled="GetDisabled()"
                  Size="GetIconSize()" />
     }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -91,16 +91,6 @@ namespace MudBlazor
         public string? Icon { get; set; }
 
         /// <summary>
-        /// The icon displayed at the end of this menu item if it's a sub menu activator.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="Icons.Material.Filled.ChevronRight"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.List.Behavior)]
-        public string? ChevronIcon { get; set; } = Icons.Material.Filled.ChevronRight;
-
-        /// <summary>
         /// The color of the icon when <see cref="Icon"/> is set.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -91,6 +91,16 @@ namespace MudBlazor
         public string? Icon { get; set; }
 
         /// <summary>
+        /// The icon displayed at the end of this menu item if it's a sub menu activator.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.ChevronRight"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string? ChevronIcon { get; set; } = Icons.Material.Filled.ChevronRight;
+
+        /// <summary>
         /// The color of the icon when <see cref="Icon"/> is set.
         /// </summary>
         /// <remarks>
@@ -125,6 +135,11 @@ namespace MudBlazor
         protected Typo GetTypo() => GetDense() ? Typo.body2 : Typo.body1;
 
         protected Size GetIconSize() => GetDense() ? Size.Small : Size.Medium;
+
+        /// <summary>
+        /// The menu item is acting as the activator for a sub menu.
+        /// </summary>
+        protected bool ActivatesSubMenu => Class?.Contains("mud-menu-sub-menu-activator") == true;
 
         protected async Task OnClickHandlerAsync(MouseEventArgs ev)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Arrows are now added to the end of a submenu activator. The anchor origin is also chosen by the library if none are specified by the user so now you won't have to manually set it for submenus to open in the right place.

Contains a small behavior change where PositionAtCursor will now be overridden if the user has specified their own AnchorOrigin.

Next up: Automatic mouse event, support for primary click, support for primary click AND mouse over.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/user-attachments/assets/11cea933-6425-4899-a569-30910aba04ab)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
