### PR TITLE
Docs: Add Chat Bubble example to the DocsExplore demos

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
@@ -317,17 +317,22 @@
                             </MudPaper>
                         </DocsExploreCard>
                         <DocsExploreCard Title="Chat">
-                            <MudPaper Elevation="25" Width="100%" Class="d-flex flex-column align-start flex-grow-1">
-                                <div class="d-flex flex-column align-center flex-grow-1 px-3">
-                                    <MudPaper Elevation="25" Class="d-flex justify-center align-center rounded-circle pa-1">
-                                        <MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Inherit" Size="Size.Medium" Style="font-size:14px;"/>
-                                    </MudPaper>
-                                    <MudPaper Elevation="0" Width="100%" Class="pa-2 d-flex flex-column align-start mt-3 mud-theme-primary z-20">
-                                        <MudPaper Elevation="0" Width="100%" Height="4px" Class="docs-gray-bg"/>
-                                    </MudPaper>
-                                    <MudPaper Elevation="0" Width="18px" Height="18px" Class="mud-theme-primary rounded-0 mt-n6 z-10" Style="transform:rotate(45deg);"/>
-                                </div>
-                            </MudPaper>
+                            <MudStack Class="pa-6">
+                                <MudStack Row Class="overflow-hidden" Spacing="0">
+                                    <MudPaper Elevation="25" Width="16px" Height="16px"
+                                              Class="mud-theme-primary rounded-0 z-10"
+                                              Style="transform: rotate(45deg) translate(0px, -12px)"/>
+                                    <MudPaper Elevation="25" Width="96px" Height="32px"
+                                              Class="mud-theme-primary z-20 mr-3"/>
+                                </MudStack>
+                                <MudStack Row Class="overflow-hidden" Spacing="0">
+                                    <MudPaper Elevation="25" Width="96px" Height="32px"
+                                              Class="mud-theme-primary z-20 ml-3"/>
+                                    <MudPaper Elevation="25" Width="16px" Height="16px"
+                                              Class="mud-theme-primary rounded-0 z-10"
+                                              Style="transform: rotate(45deg) translate(-12px, 0px)"/>
+                                </MudStack>
+                            </MudStack>
                         </DocsExploreCard>
                         <DocsExploreCard Title="Chips">
                             <MudPaper Elevation="25" Class="px-2 py-1 d-flex rounded-pill">

--- a/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overview/OverviewPage.razor
@@ -11,7 +11,7 @@
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
-    <DocsPageSection>
+        <DocsPageSection>
             <MudGrid>
                 <MudItem xs="12" md="3" Class="mt-16">
                     <div class="docs-sticky-info explore-text">
@@ -31,6 +31,7 @@
                                 </MudPaper>
                             </MudPaper>
                         </DocsExploreCard>
+        
                         <DocsExploreCard Title="Typography" Link="/components/typography">
                             <MudIcon Icon="@Icons.Material.Filled.TextFields" Color="Color.Primary" Style="font-size:64px;"/>
                         </DocsExploreCard>
@@ -315,7 +316,7 @@
                                 </div>
                             </MudPaper>
                         </DocsExploreCard>
-                        <DocsExploreCard Title="Chat Bubble">
+                        <DocsExploreCard Title="Chat">
                             <MudPaper Elevation="25" Width="100%" Class="d-flex flex-column align-start flex-grow-1">
                                 <div class="d-flex flex-column align-center flex-grow-1 px-3">
                                     <MudPaper Elevation="25" Class="d-flex justify-center align-center rounded-circle pa-1">
@@ -340,60 +341,60 @@
                                 <MudPaper Elevation="0" Width="100%" Class="docs-gray-bg px-4 py-1 rounded-pill ml-1"/>
                             </MudPaper>
                         </DocsExploreCard>
