### PR TITLE
Docs: MudSlider to MudStepper: Add XML Documentation for Public Members

### DIFF
--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -80,8 +80,11 @@ namespace MudBlazor
         public bool Disabled { get; set; } = false;
 
         /// <summary>
-        /// The content within this component.
+        /// The option content rendered above the slider.
         /// </summary>
+        /// <remarks>
+        /// Typically used for displaying text.   When the slider is vertical, content is displayed to the left of the slider.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Behavior)]
         public RenderFragment? ChildContent { get; set; }
@@ -144,7 +147,7 @@ namespace MudBlazor
         /// Displays this slider vertically.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.
+        /// Defaults to <c>false</c>.  When <c>true</c>, the slider is displayed like a horizontal slider, but rotated 90° counterclockwise.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -10,7 +8,7 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a slider component, allowing users to select a value within a specified range.
+    /// A component which users to select a value within a specified range.
     /// </summary>
     /// <typeparam name="T">The type of the value the slider represents.</typeparam>
     public partial class MudSlider<T> : MudComponentBase where T : struct, INumber<T>
@@ -42,115 +40,152 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
-        /// The minimum allowed value of the slider. Should not be equal to max.
+        /// The minimum allowed value.
         /// </summary>
+        /// <remarks>
+        /// Defauls to <c>0</c>.  Must be less than <see cref="Max"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Validation)]
         public T Min { get; set; } = T.Zero;
 
         /// <summary>
-        /// The maximum allowed value of the slider. Should not be equal to min.
+        /// The maximum allowed value.
         /// </summary>
-        /// 
+        /// <remarks>
+        /// Defaults to <c>100</c>.  Must be greater than <see cref="Min"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Validation)]
         public T Max { get; set; } = T.CreateTruncating(100);
 
         /// <summary>
-        /// How many steps the slider should take on each move.
+        /// How much the value changes on each move.
         /// </summary>
-        /// 
+        /// <remarks>
+        /// Defaults to <c>1</c>.  
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Validation)]
         public T Step { get; set; } = T.One;
 
         /// <summary>
-        /// If true, the slider will be disabled.
+        /// Prevents the user from interacting with this slider.
         /// </summary>
-        /// 
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Behavior)]
         public bool Disabled { get; set; } = false;
 
         /// <summary>
-        /// Child content of component.
+        /// The content within this component.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Slider.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Event callback invoked when the value of the slider changes.
+        /// Occurs ehn <see cref="Value"/> has changed.
         /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
 
         /// <summary>
-        /// Event callback invoked when the nullable value of the slider changes.
+        /// Occurs when  Event callback invoked when the nullable value of the slider changes.
         /// </summary>
         [Parameter]
         public EventCallback<T?> NullableValueChanged { get; set; }
 
         /// <summary>
-        /// The value of the slider.
+        /// The value of this slider.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>0</c>.  When this value changes, <see cref="ValueChanged"/> occurs.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Data)]
         public T Value { get; set; } = T.Zero;
 
         /// <summary>
-        /// The nullable value of the slider.
+        /// The nullable value of this slider.
         /// </summary>
+        /// <remarks>
+        /// When this value changes, <see cref="NullableValueChanged"/> occurs.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Data)]
         public T? NullableValue { get; set; } = default;
 
         /// <summary>
-        /// The color of the component. It supports the Primary, Secondary and Tertiary theme colors.
+        /// The color of this slider.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Primary"/>.  <c>Primary</c>, <c>Secondary</c> and <c>Tertiary</c> colors are supported.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]
         public Color Color { get; set; } = Color.Primary;
 
         /// <summary>
-        /// If true, the dragging the slider will update the Value immediately.
-        /// If false, the Value is updated only on releasing the handle.
+        /// Controls when the value is updated.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.<br />
+        /// When <c>true</c>, dragging the slider changes <see cref="Value"/> (or <see cref="NullableValue"/>) immediately.<br />
+        /// When <c>false</c>, <see cref="Value"/> (or <see cref="NullableValue"/>) changes when releasing the handle.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Behavior)]
         public bool Immediate { get; set; } = true;
 
         /// <summary>
-        /// If true, displays the slider vertical.
+        /// Displays this slider vertically.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]
         public bool Vertical { get; set; } = false;
 
         /// <summary>
-        /// If true, displays tick marks on the track.
+        /// Displays tick marks along the track.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]
         public bool TickMarks { get; set; } = false;
 
         /// <summary>
-        /// Labels for tick marks, will attempt to map the labels to each step in index order.
+        /// The tick mark labels for each step.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Only applies when <see cref="TickMarks"/> is <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]
         public string[]? TickMarkLabels { get; set; }
 
         /// <summary>
-        /// Size of the slider.
+        /// The size of this slider.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Small"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Slider.Appearance)]
         public Size Size { get; set; } = Size.Small;
 
         /// <summary>
-        /// The variant to use.
+        /// The display variant to use.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Text"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public Variant Variant { get; set; } = Variant.Text;
@@ -158,29 +193,41 @@ namespace MudBlazor
         /// <summary>
         /// Displays the value over the slider thumb.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public bool ValueLabel { get; set; }
 
         /// <summary>
-        /// Sets the culture information used for ValueLabel. Default is <see cref="CultureInfo.InvariantCulture"/>.
+        /// The culture used to format the value label.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="CultureInfo.InvariantCulture"/>.  Only applied when <see cref="ValueLabel"/> is <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
-        /// Sets the formatting information used for ValueLabel. Default is no formatting.
+        /// The format of the value label.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  
+        /// Only applies when <see cref="ValueLabelContent"/> is not set.<br />
+        /// See: <see href="https://learn.microsoft.com/dotnet/standard/base-types/standard-numeric-format-strings">Standard Numeric Format Strings</see>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
         public string? ValueLabelFormat { get; set; }
 
         /// <summary>
-        /// Sets custom RenderFragment for ValueLabel.
+        /// The custom content for value labels.
         /// </summary>
         /// <remarks>
-        /// Keep in mind that for this RenderFragment to show the <see cref="ValueLabel"/> needs to be <c>true</c>.
+        /// Use the supplied context to access the current value.<br />
+        /// Only applies when <see cref="ValueLabel"/> is <c>true</c> and <see cref="ValueLabelFormat"/> is not set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// A component which users to select a value within a specified range.
+    /// A component which allows users to select a value within a specified range.
     /// </summary>
     /// <typeparam name="T">The type of the value the slider represents.</typeparam>
     public partial class MudSlider<T> : MudComponentBase where T : struct, INumber<T>
@@ -87,13 +87,13 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// Occurs ehn <see cref="Value"/> has changed.
+        /// Occurs when <see cref="Value"/> has changed.
         /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
 
         /// <summary>
