### PR TITLE
MudTreeViewItem: make Items two-way for returning server-loaded children

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -39,7 +39,7 @@
 
     public async Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)
     {
-        // wait 500ms to simulate a server load, then recursively search through our tree to find the child items for the given value
+        // wait 500ms to simulate a server load
         await Task.Delay(500);
         // normally you would use the parentValue to query your server for the children of the given parent
         // but for the sake of this example we will just return some hardcoded children

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -7,7 +7,7 @@
             <MudTreeViewItem 
                 Value="@context.Value" 
                 Items="@context.Children" 
-                ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string>>>((items) => OnItemsLoaded(context, items)))" 
+                ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string>>>(items => OnItemsLoaded(context, items)))" 
                 @bind-Expanded="@context.Expanded"
                 CanExpand="@context.Expandable"
                 Icon="@context.Icon" 
@@ -54,6 +54,8 @@
 
     private void OnItemsLoaded(TreeItemData<string> treeItemData, IReadOnlyCollection<TreeItemData<string>> children)
     {
+        // here we store the server-loaded children in the treeItemData so that they are available in the InitialTreeItems
+        // if you don't do this you loose already loaded children on next render update
         treeItemData.Children = children?.ToList();
     }
 

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -4,66 +4,54 @@
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView ServerData="@LoadServerData" Items="@InitialTreeItems">
         <ItemTemplate>
