### PR TITLE
MudTooltip: Remove `width:fit-content`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipFlexScenariosTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipFlexScenariosTest.razor
@@ -1,0 +1,138 @@
+﻿<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+    <MudTabPanel Text="Simple Tooltip">
+        <MudTooltip Text="Delete">
+            <MudIconButton Icon="@Icons.Material.Filled.Delete" />
+        </MudTooltip>
+        <MudTooltip Text="Add" Placement="Placement.Top" Arrow>
+            <MudFab StartIcon="@Icons.Material.Filled.Add" Color="Color.Secondary" />
+        </MudTooltip>
+    </MudTabPanel>
+    <MudTabPanel Text="Grid TextField">
+        <MudGrid>
+            <MudItem xs="12">
+                <MudTextField T="string" Text="Fully expanded - No Tooltip" Variant="Variant.Outlined" HelperText="https://github.com/MudBlazor/MudBlazor/issues/7685#issue-1960816701" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTooltip Text="Issue 7685" Inline="true">
+                    <MudTextField T="string" Text="Tooltip - Inline True" Variant="Variant.Outlined"></MudTextField>
+                </MudTooltip>
+            </MudItem>
+            <MudItem xs="12">
+                <MudTooltip Text="Issue 7685" Inline="false">
+                    <MudTextField T="string" Text="Tooltip - Inline False" Variant="Variant.Outlined"></MudTextField>
+                </MudTooltip>
+            </MudItem>
+        </MudGrid>
+    </MudTabPanel>
+    <MudTabPanel Text="Grid DatePicker">
+        <MudGrid>
+            <MudItem xs="6">
+                <MudTooltip Text="Issue 1167" Color="Color.Primary" Arrow>
+                    <MudDatePicker Label="Tooltip - Inline True" AutoClose/>
+                </MudTooltip>
+            </MudItem>
+            <MudItem xs="6">
+                <MudDatePicker Label="End date" AutoClose />
+            </MudItem>
+        </MudGrid>
+        <MudGrid>
+            <MudItem xs="6">
+                <MudTooltip Text="Issue 1167" Color="Color.Primary" Inline="false" Arrow>
+                    <MudDatePicker Label="Tooltip - Inline False" AutoClose/>
+                </MudTooltip>
+            </MudItem>
+            <MudItem xs="6">
+                <MudDatePicker Label="End date" AutoClose HelperText="https://github.com/MudBlazor/MudBlazor/issues/1167#issuecomment-968830224" />
+            </MudItem>
+        </MudGrid>
+    </MudTabPanel>
+    <MudTabPanel Text="MudList Direction">
+        <MudPaper Width="fit-content">
+            <MudList T="string">
+                <MudTooltip Text="Inline False" Inline="false">
+                    <MudListItem Text="Inbox" />
+                </MudTooltip>
+                <MudTooltip Text="Inline False" Inline="false">
+                    <MudListItem Text="Sent" />
+                </MudTooltip>
+                <MudTooltip Text="Inline False" Inline="false">
+                    <MudListItem Text="Spam" />
+                </MudTooltip>
+                <MudDivider />
+                <MudTooltip Text="List renders horizontally if Inline=true" Inline="false">
+                    <MudListItem Text="Issue 3844" SecondaryText="https://github.com/MudBlazor/MudBlazor/issues/3844#issue-1119522527" />
+                </MudTooltip>
+            </MudList>
+        </MudPaper>
+    </MudTabPanel>
+    <MudTabPanel Text="Grid Chip">
+        <MudDataGrid Items="@([("updated", Color.Secondary), ("in progress", Color.Warning), ("submitted", Color.Info), ("approved", Color.Success)])">
+            <Columns>
+                <TemplateColumn Title="GitHub Issue">
+                    <CellTemplate>
+                        <MudText>Issue #1167</MudText>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="Inline True">
+                    <CellTemplate>
+                        <MudTooltip Text="Inline True" Color="Color.Primary" Arrow Placement="Placement.Bottom" Inline="true">
+                            <MudChip T="string" Class="mud-width-full ma-0" Color="@context.Item.Item2" Size="Size.Small">
+                                @context.Item.Item1
+                            </MudChip>
+                        </MudTooltip>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="Inline False">
+                    <CellTemplate>
+                        <MudTooltip Text="Inline False" Color="Color.Primary" Arrow Placement="Placement.Bottom" Inline="false">
+                            <MudChip T="string" Class="mud-width-full ma-0" Color="@context.Item.Item2" Size="Size.Small">
+                                @context.Item.Item1
+                            </MudChip>
+                        </MudTooltip>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="Comment">
+                    <CellTemplate>
+                        <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/1167#issuecomment-2611085518">MudChip inside DataGrid workaround</MudLink>
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
+    </MudTabPanel>
+    <MudTabPanel Text="Grid Stack" BadgeDot BadgeColor="Color.Error">
+        <MudGrid>
+            <MudItem xs="12">
+                <MudStack>
+                    <MudStack Row>
+                        <MudTextField T="string" Text="Fully expanded - No Tooltip" Variant="Variant.Outlined" HelperText="https://github.com/MudBlazor/MudBlazor/issues/1167#issuecomment-1915676589" />
+                        <MudButton>Text</MudButton>
+                    </MudStack>
+                    <MudStack Row>
+                        <MudTooltip Text="Issue 1167" RootClass="mud-width-full">
+                            <MudTextField T="string" Text="Tooltip - requires RootClass='mud-width-full'" Variant="Variant.Outlined"></MudTextField>
+                        </MudTooltip>
+                        <MudButton>Text</MudButton>
+                    </MudStack>
+                </MudStack>
+            </MudItem>
+        </MudGrid>
+    </MudTabPanel>
+    <MudTabPanel Text="Table Data" BadgeDot BadgeColor="Color.Error">
+        <MudTable T="string" Items="@(["one", "two", "three", "four"])">
+            <HeaderContent>
+                <MudTh>Issue</MudTh>
+                <MudTh>Data</MudTh>
+                <MudTh>Comment</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Issue">Discord Help</MudTd>
+                <MudTd DataLabel="Data">
+                    <MudTooltip Text="RootClass='mud-width-full'" RootClass="mud-width-full">
+                        @context
+                    </MudTooltip>
+                </MudTd>
+                <MudTd DataLabel="Comment">User was wrapping outside 'MudTd', wrap inside instead</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+</MudTabs>

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -1,7 +1,5 @@
-﻿
-.mud-tooltip-root {
-  width: fit-content;
 
+.mud-tooltip-root {
   &.mud-tooltip-inline {
     display: inline-block;
   }


### PR DESCRIPTION
## Description
Setting `width: fit-content` on `mud-tooltip-root` prevented the `Inline` toggle from working as [expected](https://github.com/MudBlazor/MudBlazor/issues/1167#issuecomment-1713352841).  

This removes the unnecessary width definition. I've added visual test cases for all the reported odd tooltip wrapping behavior that I could find. With `fit-content` removed, most can be solved by setting `Inline="false"` while a few resolved naturally with just the removal of `fit-content`. There were two cases where `RootClass="mud-width-full"` was required (i.e. wrapping the Tooltip in a `MudStack` or a `MudTd`)

### Question: 
**Should we add a `FullWidth` option to the `MudTooltip` to facilitate the cases where `RootClass="mud-width-full"` may be needed?**

## How Has This Been Tested?
Visually - Test view and Docs

Fixes: #1167 
Fixes: #3844 (closed incorrectly)

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