-                    <DocsExploreCard Title="Data Grid">
-                        <MudPaper Elevation="25" Width="100%" Class="px-2 pb-2 pt-3 rounded-lg">
-                            <div class="d-flex">
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary mx-1"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
-                            </div>
-                            <div class="d-flex my-1">
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg mx-1"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
-                            </div>
-                            <div class="d-flex">
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg mx-1"/>
-                                <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
-                            </div>
-                        </MudPaper>
-                    </DocsExploreCard>
-                    <DocsExploreCard Title="Drop Zone">
-                        <MudPaper Elevation="25" Class="d-flex flex-wrap pa-1 rounded-lg relative">
-                            <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-primary ma-1"/>
-                            <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
-                            <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
-                            <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
-                            <div class="absolute mud-width-full mud-height-full d-flex justify-center align-center">
-                                <MudPaper Elevation="25" Width="34px" Height="34px" Class="ml-n6 mt-n6 d-flex justify-center align-center">
-                                    <MudIcon Icon="@Icons.Material.Outlined.Image" Class="mud-text-secondary"/>
+                        <DocsExploreCard Title="Data Grid">
+                            <MudPaper Elevation="25" Width="100%" Class="px-2 pb-2 pt-3 rounded-lg">
+                                <div class="d-flex">
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary mx-1"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
+                                </div>
+                                <div class="d-flex my-1">
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="mud-theme-primary"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg mx-1"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
+                                </div>
+                                <div class="d-flex">
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg mx-1"/>
+                                    <MudPaper Elevation="0" Width="100%" Height="12px" Class="docs-gray-bg"/>
+                                </div>
+                            </MudPaper>
+                        </DocsExploreCard>
+                        <DocsExploreCard Title="Drop Zone">
+                            <MudPaper Elevation="25" Class="d-flex flex-wrap pa-1 rounded-lg relative">
+                                <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-primary ma-1"/>
+                                <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
+                                <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
+                                <MudPaper Elevation="0" Width="34px" Height="34px" Class="border-2 border-dashed mud-border-lines-default ma-1"/>
+                                <div class="absolute mud-width-full mud-height-full d-flex justify-center align-center">
+                                    <MudPaper Elevation="25" Width="34px" Height="34px" Class="ml-n6 mt-n6 d-flex justify-center align-center">
+                                        <MudIcon Icon="@Icons.Material.Outlined.Image" Class="mud-text-secondary"/>
+                                    </MudPaper>
+                                </div>
+                            </MudPaper>
+                        </DocsExploreCard>
+                        <DocsExploreCard Title="Expansion Panels">
+                            <div class="d-flex flex-column flex-grow-1">
+                                <MudPaper Elevation="25" Width="100%" Class="px-2 py-1 d-flex align-center">
+                                    <MudPaper Elevation="0" Width="30%" Height="8px" Class="docs-gray-bg mr-auto"/>
+                                    <MudIcon Icon="@Icons.Material.Rounded.ArrowDropDown" Class="my-n2 mr-n1" Size="Size.Small"/>
+                                </MudPaper>
+                                <MudPaper Elevation="25" Width="100%" Class="px-2 py-1 d-flex flex-column mt-2">
+                                    <div class="d-flex flex-grow-1">
+                                        <MudPaper Elevation="0" Width="40%" Height="8px" Class="docs-gray-bg mr-auto"/>
+                                        <MudIcon Icon="@Icons.Material.Rounded.ArrowDropUp" Color="Color.Primary" Class="my-n2 mr-n1" Size="Size.Small"/>
+                                    </div>
+                                    <MudPaper Elevation="0" Width="80%" Height="8px" Class="docs-gray-bg mr-auto mt-2"/>
                                 </MudPaper>
                             </div>
