### PR TITLE
MudSelect: Fix ResetAsync

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTestRequiredValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTestRequiredValue.razor
@@ -1,20 +1,40 @@
 ﻿<MudPopoverProvider />
 
-<MudSelect @bind-Value="_value" Label="String Binding" MultiSelection="true" Required="true" Clearable="true">
+<MudSelect @ref="_stringSelect" @bind-Value="_value" Label="String Binding" MultiSelection="true" Required="true" Clearable="true">
     <MudSelectItem Value="@("1")">1</MudSelectItem>
     <MudSelectItem Value="@("2")">2</MudSelectItem>
     <MudSelectItem Value="@("3")">3</MudSelectItem>
 </MudSelect>
 
-<MudSelect T="TestClass" Label="Object Binding" MultiSelection="true" Required="true" @bind-SelectedValues="_selectedRoles" Clearable="true">
+<MudStack Row Class="py-8">
+    <MudButton id="clear-string" Variant="Variant.Filled" OnClick="@(() => _stringSelect.ClearAsync())">Clear</MudButton>
+    <MudButton id="reset-string" Variant="Variant.Filled" OnClick="@(() => _stringSelect.ResetAsync())">Reset</MudButton>
+</MudStack>
+
+<MudText>Value: @_stringSelect?.Value</MudText>
+<MudText>Selected values: @((_stringSelect?.SelectedValues is null) ? null : string.Join(", ", _stringSelect.SelectedValues.Select(x => x)))</MudText>
+
+<MudSelect @ref="_objectSelect" T="TestClass" Label="Object Binding" MultiSelection="true" Required="true" @bind-SelectedValues="_selectedRoles" Clearable="true">
     @foreach(var role in _roles)
     {
         <MudSelectItem T="TestClass" Value=@role/>
     }
 </MudSelect>
 
+<MudStack Row Class="py-8">
+    <MudButton id="clear-object" Variant="Variant.Filled" OnClick="@(() => _objectSelect.ClearAsync())">Clear</MudButton>
+    <MudButton id="reset-object" Variant="Variant.Filled" OnClick="@(() => _objectSelect.ResetAsync())">Reset</MudButton>
+</MudStack>
+
+<MudText>Value: @_objectSelect?.Value?.Name</MudText>
+<MudText>Selected values: @((_objectSelect?.SelectedValues is null) ? null : string.Join(", ", _objectSelect.SelectedValues.Select(x => x!.Name)))</MudText>
+
+
 @code {
-	public static string __description__ = "Multi-Select Required Should Recognize Values";
+    public static string __description__ = "Multi-Select Required Should Recognize Values";
+
+    private MudSelect<string?> _stringSelect = null!;
+    private MudSelect<TestClass> _objectSelect = null!;
 
     private string? _value = null;
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1217,6 +1217,91 @@ namespace MudBlazor.UnitTests.Components
             selectWithT.ValidationErrors.Count.Should().Be(0);
         }
 
