### PR TITLE
MudInput: Fix legend style incorrectly inherited to child components

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldNestedInFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldNestedInFieldTest.razor
@@ -1,0 +1,12 @@
+﻿<MudTextField T="string" Label="Test" Variant="Variant.Outlined"/>
+
+<MudField Variant="Variant.Outlined" Label="Testing Field">
+    <MudTextField T="string" Variant="Variant.Outlined" Label="Child Field"/>
+</MudField>
+
+<MudField Variant="Variant.Outlined" Label="Testing Field">
+    <MudField Variant="Variant.Outlined" Label="">
+        <MudTextField T="string" ShrinkLabel="true" Variant="Variant.Outlined" Label="Child Field"/>
+    </MudField>
+</MudField>
+    

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -157,7 +157,9 @@
       border-width: 1px;
       border-style: solid;
       transition: border-width,border-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    }
 
+    & > .mud-input-outlined-border {
       legend {
         float: none;
         visibility: hidden;
@@ -177,15 +179,15 @@
       }
     }
 
-    &.mud-shrink .mud-input-outlined-border {
-      & legend {
+    &.mud-shrink > .mud-input-outlined-border {
+      legend {
         width: auto;
         padding: 0 5px;
       }
     }
 
-    &:focus-within .mud-input-outlined-border, &:focus-within .mud-shrink .mud-input-outlined-border {
-      & legend {
+    &:focus-within > .mud-input-outlined-border, &:focus-within .mud-shrink > .mud-input-outlined-border {
+      legend {
         width: auto;
         padding: 0 5px;
       }


### PR DESCRIPTION
## Description
Close #10681 

## How Has This Been Tested?

Add a test viewer page named TextFieldNestedInFieldTest

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![msedge_sxUJVyF5qN](https://github.com/user-attachments/assets/bf390345-6b6d-4674-9597-106af4629bac)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
