### PR TITLE
MudMenu: Open standard sub menus with left click

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuWithNestingExample.razor
@@ -4,24 +4,24 @@
     <MudMenuItem Label="Add reaction" />
     <MudMenuItem Label="Add bookmark" />
 
-    <MudMenu Label="Format" ActivationEvent="@MouseEvent.MouseOver">
-        <MudMenu Label="Text" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenu Label="Format">
+        <MudMenu Label="Text">
             <MudMenuItem Label="Bold" />
             <MudMenuItem Label="Italic" />
             <MudMenuItem Label="Underline" />
 
-            <MudMenu Label="Size" ActivationEvent="@MouseEvent.MouseOver">
+            <MudMenu Label="Size">
                 <MudMenuItem Label="Increase font size" />
                 <MudMenuItem Label="Decrease font size" />
             </MudMenu>
         </MudMenu>
 
-        <MudMenu Label="Points" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Points">
             <MudMenuItem Label="Bullet" />
             <MudMenuItem Label="Number" />
         </MudMenu>
 
-        <MudMenu Label="Alignment" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Alignment">
             <MudMenuItem Label="Left" />
             <MudMenuItem Label="Right" />
         </MudMenu>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuWithNestingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuWithNestingTest.razor
@@ -4,24 +4,24 @@
     <MudMenuItem Label="Add reaction" />
     <MudMenuItem Label="Add bookmark" />
 
-    <MudMenu Label="Format" ActivationEvent="@MouseEvent.MouseOver">
-        <MudMenu Label="Text" ActivationEvent="@MouseEvent.MouseOver">
+    <MudMenu Label="Format">
+        <MudMenu Label="Text">
             <MudMenuItem Label="Bold" />
             <MudMenuItem Label="Italic" />
             <MudMenuItem Label="Underline" />
 
-            <MudMenu Label="Size" ActivationEvent="@MouseEvent.MouseOver">
+            <MudMenu Label="Size">
                 <MudMenuItem Label="Increase font size" />
                 <MudMenuItem Label="Decrease font size" />
             </MudMenu>
         </MudMenu>
 
-        <MudMenu Label="Points" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Points">
             <MudMenuItem Label="Bullet" />
             <MudMenuItem Label="Number" />
         </MudMenu>
 
-        <MudMenu Label="Alignment" ActivationEvent="@MouseEvent.MouseOver">
+        <MudMenu Label="Alignment">
             <MudMenuItem Label="Left" />
             <MudMenuItem Label="Right" />
         </MudMenu>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -46,6 +46,8 @@
                          Icon="@StartIcon"
                          IconColor="@IconColor"
                          Disabled="@Disabled"
