### PR TITLE
MudTabPanel: Implement Sorting by Text, SortKey, or Custom IComparer

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByComparerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByComparerExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs SortComparer="CustomComparer" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+    <MudTabPanel Text="Tab 2 (Tag=C)" Tag="@( "C" )">
+        <MudText>Content Two</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 1 (Tag=B)" Tag="@( "B" )">
+        <MudText>Content One</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 3 (Tag=A)" Tag="@( "A" )">
+        <MudText>Content Three</MudText>
+    </MudTabPanel>
+</MudTabs>
+
+@code {
+    static IComparer<MudTabPanel> CustomComparer = new CompareByTagAscending();
+
+    class CompareByTagAscending : IComparer<MudTabPanel>
+    {
+        public int Compare(MudTabPanel x, MudTabPanel y)
+        {
+            return Comparer<string>.Default.Compare( x?.Tag as string, y?.Tag as string );
+        }
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByComparerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByComparerExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTabs SortComparer="CustomComparer" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+<MudTabs SortComparer="_customComparer" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
     <MudTabPanel Text="Tab 2 (Tag=C)" Tag="@( "C" )">
         <MudText>Content Two</MudText>
     </MudTabPanel>
@@ -13,14 +13,13 @@
 </MudTabs>
 
 @code {
-    static IComparer<MudTabPanel> CustomComparer = new CompareByTagAscending();
+    private readonly IComparer<MudTabPanel> _customComparer = new CompareByTagAscending();
 
-    class CompareByTagAscending : IComparer<MudTabPanel>
+    private class CompareByTagAscending : IComparer<MudTabPanel>
     {
         public int Compare(MudTabPanel x, MudTabPanel y)
         {
             return Comparer<string>.Default.Compare( x?.Tag as string, y?.Tag as string );
         }
     }
-
 }

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortBySortKeyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortBySortKeyExample.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudTabs SortDirection="SortDirection.Ascending" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
-	<MudTabPanel Text="Tab 2 (SortKey=F)" SortKey="F">
-		<MudText>Content Two, sorted as 'F'</MudText>
-	</MudTabPanel>
-	<MudTabPanel Text="Tab 1 (SortKey=G)" SortKey="G">
-		<MudText>Content One, sorted as 'G'</MudText>
-	</MudTabPanel>
-	<MudTabPanel Text="Tab 3 (no SortKey)">
-		<MudText>Content Three, sorted as 'Tab 3' as the SortKey is not set</MudText>
-	</MudTabPanel>
+    <MudTabPanel Text="Tab 2 (SortKey=F)" SortKey="F">
+        <MudText>Content Two, sorted as 'F'</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 1 (SortKey=G)" SortKey="G">
+        <MudText>Content One, sorted as 'G'</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 3 (no SortKey)">
+        <MudText>Content Three, sorted as 'Tab 3' as the SortKey is not set</MudText>
+    </MudTabPanel>
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortBySortKeyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortBySortKeyExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs SortDirection="SortDirection.Ascending" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+	<MudTabPanel Text="Tab 2 (SortKey=F)" SortKey="F">
+		<MudText>Content Two, sorted as 'F'</MudText>
+	</MudTabPanel>
+	<MudTabPanel Text="Tab 1 (SortKey=G)" SortKey="G">
+		<MudText>Content One, sorted as 'G'</MudText>
+	</MudTabPanel>
+	<MudTabPanel Text="Tab 3 (no SortKey)">
+		<MudText>Content Three, sorted as 'Tab 3' as the SortKey is not set</MudText>
+	</MudTabPanel>
+</MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByTextExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByTextExample.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudTabs SortDirection="SortDirection.Descending" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
-	<MudTabPanel Text="Tab 2">
-		<MudText>Content Two</MudText>
-	</MudTabPanel>
-	<MudTabPanel Text="Tab 1">
-		<MudText>Content One</MudText>
-	</MudTabPanel>
-	<MudTabPanel Text="Tab 3">
-		<MudText>Content Three</MudText>
-	</MudTabPanel>
+    <MudTabPanel Text="Tab 2">
+        <MudText>Content Two</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 1">
+        <MudText>Content One</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 3">
+        <MudText>Content Three</MudText>
+    </MudTabPanel>
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByTextExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsSortByTextExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs SortDirection="SortDirection.Descending" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+	<MudTabPanel Text="Tab 2">
+		<MudText>Content Two</MudText>
+	</MudTabPanel>
+	<MudTabPanel Text="Tab 1">
+		<MudText>Content One</MudText>
+	</MudTabPanel>
+	<MudTabPanel Text="Tab 3">
+		<MudText>Content Three</MudText>
+	</MudTabPanel>
+</MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -46,6 +46,44 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Tab Sorting">
+                <Description>
+                    TabPanels appear in the order they are processed by the RenderTreeBuilder, which can be affected by component nesting in complex scenarios.
+                    Use the <CodeInline>SortDirection</CodeInline> property to sort lexicographically by <CodeInline>Text</CodeInline>.<br />
+                    <br />
+                    Note that sorting is applied during initial rendering, when TabPanels are being added to the parent Tabs. Sorting is not re-evaluated
+                    if properties are changed at runtime.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TabsSortByTextExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TabsSortByTextExample />
+            </SectionContent>
+            <SectionSubGroups>
+                <DocsPageSection>
+                    <SectionHeader Title="Sort Keys">
+                        <Description>
+                            The TabPanel's <CodeInline>SortKey</CodeInline> property is used in preference to the <CodeInline>Text</CodeInline> property, if set.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TabsSortBySortKeyExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TabsSortBySortKeyExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="Custom Sorting">
+                        <Description>
+                            Specify a custom <CodeInline>SortComparer</CodeInline> which implements <CodeInline>IComparer&lt;MudTabPanel&gt;</CodeInline> to
+                            override the default sorting behaviour. In this scenario, sort direction must be handled by the custom SortComparer.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TabsSortByComparerExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TabsSortByComparerExample />
+                    </SectionContent>
+                </DocsPageSection>
+            </SectionSubGroups>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Tab Width">
                 <Description>
                     The <CodeInline>MinimumTabWidth</CodeInline> property defines a minimum width for each tab.

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
@@ -1,0 +1,64 @@
+﻿@if (SortKeys is null && SortComparer is null)
+{
+    @if (SortDirection.HasValue)
+    {
+        @* default case - sorting by label text *@
+        <MudTabs SortDirection="@SortDirection.Value">
+            <MudTabPanel Text="2"></MudTabPanel>
+            <MudTabPanel Text="1"></MudTabPanel>
+            <MudTabPanel Text="3"></MudTabPanel>
+        </MudTabs>
+    }
+    else
+    {
+        @* default case - natural order when unspecified *@
+        <MudTabs>
+            <MudTabPanel Text="2"></MudTabPanel>
+            <MudTabPanel Text="1"></MudTabPanel>
+            <MudTabPanel Text="3"></MudTabPanel>
+        </MudTabs>
+    }
+}
+else if (SortKeys is not null)
+{
+    @if (SortDirection.HasValue)
+    {
+        @* default case - sorting by label text *@
+        <MudTabs SortDirection="@SortDirection.Value">
+            <MudTabPanel SortKey="@SortKeys[0]" Text="2"></MudTabPanel>
+            <MudTabPanel SortKey="@SortKeys[1]" Text="1"></MudTabPanel>
+            <MudTabPanel SortKey="@SortKeys[2]" Text="3"></MudTabPanel>
+            <MudTabPanel Text="4"></MudTabPanel>
+        </MudTabs>
+    }
+    else
+    {
+        @* default case - natural order when unspecified *@
+        <MudTabs>
+            <MudTabPanel SortKey="@SortKeys[0]" Text="2"></MudTabPanel>
+            <MudTabPanel SortKey="@SortKeys[1]" Text="1"></MudTabPanel>
+            <MudTabPanel SortKey="@SortKeys[2]" Text="3"></MudTabPanel>
+            <MudTabPanel Text="4"></MudTabPanel>
+        </MudTabs>
+    }
+}
+else if (SortComparer is not null)
+{
+    <MudTabs SortDirection="MudBlazor.SortDirection.Descending" SortComparer="SortComparer">
+        <MudTabPanel Tag="@( "Y" )" SortKey="3" Text="Apple"></MudTabPanel>
+        <MudTabPanel Tag="@( "Z" )" SortKey="2" Text="Banana"></MudTabPanel>
+        <MudTabPanel Tag="@( "X" )" SortKey="1" Text="Cherry"></MudTabPanel>
+    </MudTabs>
+}
+
+@code {
+    [Parameter] public SortDirection? SortDirection { get; set; }
+    [Parameter] public string[]? SortKeys { get; set; }
+    [Parameter] public IComparer<MudTabPanel>? SortComparer { get; set; }
+
+    public class TestComparer : IComparer<MudTabPanel>
+    {
+        public int Compare(MudTabPanel? x, MudTabPanel? y)
+            => Comparer<string>.Default.Compare(x?.Tag as string, y?.Tag as string);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
@@ -52,9 +52,14 @@ else if (SortComparer is not null)
 }
 
 @code {
-    [Parameter] public SortDirection? SortDirection { get; set; }
-    [Parameter] public string[]? SortKeys { get; set; }
-    [Parameter] public IComparer<MudTabPanel>? SortComparer { get; set; }
+    [Parameter]
+    public SortDirection? SortDirection { get; set; }
+
+    [Parameter]
+    public string[]? SortKeys { get; set; }
+
+    [Parameter]
+    public IComparer<MudTabPanel>? SortComparer { get; set; }
 
     public class TestComparer : IComparer<MudTabPanel>
     {

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -1334,6 +1334,123 @@ namespace MudBlazor.UnitTests.Components
             {
                 panel.ClassList.Should().Contain("mud-tab-panel-hidden");
             }
+        }
+
+        [Test]
+        public void LabelSorting_NaturalOrderIfSortingUnspecified()
+        {
+            // all parameters unspecified
+            var comp = Context.RenderComponent<LabelSortTest>();
+
+            // all labels should be present and in natural order
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("3");
+        }
+
+        [Test]
+        public void LabelSorting_SpecifiedDirectionWithoutKeysOrComparer()
+        {
+            /* ***
+             * all labels should be present and in natural order
+             */
+            var comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.None)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("3");
+
+            /* ***
+             * all labels should be present and in lexicographically ascending order
+             */
+            comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.Ascending)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("3");
+
+            /* ***
+             * all labels should be present and in lexicographically descending order
+             */
+            comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.Descending)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("3");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("1");
+        }
+
+        [Test]
+        public void LabelSorting_SpecifiedDirectionWithKeysAndDefaultComparer()
+        {
+            // Caution: intentionally descending order to ensure this behaviour overrides Text ordering
+            string[] sortKeys = ["c", "b", "a"];
+
+            /* ***
+             * all labels should be present and in natural order
+             */
+            var comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.None),
+                            ComponentParameter.CreateParameter("SortKeys", sortKeys)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(4);
+            // sort order is per markup: 2, 1, 3, 4. Keys are ignored as list is unsorted.
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("3");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[3].InnerHtml.Should().Be("4");
+
+            /* ***
+             * all labels should be present and in lexicographically ascending order
+             */
+            comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.Ascending),
+                            ComponentParameter.CreateParameter("SortKeys", sortKeys)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(4);
+            // sort order is: 4, a=3, b=1, c=2
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("4");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("3");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[3].InnerHtml.Should().Be("2");
+
+            /* ***
+             * all labels should be present and in lexicographically descending order
+             */
+            comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.Descending),
+                            ComponentParameter.CreateParameter("SortKeys", sortKeys)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(4);
+            // sort order is: c=2, b=1, a=3, 4
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("2");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("1");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("3");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[3].InnerHtml.Should().Be("4");
+        }
+
+        [Test]
+        public void LabelSorting_CustomSortComparer()
+        {
+            /* ***
+             * All labels should be present and in Tag order, ignoring SortDirection and Keys.
+             * For this test the Tabs.SortDirection is set to Descending in markup, and the SortKeys
+             * are set to Apple=3, Banana=2, Cherry=1, so there is no combination of SortKey, Label
+             * or SortDirection that could ellicit the same sort order as we get from TestComparer.
+             */
+            var comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortComparer", new LabelSortTest.TestComparer())
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("Cherry");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("Apple");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("Banana");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
@@ -190,6 +190,16 @@ public partial class MudTabPanel
     [Category(CategoryTypes.Tabs.Behavior)]
     public string? ToolTip { get; set; }
 
+    /// <summary>
+    /// Value to use when ordering tabs lexicographically, in place of <see cref="MudTabPanel.Text" />.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Tabs.Appearance)]
+    public string? SortKey { get; set; }
+
     /// <inheritdoc/>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -637,7 +637,7 @@ namespace MudBlazor
                 return SortComparer.Compare(a, b);
 
             var dir = SortDirection is SortDirection.Ascending ? 1 : -1;
-            return Comparer.Default.Compare( GetTabSortKey( a ), GetTabSortKey( b ) ) * dir;
+            return Comparer.Default.Compare(GetTabSortKey(a), GetTabSortKey(b)) * dir;
         }
         private static string? GetTabSortKey(MudTabPanel panel)
             => panel.SortKey ?? panel.Text;

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -411,6 +412,26 @@ namespace MudBlazor
         public Func<TabInteractionEventArgs, Task>? OnPreviewInteraction { get; set; }
 
         /// <summary>
