### PR TITLE
MudList: Accessibility Enhance

### DIFF
--- a/src/MudBlazor/Components/List/MudList.razor
+++ b/src/MudBlazor/Components/List/MudList.razor
@@ -3,7 +3,14 @@
 @typeparam T
 @attribute [CascadingTypeParameter(nameof(T))]
 
-<div @attributes="UserAttributes" class="@Classname" style="@Style">
+<div 
+    role="@GetRole()" 
+    id="@_elementId"  
+    @attributes="UserAttributes" 
+    class="@Classname" 
+    style="@Style"
+    aria-multiselectable="@GetAriaMultiselectableValue()"
+    aria-activedescendant="@_activeItemId">
     <CascadingValue Value="@this" IsFixed="true">
         @ChildContent
     </CascadingValue>

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
+using MudBlazor.Services;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -18,6 +20,12 @@ namespace MudBlazor
     /// <seealso cref="MudListSubheader"/>
     public partial class MudList<T> : MudComponentBase, IDisposable
     {
+        [Inject]
+        private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
+
+        private string _elementId = Identifier.Create("list");
+        private string? _activeItemId;
+
         public MudList()
         {
             TopLevelList = this;
@@ -227,6 +235,18 @@ namespace MudBlazor
         [Category(CategoryTypes.TreeView.Selecting)]
         public string UncheckedIcon { get; set; } = Icons.Material.Filled.CheckBoxOutlineBlank;
 
+        /// <summary>
+        /// Occurs when a key has been pressed down.
+        /// </summary>
+        [Parameter]
+        public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
+
+        /// <summary>
+        /// Occurs when a pressed key has been released.
+        /// </summary>
+        [Parameter]
+        public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
+
         protected override void OnInitialized()
         {
             base.OnInitialized();
@@ -237,8 +257,34 @@ namespace MudBlazor
             }
         }
 
-        protected override void OnAfterRender(bool firstRender)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
+            // setup key interceptor    
+            if (firstRender)
+            {
+                var options = new KeyInterceptorOptions(
+                    "mud-list-item", true,
+                    [
+                        // prevent scrolling page, toggle open/close
+                        new(" ", preventDown: "key+none"),
+                        // prevent scrolling page, instead highlight previous item
+                        new("ArrowUp", preventDown: "key+none"),
+                        // prevent scrolling page, instead highlight next item
+                        new("ArrowDown", preventDown: "key+none"),
+                        new("Home", preventDown: "key+none"),
+                        new("End", preventDown: "key+none"),
+                        new("Enter", preventDown: "key+none"),
+                        new("NumpadEnter", preventDown: "key+none"),
+                        // select all items instead of all page text
+                        new("a", preventDown: "key+ctrl"),
+                        // select all items instead of all page text
+                        new("A", preventDown: "key+ctrl"),
+                        // for our users
+                        new("/./", subscribeDown: true, subscribeUp: true)
+                    ]);
+
+                await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDownAsync, keyUp: HandleKeyUpAsync);
+            }
             base.OnAfterRender(firstRender);
             if (firstRender && TopLevelList == this)
             {
@@ -251,6 +297,57 @@ namespace MudBlazor
                     UpdateSelectedItem(_selectedValueState);
                 }
             }
+        }
+
+        private async Task HandleKeyDownAsync(KeyboardEventArgs args)
+        {
+            if (GetDisabled() || GetReadOnly())
+                return;
+
+            var key = args.Key.ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(key) == false
+                && key.Length == 1
+                && char.IsLetterOrDigit(key[0]))
+            {
+                await FocusFirstItemAsync(key);
+                return;
+            }
+
+            switch (args.Key)
+            {
+                case "ArrowDown":
+                    await FocusNextItemAsync();
+                    break;
+                case "ArrowUp":
+                    await FocusPreviousItemAsync();
+                    break;
+                case "Home":
+                    await FocusFirstItemAsync();
+                    break;
+                case "End":
+                    await FocusLastItemAsync();
+                    break;
+                case "Enter":
+                case "NumpadEnter":
+                case " ":
+                    {
+                        if (_activeItemId is not null)
+                        {
+                            var item = _items.FirstOrDefault(x => x.ItemId == _activeItemId);
+                            item?.OnItemClickAsync();
+                        }
+
+                        break;
+                    }
+                default:
+                    await OnKeyDown.InvokeAsync(args);
+                    break;
+            }
+        }
+
+        private Task HandleKeyUpAsync(KeyboardEventArgs args)
+        {
+            return OnKeyUp.InvokeAsync(args);
         }
 
         internal void Update()
