### PR TITLE
MudImage: Add fallback source 

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Image/Examples/ImageFallbackExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/Examples/ImageFallbackExample.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTooltip Text="Valid source">
+    <MudImage Src="images/jonny.jpg" Alt="Here's Johnny" Elevation="25" Class="rounded-lg ma-4" FallbackSrc="images/mony.jpg" />
+</MudTooltip>
+<MudTooltip Text="Invalid source (typo)">
+    <MudImage Src="images/johnny.jpg" Alt="Here's Johnny" Elevation="25" Class="rounded-lg ma-4" FallbackSrc="images/mony.jpg" />
+</MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
@@ -26,7 +26,7 @@
                 <ImageFallbackExample />
             </SectionContent>
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader Title="Size">
                 <Description>Size can be directly set on the image with the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> property, it can also be useful to set this even if you want a responsive image, setting them will make the image take up set space even before they are loaded which can be useful if your pictures takes long time to load.</Description>
@@ -35,7 +35,7 @@
                 <ImageSizeExample />
             </SectionContent>
         </DocsPageSection>
-                
+
         <DocsPageSection>
             <SectionHeader Title="Responsive Images">
                 <Description>
@@ -71,7 +71,7 @@
                 <ImagePositionExample />
             </SectionContent>
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader Title="Playground">
                 <Description></Description>
@@ -80,6 +80,5 @@
                 <ImagePlaygroundExample />
             </SectionContent>
         </DocsPageSection>
-
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
@@ -80,7 +80,6 @@
                 <ImagePlaygroundExample />
             </SectionContent>
         </DocsPageSection>
-        
 
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
@@ -15,6 +15,17 @@
                 <ImageUsageExample />
             </SectionContent>
         </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Fallback Image">
+                <Description>
+                    If the <CodeInline>Src</CodeInline> image fails to load, the <CodeInline>FallbackSrc</CodeInline> will be loaded.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(ImageFallbackExample)" Block="true">
+                <ImageFallbackExample />
+            </SectionContent>
+        </DocsPageSection>
         
         <DocsPageSection>
             <SectionHeader Title="Size">
@@ -60,7 +71,7 @@
                 <ImagePositionExample />
             </SectionContent>
         </DocsPageSection>
- 
+        
         <DocsPageSection>
             <SectionHeader Title="Playground">
                 <Description></Description>

--- a/src/MudBlazor.UnitTests/Components/ImageTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ImageTests.cs
@@ -2,10 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -53,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
             img.GetAttribute("width").Should().Be("120");
             img.GetAttribute("style").Should().Be("background:gray");
 
-            img.ClassList.Should().BeEquivalentTo(new[] { "my-custom-class", "mud-elevation-25", "object-bottom", "object-cover", "mud-image", "fluid" });
+            img.ClassList.Should().BeEquivalentTo("my-custom-class", "mud-elevation-25", "object-bottom", "object-cover", "mud-image", "fluid");
         }
 
         [Test]
@@ -93,7 +91,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var img = comp.Find("img");
-            img.ClassList.Should().Contain(new[] { "mud-image", $"object-{expectedClass}" });
+            img.ClassList.Should().Contain(["mud-image", $"object-{expectedClass}"]);
         }
 
         [Test]
@@ -108,11 +106,28 @@ namespace MudBlazor.UnitTests.Components
             );
 
             // Trigger the `onerror` event
-            comp.Find("img").TriggerEvent("onerror", new EventArgs());
+            comp.Find("img").TriggerEvent("onerror", EventArgs.Empty);
 
             var img = comp.Find("img");
 
             img.GetAttribute("src").Should().Be(fallbackSrc);
+        }
+
+        [Test]
+        public void FallbackMissingOnError()
+        {
+            var initialSrc = "primary-image.jpg";
+
+            var comp = Context.RenderComponent<MudImage>(parameters => parameters
+                .Add(p => p.Src, initialSrc)
+            );
+
+            // Trigger the `onerror` event
+            comp.Find("img").TriggerEvent("onerror", EventArgs.Empty);
+
+            var img = comp.Find("img");
+
+            img.GetAttribute("src").Should().Be(initialSrc);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ImageTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ImageTests.cs
@@ -95,6 +95,25 @@ namespace MudBlazor.UnitTests.Components
             var img = comp.Find("img");
             img.ClassList.Should().Contain(new[] { "mud-image", $"object-{expectedClass}" });
         }
