### PR TITLE
MudDataGrid: Backport #10436 #10220

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyColumnsResizerTest.razor
@@ -6,22 +6,22 @@
         <PropertyColumn Property="x => x.Column2" />
         <PropertyColumn Property="x => x.Column3" />
         <PropertyColumn Property="x => x.Column4" />
-        <PropertyColumn Property="x => x.Column5" />
+        <PropertyColumn Property="x => x.Column5" Resizable="true" />
         <PropertyColumn Property="x => x.Column6" />
         <PropertyColumn Property="x => x.Column7" />
         <PropertyColumn Property="x => x.Column8" />
         <PropertyColumn Property="x => x.Column9" />
-        <PropertyColumn Property="x => x.Column10" />
+        <PropertyColumn Property="x => x.Column10" Resizable="false" />
         <PropertyColumn Property="x => x.Column11" />
         <PropertyColumn Property="x => x.Column12" />
         <PropertyColumn Property="x => x.Column13" />
         <PropertyColumn Property="x => x.Column14" />
-        <PropertyColumn Property="x => x.Column15" />
+        <PropertyColumn Property="x => x.Column15" Resizable="true"/>
         <PropertyColumn Property="x => x.Column16" />
         <PropertyColumn Property="x => x.Column17" />
         <PropertyColumn Property="x => x.Column18" />
         <PropertyColumn Property="x => x.Column19" />
-        <PropertyColumn Property="x => x.Column20" />
+        <PropertyColumn Property="x => x.Column20" Resizable="false" />
         <PropertyColumn Property="x => x.Column21" />
         <PropertyColumn Property="x => x.Column22" />
         <PropertyColumn Property="x => x.Column23" />
@@ -33,7 +33,9 @@
 </MudDataGrid>
 
 @code {
-    private IEnumerable<Model> _items = new List<Model>()
+    public static string __description__ = "Columns 5 & 15 Resizable=true | Columns 10 & 20 Resizable=false | All others null (resizable by default)";
+
+    private readonly IEnumerable<Model> _items = new List<Model>
     {
         new Model("Column1", "Column2", "Column3", "Column4", "Column5", "Column6", "Column7", "Column8", "Column9", "Column10", "Column11", "Column12",
             "Column13", "Column14", "Column15", "Column16", "Column17", "Column18", "Column19", "Column20", "Column21", "Column22", "Column23", "Column24"), 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -33,26 +33,26 @@ namespace MudBlazor.UnitTests.Components
     public class DataGridTests : BunitTest
     {
         [Test]
-        [SetCulture("en-US")]
-        [SetUICulture("en-US")]
+        [SetCulture("")]
+        [SetUICulture("")]
         public void DataGridPropertyNullCheck()
         {
             var comp = Context.RenderComponent<DataGridPropertyColumnNullCheckTest>();
             var cells = comp.FindAll("td").ToArray();
 
             // First Row
-            cells[0].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[0].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[1].TextContent.Should().BeEmpty();
-            cells[2].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[2].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[3].TextContent.Should().BeEmpty();
             cells[4].TextContent.Should().BeEmpty();
             cells[5].TextContent.Should().BeEmpty();
 
             // Second Row
-            cells[6].TextContent.Should().Be("1/1/0001 12:00:00 AM");
-            cells[7].TextContent.Should().Be("1/1/0001 12:00:00 AM +00:00");
-            cells[8].TextContent.Should().Be("1/1/0001 12:00:00 AM");
-            cells[9].TextContent.Should().Be("1/1/0001 12:00:00 AM");
+            cells[6].TextContent.Should().Be("01/01/0001 00:00:00");
+            cells[7].TextContent.Should().Be("01/01/0001 00:00:00 +00:00");
+            cells[8].TextContent.Should().Be("01/01/0001 00:00:00");
+            cells[9].TextContent.Should().Be("01/01/0001 00:00:00");
             cells[10].TextContent.Should().Be("some text");
             cells[11].TextContent.Should().BeEmpty();
         }

--- a/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridColumnResizeService.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         internal async Task<bool> StartResizeColumn(HeaderCell<T> headerCell, double clientX, IList<Column<T>> columns,
             ResizeMode columnResizeMode, bool rightToLeft)
         {
-            if ((headerCell.Column?.Resizable ?? false) || columnResizeMode == ResizeMode.None ||
+            if (headerCell.Column?.Resizable is false || columnResizeMode == ResizeMode.None ||
                 _pointerMoveSubscriptionId != default || _pointerUpSubscriptionId != default)
                 return false;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Currently, setting Resizable to true on a column enables the drag indicators, however users are unable to resize the column. This was fixed on dev branch via this PR https://github.com/MudBlazor/MudBlazor/pull/10436 so I have cherry picked the change into the v7 branch

Resolves #9760 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