-        /// Occurs when  Event callback invoked when the nullable value of the slider changes.
+        /// Occurs when <see cref="NullableValue" /> has changed.
         /// </summary>
         [Parameter]
         public EventCallback<T?> NullableValueChanged { get; set; }

--- a/src/MudBlazor/Components/Slider/SliderContext.cs
+++ b/src/MudBlazor/Components/Slider/SliderContext.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor;
 
 #nullable enable
+
 /// <summary>
-/// Represents the context of a slider component, containing both the value and nullable value of the slider.
+/// The current state of a <see cref="MudSlider{T}"/> component, containing both the value and nullable value.
 /// </summary>
 /// <typeparam name="T">The type of the value the slider represents.</typeparam>
 public class SliderContext<T> where T : struct

--- a/src/MudBlazor/Components/Slider/SliderContext.cs
+++ b/src/MudBlazor/Components/Slider/SliderContext.cs
@@ -9,6 +9,9 @@ namespace MudBlazor;
 /// <summary>
 /// The current state of a <see cref="MudSlider{T}"/> component, containing both the value and nullable value.
 /// </summary>
+/// <remarks>
+/// This state is a cascading parameter for <see cref="MudSlider{T}"/> components.
+/// </remarks>
 /// <typeparam name="T">The type of the value the slider represents.</typeparam>
 public class SliderContext<T> where T : struct
 {

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -11,7 +11,7 @@ namespace MudBlazor;
 public abstract class CommonSnackbarOptions
 {
     /// <summary>
-    /// The maximum opacity for each snackbar.
+    /// The maximum opacity for the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>95</c>.  The maximum value is <c>100</c>.
@@ -19,7 +19,7 @@ public abstract class CommonSnackbarOptions
     public int MaximumOpacity { get; set; } = 95;
 
     /// <summary>
-    /// The time, in milliseconds, to animate showing each snackbar.
+    /// The time, in milliseconds, to animate showing the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>1000</c> (one second).
@@ -27,7 +27,7 @@ public abstract class CommonSnackbarOptions
     public int ShowTransitionDuration { get; set; } = 1000;
 
     /// <summary>
-    /// The time, in milliseconds, to show each snackbar.
+    /// The time, in milliseconds, to show the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>5000</c> (five seconds).
@@ -35,7 +35,7 @@ public abstract class CommonSnackbarOptions
     public int VisibleStateDuration { get; set; } = 5000;
 
     /// <summary>
-    /// The time, in milliseconds, to hide each snackbar.
+    /// The time, in milliseconds, to hide the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>2000</c> (two seconds).
@@ -43,7 +43,7 @@ public abstract class CommonSnackbarOptions
     public int HideTransitionDuration { get; set; } = 2000;
 
     /// <summary>
-    /// Displays a close icon for each snackbar.
+    /// Displays a close icon for the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.
@@ -51,7 +51,7 @@ public abstract class CommonSnackbarOptions
     public bool ShowCloseIcon { get; set; } = true;
 
     /// <summary>
-    /// Shows each snackbar until a user manually closes them.
+    /// Shows the snackbar until a user manually closes them.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.
@@ -59,7 +59,7 @@ public abstract class CommonSnackbarOptions
     public bool RequireInteraction { get; set; } = false;
 
     /// <summary>
-    /// Blurs the background of each snackbar.
+    /// Blurs the background of the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.
@@ -67,7 +67,7 @@ public abstract class CommonSnackbarOptions
     public bool BackgroundBlurred { get; set; } = false;
 
     /// <summary>
-    /// The default display variant for each snackbar.
+    /// The default display variant for the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Variant.Filled"/>.
@@ -75,7 +75,7 @@ public abstract class CommonSnackbarOptions
     public Variant SnackbarVariant { get; set; } = Variant.Filled;
 
     /// <summary>
-    /// The default icon size for each snackbar.
+    /// The default icon size for the snackbar.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Size.Medium"/>.

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -51,7 +51,7 @@ public abstract class CommonSnackbarOptions
     public bool ShowCloseIcon { get; set; } = true;
 
     /// <summary>
-    /// Shows the snackbar until a user manually closes them.
+    /// Shows the snackbar until a user manually closes it.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -4,49 +4,122 @@
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// The options which control Snackbar pop-ups.
+/// </summary>
 public abstract class CommonSnackbarOptions
 {
+    /// <summary>
+    /// The maximum opacity for each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>95</c>.  The maximum value is <c>100</c>.
+    /// </remarks>
     public int MaximumOpacity { get; set; } = 95;
 
+    /// <summary>
+    /// The time, in milliseconds, to animate showing each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>1000</c> (one second).
+    /// </remarks>
     public int ShowTransitionDuration { get; set; } = 1000;
 
+    /// <summary>
+    /// The time, in milliseconds, to show each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>5000</c> (five seconds).
+    /// </remarks>
     public int VisibleStateDuration { get; set; } = 5000;
 
+    /// <summary>
+    /// The time, in milliseconds, to hide each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>2000</c> (two seconds).
+    /// </remarks>
     public int HideTransitionDuration { get; set; } = 2000;
 
+    /// <summary>
+    /// Displays a close icon for each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
     public bool ShowCloseIcon { get; set; } = true;
 
+    /// <summary>
+    /// Shows each snackbar until a user manually closes them.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     public bool RequireInteraction { get; set; } = false;
 
+    /// <summary>
+    /// Blurs the background of each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     public bool BackgroundBlurred { get; set; } = false;
 
+    /// <summary>
+    /// The default display variant for each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Variant.Filled"/>.
+    /// </remarks>
     public Variant SnackbarVariant { get; set; } = Variant.Filled;
 
+    /// <summary>
+    /// The default icon size for each snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Size.Medium"/>.
+    /// </remarks>
     public Size IconSize { get; set; } = Size.Medium;
 
     /// <summary>
-    /// Custom normal icon.
+    /// The icon displayed for <c>Normal</c> severity snackbars.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.EventNote"/>.
+    /// </remarks>
     public string NormalIcon { get; set; } = Icons.Material.Outlined.EventNote;
 
     /// <summary>
-    /// Custom info icon.
+    /// The icon displayed for <c>Info</c> severity snackbars.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.Info"/>.
+    /// </remarks>
     public string InfoIcon { get; set; } = Icons.Material.Outlined.Info;
 
     /// <summary>
-    /// Custom success icon.
+    /// The icon displayed for <c>Success</c> severity snackbars.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Custom.Uncategorized.AlertSuccess"/>.
+    /// </remarks>
     public string SuccessIcon { get; set; } = Icons.Custom.Uncategorized.AlertSuccess;
 
     /// <summary>
-    /// Custom warning icon.
+    /// The icon displayed for <c>Warning</c> severity snackbars.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.ReportProblem"/>.
+    /// </remarks>
     public string WarningIcon { get; set; } = Icons.Material.Outlined.ReportProblem;
 
     /// <summary>
-    /// Custom error icon.
+    /// The icon displayed for <c>Error</c> severity snackbars.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.ErrorOutline"/>.
+    /// </remarks>
     public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
 
     protected CommonSnackbarOptions() { }

--- a/src/MudBlazor/Components/Snackbar/Defaults.cs
+++ b/src/MudBlazor/Components/Snackbar/Defaults.cs
@@ -46,7 +46,7 @@ public static class Defaults
             public const string TopEnd = "mud-snackbar-location-top-end";
 
             /// <summary>
-            /// Snackbars will appear in the lower-left corner.
+            /// Snackbars will appear in the bottom-left corner.
             /// </summary>
             public const string BottomLeft = "mud-snackbar-location-bottom-left";
 
@@ -56,7 +56,7 @@ public static class Defaults
             public const string BottomCenter = "mud-snackbar-location-bottom-center";
 
             /// <summary>
-            /// Snackbars will appear in the lower-right corner.
+            /// Snackbars will appear in the bottom-right corner.
             /// </summary>
             public const string BottomRight = "mud-snackbar-location-bottom-right";
 

--- a/src/MudBlazor/Components/Snackbar/Defaults.cs
+++ b/src/MudBlazor/Components/Snackbar/Defaults.cs
@@ -4,22 +4,70 @@
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// Contains common snackbar CSS classes.
+/// </summary>
 public static class Defaults
 {
+    /// <summary>
+    /// Contains common snackbar CSS classes.
+    /// </summary>
     public static class Classes
     {
+        /// <summary>
+        /// The CSS classes used to position snackbars.
+        /// </summary>
         public static class Position
         {
+            /// <summary>
+            /// Snackbars will appear in the upper-left corner.
+            /// </summary>
             public const string TopLeft = "mud-snackbar-location-top-left";
+
+            /// <summary>
+            /// Snackbars will appear at the top, centered horizontally.
+            /// </summary>
             public const string TopCenter = "mud-snackbar-location-top-center";
+
+            /// <summary>
+            /// Snackbars will appear in the upper-right corner.
+            /// </summary>
             public const string TopRight = "mud-snackbar-location-top-right";
+
+            /// <summary>
+            /// Snackbars will appear on the top, aligned based on Right-to-Left settings.
+            /// </summary>
             public const string TopStart = "mud-snackbar-location-top-start";
+
+            /// <summary>
+            /// Snackbars will appear on the top, aligned based on Right-to-Left settings.
+            /// </summary>
             public const string TopEnd = "mud-snackbar-location-top-end";
 
+            /// <summary>
+            /// Snackbars will appear in the lower-left corner.
+            /// </summary>
             public const string BottomLeft = "mud-snackbar-location-bottom-left";
+
+            /// <summary>
+            /// Snackbars will appear on the bottom, centered horizontally.
+            /// </summary>
             public const string BottomCenter = "mud-snackbar-location-bottom-center";
+
+            /// <summary>
+            /// Snackbars will appear in the lower-right corner.
+            /// </summary>
             public const string BottomRight = "mud-snackbar-location-bottom-right";
+
+            /// <summary>
+            /// Snackbars will appear on the bottom, aligned based on Right-to-Left settings.
+            /// </summary>
             public const string BottomStart = "mud-snackbar-location-bottom-start";
+
+            /// <summary>
+            /// Snackbars will appear on the bottom, aligned based on Right-to-Left settings.
+            /// </summary>
             public const string BottomEnd = "mud-snackbar-location-bottom-end";
         }
     }

--- a/src/MudBlazor/Components/Snackbar/Defaults.cs
+++ b/src/MudBlazor/Components/Snackbar/Defaults.cs
@@ -36,12 +36,12 @@ public static class Defaults
             public const string TopRight = "mud-snackbar-location-top-right";
 
             /// <summary>
-            /// Snackbars will appear on the top, aligned based on Right-to-Left settings.
+            /// Snackbars will appear at the top, aligned based on Right-to-Left settings.
             /// </summary>
             public const string TopStart = "mud-snackbar-location-top-start";
 
             /// <summary>
-            /// Snackbars will appear on the top, aligned based on Right-to-Left settings.
+            /// Snackbars will appear at the top, aligned based on Right-to-Left settings.
             /// </summary>
             public const string TopEnd = "mud-snackbar-location-top-end";
 

--- a/src/MudBlazor/Components/Snackbar/Defaults.cs
+++ b/src/MudBlazor/Components/Snackbar/Defaults.cs
@@ -21,7 +21,7 @@ public static class Defaults
         public static class Position
         {
             /// <summary>
-            /// Snackbars will appear in the upper-left corner.
+            /// Snackbars will appear in the top-left corner.
             /// </summary>
             public const string TopLeft = "mud-snackbar-location-top-left";
 
@@ -31,7 +31,7 @@ public static class Defaults
             public const string TopCenter = "mud-snackbar-location-top-center";
 
             /// <summary>
-            /// Snackbars will appear in the upper-right corner.
+            /// Snackbars will appear in the top-right corner.
             /// </summary>
             public const string TopRight = "mud-snackbar-location-top-right";
 

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -7,6 +7,9 @@ using MudBlazor.Components.Snackbar;
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// The service used to display snackbar messages.
+    /// </summary>
     public class Snackbar : IDisposable
     {
         private bool _paused = false;
@@ -14,10 +17,27 @@ namespace MudBlazor
         private bool _hideOnResume = false;
         private Timer Timer { get; }
         internal SnackBarMessageState State { get; }
+
+        /// <summary>
+        /// The message to display.
+        /// </summary>
         public string? Message => SnackbarMessage.Text;
+
         internal SnackbarMessage SnackbarMessage { get; }
+
+        /// <summary>
+        /// Occurs when a snackbar is closed.
+        /// </summary>
         public event Action<Snackbar>? OnClose;
+
+        /// <summary>
+        /// Occurs when a snackbar changes.
+        /// </summary>
         public event Action? OnUpdate;
+
+        /// <summary>
+        /// The severity of the snackbar message.
+        /// </summary>
         public Severity Severity => State.Options.Severity;
 
         internal Snackbar(SnackbarMessage message, SnackbarOptions options)
@@ -62,7 +82,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Forcibly close the snackbar without performing any animations.
+        /// Forcibly closes the snackbar without performing any animations.
         /// </summary>
         public void ForceClose()
         {

--- a/src/MudBlazor/Components/Snackbar/SnackbarDuplicatesBehavior.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarDuplicatesBehavior.cs
@@ -2,12 +2,25 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Controls what happens when duplicate snackbars are detected.
+/// </summary>
+public enum SnackbarDuplicatesBehavior
 {
-    public enum SnackbarDuplicatesBehavior
-    {
-        Allow,
-        Prevent,
-        GlobalDefault,
-    }
+    /// <summary>
+    /// Duplicate snackbars are allowed.
+    /// </summary>
+    Allow,
+
+    /// <summary>
+    /// Duplicate snackbars will not be displayed.
+    /// </summary>
+    Prevent,
+
+    /// <summary>
+    /// The global default is used to control duplicate snackbars.
+    /// </summary>
+    GlobalDefault,
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -4,38 +4,107 @@
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// The options applied to an individual snackbar.
+    /// </summary>
     public class SnackbarOptions : CommonSnackbarOptions
     {
         /// <summary>
-        /// The asynchronous delegate that is invoked when the Snackbar is clicked.
+        /// Occurs when the snackbar is clicked.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         public Func<Snackbar, Task>? OnClick { get; set; }
 
         /// <summary>
-        /// The asynchronous delegate that is invoked when the close button of the Snackbar is clicked.
+        /// Occurs when the <c>Close</c> button is clicked.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         public Func<Snackbar, Task>? CloseButtonClickFunc { get; set; }
 
+        /// <summary>
+        /// The text for a custom button in the snackbar message.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         public string? Action { get; set; }
 
+        /// <summary>
+        /// The display variant of the action button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         public Variant? ActionVariant { get; set; }
 
+        /// <summary>
+        /// The color of the action button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         public Color ActionColor { get; set; } = Color.Default;
 
+        /// <summary>
+        /// The severity of the snackbar.
+        /// </summary>
         public Severity Severity { get; }
 
+        /// <summary>
+        /// The custom CSS classes for the snackbar.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Multiple classes must be separated by spaces.
+        /// </remarks>
         public string? SnackbarTypeClass { get; set; }
 
+        /// <summary>
+        /// Closes the snackbar after navigating away from the current page.
+        /// </summary>
         public bool CloseAfterNavigation { get; set; }
 
+        /// <summary>
+        /// Hides the icon for the snackbar.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         public bool HideIcon { get; set; }
 
+        /// <summary>
+        /// The custom icon to display for the snackbar.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Will be set to match the <see cref="Severity"/>.
+        /// </remarks>
         public string Icon { get; set; }
 
+        /// <summary>
+        /// The color of the icon to display.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Inherit" />.
+        /// </remarks>
         public Color IconColor { get; set; } = Color.Inherit;
 
+        /// <summary>
+        /// The action applied when duplicate snackbars are detected.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="SnackbarDuplicatesBehavior.GlobalDefault"/> which is set via <see cref="SnackbarConfiguration.PreventDuplicates"/>.
+        /// </remarks>
         public SnackbarDuplicatesBehavior DuplicatesBehavior { get; set; } = SnackbarDuplicatesBehavior.GlobalDefault;
 
+        /// <summary>
+        /// Creates new options for a snackbar.
+        /// </summary>
+        /// <param name="severity">The severity of the snackbar to display.</param>
+        /// <param name="options">Any other options to apply.</param>
         public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {
             Severity = severity;

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -12,7 +12,9 @@ using MudBlazor.Components.Snackbar.InternalComponents;
 
 namespace MudBlazor
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// A service for managing snackbars.
+    /// </summary>
     public class SnackbarService : ISnackbar
     {
         private readonly List<Snackbar> _snackBarList;
@@ -34,6 +36,7 @@ namespace MudBlazor
             _snackBarList = new List<Snackbar>();
         }
 
+        /// <inheritdoc />
         public IEnumerable<Snackbar> ShownSnackbars
         {
             get

--- a/src/MudBlazor/Components/Stack/MudStack.razor.cs
+++ b/src/MudBlazor/Components/Stack/MudStack.razor.cs
@@ -8,6 +8,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// A component for aligning child items horizontally or vertically.
+/// </summary>
 public partial class MudStack : MudComponentBase
 {
     protected string Classname =>
@@ -22,40 +26,53 @@ public partial class MudStack : MudComponentBase
             .Build();
 
     /// <summary>
-    /// If true, items will be placed horizontally in a row instead of vertically.
+    /// Displays items horizontally.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="MudGlobal.StackDefaults.Row"/>.  
+    /// When <c>true</c>, items will be displayed horizontally.  When <c>false</c>, items are displayed vertically.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public bool Row { get; set; } = MudGlobal.StackDefaults.Row;
 
     /// <summary>
-    /// Reverses the order of its items.
+    /// Reverses the order of items.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="MudGlobal.StackDefaults.Reverse"/>.  
+    /// When <c>true</c>, items will be reversed.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public bool Reverse { get; set; } = MudGlobal.StackDefaults.Reverse;
 
     /// <summary>
-    /// The gap between items, measured in increments of <c>4px</c>.
+    /// The gap between items in increments of <c>4px</c>.
     /// </summary>
     /// <remarks>
-    /// Default is <c>3</c>.
-    /// Maximum is <c>20</c>.
+    /// Defaults to <see cref="MudGlobal.StackDefaults.Spacing"/>.  Maximum is <c>20</c> (<c>80px</c>).
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public int Spacing { get; set; } = MudGlobal.StackDefaults.Spacing;
 
     /// <summary>
-    /// Defines the distribution of children along the main axis within a <see cref="MudStack"/> component.
+    /// Defines the distribution of child items.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public Justify? Justify { get; set; }
 
     /// <summary>
-    /// Defines the alignment of children along the cross axis within a <see cref="MudStack"/> component.
+    /// Defines the vertical alignment of child items.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public AlignItems? AlignItems { get; set; }
@@ -64,25 +81,24 @@ public partial class MudStack : MudComponentBase
     /// Defines the stretching behaviour of children along the main axis within a <see cref="MudStack"/> component.
     /// </summary>
     /// <remarks>
-    /// Note: This property affects children of the <see cref="MudStack"/> component.
-    /// If there is only one child, <see cref="StretchItems.Start"/> and <see cref="StretchItems.End"/>
-    /// will have the same effect, and the child will be stretched.
-    /// <see cref="StretchItems.Middle"/> stretches all children except the first and last child.
-    /// If there are two or fewer elements, <see cref="StretchItems.Middle"/> will have no effect.
+    /// Defaults to <c>null</c>.  
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public StretchItems? StretchItems { get; set; }
 
     /// <summary>
-    /// Defines the flexbox wrapping behavior of its items.
+    /// Controls how items are wrapped.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]
     public Wrap? Wrap { get; set; }
 
     /// <summary>
-    /// Child content of the component.
+    /// The content within this component.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Stack.Behavior)]

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -66,7 +66,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// The content for this step.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>null</c>.
+    /// Defaults to <c>null</c>.  Only shown when this step is active.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -7,6 +7,9 @@ using MudBlazor.Utilities;
 #nullable enable
 namespace MudBlazor;
 
+/// <summary>
+/// A individual step as part of a <see cref="MudStepper"/>.
+/// </summary>
 public class MudStep : MudComponentBase, IAsyncDisposable
 {
     public MudStep()
@@ -60,97 +63,120 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     [CascadingParameter] internal MudStepper? Parent { get; set; }
 
     /// <summary>
-    /// The content to be shown when the step is active
+    /// The content for this step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// The title that summarizes the step, shown next to the icon
+    /// The title of this step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? Title { get; set; }
 
     /// <summary>
-    /// An optional subtitle describing the step
+    /// The subtitle describing this step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? SecondaryText { get; set; }
 
     /// <summary>
-    /// Returns true if this step is the stepper's ActiveStep
+    /// Whether this step is the current one being displayed.
     /// </summary>
     public bool IsActive => Parent?.ActiveStep == this;
 
     /// <summary>
-    /// The color of the completed step. It supports the theme colors.
+    /// The color used when this step is completed.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public Color? CompletedStepColor { get; set; }
 
     /// <summary>
-    /// The color of the error step. It supports the theme colors.
+    /// The color used when this step has an error.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public Color? ErrorStepColor { get; set; }
 
     /// <summary>
-    /// If set to true this step can be skipped over in a linear stepper using the skip button.
+    /// Whether the user can skip this step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool Skippable { get; set; }
 
     /// <summary>
-    /// Sets whether the step is completed, this can be used for reviving lost position of process. Default is false.
+    /// Whether this step is completed.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool Completed { get; set; }
 
     /// <summary>
-    /// Raised when Completed changed.
+    /// Occurs when <see cref="Completed"/> has changed.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<bool> CompletedChanged { get; set; }
 
     /// <summary>
-    /// If true, disables the step so that it can not be selected
+    /// Prevents this step from being selected.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Raised when Disabled changed.
+    /// Occurs when <see cref="Disabled"/> has changed.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<bool> DisabledChanged { get; set; }
 
     /// <summary>
-    /// If true, the step will be marked as error. You can use this to show to the user
-    /// that the input data is faulty or insufficient
+    /// Whether this step has an error.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool HasError { get; set; }
 
     /// <summary>
-    /// Raised when HasError changed.
+    /// Occurs when <see cref="HasError"/> has changed.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<bool> HasErrorChanged { get; set; }
 
     /// <summary>
-    /// Raised when step is clicked
+    /// Occurs when this step is clicked.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
@@ -167,7 +193,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     private void OnParameterChanged() => RefreshParent();
 
     /// <summary>
-    /// Sets HasError
+    /// Sets the <see cref="HasError"/> parameter, and optionally refreshes the parent <see cref="MudStepper"/>.
     /// </summary>
     public async Task SetHasErrorAsync(bool value, bool refreshParent = true)
     {
@@ -177,7 +203,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Sets Completed
+    /// Sets the <see cref="Completed"/> parameter, and optionally refreshes the parent <see cref="MudStepper"/>.
     /// </summary>
     public async Task SetCompletedAsync(bool value, bool refreshParent = true)
     {
@@ -187,7 +213,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Sets Disabled
+    /// Sets the <see cref="Disabled"/> parameter, and optionally refreshes the parent <see cref="MudStepper"/>.
     /// </summary>
     public async Task SetDisabledAsync(bool value, bool refreshParent = true)
     {
@@ -201,6 +227,9 @@ public class MudStep : MudComponentBase, IAsyncDisposable
         (Parent as IMudStateHasChanged)?.StateHasChanged();
     }
 
+    /// <summary>
+    /// Releases resources used by this component.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         if (_disposed)

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -195,7 +195,7 @@ public partial class MudStepper : MudComponentBase
     /// Shows a button to start over at the first step.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>false</c>.
+    /// Defaults to <c>false</c>.  Clicking the reset button sets this stepper back to its initial state, discarding all progress and errors.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Link.Appearance)]
@@ -262,7 +262,7 @@ public partial class MudStepper : MudComponentBase
     /// Occurs when the user attempts to go to a step.
     /// </summary>
     /// <remarks>
-    /// Use this function to customize when the user can navigate to a step, such as when a form has been properly completed.
+    /// Use this function to customize when the user can navigate to a step, such as when a form has been properly completed.  The attempted navigation can be prevented by setting <see cref="StepperInteractionEventArgs.Cancel"/> to <c>true</c>.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]
@@ -271,6 +271,9 @@ public partial class MudStepper : MudComponentBase
     /// <summary>
     /// Whether the current step can be skipped.
     /// </summary>
+    /// <remarks>
+    /// Typically used to enable or disable a custon <c>Skip</c> button.
+    /// </remarks>
     public bool IsCurrentStepSkippable => _steps.Any() && ActiveStep is not null && ActiveStep.Skippable;
 
     private bool CanReset => _steps.Any(x => x.CompletedState || x.HasErrorState) || _activeIndex > 0;
@@ -278,6 +281,9 @@ public partial class MudStepper : MudComponentBase
     /// <summary>
     /// Whether the user can go to the next step.
     /// </summary>
+    /// <remarks>
+    /// Typically used to enable or disable a custon <c>Next</c> button.
+    /// </remarks>
     public bool CanGoToNextStep => _steps.Any() && _steps.SkipWhile(x => _steps.IndexOf(x) <= _activeIndex).Count(x => !x.DisabledState) > 0;
 
     /// <summary>
@@ -302,7 +308,7 @@ public partial class MudStepper : MudComponentBase
     /// The steps in this component.
     /// </summary>
     /// <remarks>
-    /// Typically a set of <see cref="MudStep"/> components.
+    /// Must be a set of <see cref="MudStep"/> components.  
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
@@ -312,7 +318,7 @@ public partial class MudStepper : MudComponentBase
     /// The custom template for displaying each step's title.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>null</c>.
+    /// Defaults to <c>null</c>.  The current <see cref="MudStep"/> is passed as context for this render fragment.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
@@ -534,7 +540,7 @@ public partial class MudStepper : MudComponentBase
     }
 
     /// <summary>
-    /// Resets the completed status of all steps and goes to the first step.
+    /// Resets the completed status of all steps and goes to the first step, resetting all progress and errors.
     /// </summary>
     public async Task ResetAsync(bool resetErrors = false)
     {

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -10,6 +10,9 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
+/// <summary>
+/// A wizard that guides the user through a series of steps to complete a transaction.
+/// </summary>
 public partial class MudStepper : MudComponentBase
 {
     public MudStepper()
@@ -45,200 +48,292 @@ public partial class MudStepper : MudComponentBase
             .Build();
 
     /// <summary>
-    /// The steps that have been defined in razor.
+    /// The steps to step through.
     /// </summary>
     public IReadOnlyList<MudStep> Steps => _steps;
 
     /// <summary>
-    /// The actively selected step. Can be not selected.
+    /// The currently active step.
     /// </summary>
     public MudStep? ActiveStep { get; private set; }
 
     /// <summary>
-    /// Index of the currently shown step. If set, it doesn't save the position into the history
+    /// The index of the currently active step.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public int ActiveIndex { get; set; } = -1;
 
+    /// <summary>
+    /// Occurs when <see cref="ActiveIndex"/> has changed.
+    /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<int> ActiveIndexChanged { get; set; }
 
     /// <summary>
-    /// The color of a completed step. It supports the theme colors.
+    /// The color of completed steps.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Primary"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public Color CompletedStepColor { get; set; } = Color.Primary;
 
-
     /// <summary>
-    /// The color of the current step. It supports the theme colors.
+    /// The color of the current step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Primary"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public Color CurrentStepColor { get; set; } = Color.Primary;
 
     /// <summary>
-    /// The color of the error step. Sets the color globally for the whole stepper. It supports the theme colors.
+    /// The color of steps with errors.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Error"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public Color ErrorStepColor { get; set; } = Color.Error;
 
     /// <summary>
-    /// The icon of a completed step.
+    /// The icon shown for completed steps.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.Done"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string StepCompleteIcon { get; set; } = Icons.Material.Outlined.Done;
 
     /// <summary>
-    /// The icon of a step that has an error.
+    /// The icon shown for steps with errors.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.PriorityHigh"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string StepErrorIcon { get; set; } = Icons.Material.Outlined.PriorityHigh;
 
     /// <summary>
-    /// The icon of the reset button.
+    /// The icon shown for the reset button.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.FirstPage"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string ResetButtonIcon { get; set; } = Icons.Material.Filled.FirstPage;
 
     /// <summary>
-    /// The icon of the previous button.
+    /// The icon shown for the <c>Previous</c> button.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.NavigateBefore"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string PreviousButtonIcon { get; set; } = Icons.Material.Filled.NavigateBefore;
 
     /// <summary>
-    /// The icon of the skip button.
+    /// The icon shown for the <c>Skip</c> button.
     /// </summary>
+    /// <remarks>
+    /// Defaults to a custom icon.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string SkipButtonIcon { get; set; } = @"<svg style=""width:24px;height:24px"" viewBox=""0 0 24 24""><path fill=""currentColor"" d=""M12,14A2,2 0 0,1 14,16A2,2 0 0,1 12,18A2,2 0 0,1 10,16A2,2 0 0,1 12,14M23.46,8.86L21.87,15.75L15,14.16L18.8,11.78C17.39,9.5 14.87,8 12,8C8.05,8 4.77,10.86 4.12,14.63L2.15,14.28C2.96,9.58 7.06,6 12,6C15.58,6 18.73,7.89 20.5,10.72L23.46,8.86Z"" /></svg>";
 
     /// <summary>
-    /// The icon of the next button.
+    /// The icon shown for the <c>Next</c> button.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Filled.NavigateNext"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string NextButtonIcon { get; set; } = Icons.Material.Filled.NavigateNext;
 
     /// <summary>
-    /// The icon of the complete button.
+    /// The icon shown for the <c>Complete</c> button.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.Done"/>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string CompleteButtonIcon { get; set; } = Icons.Material.Outlined.Done;
 
     /// <summary>
-    /// Class for the navigation bar of the component
+    /// The CSS classes applied to the navigation bar.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Multiple classes must be separated by spaces.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? NavClass { get; set; }
 
     /// <summary>
-    /// Set this true to allow users to move between steps arbitrarily.
+    /// Allows users to move between steps arbitrarily.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  When <c>false</c>, users must complete the active step before being allowed to move to the next step.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool NonLinear { get; set; }
 
     /// <summary>
-    /// Set this to show the reset button which sets the stepper back into the initial state.
+    /// Shows a button to start over at the first step.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Link.Appearance)]
     public bool ShowResetButton { get; set; } = false;
 
     /// <summary>
-    /// Renders the component in vertical manner. Each step is collapsible
+    /// Renders steps vertically.
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public bool Vertical { get; set; }
 
     /// <summary>
-    /// Sets css class for all steps globally
+    /// The CSS classes applied to all steps.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Multiple classes must be separated by spaces.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? StepClass { get; set; }
 
     /// <summary>
-    /// Sets style for all steps globally
+    /// The CSS styles applied to all steps.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? StepStyle { get; set; }
 
     /// <summary>
-    /// Centers the labels for each step below the circle. Applies only to horizontal steppers
+    /// Centers the labels for each step below the circle.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.  Only applies when <see cref="Vertical"/> is <c>false</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public bool CenterLabels { get; set; }
 
     /// <summary>
-    /// Displays a ripple effect when the step is clicked.
+    /// Displays a ripple effect when a step is clicked.
     /// </summary>
     /// <remarks>
-    /// Affects only non-linear steppers. Defaults to <c>false</c>.
+    /// Defaults to <c>false</c>.  Only applies when <see cref="NonLinear"/> is <c>true</c>. 
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public bool Ripple { get; set; } = true;
 
     /// <summary>
-    /// If there is too many steps, the navigation becomes scrollable.
+    /// Shows a scroll bar for steps if needed.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public bool ScrollableNavigation { get; set; } = true;
 
     /// <summary>
-    /// Fired when a step gets activated. Returned Task will be awaited.
+    /// Occurs when the user attempts to go to a step.
     /// </summary>
+    /// <remarks>
+    /// Use this function to customize when the user can navigate to a step, such as when a form has been properly completed.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Tabs.Behavior)]
     public Func<StepperInteractionEventArgs, Task>? OnPreviewInteraction { get; set; }
 
+    /// <summary>
+    /// Whether the current step can be skipped.
+    /// </summary>
     public bool IsCurrentStepSkippable => _steps.Any() && ActiveStep is not null && ActiveStep.Skippable;
 
     private bool CanReset => _steps.Any(x => x.CompletedState || x.HasErrorState) || _activeIndex > 0;
 
+    /// <summary>
+    /// Whether the user can go to the next step.
+    /// </summary>
     public bool CanGoToNextStep => _steps.Any() && _steps.SkipWhile(x => _steps.IndexOf(x) <= _activeIndex).Count(x => !x.DisabledState) > 0;
 
+    /// <summary>
+    /// Whether the <c>Previous</c> button is enabled.
+    /// </summary>
     public bool PreviousStepEnabled => _steps.Any() && _steps.TakeWhile(x => _steps.IndexOf(x) < _activeIndex).Count(x => !x.DisabledState) > 0;
 
+    /// <summary>
+    /// Whether all steps have been completed.
+    /// </summary>
     public bool IsCompleted => _steps.Any() && _steps.Where(x => !x.Skippable).All(x => x.CompletedState.Value);
 
+    /// <summary>
+    /// Whether the <c>Complete</c> or <c>Next</c> button is displayed.
+    /// </summary>
     public bool ShowCompleteInsteadOfNext => _steps.Any() &&
                                              _steps.Count(x => !x.Skippable && !x.CompletedState.Value) == 1 &&
                                              ActiveStep != null &&
                                              _steps.First(x => !x.Skippable && !x.CompletedState.Value) == ActiveStep;
 
     /// <summary>
-    /// Space for all the MudSteps
+    /// The steps in this component.
     /// </summary>
+    /// <remarks>
+    /// Typically a set of <see cref="MudStep"/> components.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// The custom template for displaying each step's title.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public RenderFragment<MudStep>? TitleTemplate { get; set; }
 
+    /// <summary>
+    /// The custom template for displaying each step's index and icon.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public RenderFragment<MudStep>? LabelTemplate { get; set; }
 
+    /// <summary>
+    /// The custom template for displaying lines connecting each step.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public RenderFragment<MudStep>? ConnectorTemplate { get; set; }
@@ -411,7 +506,7 @@ public partial class MudStepper : MudComponentBase
     }
 
     /// <summary>
-    /// Goes to the previous step
+    /// Goes to the previous step.
     /// </summary>
     public async Task PreviousStepAsync()
     {
@@ -423,7 +518,7 @@ public partial class MudStepper : MudComponentBase
     }
 
     /// <summary>
-    /// Completes the current step and goes to the next step
+    /// Completes the current step and goes to the next step.
     /// </summary>
     public Task NextStepAsync()
     {
@@ -431,7 +526,7 @@ public partial class MudStepper : MudComponentBase
     }
 
     /// <summary>
-    /// Goes to the next step without completing the current one
+    /// Goes to the next step without completing the current step.
     /// </summary>
     public Task SkipCurrentStepAsync()
     {
@@ -439,7 +534,7 @@ public partial class MudStepper : MudComponentBase
     }
 
     /// <summary>
-    /// Resets the completed status of all steps and set the first step as the active one.
+    /// Resets the completed status of all steps and goes to the first step.
     /// </summary>
     public async Task ResetAsync(bool resetErrors = false)
     {

--- a/src/MudBlazor/Components/Stepper/StepAction.cs
+++ b/src/MudBlazor/Components/Stepper/StepAction.cs
@@ -4,10 +4,31 @@
 
 namespace MudBlazor;
 
+/// <summary>
+/// Indicates the requested behavior of a button in a <see cref="MudStepper"/> component.
+/// </summary>
+/// <remarks>
+/// Typically called during <see cref="MudStepper.OnPreviewInteraction"/> to ask whether step change should be allowed.
+/// </remarks>
 public enum StepAction
 {
+    /// <summary>
+    /// A request to activate a step.
+    /// </summary>
     Activate,
+
+    /// <summary>
+    /// A request to complete the last step.
+    /// </summary>
     Complete,
+
+    /// <summary>
+    /// A request to skip the current step.
+    /// </summary>
     Skip,
+
+    /// <summary>
+    /// A request to start over at the first step.
+    /// </summary>
     Reset
 }

--- a/src/MudBlazor/Components/Stepper/StepperInteractionEventArgs.cs
+++ b/src/MudBlazor/Components/Stepper/StepperInteractionEventArgs.cs
@@ -6,9 +6,26 @@
 
 namespace MudBlazor;
 
+/// <summary>
+/// Information about a requested step change when <see cref="MudStepper.OnPreviewInteraction"/> occurs.
+/// </summary>
 public class StepperInteractionEventArgs
 {
+    /// <summary>
+    /// The desired step index.
+    /// </summary>
     public int StepIndex { get; init; }
+
+    /// <summary>
+    /// The requested step action.
+    /// </summary>
     public StepAction Action { get; set; }
+
+    /// <summary>
+    /// Whether to disallow this request.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <c>true</c> to indicate that the requested step change should not occur.
+    /// </remarks>
     public bool Cancel { get; set; }
 }

--- a/src/MudBlazor/Enums/AlignItems.cs
+++ b/src/MudBlazor/Enums/AlignItems.cs
@@ -3,18 +3,37 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies how children of a flex container are aligned along the cross axis.
+/// The vertical alignment applied to items in a <see cref="MudStack"/> or <see cref="MudDataGrid{T}"/>.
 /// </summary>
 public enum AlignItems
 {
+    /// <summary>
+    /// Items are aligned to keep text consistently aligned.
+    /// </summary>
     [Description("baseline")]
     Baseline,
+
+    /// <summary>
+    /// The center of items is aligned to the center of the container.
+    /// </summary>
     [Description("center")]
     Center,
+
+    /// <summary>
+    /// The top edge of items are aligned to the top of the container.
+    /// </summary>
     [Description("start")]
     Start,
+
+    /// <summary>
+    /// The bottom edge of items are aligned to the bottom of the container.
+    /// </summary>
     [Description("end")]
     End,
+
+    /// <summary>
+    /// Items will have the same height as the container.
+    /// </summary>
     [Description("stretch")]
     Stretch
 }

--- a/src/MudBlazor/Enums/Justify.cs
+++ b/src/MudBlazor/Enums/Justify.cs
@@ -20,7 +20,7 @@ public enum Justify
     Center,
 
     /// <summary>
-    /// Items are aligned to the start of the <see cref="MudStack"/>.
+    /// Items are aligned to the end of the <see cref="MudStack"/>.
     /// </summary>
     [Description("end")]
     FlexEnd,

--- a/src/MudBlazor/Enums/Justify.cs
+++ b/src/MudBlazor/Enums/Justify.cs
@@ -3,20 +3,43 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies the distribution of children within a flex container along the main axis. 
+/// The horizontal distribution of child items in a <see cref="MudStack"/> component.
 /// </summary>
 public enum Justify
 {
+    /// <summary>
+    /// Items are aligned to the start of the <see cref="MudStack"/>.
+    /// </summary>
     [Description("start")]
     FlexStart,
+
+    /// <summary>
+    /// Items are centered horizontally.
+    /// </summary>
     [Description("center")]
     Center,
+
+    /// <summary>
+    /// Items are aligned to the start of the <see cref="MudStack"/>.
+    /// </summary>
     [Description("end")]
     FlexEnd,
+
+    /// <summary>
+    /// Space is applied between each item, with items aligned against the start and end.
+    /// </summary>
     [Description("space-between")]
     SpaceBetween,
+
+    /// <summary>
+    /// Space is applied between each item, with additional spacing for the first and last item.
+    /// </summary>
     [Description("space-around")]
     SpaceAround,
+
+    /// <summary>
+    /// Space is applied evenly between each item, including the edges of the first and last item.
+    /// </summary>
     [Description("space-evenly")]
     SpaceEvenly
 }

--- a/src/MudBlazor/Enums/StretchItems.cs
+++ b/src/MudBlazor/Enums/StretchItems.cs
@@ -7,42 +7,42 @@ using System.ComponentModel;
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies how children of a flex container are stretched along the main axis.
+/// Specifies how items in a flex container are stretched along the main axis.
 /// </summary>
 public enum StretchItems
 {
     /// <summary>
-    /// No stretching is applied to children.
+    /// No stretching is applied.
     /// </summary>
     [Description("none")]
     None,
 
     /// <summary>
-    /// The first child is stretched.
+    /// The first item is stretched.
     /// </summary>
     [Description("start")]
     Start,
 
     /// <summary>
-    /// The last child is stretched.
+    /// The last item is stretched.
     /// </summary>
     [Description("end")]
     End,
 
     /// <summary>
-    /// The first and last children are stretched.
+    /// The first and last items are stretched.
     /// </summary>
     [Description("start-and-end")]
     StartAndEnd,
 
     /// <summary>
-    /// All children except for the first and last are stretched.
+    /// All items except for the first and last are stretched.
     /// </summary>
     [Description("middle")]
     Middle,
 
     /// <summary>
-    /// All children are stretched.
+    /// All items are stretched evenly.
     /// </summary>
     [Description("all")]
     All,

--- a/src/MudBlazor/Enums/Wrap.cs
+++ b/src/MudBlazor/Enums/Wrap.cs
@@ -3,23 +3,26 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// The flex-wrap CSS property sets whether flex items are forced onto one line or 
-    /// can wrap onto multiple lines. If wrapping is allowed, it sets the direction that lines are stacked.
+    /// Indicates how items in a <see cref="MudStack"/> are wrapped.
     /// </summary>
     public enum Wrap
     {
         /// <summary>
-        /// This is the default value.
-        /// The flex items are laid out in a single line which may cause the flex container to overflow. 
-        /// The cross-start is either equivalent to start or before depending on the flex-direction value. 
+        /// No wrapping occurs.
         /// </summary>
+        /// <remarks>
+        /// Items may overflow the container.  
+        /// </remarks>
         [Description("nowrap")]
         NoWrap,
 
         /// <summary>
-        /// The flex items break into multiple lines. The cross-start is either equivalent to start or before 
-        /// depending flex-direction value and the cross-end is the opposite of the specified cross-start.
+        /// Items are wrapped to fit the container.
         /// </summary>
+        /// <remarks>
+        /// When <see cref="MudStack.Row"/> is <c>true</c>, items are wrapped to fit into the width of the container.<br />
+        /// When <c>false</c>, items are wrapped to fit into the height of the container.
+        /// </remarks>
         [Description("wrap")]
         Wrap,
 

--- a/src/MudBlazor/Interfaces/ISnackbar.cs
+++ b/src/MudBlazor/Interfaces/ISnackbar.cs
@@ -14,12 +14,12 @@ namespace MudBlazor;
 public interface ISnackbar : IDisposable
 {
     /// <summary>
-    /// Gets the collection of currently shown snackbars.
+    /// The collection of currently shown snackbars.
     /// </summary>
     IEnumerable<Snackbar> ShownSnackbars { get; }
 
     /// <summary>
-    /// Gets the global configuration for a snackbar.
+    /// The global configuration for each snackbar.
     /// </summary>
     SnackbarConfiguration Configuration { get; }
 
@@ -32,7 +32,7 @@ public interface ISnackbar : IDisposable
     /// Adds a new snackbar with the specified message.
     /// </summary>
     /// <param name="message">The message to display in the snackbar.</param>
-    /// <param name="severity">The severity of the snackbar message. Default is <see cref="Severity.Normal"/>.</param>
+    /// <param name="severity">The severity of the snackbar message. Defaults to <see cref="Severity.Normal"/>.</param>
     /// <param name="configure">Optional action to configure the <see cref="SnackbarOptions"/>.</param>
     /// <param name="key">An optional key to uniquely identify the snackbar. Default is the value of <paramref name="message"/>.</param>
     /// <returns>The created snackbar instance, or null if not created.</returns>


### PR DESCRIPTION
## Description

This update adds XML documentation for `MudSlider` through `MudStepper` and related types:

* MudSlider
  * SliderContext
* Snackbar
  * CommonSnackbarOptions
  * Defaults 
  * ISnackbar Interface
  * SnackbarDuplicatesBehavior Enum
  * SnackbarService
* MudStack
  * AlignmentItems Enum
  * Justify Enum
  * StretchItems Enum
  * Wrap Enum
* MudStepper
  * MudStep
  * StepAction Enum
  * StepperInteractionEventArgs

> [!NOTE]  
> This PR removes an empty file named "MudStep" (without any extension).

## How Has This Been Tested?

This was tested by examining the example Razor code for all affected components:

#### MudSlider

![image](https://github.com/user-attachments/assets/7833588a-b565-428a-bf40-f5a3c404ec0f)
![image](https://github.com/user-attachments/assets/23d1086d-8a6e-4184-938b-d359aae72550)

#### Snackbar

![image](https://github.com/user-attachments/assets/ea855cb8-fa84-4a91-94c2-c6ab276af5f7)
![image](https://github.com/user-attachments/assets/eccb77de-9858-46b5-b89b-966deaf4be5c)
![image](https://github.com/user-attachments/assets/1e7814d3-dc58-42c3-9c5c-1406aa7dcf18)

#### MudStack

![image](https://github.com/user-attachments/assets/09aec256-e206-4b13-af5e-ddd904205d8d)
![image](https://github.com/user-attachments/assets/f0419baa-2277-435f-aade-191b76bad1ab)
![image](https://github.com/user-attachments/assets/3517ccaa-357f-4890-9137-16ac765684d7)

#### MudStepper

![image](https://github.com/user-attachments/assets/1975ade3-1c13-4c2f-8fe7-ce56f594e521)
![image](https://github.com/user-attachments/assets/1a835ba7-69c4-4227-9b17-eaa20e880eb5)
![image](https://github.com/user-attachments/assets/166d0c7a-ec15-4b61-a8eb-6365cee4c1a3)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
