### PR TITLE
MudDropContainer: Re-enable content selection

### DIFF
--- a/src/MudBlazor/Styles/components/_dropzone.scss
+++ b/src/MudBlazor/Styles/components/_dropzone.scss
@@ -43,7 +43,3 @@
     }
   }
 }
-
-.mud-drop-container {
-  user-select: none;
-}


### PR DESCRIPTION
## Description
Selecting items within the drop container was removed as one of the causes of the "ghost glitch" while dragging drop zone items. However, when used with components like the DataGrid, the content within the table aren't selectable. This was a minor cause of the glitch and should be fine to re-enable.

Related to #10652

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
