### PR TITLE
MudToggleGroup: Reorder Selection Logic for ToggleGroupItems

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleGroup/ToggleGroupValueChangedSameValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleGroup/ToggleGroupValueChangedSameValueTest.razor
@@ -1,0 +1,34 @@
+﻿
+<MudStack>
+    <MudText>Select an item</MudText>
+    <MudToggleGroup T="string" SelectionMode="SelectionMode.SingleSelection" Value="_value1" ValueChanged="OnValueChanged" Color="Color.Primary" CheckMark FixedContent>
+        <MudToggleItem Value="@("Yes")" Text="Yes" />
+        <MudToggleItem Value="@("No")" Text="No" />
+        <MudToggleItem Value="@("Don't know")" Text="Don't know (Click me twice)" />
+    </MudToggleGroup>
+    <MudText>
+        Selected value : @(_value1 ?? "None")
+    </MudText>
+</MudStack>
+
+
+@code {
+
+    private string? _value1;
+
+    private async Task OnValueChanged(string value)
+    {
+        if (value == "Don't know")
+        {
+
+            // I expect "Yes" to become the selected toggle button
+            _value1 = "Yes";
+        }
+        else
+        {
+            _value1 = value;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -256,65 +256,18 @@ namespace MudBlazor
 
             if (firstRender)
             {
-                var multiSelection = SelectionMode == SelectionMode.MultiSelection;
-                var value = _value.Value;
-                var values = _values.Value;
-
-                // Handle single and toggle selection mode
-                if (value is not null && !multiSelection)
-                {
-                    var selectedItem = _items.Find(x => value.Equals(x.Value));
-                    selectedItem?.SetSelected(true);
-                }
-
-                // Handle multi-selection mode
-                if (values is not null && multiSelection)
-                {
-                    foreach (var item in _items.Where(x => values.Contains(x.Value)).ToList())
-                    {
-                        item.SetSelected(true);
-                    }
-                }
-
-                StateHasChanged();
+                SetItemsSelected();
             }
         }
 
         private void OnValueChanged()
         {
-            if (SelectionMode == SelectionMode.MultiSelection)
-            {
-                return;
-            }
-
-            // Handle single and toggle selection mode 
-            DeselectAllItems();
-
-            var value = _value.Value;
-            if (value is not null)
-            {
-                var selectedItem = _items.Find(x => value.Equals(x.Value));
-                selectedItem?.SetSelected(true);
-            }
+            SetItemsSelected();
         }
 
         private void OnValuesChanged()
         {
-            if (SelectionMode != SelectionMode.MultiSelection)
-            {
-                return;
-            }
-
-            // Handle multi-selection mode
-            DeselectAllItems();
-
-            if (Values is not null)
-            {
-                foreach (var item in _items.Where(x => Values.Contains(x.Value)).ToList())
-                {
-                    item.SetSelected(true);
-                }
-            }
+            SetItemsSelected();
         }
 
         private void OnParameterChanged()
@@ -327,43 +280,59 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        private void SetItemsSelected()
+        {
+            DeselectAllItems();
+
+            if (SelectionMode == SelectionMode.MultiSelection)
+            {
+                if (Values is not null)
+                {
+                    foreach (var item in _items.Where(x => Values.Contains(x.Value)).ToList())
+                    {
+                        item.SetSelected(true);
+                    }
+                }
+            }
+            else
+            {
+                if (Value is not null)
+                {
+                    var selectedItem = _items.Find(x => Value.Equals(x.Value));
+                    selectedItem?.SetSelected(true);
+                }
+            }
+
+            StateHasChanged();
+        }
+
         protected internal async Task ToggleItemAsync(MudToggleItem<T> item)
         {
             var itemValue = item.Value;
             if (SelectionMode == SelectionMode.MultiSelection)
             {
                 var selectedValues = new HashSet<T?>(_values.Value ?? Array.Empty<T?>());
-                item.SetSelected(!item.Selected);
 
-                if (item.Selected)
+                if (!selectedValues.Remove(itemValue))
                 {
                     selectedValues.Add(itemValue);
-                }
-                else
-                {
-                    selectedValues.Remove(itemValue);
                 }
 
                 await _values.SetValueAsync(selectedValues);
             }
             else if (SelectionMode == SelectionMode.ToggleSelection)
             {
-                if (item.Selected)
+                if (EqualityComparer<T>.Default.Equals(_value.Value, itemValue))
                 {
-                    item.SetSelected(false);
                     await _value.SetValueAsync(default);
                 }
                 else
                 {
-                    DeselectAllItems();
-                    item.SetSelected(true);
                     await _value.SetValueAsync(itemValue);
                 }
             }
             else // SingleSelection
             {
-                DeselectAllItems();
-                item.SetSelected(true);
                 await _value.SetValueAsync(itemValue);
             }
         }

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -262,11 +262,13 @@ namespace MudBlazor
 
         private void OnValueChanged()
         {
+            // perform Selection after user consumes Value Changed logic
             SetItemsSelected();
         }
 
         private void OnValuesChanged()
         {
+            // perform Selection after user consumes Values Changed logic
             SetItemsSelected();
         }
 
@@ -286,9 +288,9 @@ namespace MudBlazor
 
             if (SelectionMode == SelectionMode.MultiSelection)
             {
-                if (Values is not null)
+                if (_values.Value is not null)
                 {
-                    foreach (var item in _items.Where(x => Values.Contains(x.Value)).ToList())
+                    foreach (var item in _items.Where(x => _values.Value.Contains(x.Value)).ToList())
                     {
                         item.SetSelected(true);
                     }
@@ -296,9 +298,9 @@ namespace MudBlazor
             }
             else
             {
-                if (Value is not null)
+                if (_value.Value is not null)
                 {
-                    var selectedItem = _items.Find(x => Value.Equals(x.Value));
+                    var selectedItem = _items.Find(x => _value.Value.Equals(x.Value));
                     selectedItem?.SetSelected(true);
                 }
             }
@@ -319,6 +321,10 @@ namespace MudBlazor
                 }
 
                 await _values.SetValueAsync(selectedValues);
+                if (Values is null)
+                {
+                    SetItemsSelected();
+                }
             }
             else if (SelectionMode == SelectionMode.ToggleSelection)
             {
@@ -330,10 +336,18 @@ namespace MudBlazor
                 {
                     await _value.SetValueAsync(itemValue);
                 }
+                if (Value is null)
+                {
+                    SetItemsSelected();
+                }
             }
             else // SingleSelection
             {
                 await _value.SetValueAsync(itemValue);
+                if (Value is null)
+                {
+                    SetItemsSelected();
+                }
             }
         }
 

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -311,6 +311,10 @@ namespace MudBlazor
         protected internal async Task ToggleItemAsync(MudToggleItem<T> item)
         {
             var itemValue = item.Value;
+
+            var isValueBound = ValueChanged.HasDelegate;
+            var isSelectedValuesBound = ValuesChanged.HasDelegate;
+
             if (SelectionMode == SelectionMode.MultiSelection)
             {
                 var selectedValues = new HashSet<T?>(_values.Value ?? Array.Empty<T?>());
@@ -321,8 +325,9 @@ namespace MudBlazor
                 }
 
                 await _values.SetValueAsync(selectedValues);
-                if (Values is null)
+                if (isSelectedValuesBound)
                 {
+                    // if SelectedValuesBound we don't need to run this method twice
                     SetItemsSelected();
                 }
             }
@@ -336,16 +341,18 @@ namespace MudBlazor
                 {
                     await _value.SetValueAsync(itemValue);
                 }
-                if (Value is null)
+                if (isValueBound)
                 {
+                    // if ValueBound we don't need to run this method twice
                     SetItemsSelected();
                 }
             }
             else // SingleSelection
             {
                 await _value.SetValueAsync(itemValue);
-                if (Value is null)
+                if (isValueBound)
                 {
+                    // if ValueBound we don't need to run this method twice
                     SetItemsSelected();
                 }
             }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Previously ToggleGroup repeatedly set the selected state of an item except in cases where the item value did not change. Now it only sets selected states after values are set, separating the logic of value setting and select setting. There will be similar fixes applied to the other groups (Chipset for sure, I will checked others)
resolves #10535  

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added some unit tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
