### PR TITLE
Select: Don't open while scrolling via touch

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2509,7 +2509,7 @@ namespace MudBlazor.UnitTests.Components
             // check the number of filters displayed in the filters panel is 1
             comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(1);
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             //set operator to CONTAINS
             comp.FindAll(".mud-list .mud-list-item")[0].Click();
@@ -2522,7 +2522,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to NOT CONTAINS
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[1].Click();
             comp.Find(".mud-overlay").Click();
@@ -2534,7 +2534,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to EQUALS
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[2].Click();
             comp.Find(".mud-overlay").Click();
@@ -2546,7 +2546,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to NOT EQUALS
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[3].Click();
             comp.Find(".mud-overlay").Click();
@@ -2558,7 +2558,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to STARTS WITH
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[4].Click();
             comp.Find(".mud-overlay").Click();
@@ -2570,7 +2570,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to ENDS WITH
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[5].Click();
             comp.Find(".mud-overlay").Click();
@@ -2582,7 +2582,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to IS EMPTY
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[6].Click();
             comp.Find(".mud-overlay").Click();
@@ -2594,7 +2594,7 @@ namespace MudBlazor.UnitTests.Components
             //set operator to IS NOT EMPTY
             FilterButton().Click();
 
-            await comp.Find(".filter-operator").PointerDownAsync(new PointerEventArgs());
+            await comp.Find(".filter-operator").ClickAsync(new MouseEventArgs());
 
             comp.FindAll(".mud-list .mud-list-item")[7].Click();
             comp.Find(".mud-overlay").Click();
@@ -2746,7 +2746,7 @@ namespace MudBlazor.UnitTests.Components
             selects.Count.Should().Be(2);
 
             // open operator menu
-            selects[1].PointerDown();
+            selects[1].Click();
 
             //check available operators
             var items = comp.FindAll("div.mud-list-item");

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3394,7 +3394,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".filter-button").Click();
             comp.FindAll(".filters-panel").Count.Should().Be(1);
 
-            comp.FindAll("div.mud-input-control")[0].PointerDown();
+            comp.FindAll("div.mud-input-control")[0].Click();
             comp.FindAll("div.mud-list-item").Count.Should().Be(3);
         }
 
@@ -4944,7 +4944,7 @@ namespace MudBlazor.UnitTests.Components
             FilterButton().Click();
 
             IElement SelectElement() => comp.Find("div.mud-select.filter-input");
-            SelectElement().PointerDown();
+            SelectElement().Click();
 
             var items = comp.FindAll("div.mud-list-item").ToArray();
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input");
             inputs.Count.Should().Be(3);
             inputs[1].GetAttribute("value").Should().Be("Value2");
-            await inputs[1].TriggerEventAsync("onpointerdown", new MouseEventArgs());
+            await inputs[1].TriggerEventAsync("onmousedown", new MouseEventArgs());
             await Task.Delay(500);
             var listItems = comp.FindAll(".mud-list-item");
             foreach (var listItem in listItems)

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().Be("2");
             // now we cheat and click the list without opening the menu ;)
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
 
@@ -147,7 +147,7 @@ namespace MudBlazor.UnitTests.Components
                 comp.WaitForAssertion(() =>
                     comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
                 // click and check if it has toggled the menu
-                input.PointerDown();
+                input.Click();
                 menu.ClassList.Should().Contain("mud-popover-open");
                 // now click an item and see the value change
                 comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -226,7 +226,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input").Attributes["value"]?.Value.Should().Be("First");
             comp.RenderCount.Should().Be(1);
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
@@ -246,7 +246,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().Be(17);
             select.Instance.Text.Should().Be("17");
             comp.Find("input").Attributes["value"]?.Value.Should().Be("17");
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
@@ -272,7 +272,7 @@ namespace MudBlazor.UnitTests.Components
             // BUT: we have a select with Strict="true" so the Text will not be shown because it is not in the list of selectable values
             comp.FindComponent<MudInput<string>>().Instance.Value.Should().Be(null);
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
@@ -298,7 +298,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none");
             comp.RenderCount.Should().Be(1);
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
@@ -321,7 +321,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
@@ -334,7 +334,7 @@ namespace MudBlazor.UnitTests.Components
             text.Should().Be("2");
 
             //open the menu again
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
 
@@ -375,7 +375,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
@@ -391,7 +391,7 @@ namespace MudBlazor.UnitTests.Components
             textChangedCount.Should().Be(0);
             string.Join(",", selectedValues).Should().Be("2");
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
 
@@ -432,7 +432,7 @@ namespace MudBlazor.UnitTests.Components
               });
 
             var selectElement = comp.Find("div.mud-input-control");
-            selectElement.PointerDown();
+            selectElement.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             // click list item
@@ -477,7 +477,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
 
             var selectElement = comp.Find("div.mud-input-control");