+        [Test]
+        public async Task MultiSelectClearAndReset()
+        {
+            var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            var select = comp.FindComponent<MudSelect<string>>().Instance;
+            select.Required.Should().BeTrue();
+            await comp.InvokeAsync(() => select.Validate());
+            select.ValidationErrors.First().Should().Be("Required");
+
+            await comp.Find("#clear-string").ClickAsync(new MouseEventArgs());
+            select.ValidationErrors.First().Should().Be("Required");
+
+            await comp.Find("#reset-string").ClickAsync(new MouseEventArgs());
+            select.ValidationErrors.Should().BeEmpty();
+
+            //test clearing string values
+            var inputs = comp.FindAll("div.mud-input-control");
+            await inputs[0].MouseDownAsync(new MouseEventArgs());
+
+            var items = comp.FindAll("div.mud-list-item").ToArray();
+            await items[1].ClickAsync(new MouseEventArgs());
+            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            select.Value.Should().Be("2");
+            select.SelectedValues.Should().Contain("2");
+
+            await comp.Find("#clear-string").ClickAsync(new MouseEventArgs());
+
+            select.Value.Should().BeNullOrEmpty();
+            select.SelectedValues.Should().BeEmpty();
+            select.ValidationErrors.First().Should().Be("Required");
+
+            //test resetting string values
+            inputs = comp.FindAll("div.mud-input-control");
+            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            items = comp.FindAll("div.mud-list-item").ToArray();
+            await items[1].ClickAsync(new MouseEventArgs());
+            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            select.Value.Should().Be("2");
+            select.SelectedValues.Should().Contain("2");
+
+            await comp.Find("#reset-string").ClickAsync(new MouseEventArgs());
+
+            select.Value.Should().BeNullOrEmpty();
+            select.SelectedValues.Should().BeEmpty();
+            select.ValidationErrors.Should().BeEmpty();
+
+            //test clearing object values
+            var select2 = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
+            select2.Required.Should().BeTrue();
+            await comp.InvokeAsync(() => select2.Validate());
+            select2.ValidationErrors.First().Should().Be("Required");
+
+            await comp.Find("#clear-object").ClickAsync(new MouseEventArgs());
+            select2.ValidationErrors.First().Should().Be("Required");
+
+            await comp.Find("#reset-object").ClickAsync(new MouseEventArgs());
+            select2.ValidationErrors.Should().BeEmpty();
+
+            inputs = comp.FindAll("div.mud-input-control");
+            await inputs[1].MouseDownAsync(new MouseEventArgs());
+
+            items = comp.FindAll("div.mud-list-item").ToArray();
+            await items[1].ClickAsync(new MouseEventArgs());
+            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
+
+            await comp.Find("#clear-object").ClickAsync(new MouseEventArgs());
+
+            select2.SelectedValues.Should().BeEmpty();
+            select2.ValidationErrors.First().Should().Be("Required");
+
+            //test resetting object values
+            inputs = comp.FindAll("div.mud-input-control");
+            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            items = comp.FindAll("div.mud-list-item").ToArray();
+            await items[1].ClickAsync(new MouseEventArgs());
+            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
+
+            await comp.Find("#reset-object").ClickAsync(new MouseEventArgs());
+
+            select2.SelectedValues.Should().BeEmpty();
+            select2.ValidationErrors.Should().BeEmpty();
+        }
+
         /// <summary>
         /// When MultiSelect attribute goes after SelectedValues, text should contain all selected values.
         /// </summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1226,12 +1226,7 @@ namespace MudBlazor
         [Obsolete("Use ClearAsync instead")]
         public async Task Clear()
         {
-            await SetValueAsync(default, false);
-            await SetTextAsync(default, false);
-            _selectedValues.Clear();
-            await BeginValidateAsync();
-            StateHasChanged();
-            await SelectedValuesChanged.InvokeAsync(_selectedValues);
+            await ClearAsync();
         }
 
         private async Task SelectAllClickAsync()

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1190,8 +1190,40 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Clears all selections and resets validation
+        /// </summary>
+        /// <remarks>
+        /// To maintain validation errors (e.g. requried), use <see cref="ClearAsync"/>
+        /// </remarks>
+        protected override async Task ResetValueAsync()
+        {
+            await ClearAsync();
+            await base.ResetValueAsync();
+        }
+
+        /// <summary>
         /// Clears all selections.
         /// </summary>
+        /// <remarks>
+        /// To reset validation errors (e.g. required), use <see cref="ResetValueAsync"/>
+        /// </remarks>
+        public async Task ClearAsync()
+        {
+            await SetValueAsync(default, false);
+            await SetTextAsync(default, false);
+            _selectedValues.Clear();
+            await BeginValidateAsync();
+            StateHasChanged();
+            await SelectedValuesChanged.InvokeAsync(_selectedValues);
+        }
+
+        /// <summary>
+        /// Clears all selections.
+        /// </summary>
+        /// <remarks>
+        /// To reset validation errors (e.g. required), use <see cref="ResetValueAsync"/>
+        /// </remarks>
+        [Obsolete("Use ClearAsync instead")]
         public async Task Clear()
         {
             await SetValueAsync(default, false);
@@ -1215,7 +1247,7 @@ namespace MudBlazor
             if (_selectAllChecked.Value)
                 await SelectAllItems();
             else
-                await Clear();
+                await ClearAsync();
         }
 
         private async Task SelectAllItems()


### PR DESCRIPTION
## Description
Calling `ResetAsync` on `MudSelect` clears the `Value` but does not clear the `SelectedValues` collection. 

This change overrides the base `ResetValueAsync` and ensure that the `SelectedValues` collection is cleared.

Additionally, I took the opportunity to rename the `Clear` method to `ClearAsync`. The existing `Clear` method has been marked as obsolete so as not to introduce a breaking change. 

Resolves: #2092 

## How Has This Been Tested?
Visual and unit tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
