### PR TITLE
MudDropContainer: allow scrolling on disabled dragging

### DIFF
--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 @typeparam T
 
-<div class="@Classname" style="@($"{Style};touch-action:none;transform: translate3d(0px, 0px, 0px);")"
+<div class="@Classname" style="@Stylename"
      id="@_id"
      index="@Index"
      @attributes="UserAttributes"

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -277,4 +277,11 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
             .AddClass(DisabledClass, Disabled)
             .AddClass(Class)
             .Build();
+
+    protected string Stylename =>
+        new StyleBuilder()
+            .AddStyle("touch-action", "none", !Disabled)
+            .AddStyle("transform", "translate3d(0px, 0px, 0px)")
+            .AddStyle(Style)
+            .Build();
 }


### PR DESCRIPTION
## Description
This change sets the style "touch-action:none" only if the item is not disabled. When the item is disabled it should be able to scroll on a touchscreen as then no drag&drop is possible. That fixes #7170

## How Has This Been Tested?
visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