@@ -331,6 +428,11 @@ namespace MudBlazor
             UpdateSelectedItem(value);
         }
 
+        internal void SetFocusedItem(T? value)
+        {
+            _activeItemId = _items.FirstOrDefault(x => Comparer.Equals(x.GetValue(), value))?.ItemId ?? string.Empty;
+        }
+
         internal async Task SelectValueAsync(T? value)
         {
             if (SelectionMode != SelectionMode.MultiSelection || value is null)
@@ -376,6 +478,11 @@ namespace MudBlazor
             {
                 var selected = value is not null && Comparer.Equals(value, item.GetValue());
                 item.SetSelected(selected);
+
+                if (selected)
+                {
+                    _activeItemId = item.ItemId;
+                }
             }
             foreach (var childList in _childLists.ToArray())
             {
@@ -407,5 +514,93 @@ namespace MudBlazor
         {
             ParentList?.Unregister(this);
         }
+
+        /// <summary>
+        /// gets the role of the MudList
+        /// </summary>
+        /// <returns>the role of the MudList</returns>
+        /// <remarks>
+        /// If <see crew="readonly"/> is true, the role is "list". Otherwise, the role is "listbox".
+        ///     </remarks>
+        private string GetRole()
+        {
+            return GetReadOnly() ? "list" : "listbox";
+        }
+
+        private string GetAriaMultiselectableValue() => SelectionMode == SelectionMode.MultiSelection ? "true" : "false";
+
+        private async Task FocusAdjacentItemAsync(int direction)
+        {
+            if (_items.Count == 0)
+                return;
+
+            var itemList = _items.ToList();
+            var index = itemList.FindIndex(x => x.ItemId == _activeItemId);
+            if (direction < 0 && index < 0)
+                index = 0;
+            MudListItem<T>? item = null;
+            // the loop allows us to jump over disabled items until we reach the next non-disabled one
+            for (var i = 0; i < itemList.Count; i++)
+            {
+                index += direction;
+                if (index < 0)
+                    index = 0;
+                if (index >= itemList.Count)
+                    index = itemList.Count - 1;
+                if (itemList[index].Disabled)
+                    continue;
+                item = itemList[index];
+                await item.OnFocusAsync();
+                _activeItemId = item.ItemId;
+                break;
+            }
+        }
+
+        private async Task FocusPreviousItemAsync() => await FocusAdjacentItemAsync(-1);
+
+        private async Task FocusNextItemAsync() => await FocusAdjacentItemAsync(1);
+
+        private async Task FocusFirstItemAsync(string? startChar = null)
+        {
+            if (_items.Count == 0)
+                return;
+
+            var items = _items.Where(x => !x.Disabled);
+
+            if (!string.IsNullOrWhiteSpace(startChar))
+            {
+                // Find first item that starts with the letter
+                var currentItem = items.FirstOrDefault(x => x.ItemId == _activeItemId);
+                if (currentItem is not null &&
+                    currentItem.Text?.ToLowerInvariant().StartsWith(startChar) == true)
+                {
+                    // Step through items starting with the same letter
+                    items = items.SkipWhile(x => x != currentItem).Skip(1);
+                }
+                items = items.Where(x => x.Text?.ToLowerInvariant().StartsWith(startChar) == true);
+            }
+
+            var item = items.FirstOrDefault();
+            if (item is null)
+                return;
+
+            await item.OnFocusAsync();
+        }
+
+        private async Task FocusLastItemAsync()
+        {
+            if (_items.Count == 0)
+                return;
+            var item = _items.LastOrDefault(x => !x.Disabled);
+            if (item is null)
+                return;
+
+            await item.OnFocusAsync();
+        }
+
+        internal int GetItemCount() => _items.Count;
+
+        internal int GetIndexOfItemById(string itemId) => _items.ToList().FindIndex(x => x.ItemId == itemId);
+
     }
 }

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -6,12 +6,20 @@
             Class="@Classname"
             Style="@Style"
             tabindex="0"
