### PR TITLE
MudTable: Enable text selection in sortable table header columns

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -31,6 +31,10 @@
       color: var(--mud-palette-text-primary);
       font-weight: 500;
       line-height: 1.5rem;
+
+      & .mud-button-root {
+          user-select: auto;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Allows text selection in sortable table header columns, ensuring sortable header columns behavior being consistent with non-sortable header columns.
It is related with #10603, however it doesn't solves it entirely.
When this change will be accepted, I will add another PR with cursor icon change.

## How Has This Been Tested?
Visually

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/user-attachments/assets/503766cb-777e-4594-a2c5-9f61aef779e1)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