-            selectElement.PointerDown();
+            selectElement.Click();
 
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item-disabled").Count.Should().Be(1));
             comp.FindAll("div.mud-list-item-disabled")[0].Click();
@@ -506,7 +506,7 @@ namespace MudBlazor.UnitTests.Components
                 comp.WaitForAssertion(() =>
                     comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
                 // click and check if it has toggled the menu
-                input.PointerDown();
+                input.Click();
                 comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
                 comp.WaitForAssertion(() => menu.ClassList.Should().Contain("mud-popover-open"));
                 // now click an item and see the value change
@@ -543,7 +543,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click the first checkbox
             comp.FindAll("div.mud-list-item")[0].Click();
@@ -561,7 +561,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
 
             // get the first (select all item) and check if it is selected
@@ -596,7 +596,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
             // Check that the icon corresponds to an unchecked checkbox
             var mudListItem = comp.FindComponent<MudListItem<string>>();
@@ -611,7 +611,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click the first checkbox to select all
             var items = comp.FindAll("div.mud-list-item").ToArray();
@@ -645,7 +645,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            input.PointerDown();
+            input.Click();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -657,7 +657,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Text.Should().Be("2");
             validatedValue.Should().Be("2");
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             comp.FindAll("div.mud-list-item")[0].Click();
 
@@ -712,7 +712,7 @@ namespace MudBlazor.UnitTests.Components
             // No button when initialized
             comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             // Button shows after selecting item
             var items = comp.FindAll("div.mud-list-item").ToArray();
@@ -741,7 +741,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
 
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             select.Instance.Value.Should().Be("Apple");
 
@@ -755,7 +755,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ChangeCount.Should().Be(1);
 
             // now click an item and see the value change
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
@@ -829,7 +829,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().BeNullOrEmpty();
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // no option should be hilited
             comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(0));
@@ -838,7 +838,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("2"));
             // open again and check hilited option
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // Nr 2 should be hilited
             comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
@@ -863,7 +863,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().Be("2");
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // Nr 2 should be hilited
             comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
@@ -873,12 +873,12 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("1"));
             // open again and check hilited option
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // Nr 1 should be hilited
             comp.WaitForAssertion(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
             comp.FindAll("div.mud-list-item")[0].ToMarkup().Should().Contain("mud-selected-item");
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
         }
 
@@ -888,17 +888,17 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<ReloadSelectItemsTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             // normal, without reloading
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[0].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("American Samoa"));
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[1].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("Arizona"));
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[2].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -906,17 +906,17 @@ namespace MudBlazor.UnitTests.Components
             // reloading!
             comp.Find(".reload").Click();
             // check again, different values expected now
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[0].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("Alabama"));
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[1].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("Alaska"));
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[2].Click();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1089,7 +1089,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MultiSelectTest6>();
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             select.Instance._open.Should().BeTrue();
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[0].Click();
@@ -1127,7 +1127,7 @@ namespace MudBlazor.UnitTests.Components
             // Check input text
             comp.Find("input").GetAttribute("value").Should().Be("Selected Cafe Latte, Selected Espresso");
             // Click to render the menu
-            comp.Find("div.mud-input-control").PointerDown();
+            comp.Find("div.mud-input-control").Click();
             // Check check marks
             const string @unchecked =
                 "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
@@ -1147,7 +1147,7 @@ namespace MudBlazor.UnitTests.Components
             var sut = comp.FindComponent<MudSelect<string>>();
 
             var input = comp.Find("div.mud-input-control");
-            input.PointerDown();
+            input.Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
 
             sut.Instance.Items.Should().HaveCountGreaterOrEqualTo(4);
@@ -1201,14 +1201,14 @@ namespace MudBlazor.UnitTests.Components
 
             //2a. Now check when SelectedItems is greater than one - Validation Should Pass
             var inputs = comp.FindAll("div.mud-input-control");
-            inputs[0].PointerDown();//The 2nd one is the
+            inputs[0].Click();//The 2nd one is the
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
             await comp.InvokeAsync(() => select.Validate());
             select.ValidationErrors.Count.Should().Be(0);
 
             //2b.
-            inputs[1].PointerDown();//selectWithT
+            inputs[1].Click();//selectWithT
             //wait for render and it will find 5 items from the component
             comp.WaitForState(() => comp.FindAll("div.mud-list-item").Count == 5);
             items = comp.FindAll("div.mud-list-item").ToArray();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1445,18 +1445,18 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open restricted popover
-            await comp.Find("#restricted-select").PointerDownAsync(new PointerEventArgs());
+            await comp.Find("#restricted-select").ClickAsync(new PointerEventArgs());
 
             //confirm relative width class
             comp.Find(".restricted").ClassList.Should().Contain("mud-popover-open").And.Contain("mud-popover-relative-width");
 
             //close popover
