### PR TITLE
Analyzer: Fix HTMLAttributes mode defaults

### DIFF
--- a/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
+++ b/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MudBlazor.Analyzers
                 }
 
                 if (!global.TryGetValue(AllowedAttributePatternProperty, out var allowPattern)
-                   || !Enum.TryParse<AllowedAttributePattern>(allowPattern, out var allowedAttributePattern))
+                   || !Enum.TryParse<AllowedAttributePattern>(allowPattern, true, out var allowedAttributePattern))
                 {
                     allowedAttributePattern = AllowedAttributePattern.LowerCase;
                 }
@@ -58,7 +58,8 @@ namespace MudBlazor.Analyzers
                 if (allowedAttributePattern == AllowedAttributePattern.Any)
                     return;
 
-                if (!global.TryGetValue(AllowedAttributeListProperty, out var allowedAttributes))
+                if (!global.TryGetValue(AllowedAttributeListProperty, out var allowedAttributes)
+                    || string.IsNullOrEmpty(allowedAttributes))
                 {
                     allowedAttributes = HTMLAttributes.DefaultAttributes;
                 }

--- a/src/MudBlazor.UnitTests/Analyzers/Internal/TestAnalyzerOptions.cs
+++ b/src/MudBlazor.UnitTests/Analyzers/Internal/TestAnalyzerOptions.cs
@@ -16,21 +16,11 @@ namespace MudBlazor.UnitTests.Analyzers.Internal
             AllowedAttributePattern attributeProviderAttribute,
              ImmutableArray<AdditionalText> additionalText, string? attributeList = null)
         {
-            if (attributeList is null)
-            {
-                return new AnalyzerOptions(additionalText, new TestAnalyzerOptions(new Dictionary<string, string>()
-                {
-                    [MudComponentUnknownParametersAnalyzer.AllowedAttributePatternProperty] = attributeProviderAttribute.ToString()!
-                }));
-            }
-            else
-            {
-                return new AnalyzerOptions(additionalText, new TestAnalyzerOptions(new Dictionary<string, string>()
+            return new AnalyzerOptions(additionalText, new TestAnalyzerOptions(new Dictionary<string, string>()
                 {
                     [MudComponentUnknownParametersAnalyzer.AllowedAttributePatternProperty] = attributeProviderAttribute.ToString()!,
-                    [MudComponentUnknownParametersAnalyzer.AllowedAttributeListProperty] = attributeList
+                    [MudComponentUnknownParametersAnalyzer.AllowedAttributeListProperty] = attributeList ?? string.Empty
                 }));
-            }
         }
 
         private readonly Dictionary<string, string> _values;

--- a/src/MudBlazor.UnitTests/Analyzers/Internal/TestAnalyzerOptions.cs
+++ b/src/MudBlazor.UnitTests/Analyzers/Internal/TestAnalyzerOptions.cs
@@ -17,10 +17,10 @@ namespace MudBlazor.UnitTests.Analyzers.Internal
              ImmutableArray<AdditionalText> additionalText, string? attributeList = null)
         {
             return new AnalyzerOptions(additionalText, new TestAnalyzerOptions(new Dictionary<string, string>()
-                {
-                    [MudComponentUnknownParametersAnalyzer.AllowedAttributePatternProperty] = attributeProviderAttribute.ToString()!,
-                    [MudComponentUnknownParametersAnalyzer.AllowedAttributeListProperty] = attributeList ?? string.Empty
-                }));
+            {
+                [MudComponentUnknownParametersAnalyzer.AllowedAttributePatternProperty] = attributeProviderAttribute.ToString()!,
+                [MudComponentUnknownParametersAnalyzer.AllowedAttributeListProperty] = attributeList ?? string.Empty
+            }));
         }
 
         private readonly Dictionary<string, string> _values;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->
Fixes a bug that prevented the analyzers HTMLAttributes mode from using a default list of HTML attributes.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
The new HTMLAttributes mode of the analyzer isn't using the default list of HTML attributes when the .csproj doesn't contain an alternative  list. This is because MudAllowedAttributeList is string.Empty rather than null. This wasn't apparent in testing because I have to manually create the configuration.
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

## How Has This Been Tested?
Updated test code to make the value string.Empty rather than null and tested.
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
