### PR TITLE
Add theme toggler to unit tests viewer

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -43,11 +43,11 @@
 
                 <div class="d-flex flex-row align-center gap-2">
                     <MudTextField T="string" @bind-Value="@_currentSearchText" Immediate="true" FullWidth="true"
-                    Typo="Typo.subtitle1" Placeholder="Search by component" Clearable DebounceInterval="200" />
+                                  Typo="Typo.subtitle1" Placeholder="Search by component" Clearable DebounceInterval="200" />
 
                     <MudTooltip Text="@(_expandedState ? "Collapse all" : "Expand all")">
                         <MudIconButton Icon="@(_expandedState ? CollapseAllIcon : ExpandAllIcon)" Size="Size.Small"
-                        OnClick="@(() => ToggleExpanded())" />
+                                       OnClick="@(() => ToggleExpanded())" />
                     </MudTooltip>
                 </div>
             </MudDrawerHeader>
@@ -64,7 +64,7 @@
                             @foreach (var type in typesInDir)
                             {
                                 <MudNavLink Class="@(_selectedType == type ? "mode-links active" : "")"
-                                OnClick="@(() => _selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
+                                            OnClick="@(() => _selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
                             }
                         </MudNavGroup>
                     }
@@ -105,40 +105,40 @@
 </MudLayout>
 <style>
     .docs-search-bar .mud-input {
-    height: 42px;
+        height: 42px;
     }
 
     .docs-search-bar.mud-input-control {
-    background-color: rgba(255,255,255,.15);
-    margin-bottom: 5px;
-    height: 42px;
-    border-radius: var(--mud-default-borderradius);
+        background-color: rgba(255,255,255,.15);
+        margin-bottom: 5px;
+        height: 42px;
+        border-radius: var(--mud-default-borderradius);
     }
 
     .docs-search-bar.mud-input-control .mud-input-root, .docs-search-bar.mud-input-control .mud-icon-default {
-    color: #fafafa;
+        color: #fafafa;
     }
 
     .docs-search-bar .mud-input.mud-input-outlined .mud-input-outlined-border {
-    border: none;
-    border-radius: var(--mud-default-borderradius);
+        border: none;
+        border-radius: var(--mud-default-borderradius);
     }
 
     .mode-links.active {
-    color: var(--mud-palette-primary);
-    background-color: var(--mud-palette-primary-hover)
+        color: var(--mud-palette-primary);
+        background-color: var(--mud-palette-primary-hover);
     }
 
     .mud-nav-link {
-    padding: 4px;
+        padding: 4px;
     }
 
     .mud-collapse-container {
-    transition-duration: 100ms;
+        transition-duration: 100ms;
     }
 
     .mud-appbar .mud-icon-button {
-    color: var(--mud-palette-appbar-text) !important;
+        color: var(--mud-palette-appbar-text) !important;
     }
 </style>
 

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -169,7 +169,7 @@
 
     private void ToggleTheme() => _isDarkMode = !_isDarkMode;
 
-    private string ThemeIcon => _isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode;
+    private string ThemeIcon => _isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode;
 
     private string ThemeLabel => _isDarkMode ? "Switch to light theme" : "Switch to dark theme";
 

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -1,6 +1,8 @@
 ﻿@page "/"
 @using System.Reflection
 
+<MudThemeProvider Theme="@_customTheme" IsDarkMode="@_isDarkMode"  />
+
 <MudLayout>
     <MudRTLProvider RightToLeft="_rightToLeft">
         <MudAppBar Elevation="0">
@@ -14,6 +16,9 @@
                 </ItemTemplate>
             </MudAutocomplete>
             <MudSpacer />
+            <MudTooltip Text="@ThemeLabel">
+                <MudIconButton Icon="@ThemeIcon" OnClick="ToggleTheme" aria-label="@ThemeLabel" />
+            </MudTooltip>
             <MudTooltip Text="@(_rightToLeft ? "Left-to-right" : "Right-to-left")">
                 <MudIconButton Icon="@(_rightToLeft ? @Icons.Material.Filled.FormatTextdirectionLToR : @Icons.Material.Filled.FormatTextdirectionRToL)" OnClick="() => _rightToLeft = !_rightToLeft" aria-label="@(_rightToLeft ? "Left-to-right" : "Right-to-left")" />
             </MudTooltip>
@@ -38,11 +43,11 @@
 
                 <div class="d-flex flex-row align-center gap-2">
                     <MudTextField T="string" @bind-Value="@_currentSearchText" Immediate="true" FullWidth="true"
-                                  Typo="Typo.subtitle1" Placeholder="Search by component" Clearable DebounceInterval="200" />
+                    Typo="Typo.subtitle1" Placeholder="Search by component" Clearable DebounceInterval="200" />
 
                     <MudTooltip Text="@(_expandedState ? "Collapse all" : "Expand all")">
                         <MudIconButton Icon="@(_expandedState ? CollapseAllIcon : ExpandAllIcon)" Size="Size.Small"
