### PR TITLE
MudOverlay: Introduce `mud-skip-overlay-section`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -60,12 +60,11 @@ namespace MudBlazor.UnitTests.Components
         public void TemporaryClosed_Open_CheckOpened_Close_CheckClosed()
         {
             _ = AddBrowserViewportService();
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerTest1>(Parameter(nameof(DrawerTest1.Variant), DrawerVariant.Temporary));
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
-            providerComp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
+            comp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
@@ -77,8 +76,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task Temporary_OverlayAutoClose(bool overlayAutoClose)
         {
-            _ = AddBrowserViewportService();
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
                 .Add(parameter => parameter.Variant, DrawerVariant.Temporary)
                 .Add(parameter => parameter.OverlayAutoClose, overlayAutoClose));
@@ -87,18 +84,18 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#toggle-drawer-button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
-            providerComp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
+            comp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Clicking on the overlay
-            await providerComp.Find("div.mud-overlay").ClickAsync(new MouseEventArgs());
+            await comp.Find("div.mud-overlay").ClickAsync(new MouseEventArgs());
 
             if (overlayAutoClose)
             {
                 // Drawer should close
                 comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(0);
                 comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
-                providerComp.FindAll(".mud-overlay-drawer").Count.Should().Be(0);
+                comp.FindAll(".mud-overlay-drawer").Count.Should().Be(0);
                 comp.Instance.Drawer.Open.Should().BeFalse();
             }
             else
@@ -106,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
                 // Drawer should stay open
                 comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
                 comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(0);
-                providerComp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
+                comp.FindAll(".mud-overlay-drawer").Count.Should().Be(1);
                 comp.Instance.Drawer.Open.Should().BeTrue();
             }
         }
@@ -226,12 +223,11 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveSmallClosed_Open_CheckOpenedAndOverlay(Breakpoint point)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(point));
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
@@ -259,7 +255,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
@@ -282,12 +278,11 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveClosed_StartSmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(breakpoint == Breakpoint.Xs ? 0 : 1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(breakpoint == Breakpoint.Xs ? 0 : 1);
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
@@ -299,7 +294,6 @@ namespace MudBlazor.UnitTests.Components
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
@@ -334,14 +328,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#toggle-drawer-button").Click();
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
 
             // Resize to large, drawer should stays open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.Instance.Drawer.Open.Should().BeTrue();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
         }
 
         /// <summary>
@@ -602,13 +596,12 @@ namespace MudBlazor.UnitTests.Components
             )] bool initialState)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
             var comp = Context.RenderComponent<DrawerNonResponsiveTest>(Parameter(nameof(DrawerNonResponsiveTest.InitialOpenState), initialState));
 
             var expectedDrawerCount = initialState ? 1 : 0;
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedDrawerCount);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(expectedDrawerCount);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(expectedDrawerCount);
             comp.Instance.Drawer.Open.Should().Be(initialState);
 
             // Make sure that we can toggle the drawer without issues
@@ -617,7 +610,7 @@ namespace MudBlazor.UnitTests.Components
             var expectedToggledDrawerCount = initialState ? 0 : 1;
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(expectedToggledDrawerCount);
-            providerComp.FindAll(".mud-drawer-overlay").Count.Should().Be(expectedToggledDrawerCount);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(expectedToggledDrawerCount);
             comp.Instance.Drawer.Open.Should().Be(!initialState);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -152,8 +152,7 @@ public class OverlayTests : BunitTest
 
     [Test]
     [TestCase(true, "", false, 0)] // Absolute is true
-    [TestCase(false, "mud-overlay-dialog", false, 1)] // Dialog
-    [TestCase(false, "mud-drawer-overlay", false, 2)] // Drawer
+    [TestCase(false, "mud-skip-overlay-section", false, 1)] // Dialog
     [TestCase(false, "", true, 3)]  // Child content
     [TestCase(false, "", false, 4)] // no exception
     public void ShouldRender_SectionLocation(bool absolute, string expectedClass, bool hasChildContent, int testNum)
@@ -195,8 +194,8 @@ public class OverlayTests : BunitTest
                 comp.Instance.RenderOutsideOfSection.Should().BeTrue();
                 break;
             case 2:
