### PR TITLE
MudDataGrid: Fix no records found appearance with Virtualize

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNoRecordsContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNoRecordsContentTest.razor
@@ -1,6 +1,4 @@
-﻿
-
-<MudDataGrid Items="@_items">
+﻿<MudDataGrid Items="@_items">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -12,7 +10,7 @@
 </MudDataGrid>
 
 @code {
-    private IEnumerable<Model> _items = new List<Model>();
+    private readonly IEnumerable<Model> _items = new List<Model>();
 
     public record Model (string Name, int Age, Severity Status);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNoRecordsContentVirtualizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNoRecordsContentVirtualizeTest.razor
@@ -1,0 +1,18 @@
+﻿
+
+<MudDataGrid Items="@_items" Virtualize>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.Status" />
+    </Columns>
+    <NoRecordsContent>
+        There are no records to view.
+    </NoRecordsContent>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>();
+
+    public record Model (string Name, int Age, Severity Status);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor
@@ -80,10 +80,10 @@
         {
             _events.Add($"ServerDataFunc index : {state.StartIndex} (Cancelled)");
             return new GridData<Model>
-                {
-                    Items = [],
-                    TotalItems = 0,
-                };
+            {
+                Items = [],
+                TotalItems = 0,
+            };
         }
     }
 
@@ -101,7 +101,7 @@
                     || (x.Column2?.Contains(searchValue, StringComparison.OrdinalIgnoreCase) ?? false)
                 );
         }
-        return (_gridComponentReference?.ReloadServerData() ?? Task.CompletedTask);
+        return _gridComponentReference?.ReloadServerData() ?? Task.CompletedTask;
     }
 
     public record Model(int Index, string Column2);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor
@@ -1,0 +1,108 @@
+<MudDataGrid T="Model"
+             @ref="_gridComponentReference"
+             Virtualize="true"
+             VirtualizeServerData="ServerDataFunc"
+             FixedHeader="true"
+             Height="350px"
+             Groupable>
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">MudBlazor grid</MudText>
+        <MudSpacer />
+        <MudTextField T="string?" @bind-Value:get="_searchString" @bind-Value:set="SetSearchString" Placeholder="Search" Adornment="Adornment.Start" Immediate="true"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0" />
+    </ToolBarContent>
+    <NoRecordsContent>
+        No data
+    </NoRecordsContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Index" Grouping />
+        <PropertyColumn Property="x => x.Column2" />
+    </Columns>
+</MudDataGrid>
+<MudExpansionPanels Style="flex:1">
+    <MudExpansionPanel Text="Show Events">
+        @foreach (var message in _events)
+        {
+            <MudText Typo="@Typo.body2">@message</MudText>
+        }
+        @if (_events.Count > 0)
+        {
+            <div class="d-flex">
+                <MudButton Class="mt-3" ButtonType="ButtonType.Button" Variant="Variant.Filled" OnClick="@StateHasChanged">Update</MudButton>
+                <MudSpacer />
+                <MudButton Class="mt-3" ButtonType="ButtonType.Button" Variant="Variant.Filled" OnClick="@(() => _events.Clear())">Clear</MudButton>
+            </div>
+        }
+    </MudExpansionPanel>
+</MudExpansionPanels>
+
+@code {
+    public static string __description__ = @"The data grid should reload data correctly when using VirtualizeServerData with external filter. Empty result must show 'No data'.";
+
+    private readonly List<string> _events = [];
+    private string? _searchString;
+    private MudDataGrid<Model>? _gridComponentReference;
+
+    private readonly IEnumerable<Model> _sourceElements = Enumerable.Range(0, 100)
+            .Select(i => new Model(i, $"Value_{i}"))
+            .ToArray();
+    private IEnumerable<Model> _elements = Enumerable.Empty<Model>();
+
+    protected override void OnInitialized()
+    {
+        _elements = _sourceElements;
+    }
+
+    /// <summary>
+    /// Reloads the data from the server, with support for cancellation.
+    /// </summary>
+    private async Task<GridData<Model>> ServerDataFunc(GridStateVirtualize<Model> state, CancellationToken token)
+    {
+        try
+        {
+            // Simulate "loading data"
+            await Task.Delay(500, token);
+
+            IEnumerable<Model> data = _elements;
+
+            data = data
+                .Skip(state.StartIndex)
+                .Take(state.Count)
+                .ToList();
+
+            // Return the data
+            var result = new GridData<Model>() { TotalItems = _elements.Count(), Items = data.ToArray() };
+            _events.Add($"ServerDataFunc index : {state.StartIndex} (TotalItems : {result.TotalItems})");
+
+            return result;
+        }
+        catch (Exception ex) when (ex is TaskCanceledException)
+        {
+            _events.Add($"ServerDataFunc index : {state.StartIndex} (Cancelled)");
+            return new GridData<Model>
+                {
+                    Items = [],
+                    TotalItems = 0,
+                };
+        }
+    }
+
+    private Task SetSearchString(string? searchValue)
+    {
+        _searchString = searchValue;
+        if (string.IsNullOrEmpty(searchValue))
+        {
+            _elements = _sourceElements;
+        }
+        else
+        {
+            _elements = _sourceElements.Where(x =>
+                    x.Index.ToString() == searchValue
+                    || (x.Column2?.Contains(searchValue, StringComparison.OrdinalIgnoreCase) ?? false)
+                );
+        }
+        return (_gridComponentReference?.ReloadServerData() ?? Task.CompletedTask);
+    }
+
+    public record Model(int Index, string Column2);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeServerDataLoadingWithSearchTest.razor
@@ -16,11 +16,7 @@
                               AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0" />
             </ToolBarContent>
             <NoRecordsContent>
-                <tr class="mud-table-row">
-                    <td class="mud-table-cell" colspan="1000">
-                        No data
-                    </td>
-                </tr>
+                No data
             </NoRecordsContent>
             <Columns>
                 <PropertyColumn Property="x => x.Index" />

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.UnitTests.TestComponents.DataGrid;
-using MudBlazor.UnitTests.TestComponents.Table;
 using MudBlazor.Utilities.Clone;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -3040,6 +3039,15 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<DataGridNoRecordsContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNoRecordsContentTest.Model>>();
+
+            dataGrid.Find("th.mud-table-empty-row div").TextContent.Trim().Should().Be("There are no records to view.");
+        }
+
+        [Test]
+        public void DataGridNoRecordsContentVirtualizeTest()
+        {
+            var comp = Context.RenderComponent<DataGridNoRecordsContentVirtualizeTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridNoRecordsContentVirtualizeTest.Model>>();
 
             dataGrid.Find("th.mud-table-empty-row div").TextContent.Trim().Should().Be("There are no records to view.");
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -282,7 +282,13 @@
                                                 }
                                             </ChildContent>
                                             <NoRecordsContent>
