### PR TITLE
MudTextField : With Required parameter, shows error when only one space is entered

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1385,6 +1385,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Bug : https://github.com/MudBlazor/MudBlazor/issues/10606
+        /// When the user inputs a single space, the required text field should show an error.
+        /// </summary>
+        [Test]
+        public void RequiredTextField_WhenInputOneSpace_ShowError()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudTextField<string>>(parameters =>
+                parameters.Add(p => p.Required, true)
+            );
+            var textfield = comp.Instance;
+
+            // Act
+
+            comp.Find("input").Change(" ");
+
+            // Assert
+
+            textfield.Error.Should().BeTrue();
+        }
+
+        /// <summary>
         /// Required and aria-required TextField attributes should be dynamic.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -440,7 +440,7 @@ namespace MudBlazor
                 Text = text;
                 _validated = false;
 
-                if (!string.IsNullOrWhiteSpace(Text))
+                if (!string.IsNullOrEmpty(Text))
                 {
                     Touched = true;
                 }


### PR DESCRIPTION
## Description

Fixes #10606

Actually, when a user inputs one space or copy/paste many spaces in a required text field, then no error.
The PR modify this behavior to show required error as soon as the user enters one or many spaces.

## How Has This Been Tested?

Test added

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
