### PR TITLE
MudTable: Fix TableRowClassStyleTest

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1467,15 +1467,15 @@ namespace MudBlazor.UnitTests.Components
             tds[2].TextContent.Trim().Should().Be("2");
             tds[3].TextContent.Trim().Should().Be("3");
 
-            trs[1].GetAttribute("style").Contains("color: red");
-            trs[2].GetAttribute("style").Contains("color: red");
-            trs[3].GetAttribute("style").Contains("color: blue");
-            trs[4].GetAttribute("style").Contains("color: blue");
+            trs[1].GetAttribute("style").Should().Contain("color: red");
+            trs[2].GetAttribute("style").Should().Contain("color: red");
+            trs[3].GetAttribute("style").Should().Contain("color: blue");
+            trs[4].GetAttribute("style").Should().Contain("color: blue");
 
-            trs[1].GetAttribute("class").Contains("even");
-            trs[2].GetAttribute("class").Contains("odd");
-            trs[3].GetAttribute("class").Contains("even");
-            trs[4].GetAttribute("class").Contains("odd");
+            trs[1].GetAttribute("class").Should().Contain("even");
+            trs[2].GetAttribute("class").Should().Contain("odd");
+            trs[3].GetAttribute("class").Should().Contain("even");
+            trs[4].GetAttribute("class").Should().Contain("odd");
         }
 
         public class TableRowValidatorTest : TableRowValidator


### PR DESCRIPTION
## Description
Fixes the test case `TableRowClassStyleTest`.

Currently the test case uses only `.Contains()` method which only returns a bool value and doesn't actually verify whether the result is true of false.

Replacing `.Contains()` with `.Should().Contain()` ensures that the test properly verifies if the string really contains the expected substring.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