+        /// Sort tab labels lexicographically by <see cref="MudTabPanel.Text"/> or <see cref="MudTabPanel.SortKey"/>. Ignored if <see cref="SortComparer" /> is set.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="SortDirection.None"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Tabs.Appearance)]
+        public SortDirection SortDirection { get; set; } = SortDirection.None;
+
+        /// <summary>
+        /// Specify a custom Comparer to sort tabs. When set, <see cref="SortDirection" /> is not used.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Tabs.Appearance)]
+        public IComparer<MudTabPanel>? SortComparer { get; set; }
+
+        /// <summary>
         /// Can be used in derived class to add a class to the main container. If not overwritten return an empty string
         /// </summary>
         protected virtual string InternalClassName { get; } = string.Empty;
@@ -489,8 +510,11 @@ namespace MudBlazor
         internal void AddPanel(MudTabPanel tabPanel)
         {
             _panels.Add(tabPanel);
+            SortPanels();
+
             if (_panels.Count == _activePanelIndex + 1 || _activePanelIndex == -1 && _panels.Count == 1)
                 ActivePanel = tabPanel;
+
             StateHasChanged();
         }
 
@@ -600,6 +624,23 @@ namespace MudBlazor
             }
         }
 
+        private void SortPanels()
+        {
+            if (_panels.Count == 0 || SortDirection == SortDirection.None)
+                return;
+
+            _panels.Sort(GetTabSortExpression);
+        }
+        private int GetTabSortExpression(MudTabPanel a, MudTabPanel b)
+        {
+            if (SortComparer is not null)
+                return SortComparer.Compare(a, b);
+
+            var dir = SortDirection is SortDirection.Ascending ? 1 : -1;
+            return Comparer.Default.Compare( GetTabSortKey( a ), GetTabSortKey( b ) ) * dir;
+        }
+        private static string? GetTabSortKey(MudTabPanel panel)
+            => panel.SortKey ?? panel.Text;
         #endregion
 
         #region Style and classes

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -631,6 +631,7 @@ namespace MudBlazor
 
             _panels.Sort(GetTabSortExpression);
         }