-            <MudTreeViewItem Value="@context.Value" Icon="@context.Icon" LoadingIconColor="Color.Info" CanExpand="@context.Expandable"/>
+            <MudTreeViewItem Value="@context.Value" 
+            Items="@context.Children" 
+            ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string>>>((items) => OnItemsLoaded(context, items)))" 
+            Icon="@context.Icon" 
+            LoadingIconColor="Color.Info" 
+            CanExpand="@context.Expandable"/>
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>
 
 @code {
+
     private List<TreeItemData<string>> InitialTreeItems { get; set; } = new();
-    private List<TreeItemData<string>> ServerTreeItems { get; set; } = new();
+    private int _idCounter=1; // <- the counter makes sure the generated items are unique
 
     protected override void OnInitialized()
     {
         // MudTreeView initially only gets these top-level items
-        InitialTreeItems.Add(new TreeItemData<string> { Value = "All Mail", Icon = Icons.Material.Filled.Label, });
+        InitialTreeItems.Add(new TreeItemData<string> {
+            Value = "All Mail", Icon = Icons.Material.Filled.Label,
+            Expanded = true,
+            Children = [
+                new TreeItemData<string> { Value = "Promotions", Icon = Icons.Material.Filled.Group, },
+                new TreeItemData<string> { Value = "Updates", Icon = Icons.Material.Filled.Info, },
+                new TreeItemData<string> { Value = "Forums", Icon = Icons.Material.Filled.QuestionAnswer, Expandable = false },
+                new TreeItemData<string> { Value = "Social", Icon = Icons.Material.Filled.LocalOffer, Expandable = false }
+            ] });
         InitialTreeItems.Add(new TreeItemData<string> { Value = "Trash", Icon = Icons.Material.Filled.Delete });
-
-        // LoadServerData will load from this hierarchy
-        ServerTreeItems.Add(new TreeItemData<string> {
-                Value = "All Mail", Icon = Icons.Material.Filled.Label,
-                Children = [
-                        new TreeItemData<string> { Value = "Promotions", Icon = Icons.Material.Filled.Group, 
-                                Children = [
-                                    new TreeItemData<string> { Value = "L.E.D Door Mats", Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
-                                    new TreeItemData<string> { Value = "Car Beauty Salon", Icon = Icons.Material.Filled.CarRepair, Expandable = false },
-                                    new TreeItemData<string> { Value = "Fakedoors.com", Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
-                                    new TreeItemData<string> { Value = "Bluetooth Toilet", Icon = Icons.Material.Filled.Wc, Expandable = false }
-                                ]},
-                    new TreeItemData<string> { Value = "Updates", Icon = Icons.Material.Filled.Info, Expandable = false },
-                    new TreeItemData<string> { Value = "Forums", Icon = Icons.Material.Filled.QuestionAnswer, Expandable = false },
-                    new TreeItemData<string> { Value = "Social", Icon = Icons.Material.Filled.LocalOffer, Expandable = false }
-                ]});
     }
 
     public async Task<IReadOnlyCollection<TreeItemData<string>>> LoadServerData(string parentValue)
     {
         // wait 500ms to simulate a server load, then recursively search through our tree to find the child items for the given value
         await Task.Delay(500);
-        foreach (var item in ServerTreeItems) {
-            if (item.Value == parentValue)
-                return item.Children;
-            if (!item.HasChildren)
-                continue;
-            var descendentItem = FindTreeItemData(parentValue, item);
-            if (descendentItem != null)
-                return descendentItem.Children;
-        }
-        return null;
+        // normally you would use the parentValue to query your server for the children of the given parent
+        // but for the sake of this example we will just return some hardcoded children
+        return [
+            new TreeItemData<string> { Value = $"More Spam ({_idCounter++})", Icon = Icons.Material.Filled.Group, },
+            new TreeItemData<string> { Value = $"L.E.D Door Mats ({_idCounter++})", Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
+            new TreeItemData<string> { Value = $"Car Beauty Salon ({_idCounter++})", Icon = Icons.Material.Filled.CarRepair, Expandable = false },
+            new TreeItemData<string> { Value = $"Fakedoors.com ({_idCounter++})", Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
+            new TreeItemData<string> { Value = $"Bluetooth Toilet ({_idCounter++})", Icon = Icons.Material.Filled.Wc, Expandable = false }
+        ];        
     }
 
-    private TreeItemData<string> FindTreeItemData(string value, TreeItemData<string> parent)
+    private void OnItemsLoaded(TreeItemData<string> treeItemData, IReadOnlyCollection<TreeItemData<string>> children)
     {
-        foreach (var child in parent.Children) {
-            if (child.Value == value)
-                return child;
-            if (!child.HasChildren)
-                continue;
-            var descendentItem = FindTreeItemData(value, child);
-            if (descendentItem != null)
-                return descendentItem;
-        }
-        return null;
+        treeItemData.Children = children?.ToList();
     }
 
 }

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewServerExample.razor
@@ -4,12 +4,15 @@
 <MudPaper Width="300px" Elevation="0">
     <MudTreeView ServerData="@LoadServerData" Items="@InitialTreeItems">
         <ItemTemplate>
-            <MudTreeViewItem Value="@context.Value" 
-            Items="@context.Children" 
-            ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string>>>((items) => OnItemsLoaded(context, items)))" 
-            Icon="@context.Icon" 
-            LoadingIconColor="Color.Info" 
-            CanExpand="@context.Expandable"/>
+            <MudTreeViewItem 
+                Value="@context.Value" 
+                Items="@context.Children" 
+                ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string>>>((items) => OnItemsLoaded(context, items)))" 
+                @bind-Expanded="@context.Expanded"
+                CanExpand="@context.Expandable"
+                Icon="@context.Icon" 
+                LoadingIconColor="Color.Info" 
+                />
         </ItemTemplate>
     </MudTreeView>
 </MudPaper>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerTest.razor
@@ -1,53 +1,51 @@
 ﻿<MudTreeView ExpandOnClick="true" ServerData="LoadServerData" Items="_treeItems" Width="350px">
     <ItemTemplate>
-        <MudTreeViewItem Text="@context.Text" Value="@context.Value" Icon="@context.Icon" CanExpand="@context.Expandable"
-                EndText="@(((TreeItemData)context).Number?.ToString())" EndTextTypo="@Typo.caption" />
+        <MudTreeViewItem 
+            Text="@context.Text"
+            Value="@context.Value"
+            Items="@context.Children"
+            ItemsChanged="@(new Action<IReadOnlyCollection<TreeItemData<string?>>?>(items =>  OnItemsLoaded(context, items)))"
+            Icon="@context.Icon"
+            CanExpand="@context.Expandable"
+            Expanded="@context.Expanded"
+            />
     </ItemTemplate>
 </MudTreeView>
 
-@code{
+@code {
 
-    private readonly List<TreeItemData> _treeItems = [];
-
+    private readonly List<TreeItemData<string?>> _treeItems = [];
+    private int _idCounter = 1;
     protected override void OnInitialized()
     {
-        _treeItems.Add(new TreeItemData("All Mail", Icons.Material.Filled.Email));
-        _treeItems.Add(new TreeItemData("Trash", Icons.Material.Filled.Delete));
-        _treeItems.Add(new TreeItemData("Categories", Icons.Material.Filled.Label)
+        _treeItems.Add(new TreeItemData<string?> { Value = "All Mail", Icon = Icons.Material.Filled.Email });
+        _treeItems.Add(new TreeItemData<string?>
         {
-            Children =
-            [
-                new TreeItemData("Social", Icons.Material.Filled.Group, 90),
-                new TreeItemData("Updates", Icons.Material.Filled.Info, 2294),
-                new TreeItemData("Forums", Icons.Material.Filled.QuestionAnswer, 3566),
-                new TreeItemData("Promotions", Icons.Material.Filled.LocalOffer, 733)
-            ]
+            Value = "Categories",
+            Icon = Icons.Material.Filled.Label,
+            Expanded = true,
+            Children = new List<TreeItemData<string?>>
+            {
+                new() { Value = "Social", Icon = Icons.Material.Filled.Group, },
+                new() { Value = "Updates", Icon = Icons.Material.Filled.Info,  }
+            }
         });
-        _treeItems.Add(new TreeItemData("History", Icons.Material.Filled.Label, null, false));
-
+        _treeItems.Add(new TreeItemData<string?> { Value = "Trash", Icon = Icons.Material.Filled.Delete, Expandable = false });
         base.OnInitialized();
     }
 
-    public Task<IReadOnlyCollection<TreeItemData<string>>?> LoadServerData(string parentValue)
+    public Task<IReadOnlyCollection<TreeItemData<string?>>?> LoadServerData(string? parentValue)
     {
-        var children = _treeItems.FirstOrDefault(x => x.Value == parentValue)?.Children;
-
-        return Task.FromResult<IReadOnlyCollection<TreeItemData<string>>?>(children);
-
+        return Task.FromResult<IReadOnlyCollection<TreeItemData<string?>>?>(new List<TreeItemData<string?>>
+        {
+            new() { Value = $"Loaded {_idCounter++}", Icon = Icons.Material.Filled.Web, Expandable  = true }
+        });
     }
 
-    public sealed class TreeItemData : TreeItemData<string>
+    private void OnItemsLoaded(TreeItemData<string?> treeItemData, IReadOnlyCollection<TreeItemData<string?>>? children)
     {
-        public int? Number { get; set; }
-
-        public List<TreeItemData> TreeItems { get; set; } = [];
-
-        public TreeItemData(string title, string icon, int? number = null, bool canExpand = true) : base(title)
-        {
-            Text = title;
-            Icon = icon;
-            Number = number;
-            Expandable = canExpand;
-        }
+        // here we store the server-loaded children in the treeItemData so that they are available in the InitialTreeItems
+        // if you don't do this you loose already loaded children on next render update
+        treeItemData.Children = children?.ToList();
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -492,6 +492,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [SetCulture("en-US")]
         public void HeatMap_ShouldHandleCustomHeatMapCellOverrides()
         {
             static void CellFragment(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1,4 +1,5 @@
-﻿using Bunit;
+﻿using System.Linq;
+using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -660,14 +661,20 @@ namespace MudBlazor.UnitTests.Components
         public void TreeViewServerTest()
         {
             var comp = Context.RenderComponent<TreeViewServerTest>();
-            comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
+            string.Join('|', comp.FindAll("div.mud-treeview-item-content").Select(x => x.TextContent)).Should()
+                .Be("All Mail|Categories|Social|Updates|Trash");
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(5);
+            comp.FindAll("div.mud-treeview-item-content")[4].Click();
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(5); // <-- nothing loaded as it's not expandable
             comp.FindAll("div.mud-treeview-item-content")[0].Click();
-            comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
-            comp.FindAll("div.mud-treeview-item-content")[3]
-                .GetElementsByClassName("mud-treeview-item-arrow")[0]
-                .ChildElementCount.Should().Be(0);
-            comp.FindAll("div.mud-treeview-item-content")[2].Click();
-            comp.FindAll("li.mud-treeview-item").Count.Should().Be(8);
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(6); // <- loaded one more from server
+            comp.FindAll("div.mud-treeview-item-content")[3].Click();
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(7); // <- loaded another one from server
+            // now loading a child of a server loaded item
+            comp.FindAll("div.mud-treeview-item-content")[1].Click();
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(8); // <- loaded another one from server
+            string.Join('|', comp.FindAll("div.mud-treeview-item-content").Select(x => x.TextContent)).Should()
+                .Be("All Mail|Loaded 1|Loaded 3|Categories|Social|Loaded 2|Updates|Trash");
         }
 
         [Test]

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -66,7 +66,6 @@ namespace MudBlazor
                 .AddStyle(Style)
                 .Build();
 
-
         [CascadingParameter]
         private MudTreeView<T> MudTreeRoot { get; set; }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -58,7 +58,7 @@
             <MudCollapse Expanded="@_expandedState.Value">
                 <CascadingValue Value="@MudTreeRoot" IsFixed="true">
                     <CascadingValue Value="this" IsFixed="true">
-                        <MudTreeView Items="Items" ItemTemplate="MudTreeRoot?.ItemTemplate" Class="mud-treeview-group">
+                        <MudTreeView Items="@_itemsState.Value" ItemTemplate="MudTreeRoot?.ItemTemplate" Class="mud-treeview-group">
                             @ChildContent
                         </MudTreeView>
                     </CascadingValue>

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -288,11 +288,18 @@ namespace MudBlazor
         private bool HasChildren()
         {
             return ChildContent != null
-                || (MudTreeRoot != null && Items != null && Items.Count != 0)
-                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && (Items == null || Items.Count == 0));
+                || (MudTreeRoot != null && GetItems().Count != 0)
+                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && GetItems().Count == 0);
         }
 
-        private bool AreChildrenVisible() => Items is null || Items.Any(i => i.Visible);
+        private bool AreChildrenVisible() => _itemsState.Value is null || _itemsState.Value.Any(i => i.Visible);
+
+        private IReadOnlyCollection<TreeItemData<T>> GetItems()
+        {
+            if (_itemsState.Value == null)
+                return Array.Empty<TreeItemData<T>>();
+            return _itemsState.Value!;
+        }
 
         internal T? GetValue()
         {
@@ -470,9 +477,9 @@ namespace MudBlazor
         /// </summary>
         public async Task ReloadAsync()
         {
-            if (Items is not null)
+            if (_itemsState.Value is not null)
             {
-                Items = Array.Empty<TreeItemData<T?>>();
+                await _itemsState.SetValueAsync( Array.Empty<TreeItemData<T?>>());
             }
             await TryInvokeServerLoadFunc();
 
@@ -514,7 +521,7 @@ namespace MudBlazor
 
         internal async Task TryInvokeServerLoadFunc()
         {
-            if ((Items != null && Items.Count != 0) || !CanExpand || MudTreeRoot?.ServerData == null)
+            if (GetItems().Count != 0 || !CanExpand || MudTreeRoot?.ServerData == null)
                 return;
             _loading = true;
             StateHasChanged();

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
         private bool _isServerLoaded;
         private readonly ParameterState<bool> _selectedState;
         private readonly ParameterState<bool> _expandedState;
+        private readonly ParameterState<IReadOnlyCollection<TreeItemData<T?>>?> _itemsState;
         private Converter<T> _converter = new DefaultConverter<T>();
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
 
@@ -28,6 +29,9 @@ namespace MudBlazor
                 .WithParameter(() => Selected)
                 .WithEventCallback(() => SelectedChanged)
                 .WithChangeHandler(OnSelectedParameterChangedAsync);
+            _itemsState = registerScope.RegisterParameter<IReadOnlyCollection<TreeItemData<T?>>?>(nameof(Items))
+                .WithParameter(() => Items)
+                .WithEventCallback(() => ItemsChanged);
         }
 
         protected string Classname =>
@@ -163,6 +167,12 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
         public IReadOnlyCollection<TreeItemData<T?>>? Items { get; set; }
+
+        /// <summary>
+        /// Called whenever children were loaded from the server
+        /// </summary>
+        [Parameter]
+        public EventCallback<IReadOnlyCollection<TreeItemData<T?>>?> ItemsChanged { get; set; }
 
         /// <summary>
         /// Expand or collapse TreeView item when it has children. Two-way bindable. Note: if you directly set this to
@@ -510,7 +520,8 @@ namespace MudBlazor
             StateHasChanged();
             try
             {
-                Items = await MudTreeRoot.ServerData(GetValue());
+                var items = await MudTreeRoot.ServerData(GetValue());
+                await _itemsState.SetValueAsync(items);
             }
             finally
             {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -479,7 +479,7 @@ namespace MudBlazor
         {
             if (_itemsState.Value is not null)
             {
-                await _itemsState.SetValueAsync( Array.Empty<TreeItemData<T?>>());
+                await _itemsState.SetValueAsync(Array.Empty<TreeItemData<T?>>());
             }
             await TryInvokeServerLoadFunc();
 


### PR DESCRIPTION
## Description
This change fixes two problems at once.
1) In MudTreeViewItem the parameter Items was overwritten from within the component which is forbidden by our own rules
2) It allows people to have an initial tree of items which can be extended with server loading. fixes #9939 

The example has been improved to show how an existing initial tree can be extended with server loading. Initial view of the example:
![image](https://github.com/user-attachments/assets/5c31783f-6b2c-42d4-ac3e-497da16d353d)

After clicking Promotions:
![image](https://github.com/user-attachments/assets/acb14c9c-6400-43e5-9193-bbbf776176e8)

After clicking More Spam:
![image](https://github.com/user-attachments/assets/1da7bd51-39ab-4618-b5d4-4a4c7a4ef408)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
