### PR TITLE
CSS: Remove `ul` from base reset

### DIFF
--- a/src/MudBlazor.Docs/Styles/core/_base.scss
+++ b/src/MudBlazor.Docs/Styles/core/_base.scss
@@ -165,3 +165,8 @@
     }
   }
 }
+
+ol,
+ul {
+  list-style: none;
+}

--- a/src/MudBlazor/Styles/components/_breadcrumbs.scss
+++ b/src/MudBlazor/Styles/components/_breadcrumbs.scss
@@ -3,7 +3,7 @@
   flex-wrap: wrap;
   flex: 0 1 auto;
   align-items: center;
-  list-style-type: none;
+  list-style: none;
   margin: 0;
   padding: 16px 12px;
 }

--- a/src/MudBlazor/Styles/core/_reset.scss
+++ b/src/MudBlazor/Styles/core/_reset.scss
@@ -1,4 +1,4 @@
-﻿a {
+a {
   text-decoration: none;
 
   &:focus-visible {
@@ -72,10 +72,4 @@ iframe {
   border: none;
   height: 100%;
   width: 100%;
-}
-
-ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Removes the default global reset on `ul`.
We still want to keep it on the others for now but this one isn't important.

Related to #10608

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
