### PR TITLE
MudTextField: Fix line height for outlined frame

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -74,7 +74,7 @@
 
   & > .mud-input-control-input-container > .mud-input-label-outlined {
     &.mud-input-label-inputcontrol {
-      line-height: 19px;
+      line-height: 1.15rem;
     }
   }
 

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -74,7 +74,7 @@
 
   & > .mud-input-control-input-container > .mud-input-label-outlined {
     &.mud-input-label-inputcontrol {
-      line-height: 18px;
+      line-height: 19px;
     }
   }
 


### PR DESCRIPTION
## Description
The text on a outlined MudTextField is cropped at the bottom for letters who go below the textline, e.g. g,y,j,q,p,.. 
It could be seen in the [official documentation](https://mudblazor.com/components/textfield#adornments-select), the 'g' of "Single select" is cut.
It could also be seen in the screenshot, especially at the 'g' in the end of the string "QjpqyLlg".

![lineHeight18](https://github.com/user-attachments/assets/d6e303fa-1df0-4659-b840-97140a33b1ad)


## How Has This Been Tested?
visually

![lineHeight19](https://github.com/user-attachments/assets/659fc30d-317f-43d6-a42e-2d84b85edf0e)


## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
