### PR TITLE
MudInput: Fix outline label conflict with third-party CSS

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -159,6 +159,7 @@
       transition: border-width,border-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
       legend {
+        float: none;
         visibility: hidden;
         font-size: 1rem * 0.75;
         font-weight: inherit;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes an issue mentioned in https://github.com/MudBlazor/MudBlazor/issues/10653#issuecomment-2603141384 where Bootstrap CSS was setting a default value for `float` on `legend` elements which caused ours to render incorrectly since #10385.

Now we apply a reset on the aforementioned property using a deeper selector which should take precedence (haven't actually tested with bootstrap).

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before:

![image](https://github.com/user-attachments/assets/239909b8-9003-4db9-832d-a37a723c5f31)


After:

![image](https://github.com/user-attachments/assets/8e8accb2-a1c4-41a7-b631-4a085f354456)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
