### PR TITLE
MudMenu: Bring style closer to Material Design

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -305,25 +305,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void MenuItem_Should_RenderIcons(bool dense)
+        public void MenuItem_Should_RenderIcons()
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>(parameters => parameters
-                .Add(p => p.Dense, dense)
-            );
+            var comp = Context.RenderComponent<MenuItemIconTest>();
 
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
 
-            if (dense)
-            {
-                comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-small").Count.Should().Be(3);
-            }
-            else
-            {
-                comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-medium").Count.Should().Be(3);
-            }
+            comp.FindAll(".mud-menu-list div.mud-menu-item svg.mud-svg-icon.mud-menu-item-icon.mud-icon-size-medium").Count.Should().Be(3);
         }
 
         [Test]

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -17,8 +17,7 @@
         <MudIcon Class="mud-menu-item-icon"
                  Icon="@Icon"
                  Color="IconColor"
-                 Disabled="GetDisabled()"
-                 Size="GetIconSize()" />
+                 Disabled="GetDisabled()" />
     }
 
     <MudText Class="mud-menu-item-text"
@@ -37,7 +36,6 @@
     {
         <MudIcon Class="mud-menu-item-chevron"
                  Icon="@Icons.Material.Filled.ArrowRight"
-                 Disabled="GetDisabled()"
-                 Size="GetIconSize()" />
+                 Disabled="GetDisabled()" />
     }
 </MudElement>

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -124,8 +124,6 @@ namespace MudBlazor
 
         protected Typo GetTypo() => GetDense() ? Typo.body2 : Typo.body1;
 
-        protected Size GetIconSize() => GetDense() ? Size.Small : Size.Medium;
-
         /// <summary>
         /// The menu item is acting as the activator for a sub menu.
         /// </summary>

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -50,6 +50,9 @@
   padding: 8px 12px;
 
   .mud-menu-item-icon {
+    color: var(--mud-palette-action-default);
+    display: inline-flex;
+    flex-shrink: 0;
     margin-right: 12px;
   }
 

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -27,14 +27,14 @@
 }
 
 .mud-menu-list {
-  /*padding: 8px 0;*/
-
-  &.mud-menu-list-dense {
-    /*padding: 0;*/
-  }
+  padding: 4px 0;
 
   > .mud-menu {
     width: 100%;
+  }
+
+  > .mud-divider {
+    margin: 4px 0;
   }
 }
 
@@ -45,26 +45,21 @@
   box-sizing: border-box;
   text-align: start;
   align-items: center;
-  padding: 8px 16px;
   justify-content: flex-start;
   text-decoration: none;
+  padding: 8px 12px;
 
   .mud-menu-item-icon {
-    color: var(--mud-palette-action-default);
-    display: inline-flex;
-    flex-shrink: 0;
-    margin: 0 20px 0 8px;
+    margin-right: 12px;
   }
 
   .mud-menu-item-text {
     flex: 1 1 auto;
-    min-width: 0;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin: 4px 0;
   }
 
   &.mud-menu-item-dense {
-    padding: 4px 16px;
+    padding: 2px 12px;
   }
 
   &.mud-disabled {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- All padding tweaked
- Icons are now always medium sized
- Padding added around the list itself
- Divider gap increased
- Dense items are now 32px instead of 36px

Closes #10077. Resolves #9097 as an alternative to #9143 after building on top of #10478.

Using materials from:
- https://m2.material.io/components/menus
- https://m3.material.io/components/menus/overview

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before

![image](https://github.com/user-attachments/assets/d0170622-fd3b-485f-a02f-42252fe17e6b)

![image](https://github.com/user-attachments/assets/4dc3f263-87ca-4a0c-afb7-b938642106db)


After

![image](https://github.com/user-attachments/assets/54df9f03-a198-4f64-af62-d42dd76a0980)

![image](https://github.com/user-attachments/assets/11b3bbfa-909c-448b-8d65-9feee74650ed)


Before

![image](https://github.com/user-attachments/assets/53f7f545-629f-4d38-a036-22023cd26360)

![image](https://github.com/user-attachments/assets/2367cb87-b054-4fa5-9db2-d4c2589cf28e)


After

![image](https://github.com/user-attachments/assets/f1a035c2-e9f8-49a8-9b25-996ce5f90e8c)

![image](https://github.com/user-attachments/assets/f810fd1a-0292-4c42-9144-aebf385a8243)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
