### PR TITLE
MudProgressLinear: prevent buffer clipping on Medium/Large sizes

### DIFF
--- a/src/MudBlazor/Styles/components/_progresslinear.scss
+++ b/src/MudBlazor/Styles/components/_progresslinear.scss
@@ -1,4 +1,4 @@
-﻿
+
 .mud-progress-linear {
   position: relative;
 
@@ -118,7 +118,7 @@
       .mud-progress-linear-bar:first-child {
         background-size: 10px 10px;
         background-image: radial-gradient(var(--mud-palette-action-disabled) 0%, var(--mud-palette-action-disabled) 16%, transparent 42%);
-        background-position: 0 -23px;
+        background-position: 0 50%;
       }
 
       .mud-progress-linear-bar:nth-child(2) {
@@ -161,7 +161,7 @@
         .mud-progress-linear-bar:first-child {
           background-size: 10px 10px;
           background-image: radial-gradient(var(--mud-palette-#{$color}) 0%, var(--mud-palette-#{$color}) 16%, transparent 42%);
-          background-position: 0 -23px;
+          background-position: 0 50%;
         }
 
         .mud-progress-linear-bar:nth-child(2) {

--- a/src/MudBlazor/Styles/core/_animations.scss
+++ b/src/MudBlazor/Styles/core/_animations.scss
@@ -1,4 +1,4 @@
-﻿@keyframes mud-animation-fadein {
+@keyframes mud-animation-fadein {
   0% {
     opacity: 0;
   }
@@ -164,17 +164,17 @@
 @-webkit-keyframes mud-progress-linear-horizontal-keyframes-buffer {
   0% {
     opacity: 1;
-    background-position: 0 -23px;
+    background-position: 0 50%;
   }
 
   50% {
     opacity: 0;
-    background-position: 0 -23px;
+    background-position: 0 50%;
   }
 
   100% {
     opacity: 1;
-    background-position: -200px -23px;
+    background-position: -200px 50%;
   }
 }
 
@@ -224,17 +224,17 @@
 @-webkit-keyframes mud-progress-linear-vertical-keyframes-buffer {
   0% {
     opacity: 1;
-    background-position: -23px 0;
+    background-position: 50% 0;
   }
 
   50% {
     opacity: 0;
-    background-position: -23px 0;
+    background-position: 50% 0;
   }
 
   100% {
     opacity: 1;
-    background-position: -23px -200px;
+    background-position: 50% -200px;
   }
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
This fix addresses an issue in `MudProgressLinear` where the buffer was being clipped when the `Size` property was set to `Medium` or `Large`. The adjustment ensures proper rendering of the buffer, maintaining visual consistency across all size options.

fixes #10631 ?


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested visually on Chrome & Firefox

Before : 
![progress_before](https://github.com/user-attachments/assets/e9bdb1ea-9e29-4b1b-9be6-12f826f0f775)

After:
![progress_after](https://github.com/user-attachments/assets/ce3990d0-c527-4d11-8fc8-60845e6bdb68)


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