-                                                @NoRecordsContent
+                                                <tr>
+                                                    <th colspan="1000" class="mud-table-empty-row">
+                                                        <div Class="my-3">
+                                                            @NoRecordsContent
+                                                        </div>
+                                                    </th>
+                                                </tr>
                                             </NoRecordsContent>
                                         </MudVirtualize>
                                         @*Group Footer*@
@@ -337,7 +343,13 @@
                                         }
                                     </ChildContent>
                                     <NoRecordsContent>
-                                        @NoRecordsContent
+                                        <tr>
+                                            <th colspan="1000" class="mud-table-empty-row">
+                                                <div Class="my-3">
+                                                    @NoRecordsContent
+                                                </div>
+                                            </th>
+                                        </tr>
                                     </NoRecordsContent>
                                 </MudVirtualize>
                             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -215,6 +215,16 @@
                         {
                             if (GroupedColumn != null)
                             {
+                                if (_currentPageGroups is { Count: 0 })
+                                {
+                                    <tr>
+                                        <th colspan="1000" class="mud-table-empty-row">
+                                            <div Class="my-3">
+                                                @NoRecordsContent
+                                            </div>
+                                        </th>
+                                    </tr>
+                                }
                                 foreach (var g in _currentPageGroups)
                                 {
                                     <tr class="mud-table-row">

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1805,7 +1805,11 @@ namespace MudBlazor
                     request.CancellationToken
                 );
 
-                _currentRenderFilteredItemsCache = null;
+                //do not reset cache, the current chunk load has been cancelled, we wait for the final load
+                if (!request.CancellationToken.IsCancellationRequested)
+                {
+                    _currentRenderFilteredItemsCache = null;
+                }
 
                 return new ItemsProviderResult<IndexBag<T>>(
                     _serverData.Items.Select((item, index) => new IndexBag<T>(request.StartIndex + index, item)),


### PR DESCRIPTION
## Description
Fix #10524

## How Has This Been Tested?
unit | visually
new test : `DataGridNoRecordsContentVirtualizeTest.razor`
new viewer test : `DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor`

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.

## Additionnal note :
`DataGridVirtualizeServerDataLoadingWithSearchGroupableTest.razor` show grouping problem with Virtualize flag and didn't work - i says didn't work at all with Virtualize -

grouping must be done with the full data set and virtualization must do not refer to the same VirtualItemsProvider i guess because it reset actual grouping (set _currentRenderFilteredItemsCache to null)
BTW it didn't work on V7

### cache cancellation
when i'm looking for the grouping problem i see that specific case : virtualize component can cancel the current chunk and then return empty result => which clear the grouping (because no data)
```cs
                //do not reset cache, the current chunk load has been cancelled, we wait for the final load
                if (!request.CancellationToken.IsCancellationRequested)
                {
                    _currentRenderFilteredItemsCache = null;
                }
```