-                        </MudPaper>
-                    </DocsExploreCard>
-                    <DocsExploreCard Title="Expansion Panels">
-                        <div class="d-flex flex-column flex-grow-1">
-                            <MudPaper Elevation="25" Width="100%" Class="px-2 py-1 d-flex align-center">
-                                <MudPaper Elevation="0" Width="30%" Height="8px" Class="docs-gray-bg mr-auto"/>
-                                <MudIcon Icon="@Icons.Material.Rounded.ArrowDropDown" Class="my-n2 mr-n1" Size="Size.Small"/>
+                        </DocsExploreCard>
+                        <DocsExploreCard Title="Image">
+                            <MudPaper Elevation="25" Width="100%" Class="px-2 py-9 rounded-lg overflow-hidden relative">
+                                <MudPaper Elevation="25" Class="rounded-circle absolute mud-theme-warning" Width="12px" Height="12px" Style=" left: 8px;top: 8px;"/>
+                                <MudPaper Elevation="25" Class="rounded-lg absolute z-10" Width="52px" Height="52px" Style="background-color: var(--mud-palette-primary-lighten); transform: rotate(45deg); left: 0;bottom: -32px;"/>
+                                <MudPaper Elevation="25" Class="rounded-lg absolute z-0 mud-theme-primary" Width="72px" Height="72px" Style="transform: rotate(45deg); right: 0;bottom: -42px;"/>
                             </MudPaper>
-                            <MudPaper Elevation="25" Width="100%" Class="px-2 py-1 d-flex flex-column mt-2">
-                                <div class="d-flex flex-grow-1">
-                                    <MudPaper Elevation="0" Width="40%" Height="8px" Class="docs-gray-bg mr-auto"/>
-                                    <MudIcon Icon="@Icons.Material.Rounded.ArrowDropUp" Color="Color.Primary" Class="my-n2 mr-n1" Size="Size.Small"/>
-                                </div>
-                                <MudPaper Elevation="0" Width="80%" Height="8px" Class="docs-gray-bg mr-auto mt-2"/>
-                            </MudPaper>
-                        </div>
-                    </DocsExploreCard>
-                    <DocsExploreCard Title="Image">
-                        <MudPaper Elevation="25" Width="100%" Class="px-2 py-9 rounded-lg overflow-hidden relative">
-                            <MudPaper Elevation="25" Class="rounded-circle absolute mud-theme-warning" Width="12px" Height="12px" Style=" left: 8px;top: 8px;"/>
-                            <MudPaper Elevation="25" Class="rounded-lg absolute z-10" Width="52px" Height="52px" Style="background-color: var(--mud-palette-primary-lighten); transform: rotate(45deg); left: 0;bottom: -32px;"/>
-                            <MudPaper Elevation="25" Class="rounded-lg absolute z-0 mud-theme-primary" Width="72px" Height="72px" Style="transform: rotate(45deg); right: 0;bottom: -42px;"/>
-                        </MudPaper>
-                    </DocsExploreCard>
+                        </DocsExploreCard>
                         <DocsExploreCard Title="List">
                             <div class="d-flex flex-column justify-center align-center">
                                 <div class="d-flex flex-grow-1">


### PR DESCRIPTION
## Description
This PR introduces a new `DocsExploreCard` showcasing two simplistic chat bubbles (one with a tail on the left and one with a tail on the right). It uses `MudPaper` and `MudStack` components with minimal inline styling to create the bubble shapes. The example helps users understand how to construct chat bubbles with MudBlazor components without relying on custom CSS files.

---

## How Has This Been Tested?
- **Visually tested:** Verified the layout and appearance in a local or development environment.  
- **No unit tests:** This is a documentation/demo feature only.

<img width="618" alt="Screenshot 2025-01-19 at 15 22 24" src="https://github.com/user-attachments/assets/172669e4-1835-42d8-9b29-79c0aac7060d" />

---

## Type of Changes
- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [x] Documentation

---

## Checklist
- [x] The PR is submitted to the `dev` branch.  
- [x] My code follows the style of the MudBlazor project.  
- [ ] I've added (or not needed) relevant tests.