### PR TITLE
MudTextField: Fix Outlined text field variant label in RTL 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/OutlineLabelBackgroundTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/OutlineLabelBackgroundTest.razor
@@ -1,19 +1,29 @@
-﻿<div class="test-container1">
+﻿<MudStack Class="test-container1" Row>
     <MudTextField T="string" Variant="Variant.Outlined" Label="Normal"></MudTextField>
-</div>
-
-<div class="test-container1">
+    <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Normal" ShrinkLabel="true"></MudTextField>
     <MudTextField T="string" Variant="Variant.Outlined" Margin="Margin.Dense" Label="Dense"></MudTextField>
-</div>
+    <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Dense" ShrinkLabel="true" Margin="Margin.Dense"></MudTextField>
+</MudStack>
+
+<MudRTLProvider RightToLeft>
+    <MudStack Class="test-container1" Row>
+        <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Dense" ShrinkLabel="true" Margin="Margin.Dense"></MudTextField>
+        <MudTextField T="string" Variant="Variant.Outlined" Margin="Margin.Dense" Label="Dense"></MudTextField>
+        <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Normal" ShrinkLabel="true"></MudTextField>
+        <MudTextField T="string" Variant="Variant.Outlined" Label="Normal"></MudTextField>
+    </MudStack>
+</MudRTLProvider>
 
 <div class="test-container2">
     <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Normal" ShrinkLabel="true"></MudTextField>
 </div>
 
-<div class="test-container2">
-    <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Dense" ShrinkLabel="true"
-                  Margin="Margin.Dense"></MudTextField>
-</div>
+<MudRTLProvider RightToLeft>
+    <div class="test-container2">
+        <MudTextField T="string" Variant="Variant.Outlined" Label="Shrink Normal" ShrinkLabel="true"></MudTextField>
+    </div>
+</MudRTLProvider>
+
 
 <style>
     .test-container1 {

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -164,7 +164,7 @@
         font-weight: inherit;
         width: 0;
         height: 0;
-        margin: 0 0 0 11px;
+        margin: 0 11px 0 11px;
         padding: 0;
         position: relative;
       }


### PR DESCRIPTION
## Description
The outline partially covers the label in RTL mode

Resolves #10639 

## How Has This Been Tested?
Updated visual test to include regular and RTL rendering

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/user-attachments/assets/f6a16130-2568-4d54-9d0d-b421073901ac)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
