### PR TITLE
MudTable: Show the default cursor for sortable headers when sorting is disabled

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
@@ -10,7 +10,7 @@
 <MudSwitch @bind-Value="_sortEnabled">Sort Enabled</MudSwitch>
 
 @code {
-    public static string __description__ = "The cursor icon should change for sortable table headers when sorting is disabled.";
+    public static string __description__ = "Table sortable header styles should not be applied when sorting is disabled.";
 
     private string[] _data = ["A", "B", "C"];
     private bool _sortEnabled;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
@@ -1,0 +1,12 @@
+﻿<MudTable Items="_data" T="string">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel Enabled="SortEnabled" SortBy="new Func<string, object>(x => x)"></MudTableSortLabel></MudTh>
+    </HeaderContent>
+</MudTable>
+
+@code {
+    private string[] _data = ["test"];
+
+    [Parameter]
+    public bool SortEnabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSortLabelTest.razor
@@ -1,12 +1,27 @@
 ﻿<MudTable Items="_data" T="string">
     <HeaderContent>
-        <MudTh><MudTableSortLabel Enabled="SortEnabled" SortBy="new Func<string, object>(x => x)"></MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel Enabled="_sortEnabled" SortBy="new Func<string, object>(x => x)">Sortable Header</MudTableSortLabel></MudTh>
     </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Sortable Header">@context</MudTd>
+    </RowTemplate>
 </MudTable>
 
+<MudSwitch @bind-Value="_sortEnabled">Sort Enabled</MudSwitch>
+
 @code {
-    private string[] _data = ["test"];
+    public static string __description__ = "The cursor icon should change for sortable table headers when sorting is disabled.";
+
+    private string[] _data = ["A", "B", "C"];
+    private bool _sortEnabled;
 
     [Parameter]
-    public bool SortEnabled { get; set; }
+    public bool SortEnabled { get; set; } = true;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        _sortEnabled = SortEnabled;
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -115,6 +115,24 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("A");
         }
 
+        [Theory]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TableSortLabel(bool sortEnabled)
+        {
+            // Arrange
+            var comp = Context.RenderComponent<TableSortLabelTest>(
+                parameters => parameters.Add(x => x.SortEnabled, sortEnabled));
+            var tableSortLabel = comp.FindComponent<MudTableSortLabel<string>>();
+
+            // Assert
+            tableSortLabel
+                .Find("span")
+                .GetAttribute("class")
+                .Contains("mud-table-sort-label-disabled")
+                .Should().Be(!sortEnabled);
+        }
+
         /// <summary>
         /// Check if the loading parameter is adding a supplementary row.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -129,8 +129,8 @@ namespace MudBlazor.UnitTests.Components
             tableSortLabel
                 .Find("span")
                 .GetAttribute("class")
-                .Contains("mud-table-sort-label-disabled")
-                .Should().Be(!sortEnabled);
+                .Contains("mud-button-root")
+                .Should().Be(sortEnabled);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         private SortDirection _direction = SortDirection.None;
 
         protected string Classname => new CssBuilder("mud-button-root mud-table-sort-label")
+            .AddClass("mud-table-sort-label-disabled", !Enabled)
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -16,8 +16,8 @@ namespace MudBlazor
     {
         private SortDirection _direction = SortDirection.None;
 
-        protected string Classname => new CssBuilder("mud-button-root mud-table-sort-label")
-            .AddClass("mud-table-sort-label-disabled", !Enabled)
+        protected string Classname => new CssBuilder("mud-table-sort-label")
+            .AddClass("mud-button-root", Enabled)
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -33,7 +33,15 @@
       line-height: 1.5rem;
 
       & .mud-button-root {
-          user-select: auto;
+        @media(hover: hover) and (pointer: fine) {
+          &:hover {
+            color: var(--mud-palette-action-default);
+
+            .mud-table-sort-label-icon {
+              opacity: 0.8;
+            }
+          }
+        }
       }
     }
   }
@@ -57,25 +65,11 @@
 }
 
 .mud-table-sort-label {
-  cursor: pointer;
+  user-select: auto;
   display: inline-flex;
   align-items: center;
   flex-direction: inherit;
   justify-content: flex-start;
-
-  &.mud-table-sort-label-disabled {
-      cursor: auto;
-  }
-
-  @media(hover: hover) and (pointer: fine) {
-    &:hover {
-      color: var(--mud-palette-action-default);
-
-      .mud-table-sort-label-icon {
-        opacity: 0.8;
-      }
-    }
-  }
 
   .mud-table-sort-label-icon {
     font-size: 18px;

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -63,6 +63,10 @@
   flex-direction: inherit;
   justify-content: flex-start;
 
+  &.mud-table-sort-label-disabled {
+      cursor: auto;
+  }
+
   @media(hover: hover) and (pointer: fine) {
     &:hover {
       color: var(--mud-palette-action-default);


### PR DESCRIPTION
## Description
Closes #10603 

## How Has This Been Tested?
Added unit tests and tested it visually.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

The cursor icon for sortable table headers when sorting is enabled:

![image](https://github.com/user-attachments/assets/604a8bc8-431f-487f-8abf-6a82ad76652e)

The cursor icon for sortable table headers when sorting is not enabled:

![image](https://github.com/user-attachments/assets/7366c9a5-d0d7-45b1-8536-a3af8c335da0)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