+                         OnClick="OpenSubMenuAsync"
+                         AutoClose="false"
                          aria-label="@AriaLabel">
                 @Label
             </MudMenuItem>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -508,7 +508,7 @@ namespace MudBlazor
         {
             _isPointerOver = true;
 
-            // If hover isn't enabled (including if it's a submenu) then there's no work to be done.
+            // If hover isn't enabled (and it's not a submenu) then there's no work to be done.
             if (ActivationEvent != MouseEvent.MouseOver && ParentMenu is null)
             {
                 return;
@@ -558,7 +558,7 @@ namespace MudBlazor
         {
             _isPointerOver = false;
 
-            // If it's not transient or hover isn't enabled (including if it's a submenu) then there's no work to be done.
+            // If it's not transient or hover isn't enabled (and it's not a submenu) then there's no work to be done.
             if (!_isTransient || (ActivationEvent != MouseEvent.MouseOver && ParentMenu is null))
             {
                 return;

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -508,8 +508,8 @@ namespace MudBlazor
         {
             _isPointerOver = true;
 
-            // If hover isn't enabled then there's no work to be done.
-            if (ActivationEvent != MouseEvent.MouseOver)
+            // If hover isn't enabled (including if it's a submenu) then there's no work to be done.
+            if (ActivationEvent != MouseEvent.MouseOver && ParentMenu is null)
             {
                 return;
             }
@@ -558,8 +558,8 @@ namespace MudBlazor
         {
             _isPointerOver = false;
 
-            // If it's not transient or hover isn't enabled then there's no work to be done.
-            if (!_isTransient || ActivationEvent != MouseEvent.MouseOver)
+            // If it's not transient or hover isn't enabled (including if it's a submenu) then there's no work to be done.
+            if (!_isTransient || (ActivationEvent != MouseEvent.MouseOver && ParentMenu is null))
             {
                 return;
             }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
     public partial class MudMenu : MudComponentBase, IActivatable, IDisposable
     {
         private readonly ParameterState<bool> _openState;
-        private readonly List<MudMenu> _children = [];
+        private readonly List<MudMenu> _subMenus = [];
         private (double Top, double Left) _openPosition;
         private bool _isPointerOver;
         private bool _isTransient;
@@ -327,8 +327,6 @@ namespace MudBlazor
         [CascadingParameter]
         protected MudMenu? ParentMenu { get; set; }
 
-        public IReadOnlyList<MudMenu> GetChildren() => _children.AsReadOnly();
-
         protected bool GetActivatorHidden() => ActivatorContent is null && string.IsNullOrWhiteSpace(Label) && string.IsNullOrWhiteSpace(Icon);
 
         protected Origin GetAnchorOrigin()
@@ -352,12 +350,12 @@ namespace MudBlazor
 
         protected void RegisterChild(MudMenu child)
         {
-            _children.Add(child);
+            _subMenus.Add(child);
         }
 
         protected void UnregisterChild(MudMenu child)
         {
-            _children.Remove(child);
+            _subMenus.Remove(child);
         }
 
         protected override void OnInitialized()
@@ -379,7 +377,7 @@ namespace MudBlazor
         public async Task CloseMenuAsync()
         {
             // Recursively close all child menus.
-            foreach (var child in _children)
+            foreach (var child in _subMenus)
             {
                 await child.CloseMenuAsync();
             }
@@ -450,6 +448,24 @@ namespace MudBlazor
 
             await _openState.SetValueAsync(true);
             await InvokeAsync(StateHasChanged);
+        }
+
+        /// <summary>
+        /// Closes siblings before opening this menu which will close automatically when the pointer leaves its bounds.
+        /// </summary>
+        protected async Task OpenSubMenuAsync(EventArgs args)
+        {
+            // Close siblings.
+            if (ParentMenu is not null)
+            {
+                foreach (var sibling in ParentMenu._subMenus)
+                {
+                    await sibling.CloseMenuAsync();
+                }
+            }
+
+            // Open this menu transiently.
+            await OpenMenuAsync(args, true);
         }
 
         /// <summary>
@@ -573,10 +589,20 @@ namespace MudBlazor
             }
 
             // Close the menu only if no child menus are still active.
-            if (!_children.Any(x => x._isPointerOver))
+            if (!HasPointerOver(this))
             {
                 await CloseMenuAsync();
             }
+        }
+
+        protected bool HasPointerOver(MudMenu menu)
+        {
+            // Check if the current menu has pointer over.
+            if (menu._isPointerOver)
+                return true;
+
+            // Recursively check all child submenus.
+            return menu._subMenus.Any(HasPointerOver);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Clicking a standard sub menu activator (`mud-menu-sub-menu-activator`) will now instantly open its submenu as opposed to closing the tree.
 
Closes #10538 for a simpler approach, albeit more complex for the user to recreate.
Closes #10255 as satisfactorily complete.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**See the new click behavior (hover delayed for demonstration purposes):**

https://github.com/user-attachments/assets/9f85a23c-b190-4e90-94d1-4016bc61cc3a

This has also been tested on touch. Previously the entire tree would close on click.

**Selection style remains on the clicked button:**

![image](https://github.com/user-attachments/assets/aa7b8c14-e374-436c-b941-a7eb9cff18d0)

**The MouseOver activation event is now implicit for submenus:**

```razor
<MudMenu Label="Open Nested Menu">
    <MudMenuItem Label="Add reaction" />
    <MudMenuItem Label="Add bookmark" />

    <MudMenu Label="Format">
        <MudMenu Label="Text">
            <MudMenuItem Label="Bold" />
            <MudMenuItem Label="Italic" />
            <MudMenuItem Label="Underline" />

            <MudMenu Label="Size">
                <MudMenuItem Label="Increase font size" />
                <MudMenuItem Label="Decrease font size" />
            </MudMenu>
        </MudMenu>

        <MudMenu Label="Points">
            <MudMenuItem Label="Bullet" />
            <MudMenuItem Label="Number" />
        </MudMenu>

        <MudMenu Label="Alignment">
            <MudMenuItem Label="Left" />
            <MudMenuItem Label="Right" />
        </MudMenu>

        <MudMenuItem Label="Clear formatting" />
        <MudMenuItem Label="Headers and footers" />
    </MudMenu>
</MudMenu>
```

Before:
```razor
<MudMenu Label="Open Nested Menu">
    <MudMenuItem Label="Add reaction" />
    <MudMenuItem Label="Add bookmark" />

    <MudMenu Label="Format" ActivationEvent="@MouseEvent.MouseOver">
        <MudMenu Label="Text" ActivationEvent="@MouseEvent.MouseOver">
            <MudMenuItem Label="Bold" />
            <MudMenuItem Label="Italic" />
            <MudMenuItem Label="Underline" />

            <MudMenu Label="Size" ActivationEvent="@MouseEvent.MouseOver">
                <MudMenuItem Label="Increase font size" />
                <MudMenuItem Label="Decrease font size" />
            </MudMenu>
        </MudMenu>

        <MudMenu Label="Points" ActivationEvent="@MouseEvent.MouseOver">
            <MudMenuItem Label="Bullet" />
            <MudMenuItem Label="Number" />
        </MudMenu>

        <MudMenu Label="Alignment" ActivationEvent="@MouseEvent.MouseOver">
            <MudMenuItem Label="Left" />
            <MudMenuItem Label="Right" />
        </MudMenu>

        <MudMenuItem Label="Clear formatting" />
        <MudMenuItem Label="Headers and footers" />
    </MudMenu>
</MudMenu>
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
