### PR TITLE
MudDateRangePicker: Fix Outlined Variant label rendering

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMaskExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerMaskExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDatePicker Label="dd.MM.yyyy" Editable="true" @bind-Date="_date1" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" />
-<MudDatePicker Label="MM/dd/yyyy" Editable="true" @bind-Date="_date2" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" />
-<MudDatePicker Label="yyyy-MM-dd" Editable="true" @bind-Date="_date3" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" />
+<MudDatePicker Label="dd.MM.yyyy" Editable="true" @bind-Date="_date1" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date"  Variant="Variant.Text" />
+<MudDatePicker Label="MM/dd/yyyy" Editable="true" @bind-Date="_date2" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" Variant="Variant.Filled" />
+<MudDatePicker Label="yyyy-MM-dd" Editable="true" @bind-Date="_date3" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" Variant="Variant.Outlined" />
 
 @code {
     private DateTime? _date1 = null;

--- a/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerEditableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerEditableExample.razor
@@ -2,7 +2,7 @@
 
 <MudStack>
     <MudDateRangePicker @bind-DateRange="@_dateRange" Margin="Margin.Dense" ReadOnly="@(!_editable)" Clearable="@_clearable" 
-                        PlaceholderStart="Start Date" PlaceholderEnd="End Date"/>
+                        PlaceholderStart="Start Date" PlaceholderEnd="End Date" Label="Range"/>
 
     <MudStack Row="true">
         <MudSwitch @bind-Value="_editable" Color="Color.Secondary">Editable</MudSwitch>

--- a/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerFormatExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerFormatExample.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudStack>
-    <MudDateRangePicker @bind-DateRange="@_dateRange" DateFormat="dddd, dd MMMM, yyyy" TitleDateFormat="MMMM dd" Margin="Margin.Dense" />
+    <MudDateRangePicker @bind-DateRange="@_dateRange" DateFormat="dddd, dd MMMM, yyyy" TitleDateFormat="MMMM dd" Margin="Margin.Dense"
+                        Variant="Variant.Filled" Label="Range"/>
 </MudStack>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerMinMaxDateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DateRangePicker/Examples/DateRangePickerMinMaxDateExample.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudStack>
-    <MudDateRangePicker @bind-DateRange="@_dateRange" MinDate="_minDate" MaxDate="@_maxDate" Margin="Margin.Dense" HelperText="@HelperText"/>
+    <MudDateRangePicker @bind-DateRange="@_dateRange" MinDate="_minDate" MaxDate="@_maxDate" Margin="Margin.Dense" HelperText="@HelperText"
+                        Variant="Variant.Outlined" Label="Range" />
 </MudStack>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/VarientDatePickerRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/VarientDatePickerRenderTest.razor
@@ -1,0 +1,26 @@
+﻿<MudStack Row>
+    <MudDatePicker Label="dd.MM.yyyy" @bind-Date="_date" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" HelperText="Help Text" Variant="Variant.Text"/>
+    <MudDatePicker Label="MM/dd/yyyy" @bind-Date="_date" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" HelperText="Help Text" Variant="Variant.Filled" />
+    <MudDatePicker Label="yyyy-MM-dd" @bind-Date="_date" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" HelperText="Help Text" Variant="Variant.Outlined" />
+</MudStack>
+<MudStack Row>
+    <MudDatePicker Label="dd.MM.yyyy" @bind-Date="_date" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Text" />
+    <MudDatePicker Label="MM/dd/yyyy" @bind-Date="_date" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Filled" />
+    <MudDatePicker Label="yyyy-MM-dd" @bind-Date="_date" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Outlined" />
+</MudStack>
+
+<MudStack Row>
+    <MudDateRangePicker Label="dd.MM.yyyy" @bind-DateRange="_dateRange" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" HelperText="Help Text" Variant="Variant.Text"/>
+    <MudDateRangePicker Label="MM/dd/yyyy" @bind-DateRange="_dateRange" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" HelperText="Help Text" Variant="Variant.Filled" />
+    <MudDateRangePicker Label="yyyy-MM-dd" @bind-DateRange="_dateRange" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" HelperText="Help Text" Variant="Variant.Outlined" />
+</MudStack>
+<MudStack Row>
+    <MudDateRangePicker Label="dd.MM.yyyy" @bind-DateRange="_dateRange" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Text" />
+    <MudDateRangePicker Label="MM/dd/yyyy" @bind-DateRange="_dateRange" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Filled" />
+    <MudDateRangePicker Label="yyyy-MM-dd" @bind-DateRange="_dateRange" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" HelperText="Help Text" Margin="Margin.Dense" Variant="Variant.Outlined" />
+</MudStack>
+
+@code {
+    private DateTime? _date = DateTime.Today;
+    private DateRange _dateRange = new DateRange(DateTime.Today.AddDays(1), DateTime.Today.AddDays(5));
+}

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -84,6 +84,11 @@
 
     @if (Variant == Variant.Outlined)
     {
-        <div class="mud-input-outlined-border"></div>
+        <fieldset class="mud-input-outlined-border">
+            @if (!string.IsNullOrEmpty(Label))
+            {
+                <legend>@Label</legend>
+            }
+        </fieldset>
     }
 </div>


### PR DESCRIPTION
## Description
Missed updating a `mud-input-outlined-border` for `MudRangeInput` in #10385 .
This caused the `MudDateRangePicker` label to be rendered incorrectly for the `Outlined` variant

Resolves #10653 

## How Has This Been Tested?
Visually
- Added a single test viewer to render all variants with labels and helper text included 
- Updated docs to include each variant so quick visual checks can be done when issues are reported

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