+
         private int GetTabSortExpression(MudTabPanel a, MudTabPanel b)
         {
             if (SortComparer is not null)
@@ -639,6 +640,7 @@ namespace MudBlazor
             var dir = SortDirection is SortDirection.Ascending ? 1 : -1;
             return Comparer.Default.Compare(GetTabSortKey(a), GetTabSortKey(b)) * dir;
         }
+
         private static string? GetTabSortKey(MudTabPanel panel)
             => panel.SortKey ?? panel.Text;
         #endregion

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -635,14 +635,15 @@ namespace MudBlazor
         private int GetTabSortExpression(MudTabPanel a, MudTabPanel b)
         {
             if (SortComparer is not null)
+            {
                 return SortComparer.Compare(a, b);
+            }
 
             var dir = SortDirection is SortDirection.Ascending ? 1 : -1;
             return Comparer.Default.Compare(GetTabSortKey(a), GetTabSortKey(b)) * dir;
         }
 
-        private static string? GetTabSortKey(MudTabPanel panel)
-            => panel.SortKey ?? panel.Text;
+        private static string? GetTabSortKey(MudTabPanel panel) => panel.SortKey ?? panel.Text;
         #endregion
 
         #region Style and classes


### PR DESCRIPTION
Behaviours added to the MudTabs and MudTabPanel to allow for basic panel sorting, overriding the RenderTreeBuilder which is influenced by component nesting.

## Description
Resolves issue #10799.
Properties added to `MudTabs` and `MudTabPanel` to allow users to better control the render order of tabs in scenarios where tabs may be conditionally added, or where a long-running asynchronous task may result in non-deterministic tab ordering that is otherwise undesirable. Sorting is applied after a panel is added to the parent `MudTabs`, ensuring minimal performance impact and negligible side-effects on other behaviours that rely on panel position indexes.

Dynamic re-sorting when properties that influence sorting behaviour are changed is explicitly excluded for the following reasons:
1. Tabs changing their order without user interaction is jarring and contributes to negative user experience, so should be avoided
2. Re-calculation overhead will have a negative impact on performance
3. Manual re-sorting control through user interaction is easily implemented if needed

This feature may also form the foundation needed for drag-and-drop tab re-sorting, though many areas of Tab code rely on panel indexes that could be adversely affected.

## How Has This Been Tested?
Unit testing is provided.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Documentation updates are included.

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