+            role="@GetRole()"
             @attributes="UserAttributes"
             @onclick="OnClickHandlerAsync"
             href="@Href"
             target="@Target"
             PreventDefault="@GetPreventDefault()"
-            ClickPropagation="@GetClickPropagation()">
+            ClickPropagation="@GetClickPropagation()"
+            @bind-Ref="_elementReference"
+            aria-expanded="@GetAriaExpandedValue()"
+            aria-haspopup="@GetAriaHasPopupValue()"
+            aria-selected="@GetAriaSelectedValue()"
+            aria-checked="@GetAriaCheckedValue()"
+            aria-setsize="@GetAriaSizeValue()"
+            aria-posinset="@GetAriaPosInSet()">
 
     @if (AvatarContent is not null)
     {

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -20,6 +20,10 @@ namespace MudBlazor
 
         private ParameterState<bool> _expandedState;
 
+        internal string ItemId = Identifier.Create("list-item-");
+
+        private ElementReference _elementReference = new();
+
         public MudListItem()
         {
             using var registerScope = CreateRegisterScope();
@@ -334,6 +338,27 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// handles if a user focuses this item with the keyboard.
+        /// </summary>
+        internal async Task OnFocusAsync()
+        {
+            if (GetDisabled())
+            {
+                return;
+            }
+            if (TopLevelList is not null && GetReadOnly() == false)
+            {
+                if (SelectionMode == SelectionMode.SingleSelection)
+                {
+                    await TopLevelList.SetSelectedValueAsync(GetValue());
+                }
+                await _elementReference.FocusAsync(false);
+                MudList?.SetFocusedItem(GetValue());
+                StateHasChanged();
+            }
+        }
+
         internal void SetSelected(bool selected)
         {
             if (GetDisabled() || _selected == selected)
@@ -414,6 +439,76 @@ namespace MudBlazor
                 MudList.Unregister(this);
             }
             catch (Exception) { /*ignore*/ }
+        }
+
+        /// <summary>
+        /// Gets the role of the list item.
+        /// </summary>
+        /// <returns>The role of the list item.</returns>
+        /// <remarks>
+        /// If <see cref="ReadOnly"/> is <c>true</c>, the role is <c>listitem</c>. Otherwise, the role is <c>option</c>.
+        /// </remarks>
+        private string GetRole()
+        {
+            return ReadOnly ? "listitem" : "option";
+        }
+
+        private string GetAriaSelectedValue()
+        {
+            return _selected ? "true" : "false";
+        }
+
+        private string GetAriaCheckedValue()
+        {
+            if (MultiSelection)
+            {
+                return _selected ? "true" : "false";
+            }
+            return "undefined";
+        }
+
+        private string GetAriaHasPopupValue()
+        {
+            return NestedList != null ? "true" : "false";
+        }
+
+        private string GetAriaExpandedValue()
+        {
+            if (NestedList == null)
+            {
+                return "undefined";
+            }
+            return Expanded ? "true" : "false";
+        }
+
+        private string GetAriaSizeValue()
+        {
+            if (MudList is null)
+            {
+                return "-1";
+            }
+
+            return MudList.GetItemCount().ToString();
+        }
+
+        private string GetAriaPosInSet()
+        {
+            if (MudList is null)
+            {
+                return "-1";
+            }
+
+            var index = MudList.GetIndexOfItemById(ItemId);
+            return (index + 1).ToString();
+        }
+
+        internal async Task OnItemClickAsync()
+        {
+            if (GetDisabled())
+            {
+                return;
+            }
+            await OnClickHandlerAsync(new MouseEventArgs());
         }
     }
 }


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

The `MudList` component was not accessible for screen reader users or users relying on keyboard navigation.  

In issue #9717, it was noted that to make the `MudSelect` component accessible, the `MudList` component first needed to be made accessible.  

This pull request improves the accessibility of the `MudList` by implementing the [listbox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) and adding the [list role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) to the `MudList`.  

The `list` role is applied when the `MudList` is in readonly mode, as no user interaction is expected in this case. This role, combined with marking all `MudListItems` with the [listitem role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role), significantly improves accessibility for screen reader users.  

When the `MudList` is not readonly, the listbox pattern is applied, and all `MudListItems` are assigned the [option role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role).  


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Tested with my Screen reader (NVDA 2024.4.1) and the following browsers:
- Edge
- Mozilla Firefox
- Google Chrome

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
