### PR TITLE
MudExpansionPanels: add Panels property to expose child components

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -178,6 +178,7 @@ namespace MudBlazor.UnitTests.Components
             await panels.Instance.AddPanelAsync(panel3);
             // We check _expandedState because we do not modify Expanded directly, therefore the parameter doesn't change.
             // For parameter to change you need to bind panels Expansion it via razor syntax, so that parent would update it.
+            panels.Instance.Panels.Count.Should().Be(3);
             panel1._expandedState.Value.Should().BeFalse();
             panel2._expandedState.Value.Should().BeFalse();
             panel3._expandedState.Value.Should().BeFalse();
@@ -205,6 +206,7 @@ namespace MudBlazor.UnitTests.Components
             await panel3.ExpandAsync();
             // We check _expandedState because we do not modify Expanded directly, therefore the parameter doesn't change.
             // For parameter to change you need to bind panels Expansion it via razor syntax, so that parent would update it.
+            panels.Instance.Panels.Count.Should().Be(3);
             panel1._expandedState.Value.Should().BeTrue();
             panel2._expandedState.Value.Should().BeTrue();
             panel3._expandedState.Value.Should().BeTrue();
@@ -232,6 +234,7 @@ namespace MudBlazor.UnitTests.Components
             await panel3.ExpandAsync();
             // We check _expandedState because we do not modify Expanded directly, therefore the parameter doesn't change.
             // For parameter to change you need to bind panels Expansion it via razor syntax, so that parent would update it.
+            panels.Instance.Panels.Count.Should().Be(3);
             panel1._expandedState.Value.Should().BeTrue();
             panel2._expandedState.Value.Should().BeTrue();
             panel3._expandedState.Value.Should().BeTrue();

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -91,6 +91,14 @@ namespace MudBlazor
         [Category(CategoryTypes.ExpansionPanel.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
+        /// <summary>
+        /// A read-only list of the panels within this component. 
+        /// </summary>
+        /// <remarks>
+        /// Expansion panels are controlled by adding more <see cref="MudExpansionPanel"/> components in the Razor page.
+        /// </remarks>
+        public IReadOnlyList<MudExpansionPanel> Panels => _panels.AsReadOnly();
+
         internal async Task AddPanelAsync(MudExpansionPanel panel)
         {
             if (!MultiExpansion && _panels.Any(p => p._expandedState.Value))


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Added a new `Panels` property to provide a read-only list of `MudExpansionPanel` components within this component. This allows better access and control over the expansion panels.  

The documentation for this property was inspired by `MudTabPanels` to ensure consistency.
https://github.com/MudBlazor/MudBlazor/blob/1f2d627579a24d5ad6ab54d735e57b5b4f705f11/src/MudBlazor/Components/Tabs/MudTabs.razor.cs#L355-L361

resolves #7756

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tests


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
