### PR TITLE
MudDataGrid: remove detrimental ChildRowContent CSS

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -275,7 +275,7 @@
                                                 @if (ChildRowContent != null && (_openHierarchies.Contains(itemBag.Item) || !HasHierarchyColumn))
                                                 {
                                                     <tr class="mud-table-row">
-                                                        <td class="mud-table-cell" colspan="1000">
+                                                                <td class="mud-table-cell mud-table-child-content" colspan="1000">
                                                             @ChildRowContent(new CellContext<T>(this, itemBag.Item))
                                                         </td>
                                                     </tr>
@@ -330,7 +330,7 @@
                                         @if (ChildRowContent != null && (_openHierarchies.Contains(itemBag.Item) || !HasHierarchyColumn))
                                         {
                                             <tr class="mud-table-row">
-                                                <td class="mud-table-cell" colspan="1000">
+                                                        <td class="mud-table-cell mud-table-child-content" colspan="1000">
                                                     @ChildRowContent(new CellContext<T>(this, itemBag.Item))
                                                 </td>
                                             </tr>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -275,7 +275,7 @@
                                                 @if (ChildRowContent != null && (_openHierarchies.Contains(itemBag.Item) || !HasHierarchyColumn))
                                                 {
                                                     <tr class="mud-table-row">
-                                                                <td class="mud-table-cell mud-table-child-content" colspan="1000">
+                                                        <td class="mud-table-cell mud-table-child-content" colspan="1000">
                                                             @ChildRowContent(new CellContext<T>(this, itemBag.Item))
                                                         </td>
                                                     </tr>
@@ -330,7 +330,7 @@
                                         @if (ChildRowContent != null && (_openHierarchies.Contains(itemBag.Item) || !HasHierarchyColumn))
                                         {
                                             <tr class="mud-table-row">
-                                                        <td class="mud-table-cell mud-table-child-content" colspan="1000">
+                                                <td class="mud-table-cell mud-table-child-content" colspan="1000">
                                                     @ChildRowContent(new CellContext<T>(this, itemBag.Item))
                                                 </td>
                                             </tr>

--- a/src/MudBlazor/Styles/components/_datagrid.scss
+++ b/src/MudBlazor/Styles/components/_datagrid.scss
@@ -65,8 +65,10 @@
       right: 0px;
     }
 
-    .mud-input-text {
-      margin-top: 0 !important;
+    &:not(.mud-table-child-content) {
+      .mud-input-text {
+        margin-top: 0 !important;
+      }
     }
 
     .column-header {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
DataGrid uses CSS to alter the mud-input's it is using for it's cell and cell editing functions. I introduced a css class that ignores the margin portion of that style `mud-table-child-content` . I applied that class to the two places in the razor file it absorbs ChildRowContent. Also anytime a dev wants to use a mudtextfield with label they can now just add `mud-table-child-content` to the CellClass and it will not scrunch the settings.
Resolves #10351 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually, unit tests still operate. Before and After in first comment.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
