### PR TITLE
MudMenu: Stop contextmenu event propagation when right-click activation is used

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuContextMenuExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuContextMenuExample.razor
@@ -7,7 +7,7 @@
             <MudText Typo="Typo.body2">Peninsula in Europe</MudText>
         </CardHeaderContent>
     </MudCardHeader>
-    <div @onclick="@(OpenContextMenu)" @oncontextmenu="@(OpenContextMenu)" @oncontextmenu:preventDefault>
+    <div @onclick="@(OpenContextMenu)" @oncontextmenu="@(OpenContextMenu)" @oncontextmenu:preventDefault @oncontextmenu:stopPropagation>
         <MudCardMedia Image="images/pilars.jpg" Height="250"/>
     </div>
     <MudCardContent>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -8,7 +8,8 @@
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
      @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
-     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)">
+     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
+     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)">
     @if (GetActivatorHidden())
     {
         @* No content was set so no need to render anything *@


### PR DESCRIPTION
## Description
This pull request addresses an issue where the contextmenu event was propagating when right-click activation was used in MudMenu. This caused unintended behavior in scenarios with nested elements.

The PR introduces the `@oncontextmenu:stopPropagation` modifier to:

1. The `MudMenu` component's default behavior.
2. The advanced documentation example where a custom `div` is used to trigger the `MudMenu`.

This ensures that the event does not propagate to parent elements, preventing conflicts in hierarchical structures.

## How Has This Been Tested?
1. __Visually__: Verified the functionality in the provided documentation example to ensure the `stopPropagation` behavior works as expected.
2. No unit tests were required since this is a minor behavioral improvement and documentation change.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