-                                       OnClick="@(() => ToggleExpanded())" />
+                        OnClick="@(() => ToggleExpanded())" />
                     </MudTooltip>
                 </div>
             </MudDrawerHeader>
@@ -59,7 +64,7 @@
                             @foreach (var type in typesInDir)
                             {
                                 <MudNavLink Class="@(_selectedType == type ? "mode-links active" : "")"
-                                            OnClick="@(() => _selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
+                                OnClick="@(() => _selectedType = type)" @key="type.Name">@type.Name</MudNavLink>
                             }
                         </MudNavGroup>
                     }
@@ -100,40 +105,40 @@
 </MudLayout>
 <style>
     .docs-search-bar .mud-input {
-        height: 42px;
+    height: 42px;
     }
 
     .docs-search-bar.mud-input-control {
-        background-color: rgba(255,255,255,.15);
-        margin-bottom: 5px;
-        height: 42px;
-        border-radius: var(--mud-default-borderradius);
+    background-color: rgba(255,255,255,.15);
+    margin-bottom: 5px;
+    height: 42px;
+    border-radius: var(--mud-default-borderradius);
     }
 
-        .docs-search-bar.mud-input-control .mud-input-root, .docs-search-bar.mud-input-control .mud-icon-default {
-            color: #fafafa;
-        }
+    .docs-search-bar.mud-input-control .mud-input-root, .docs-search-bar.mud-input-control .mud-icon-default {
+    color: #fafafa;
+    }
 
     .docs-search-bar .mud-input.mud-input-outlined .mud-input-outlined-border {
-        border: none;
-        border-radius: var(--mud-default-borderradius);
+    border: none;
+    border-radius: var(--mud-default-borderradius);
     }
 
     .mode-links.active {
-        color: var(--mud-palette-primary);
-        background-color: var(--mud-palette-primary-hover)
+    color: var(--mud-palette-primary);
+    background-color: var(--mud-palette-primary-hover)
     }
 
     .mud-nav-link {
-        padding: 4px;
+    padding: 4px;
     }
 
     .mud-collapse-container {
-        transition-duration: 100ms;
+    transition-duration: 100ms;
     }
 
     .mud-appbar .mud-icon-button {
-        color: var(--mud-palette-appbar-text) !important;
+    color: var(--mud-palette-appbar-text) !important;
     }
 </style>
 
@@ -151,8 +156,22 @@
     private string _currentSearchText = string.Empty;
     private Dictionary<Type, string>? _typeDirectories;
     private MudAutocomplete<Type> _autocomplete = null!;
+    private bool _isDarkMode;
+    private readonly MudTheme _customTheme = new()
+    {
+        LayoutProperties = new LayoutProperties
+        {
+            DrawerWidthLeft = "400px"
+        }
+    };
 
     private bool ShouldFilter => !string.IsNullOrWhiteSpace(_currentSearchText) && _currentSearchText.Length > 2;
+
+    private void ToggleTheme() => _isDarkMode = !_isDarkMode;
+
+    private string ThemeIcon => _isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode;
+
+    private string ThemeLabel => _isDarkMode ? "Switch to light theme" : "Switch to dark theme";
 
     private void DocsDrawerToggle() => _drawerOpen = !_drawerOpen;
 

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -1,6 +1,6 @@
 ﻿@inherits LayoutComponentBase
 
-<MudThemeProvider Theme="@_customTheme"/>
+
 <MudPopoverProvider/>
 <MudDialogProvider/>
 <MudSnackbarProvider/>
@@ -8,13 +8,7 @@
 @Body
 
 @code {
-    private readonly MudTheme _customTheme = new()
-    {
-        LayoutProperties = new LayoutProperties
-        {
-            DrawerWidthLeft = "400px"
-        }
-    };
+
 
     static MainLayout()
     {

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -1,6 +1,5 @@
 ﻿@inherits LayoutComponentBase
 
-
 <MudPopoverProvider/>
 <MudDialogProvider/>
 <MudSnackbarProvider/>
@@ -8,8 +7,6 @@
 @Body
 
 @code {
-
-
     static MainLayout()
     {
         MudGlobal.TooltipDefaults.Delay = TimeSpan.FromMilliseconds(500);


### PR DESCRIPTION
## Description
This PR introduces a MudBlazor contributors' convenience feature for testing visual changes more easily.

Adds a theme toggler to the **MudBlazor.UnitTests.Viewer** project to aid in visual testing.
No changes have been made to the core library functionality.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/user-attachments/assets/90da2a82-7616-41e7-aefd-412114b1381b)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests (N/A).
