### PR TITLE
MudBaseDatePicker: Don't try to highlight invalid dates

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -706,6 +706,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DisableCalendarMonthButtonsWhenFixDayOutOfRange()
         {
+            var timeProvider = new FakeTimeProvider();
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            timeProvider.SetUtcNow(new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
             var comp = OpenPicker(new[]
             {
                 Parameter(nameof(MudDatePicker.OpenTo), OpenTo.Month),

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -697,9 +697,10 @@ namespace MudBlazor
             var month = FixMonth ?? (year == today.Year ? today.Month : 1);
             var day = FixDay ?? 1;
 
-            DateTime.TryParseExact($"{year}-{month}-{day}", "yyyy-M-d", Culture, DateTimeStyles.None, out var date);
-
-            HighlightedDate = date == DateTime.MinValue ? null : date;
+            if (DateTime.TryParseExact($"{year}-{month}-{day}", "yyyy-M-d", Culture, DateTimeStyles.None, out var date))
+            {
+                HighlightedDate = date;
+            }
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -697,7 +697,9 @@ namespace MudBlazor
             var month = FixMonth ?? (year == today.Year ? today.Month : 1);
             var day = FixDay ?? 1;
 
-            HighlightedDate = new DateTime(year, month, day);
+            DateTime.TryParseExact($"{year}-{month}-{day}", "yyyy-M-d", Culture, DateTimeStyles.None, out var date);
+
+            HighlightedDate = date == DateTime.MinValue ? null : date;
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
## Description
Highlighted date fails if an invalid fixed day is provided for the current month. 

The unit test regarding this scenario was updated to consistently test an invalid fixed date for a predefined current day. 
The test passed previously as it simply tested fixed date only, meaning it succeeded in months with 31 days.

## How Has This Been Tested?
Unit tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
