### PR TITLE
MudTabs: adding StretchSize

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsStretchSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsStretchSizeExample.razor
@@ -1,0 +1,18 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwitch Label="Stretch Tab Size" @bind-Value="_stretchSize" />
+<MudSwitch Label="Vertical Tabs" @bind-Value="_verticalTabs" />
+
+<MudTabs Color="Color.Primary" StretchSize="_stretchSize" Style="@GetStyle()" Position="GetPosition()">
+    <MudTabPanel Text="One" />
+    <MudTabPanel Text="Two" />
+    <MudTabPanel Text="Three" />
+</MudTabs>
+
+@code {
+    private string GetStyle() => _verticalTabs ? "height: 400px;" : "";
+    private Position GetPosition() => _verticalTabs ? Position.Left : Position.Top;
+
+    private bool _verticalTabs = false;
+    private bool _stretchSize = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -54,6 +54,19 @@
             <SectionContent Code="@nameof(TabsMinimumTabWidthExample)" ShowCode="false">
                 <TabsMinimumTabWidthExample />
             </SectionContent>
+            <SectionSubGroups>
+                <DocsPageSection>
+                    <SectionHeader Title="Stretch Size">
+                        <Description>
+                            The <CodeInline>StretchSize</CodeInline> property, if set to true, ensures that all tabs combined take up the entire available space.
+                            In case the minimum tab width of all tabs is larger than the available space, the user can scroll through the tabs.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TabsStretchSizeExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TabsStretchSizeExample />
+                    </SectionContent>
+                </DocsPageSection>
+             </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1188,6 +1188,16 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void StretchSize_TotalTabSize100Percent()
         {
+            const int TotalSize = 6000;
+
+            var observer = new MockResizeObserver
+            {
+                PanelTotalSize = TotalSize,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
             static double GetWidthFromStyle(string style)
             {
                 var result = Regex.Match(style, @".*width:\s*(\d+)px.*");
@@ -1198,9 +1208,9 @@ namespace MudBlazor.UnitTests.Components
                 return double.Parse(result.Groups[1].Value);
             }
 
-            var comp = Context.RenderComponent<MudTabs>(parameters => {
+            var comp = Context.RenderComponent<MudTabs>(parameters =>
+            {
                 parameters.Add(p => p.StretchSize, true);
-                parameters.Add(p => p.Style, "width: 3000px;");
                 parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 1"));
                 parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 2"));
                 parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 3"));
@@ -1213,7 +1223,7 @@ namespace MudBlazor.UnitTests.Components
             var totalWidth = tabs
                 .Sum(tab => GetWidthFromStyle(tab.GetAttribute("style")));
 
-            totalWidth.Should().BeApproximately(1000, 1);
+            totalWidth.Should().BeApproximately(TotalSize, 1);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -96,7 +97,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-tabs-panels > div")[0].GetAttribute("style").Should().Be("display:none;");
             comp.FindAll("div.mud-tabs-panels > div")[1].GetAttribute("style").Should().Be("display:contents;");
             comp.FindAll("div.mud-tabs-panels > div")[2].GetAttribute("style").Should().Be("display:none;");
-            // click second button twice and show button click counters. the click of the first button should still be evident 
+            // click second button twice and show button click counters. the click of the first button should still be evident
             comp.FindAll("button")[1].Click();
             comp.FindAll("button")[1].Click();
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
@@ -1182,6 +1183,37 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-tab").GetAttribute("style").Contains("min-width").Should().BeTrue();
             comp.Find(".mud-tab").GetAttribute("style").Contains("20px").Should().BeTrue();
 
+        }
+
+        [Test]
+        public void StretchSize_TotalTabSize100Percent()
+        {
+            static double GetWidthFromStyle(string style)
+            {
+                var result = Regex.Match(style, @".*width:\s*(\d+)px.*");
+
+                if (!result.Success)
+                    throw new InvalidDataException();
+
+                return double.Parse(result.Groups[1].Value);
+            }
+
+            var comp = Context.RenderComponent<MudTabs>(parameters => {
+                parameters.Add(p => p.StretchSize, true);
+                parameters.Add(p => p.Style, "width: 3000px;");
+                parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 1"));
+                parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 2"));
+                parameters.AddChildContent<MudTabPanel>(p => p.AddChildContent("Tab 3"));
+            });
+
+            comp.Render();
+
+            // Act
+            var tabs = comp.FindAll(".mud-tab");
+            var totalWidth = tabs
+                .Sum(tab => GetWidthFromStyle(tab.GetAttribute("style")));
+
+            totalWidth.Should().BeApproximately(1000, 1);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -4,7 +4,7 @@
 <div @attributes="UserAttributes" class="@TabsClassnames" style="@Style">
     <CascadingValue Value="this" IsFixed="true">
         <div class="@TabBarClassnames">
-            <div class="mud-tabs-tabbar-inner" style="@MaxHeightStyles">
+            <div @ref="_tabBar" class="mud-tabs-tabbar-inner" style="@MaxHeightStyles">
                 @if (HeaderPosition == TabHeaderPosition.Before && Header != null)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
@@ -17,7 +17,7 @@
                         <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
                     </div>
                 }
-                <div @ref="@_tabsContentSize" class="mud-tabs-tabbar-content">
+                <div @ref="@_tabBarContent" class="mud-tabs-tabbar-content">
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
                         @foreach (MudTabPanel panel in _panels)
                         {
@@ -30,7 +30,7 @@
                             else
                             {
                                 <div class="d-inline-block" style="width: fit-content;" @key="@panel">
-                                    @if (panel.TabWrapperContent is null) 
+                                    @if (panel.TabWrapperContent is null)
                                     {
                                         @RenderTab(panel)
                                     }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -20,16 +20,19 @@ namespace MudBlazor
         private int _activePanelIndex = 0;
         private int _scrollIndex = 0;
 
+        private ElementReference _tabBar;
+        private ElementReference _tabBarContent;
         private bool _isRendered = false;
         private bool _prevButtonDisabled;
         private bool _nextButtonDisabled;
         private bool _showScrollButtons;
-        private ElementReference _tabsContentSize;
         private double _sliderSize;
         private double _sliderPosition;
+        private double _tabBarSize;
         private double _tabBarContentSize;
         private double _allTabsSize;
         private double _scrollPosition;
+        private double _stretchedTabSize;
 
         private IResizeObserver? _resizeObserver = null;
 
@@ -183,6 +186,13 @@ namespace MudBlazor
         public bool SliderAnimation { get; set; } = true;
 
         /// <summary>
+        /// If true, stretches size of all tabs to fill the entire available space.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Tabs.Appearance)]
+        public bool StretchSize { get; set; } = false;
+
+        /// <summary>
         /// Child content of component.
         /// </summary>
         [Parameter]
@@ -190,7 +200,7 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// This fragment is placed between tabHeader and panels. 
+        /// This fragment is placed between tabHeader and panels.
         /// It can be used to display additional content like an address line in a browser.
         /// The active tab will be the content of this RenderFragement
         /// </summary>
@@ -339,7 +349,8 @@ namespace MudBlazor
             if (firstRender)
             {
                 var items = _panels.Select(x => x.PanelRef).ToList();
-                items.Add(_tabsContentSize);
+                items.Add(_tabBarContent);
+                items.Add(_tabBar);
 
                 if (_activePanelIndex != -1 && _panels.Count > 0)
                     ActivePanel = _panels[_activePanelIndex];
@@ -494,6 +505,7 @@ namespace MudBlazor
             new CssBuilder("mud-tabs-tabbar")
                 .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded)
                 .AddClass($"mud-tabs-vertical", IsVerticalTabs())
+                .AddClass($"mud-tabs-stretch", StretchSize)
                 .AddClass($"mud-tabs-tabbar-{Color.ToDescriptionString()}", Color != Color.Default)
                 .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border)
                 .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined)
@@ -595,9 +607,10 @@ namespace MudBlazor
         string GetTabStyle(MudTabPanel panel)
         {
             var tabStyle = new StyleBuilder()
-            .AddStyle("min-width", MinimumTabWidth)
-            .AddStyle(panel.Style)
-            .Build();
+                .AddStyle("min-width", MinimumTabWidth)
+                .AddStyle(IsVerticalTabs() ? "height" : "width", _stretchedTabSize.ToPx(), StretchSize)
+                .AddStyle(panel.Style)
+                .Build();
 
             return tabStyle;
         }
@@ -618,7 +631,7 @@ namespace MudBlazor
             _nextIcon = RightToLeft ? PrevIcon : NextIcon;
             _prevIcon = RightToLeft ? NextIcon : PrevIcon;
 
-            GetTabBarContentSize();
+            GetTabBarSizes();
             GetAllTabsSize();
             SetScrollButtonVisibility();
             SetSliderState();
@@ -639,13 +652,18 @@ namespace MudBlazor
             }
 
             _sliderPosition = GetLengthOfPanelItems(ActivePanel);
-            _sliderSize = GetRelevantSize(ActivePanel.PanelRef);
+            _sliderSize = StretchSize && !_showScrollButtons ? _stretchedTabSize : GetRelevantSize(ActivePanel.PanelRef);
         }
 
         private bool IsSliderPositionDetermined => _activePanelIndex > 0 && _sliderPosition > 0 ||
                                                    _activePanelIndex <= 0;
 
-        private void GetTabBarContentSize() => _tabBarContentSize = GetRelevantSize(_tabsContentSize);
+        private void GetTabBarSizes()
+        {
+            _tabBarSize = GetRelevantSize(_tabBar);
+            _tabBarContentSize = GetRelevantSize(_tabBarContent);
+            _stretchedTabSize = _tabBarSize / _panels.Count;
+        }
 
         private void GetAllTabsSize()
         {
@@ -695,7 +713,7 @@ namespace MudBlazor
 
         private void SetScrollButtonVisibility()
         {
-            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _tabBarContentSize || _scrollIndex != 0;
+            _showScrollButtons = AlwaysShowScrollButtons || IsNearlyGreaterThan(_allTabsSize, _tabBarSize, 0.1) || _scrollIndex != 0;
         }
 
         private void ScrollPrev()
@@ -724,7 +742,7 @@ namespace MudBlazor
             var x = 0D;
             var count = 0;
 
-            var toolbarContentSize = GetRelevantSize(_tabsContentSize);
+            var toolbarContentSize = GetRelevantSize(_tabBarContent);
 
             foreach (var panel in _panels)
             {
@@ -837,7 +855,7 @@ namespace MudBlazor
 
         private void SetScrollabilityStates()
         {
-            var isEnoughSpace = _allTabsSize <= _tabBarContentSize;
+            var isEnoughSpace = !IsNearlyGreaterThan(_allTabsSize, _tabBarSize, 0.1);
 
             if (isEnoughSpace)
             {
@@ -852,6 +870,7 @@ namespace MudBlazor
             }
         }
 
+        private static bool IsNearlyGreaterThan(double value1, double value2, double tolerance) => value1 > value2 + tolerance;
         #endregion
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -608,7 +608,8 @@ namespace MudBlazor
         {
             var tabStyle = new StyleBuilder()
                 .AddStyle("min-width", MinimumTabWidth)
-                .AddStyle(IsVerticalTabs() ? "height" : "width", _stretchedTabSize.ToPx(), StretchSize)
+                .AddStyle("width", _stretchedTabSize.ToPx(), !IsVerticalTabs() && StretchSize)
+                .AddStyle("height", _stretchedTabSize.ToPx(), IsVerticalTabs() && StretchSize)
                 .AddStyle(panel.Style)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -67,6 +67,12 @@
   }
 
   &.mud-tabs-vertical {
+    &.mud-tabs-stretch {
+      .mud-tabs-tabbar-inner {
+        height: 100%;
+      }
+    }
+
     .mud-tabs-tabbar-inner {
       flex-direction: column;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
This Pull Request adds a `StretchSize` property to `MudTabs`. If it is set to true, all tabs will be stretched, to take up 100% of the available space. If the minimum size of all tabs exceeds the available space, it will fall back to the default scrolling behavior.

`StretchSize` works with horizontal and vertical tabs.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
I've added a Unit test, checking that the width of all present tabs add up to 100% of the available space.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
