### PR TITLE
MudToggleGroup: Remove `Rounded` in favor of CSS utilities `rounded-*`

### DIFF
--- a/src/MudBlazor.Docs/Components/ApiMemberTable.razor
+++ b/src/MudBlazor.Docs/Components/ApiMemberTable.razor
@@ -57,8 +57,7 @@
                                     T="ApiMemberGrouping"
                                     Value="Grouping"
                                     ValueChanged="OnGroupingChangedAsync"
-                                    Size="Size.Small"
-                                    Rounded="true">
+                                    Size="Size.Small">
                         <MudToggleItem Value="ApiMemberGrouping.None">None</MudToggleItem>
                         <MudToggleItem Value="ApiMemberGrouping.Categories">Category</MudToggleItem>
                         <MudToggleItem Value="ApiMemberGrouping.Inheritance">Inheritance</MudToggleItem>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/Examples/ToggleBasicsExample.razor
@@ -3,13 +3,13 @@
 <MudStack>
     <MudStack Row Class="flex-wrap">
         <MudStack Spacing="16" AlignItems="@AlignItems.Start">
-            <MudToggleGroup T="string" Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled" Style="width: 30rem">
+            <MudToggleGroup T="string" Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled" Style="width: 30rem">
                 <MudToggleItem Value="@("One")" />
                 <MudToggleItem Value="@("Two")" />
                 <MudToggleItem Value="@("Three")" />
             </MudToggleGroup>
 
-            <MudToggleGroup T="string" Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled">
+            <MudToggleGroup T="string" Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled">
                 <MudToggleItem Value="@("left")">
                     <MudIcon Icon="@Icons.Material.Filled.FormatAlignLeft" />
                 </MudToggleItem>
@@ -27,7 +27,7 @@
 
         <MudSpacer />
 
-        <MudToggleGroup T="string" Vertical Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" Rounded="@_rounded" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled">
+        <MudToggleGroup T="string" Vertical Outlined="@_outlined" Delimiters="@_delimiters" Size="@_size" Color="@_color" CheckMark="@_checkMark" FixedContent="@_fixedContent" Disabled="@_disabled">
             <MudToggleItem Value="@("left")">
                 <MudIcon Icon="@Icons.Material.Filled.FormatAlignLeft" />
             </MudToggleItem>
@@ -58,7 +58,6 @@
             }
         </MudSelect>
 
-        <MudCheckBox @bind-Value="_rounded" Label="Rounded" />
         <MudCheckBox @bind-Value="_checkMark" Label="CheckMark" />
         <MudCheckBox @bind-Value="_fixedContent" Label="FixedContent" />
         <MudCheckBox @bind-Value="_outlined" Label="Outlined" />
@@ -70,7 +69,6 @@
 @code {
     Size _size = Size.Medium;
     Color _color = Color.Primary;
-    bool _rounded = false;
     bool _checkMark = false;
     bool _outlined = true;
     bool _delimiters = true;

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -169,7 +169,6 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
             {
-                builder.Add(x => x.Rounded, false);
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"));
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"));
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "c"));

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -42,9 +42,6 @@ namespace MudBlazor
             _size = registerScope.RegisterParameter<Size>(nameof(Size))
                 .WithParameter(() => Size)
                 .WithChangeHandler(OnParameterChanged);
-            _rounded = registerScope.RegisterParameter<bool>(nameof(Rounded))
-                .WithParameter(() => Rounded).
-                WithChangeHandler(OnParameterChanged);
             _checkMark = registerScope.RegisterParameter<bool>(nameof(CheckMark))
                 .WithParameter(() => CheckMark)
                 .WithChangeHandler(OnParameterChanged);
@@ -64,7 +61,6 @@ namespace MudBlazor
         private readonly ParameterState<bool> _delimiters;
         private readonly ParameterState<bool> _rtl;
         private readonly ParameterState<Size> _size;
-        private readonly ParameterState<bool> _rounded;
         private readonly ParameterState<bool> _checkMark;
         private readonly ParameterState<bool> _fixedContent;
         private readonly ParameterState<bool> _disabled;
@@ -74,8 +70,6 @@ namespace MudBlazor
             .AddClass("mud-toggle-group-horizontal", !Vertical)
             .AddClass("mud-toggle-group-vertical", Vertical)
             .AddClass($"mud-toggle-group-size-{Size.ToDescriptionString()}")
-            .AddClass("rounded", !Rounded)
-            .AddClass("rounded-xl", Rounded)
             .AddClass("mud-toggle-group-rtl", RightToLeft)
             .AddClass($"border mud-border-{Color.ToDescriptionString()} border-solid", Outlined)
             .AddClass("mud-disabled", Disabled)
@@ -143,13 +137,6 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.List.Appearance)]
         public bool Vertical { get; set; }
-
-        /// <summary>
-        /// If true, the first and last item will be rounded.
-        /// </summary>
-        [Parameter]
-        [Category(CategoryTypes.List.Appearance)]
-        public bool Rounded { get; set; }
 
         [CascadingParameter(Name = "RightToLeft")]
         public bool RightToLeft { get; set; }

--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -5,6 +5,7 @@
   overflow: hidden;
   box-sizing: border-box;
   border-width: 0;
+  border-radius: var(--mud-default-borderradius);
 
   & > .mud-toggle-item {
     box-shadow: none;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #10522 by using the theme border radius and moving any further rounding onto the user which allows greater control. Previously the rounding classes added by the component themselves would override the user's choice.

Migration:
- ToggleGroup.Rounded was removed and uses the default border radius by default. Override the rounding with CSS styles or utility classes (ex: `rounded-pill`).

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Default state with default border radius of 4px:**

<img width="430" alt="image" src="https://github.com/user-attachments/assets/ef6330b9-f19c-4fb2-8711-3216abb8cd36" />

**`rounded-pill` added to `Class` property:**

<img width="425" alt="image" src="https://github.com/user-attachments/assets/26195fe6-7148-4835-b704-a040aca5993c" />



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