-            await comp.Find("#restricted-select").PointerDownAsync(new PointerEventArgs());
+            await comp.Find("#restricted-select").ClickAsync(new PointerEventArgs());
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open expanded popover
-            await comp.Find("#expanded-select").PointerDownAsync(new PointerEventArgs());
+            await comp.Find("#expanded-select").ClickAsync(new PointerEventArgs());
 
             //confirm relative width class not applied
             comp.Find(".expanded").ClassList.Should().Contain("mud-popover-open").And.NotContain("mud-popover-relative-width");

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1213,7 +1213,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.FindAll("td")[0].TextContent.Trim().Should().Be("1"));
             comp.WaitForAssertion(() => comp.FindAll("td")[2].TextContent.Trim().Should().Be("2"));
             comp.WaitForAssertion(() => comp.FindAll("td")[4].TextContent.Trim().Should().Be("3"));
-            comp.FindAll("div.mud-select-input")[0].PointerDown(); // mobile sort drop down
+            comp.FindAll("div.mud-select-input")[0].Click(); // mobile sort drop down
             comp.FindAll("div.mud-list-item-clickable")[1].Click(); // sort b column
             comp.WaitForAssertion(() => comp.FindAll("td")[0].TextContent.Trim().Should().Be("3"));
             comp.WaitForAssertion(() => comp.FindAll("td")[2].TextContent.Trim().Should().Be("2"));
@@ -1232,7 +1232,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
             comp.FindAll("td")[4].TextContent.Trim().Should().Be("3");
-            comp.FindAll("div.mud-select-input")[0].PointerDown(); // mobile sort drop down
+            comp.FindAll("div.mud-select-input")[0].Click(); // mobile sort drop down
             comp.FindAll("div.mud-list-item-clickable")[1].Click(); // sort b column
             comp.WaitForAssertion(() => comp.FindAll("td")[0].TextContent.Trim().Should().Be("3"));
             comp.WaitForAssertion(() => comp.FindAll("td")[2].TextContent.Trim().Should().Be("2"));
@@ -2282,7 +2282,7 @@ namespace MudBlazor.UnitTests.Components
             int.Parse(t).Should().Be(rowsPerPage, "The component rendered correctly");
             //open the menu
             var menuItem = comp.Find("div.mud-input-control");
-            menuItem.PointerDown();
+            menuItem.Click();
 
             //Now select the 25 and check it
             var items = comp.FindAll("div.mud-list-item").ToArray();

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -106,8 +106,7 @@
                        Size="@Size.Small"
                        OnClick="@HandleClearButtonAsync"
                        aria-label="@Localizer[LanguageResource.MudInput_Clear]"
-                       tabindex="-1"
-                       @onpointerdown:stopPropagation />
+                       tabindex="-1" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -21,8 +21,7 @@
                            Size="@Size"
                            Color="@Color"
                            aria-label="@AriaLabel"
-                           tabindex="-1"
-                           @onpointerdown:stopPropagation />
+                           tabindex="-1" />
         }
         else
         {

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -93,8 +93,7 @@
                        Size="@Size.Small"
                        OnClick="@HandleClearButtonAsync"
                        aria-label="@Localizer[LanguageResource.MudInput_Clear]"
-                       tabindex="-1"
-                       @onpointerdown:stopPropagation/>
+                       tabindex="-1" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -19,7 +19,7 @@
                          Disabled="@GetDisabledState()"
                          Required="@Required"
                          ForId="@InputElementId"
-                         @onpointerdown="@ToggleMenu">
+                         @onclick="@ToggleMenu">
             <InputContent>
                 <MudInput @ref="_elementReference"
                           InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -19,8 +19,8 @@
                          Disabled="@GetDisabledState()"
                          Required="@Required"
                          ForId="@InputElementId"
-                         @onmousedown="@OpenMenu"
-                         @onclick="@OpenMenu">
+                         @onmousedown="@ToggleMenu"
+                         @onclick="@ToggleMenu">
             <InputContent>
                 <MudInput @ref="_elementReference"
                           InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -19,7 +19,8 @@
                          Disabled="@GetDisabledState()"
                          Required="@Required"
                          ForId="@InputElementId"
-                         @onclick="@ToggleMenu">
+                         @onmousedown="@OpenMenu"
+                         @onclick="@OpenMenu">
             <InputContent>
                 <MudInput @ref="_elementReference"
                           InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"


### PR DESCRIPTION
Fixes #10716
Refines #10129
Reverts #10353

The `onmousedown` event now toggles the menu instead of `onpointerdown` so panning the page with a touch input does't trigger it. The `onclick` event was added back to handle that case.