### PR TITLE
UnitTests: Fix DateRangePicker Test

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
@@ -4,7 +4,7 @@
     public static string __description__ = "DateTime range without a timestamp";
 
     [Parameter]
-    public DateRange? DateRange { get; set; } = new DateRange(DateTime.Now.Subtract(TimeSpan.FromDays(35)).Date, DateTime.Now.AddDays(5).Date);
+    public DateRange? DateRange { get; set; } = new DateRange(DateTime.Now.AddMonths(-1).Date, DateTime.Now.Date);
 
     public MudDateRangePicker? PickerReference;
 }


### PR DESCRIPTION
## Description
This test was meant to cover a selected range of 2 month. Instead of subtracting and adding days, which can run into problems with short months, simply subtract 1 month from the current date. This will always place you correctly within the previous month 

Example 
- 28th March - 1 Month = 28th Feb 
- 29th March - 1 Month = 28th Feb 
- 30th March - 1 Month = 28th Feb 
- 31st March - 1 Month = 28th Feb 

## How Has This Been Tested?
Sample runs with date changes

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
