### PR TITLE
MudNumericField: Ignore default UI Culture

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1021,6 +1021,36 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [SetUICulture("ru-RU")]
+        public void Format_should_use_default_culture()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+                                .Add(p => p.Format, "N3"));
+
+            comp.Find("input").Change("123,45");
+            comp.Find("input").Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(123.45M));
+            comp.Instance.Text.Should().Be("123,450");
+            comp.Instance.Culture.Name.Should().Be("ru-RU");
+        }
+
+        [Test]
+        [SetUICulture("ru-RU")]
+        public void Pattern_should_use_default_culture()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+                                .Add(p => p.Pattern, "[0-9,.\\-]"));
+
+            comp.Find("input").Change("123,45");
+            comp.Find("input").Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(123.45M));
+            comp.Instance.Text.Should().Be("123,45");
+            comp.Instance.Culture.Name.Should().Be("ru-RU");
+        }
+
+        [Test]
+        [SetUICulture("ru-RU")]
         public void Should_apply_defined_culture()
         {
             var comp = Context.RenderComponent<NumericFieldCultureTest>();
@@ -1041,6 +1071,38 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("1,234.56"));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(1234.56));
             comp.Instance.FieldImmediate.Culture.Name.Should().Be("en-US");
+        }
+
+        [Test]
+        [SetUICulture("ru-RU")]
+        public void Format_should_use_defined_culture()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+                                .Add(p => p.Format, "N3")
+                                .Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US")));
+
+            comp.Find("input").Change("123.45");
+            comp.Find("input").Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(123.45M));
+            comp.Instance.Text.Should().Be("123.450");
+            comp.Instance.Culture.Name.Should().Be("en-US");
+        }
+
+        [Test]
+        [SetUICulture("ru-RU")]
+        public void Pattern_should_use_defined_culture()
+        {
+            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+                                .Add(p => p.Pattern, "[0-9,.\\-]")
+                                .Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US")));
+
+            comp.Find("input").Change("123.45");
+            comp.Find("input").Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(123.45M));
+            comp.Instance.Text.Should().Be("123.45");
+            comp.Instance.Culture.Name.Should().Be("en-US");
         }
 
         [Test]

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -142,9 +142,12 @@ namespace MudBlazor
         private bool IsNumberMode => InputMode == InputMode.numeric || InputMode == InputMode.@decimal;
         private bool IsFormatted => Pattern is not null || Format is not null || _cultureHasValue;
 
-        protected override void OnInitialized()
+        protected override void OnAfterRender(bool firstRender)
         {
-            base.OnInitialized();
+            if (!firstRender)
+            {
+                return;
+            }
 
             // Overrides the browser's culture since <input type="number"> does not consider culture.
             // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used 
@@ -153,6 +156,8 @@ namespace MudBlazor
             {
                 SetCulture(CultureInfo.InvariantCulture);
             }
+
+            base.OnAfterRender(firstRender);
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -46,14 +46,6 @@ namespace MudBlazor
                 .WithParameter(() => Culture)
                 .WithChangeHandler((x) => _cultureHasValue = x.Value is not null);
 
-            // Overrides the browser's culture since <input type="number"> does not consider culture.
-            // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used 
-            // with the corresponding attributes applied.
-            if (!_cultureHasValue)
-            {
-                SetCulture(CultureInfo.InvariantCulture);
-            }
-
             Validation = new Func<T, Task<bool>>(ValidateInput);
             #region parameters default depending on T
 
@@ -149,6 +141,19 @@ namespace MudBlazor
 
         private bool IsNumberMode => InputMode == InputMode.numeric || InputMode == InputMode.@decimal;
         private bool IsFormatted => Pattern is not null || Format is not null || _cultureHasValue;
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            // Overrides the browser's culture since <input type="number"> does not consider culture.
+            // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used 
+            // with the corresponding attributes applied.
+            if (!IsFormatted)
+            {
+                SetCulture(CultureInfo.InvariantCulture);
+            }
+        }
 
         /// <inheritdoc />
         [ExcludeFromCodeCoverage]


### PR DESCRIPTION
## Description
This is a continuation of https://github.com/MudBlazor/MudBlazor/pull/10734. 

This extends the logic to acknowledge the default culture if either `Format` or `Pattern` are set. Since setting `Pattern` or `Format` changes the input type to `text`, this way it only ignores the culture when the input type is `number`. 

## How Has This Been Tested?
Unit tests

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