-                countInProvider.Count.Should().Be(1);
-                countInComp.Count.Should().Be(0);
+                countInProvider.Count.Should().Be(0);
+                countInComp.Count.Should().Be(1);
                 comp.Instance.RenderOutsideOfSection.Should().BeFalse();
                 break;
             case 3:

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -119,6 +119,7 @@ namespace MudBlazor
 
         protected string BackgroundClassname =>
             new CssBuilder("mud-overlay-dialog")
+                .AddClass($"mud-skip-overlay-section") // dialog overlay remains outside of Section
                 .AddClass("mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior if a user puts the dialog provider above the popover provider
                 .AddClass(GetDialogOptionsOrDefault.BackgroundClass)
                 .Build();

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -73,6 +73,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer-overlay-{_breakpointState.Value.ToDescriptionString()}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .AddClass($"mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior
+                .AddClass($"mud-skip-overlay-section") // drawer overlay remains outside of Section
                 .Build();
 
         protected string Stylename =>

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -168,7 +168,7 @@ public partial class MudOverlay : MudComponentBase, IAsyncDisposable
     /// </remarks>
     internal bool RenderOutsideOfSection =>
         Absolute ||
-        (Class?.Contains("mud-overlay-dialog") ?? false) ||
+        (Class?.Contains("mud-skip-overlay-section") ?? false) ||
         ChildContent != null;
 
     public MudOverlay()

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -407,8 +407,7 @@ window.mudpopoverHelper = {
         // set any associated overlay to equal z-index
         const provider = popoverContentNode.closest('.mud-popover-provider');
         if (provider && popoverContentNode.classList.contains("mud-popover")) {
-            if (provider) {
-                const overlay = parent.querySelector('.mud-overlay');
+                const overlay = provider.querySelector('.mud-overlay');
                 // skip any overlay marked with mud-skip-overlay
                 if (overlay && !overlay.classList.contains('mud-skip-overlay-positioning')) {
                     // Only assign z-index if it doesn't already exist
@@ -416,7 +415,6 @@ window.mudpopoverHelper = {
                         overlay.style['z-index'] = popoverContentNode.style['z-index'];
                     }
                 }
-            }
         }
     },
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -407,14 +407,14 @@ window.mudpopoverHelper = {
         // set any associated overlay to equal z-index
         const provider = popoverContentNode.closest('.mud-popover-provider');
         if (provider && popoverContentNode.classList.contains("mud-popover")) {
-                const overlay = provider.querySelector('.mud-overlay');
-                // skip any overlay marked with mud-skip-overlay
-                if (overlay && !overlay.classList.contains('mud-skip-overlay-positioning')) {
-                    // Only assign z-index if it doesn't already exist
-                    if (!overlay.style['z-index']) {
-                        overlay.style['z-index'] = popoverContentNode.style['z-index'];
-                    }
+            const overlay = provider.querySelector('.mud-overlay');
+            // skip any overlay marked with mud-skip-overlay
+            if (overlay && !overlay.classList.contains('mud-skip-overlay-positioning')) {
+                // Only assign z-index if it doesn't already exist
+                if (!overlay.style['z-index']) {
+                    overlay.style['z-index'] = popoverContentNode.style['z-index'];
                 }
+            }
         }
     },
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -407,8 +407,7 @@ window.mudpopoverHelper = {
         // set any associated overlay to equal z-index
         const provider = popoverContentNode.closest('.mud-popover-provider');
         if (provider && popoverContentNode.classList.contains("mud-popover")) {
-            const parent = provider.parentElement;
-            if (parent) {
+            if (provider) {
                 const overlay = parent.querySelector('.mud-overlay');
                 // skip any overlay marked with mud-skip-overlay
                 if (overlay && !overlay.classList.contains('mud-skip-overlay-positioning')) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Allow Drawer/Dialog separation and introduce class `mud-skip-overlay-section`
Fix overlay positioning logic to only position overlays inside mud-popover-provider (nested overlays where someone is using an autocomplete/select/datepicker/etc inside a dialog/drawer/other popover)
Resolves #10587 
Resolves #10658 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually, Unit tests adjusted to use correct container for overlays

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