+
+        [Test]
+        public void SwitchesToFallbackSrcOnError()
+        {
+            var initialSrc = "primary-image.jpg";
+            var fallbackSrc = "fallback-image.jpg";
+
+            var comp = Context.RenderComponent<MudImage>(parameters => parameters
+                .Add(p => p.Src, initialSrc)
+                .Add(p => p.FallbackSrc, fallbackSrc)
+            );
+
+            // Trigger the `onerror` event
+            comp.Find("img").TriggerEvent("onerror", new EventArgs());
+
+            var img = comp.Find("img");
+
+            img.GetAttribute("src").Should().Be(fallbackSrc);
+        }
     }
 }
 

--- a/src/MudBlazor/Components/Image/MudImage.razor
+++ b/src/MudBlazor/Components/Image/MudImage.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<img @attributes="UserAttributes" src="@Src" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height">
+<img @attributes="UserAttributes" src="@Src" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnError">

--- a/src/MudBlazor/Components/Image/MudImage.razor
+++ b/src/MudBlazor/Components/Image/MudImage.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<img @attributes="UserAttributes" src="@Src" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnError">
+<img @attributes="UserAttributes" src="@_srcState.Value" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnErrorAsync">

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -41,7 +41,11 @@ public partial class MudImage : MudComponentBase
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Image.Behavior)]
-    public string? Src { get; set; }
+    public string? Src
+    {
+        get => _src;
+        set => _src = value;
+    }
 
     /// <summary>
     /// The fallback image path to use if <see cref="Src"/> fails to load.
@@ -107,6 +111,8 @@ public partial class MudImage : MudComponentBase
     [Category(CategoryTypes.Image.Appearance)]
     public ObjectPosition ObjectPosition { set; get; } = ObjectPosition.Center;
 
+    private string? _src;
+
     /// <summary>
     /// Handles the image error event and sets the fallback image source.
     /// </summary>
@@ -114,7 +120,7 @@ public partial class MudImage : MudComponentBase
     {
         if (!string.IsNullOrEmpty(FallbackSrc) && Src != FallbackSrc)
         {
-            Src = FallbackSrc;
+            _src = FallbackSrc;
         }
     }
 }

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -44,6 +44,13 @@ public partial class MudImage : MudComponentBase
     public string? Src { get; set; }
 
     /// <summary>
+    /// The fallback image path to use if <see cref="Src"/> fails to load.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Image.Behavior)]
+    public string? FallbackSrc { get; set; }
+
+    /// <summary>
     /// The alternate text for this image.
     /// </summary>
     [Parameter]
@@ -99,4 +106,15 @@ public partial class MudImage : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Image.Appearance)]
     public ObjectPosition ObjectPosition { set; get; } = ObjectPosition.Center;
+
+    /// <summary>
+    /// Handles the image error event and sets the fallback image source.
+    /// </summary>
+    private void OnError()
+    {
+        if (!string.IsNullOrEmpty(FallbackSrc) && Src != FallbackSrc)
+        {
+            Src = FallbackSrc;
+        }
+    }
 }

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
@@ -17,6 +18,15 @@ namespace MudBlazor;
 /// </remarks>
 public partial class MudImage : MudComponentBase
 {
+    private readonly ParameterState<string?> _srcState;
+
+    public MudImage()
+    {
+        using var registerScope = CreateRegisterScope();
+        _srcState = registerScope.RegisterParameter<string?>(nameof(Src))
+            .WithParameter(() => Src);
+    }
+
     protected string Classname =>
         new CssBuilder("mud-image")
             .AddClass("fluid", Fluid)
@@ -41,11 +51,7 @@ public partial class MudImage : MudComponentBase
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Image.Behavior)]
-    public string? Src
-    {
-        get => _src;
-        set => _src = value;
-    }
+    public string? Src { get; set; }
 
     /// <summary>
     /// The fallback image path to use if <see cref="Src"/> fails to load.
@@ -111,16 +117,16 @@ public partial class MudImage : MudComponentBase
     [Category(CategoryTypes.Image.Appearance)]
     public ObjectPosition ObjectPosition { set; get; } = ObjectPosition.Center;
 
-    private string? _src;
-
     /// <summary>
     /// Handles the image error event and sets the fallback image source.
     /// </summary>
-    private void OnError()
+    private Task OnErrorAsync()
     {
-        if (!string.IsNullOrEmpty(FallbackSrc) && Src != FallbackSrc)
+        if (!string.IsNullOrEmpty(FallbackSrc) && _srcState.Value != FallbackSrc)
         {
-            _src = FallbackSrc;
+            return _srcState.SetValueAsync(FallbackSrc);
         }
+
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Description
Adds a fallback image source to be loaded if the `Src` fails to load. 

Resolves #2066 

## How Has This Been Tested?
Unit tests and visually

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
