### PR TITLE
MudAutocomplete: Fix unintended autofocus when adornment clicked

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
@@ -31,14 +31,12 @@
     string[] _values = ["Foo", "Bar", "Baz"];
     bool _dialogVisible = false;
 
-    private async Task<IEnumerable<string>> SearchValues(string value, CancellationToken token)
+    private Task<IEnumerable<string>> SearchValues(string value, CancellationToken token)
     {
         if (string.IsNullOrEmpty(value))
-            return _values;
+            return Task.FromResult<IEnumerable<string>>(_values);
 
-        await Task.CompletedTask;
-
-        return _values.Where(v => v.Contains(value, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult<IEnumerable<string>>(_values.Where(v => v.Contains(value, StringComparison.OrdinalIgnoreCase)));
     }
 
     private void OpenDialog()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
@@ -1,0 +1,53 @@
+﻿@using System.Threading
+
+<MudAutocomplete T="string"
+Variant="Variant.Outlined"
+Value="@_value"
+Label="Values"
+SearchFunc="SearchValues"
+ResetValueOnEmptyText="true"
+Adornment="Adornment.End"
+AdornmentIcon="@Icons.Material.Filled.Add"
+OnAdornmentClick="OpenDialog" />
+
+<MudDialog @bind-Visible="_dialogVisible">
+    <TitleContent>
+        Dialog Title
+    </TitleContent>
+    <DialogContent>
+        Dialog Content
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CloseDialog">
+            Cancel
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public static string __description__ = " Adornment Click should not automatically open popover ";
+
+    string _value = "Foo";
+    string[] _values = ["Foo", "Bar", "Baz"];
+    bool _dialogVisible = false;
+
+    private async Task<IEnumerable<string>> SearchValues(string value, CancellationToken token)
+    {
+        if (string.IsNullOrEmpty(value))
+            return _values;
+
+        await Task.CompletedTask;
+
+        return _values.Where(v => v.Contains(value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void OpenDialog()
+    {
+        _dialogVisible = true;
+    }
+
+    private void CloseDialog()
+    {
+        _dialogVisible = false;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentClickHandlingTest.razor
@@ -1,14 +1,14 @@
 ﻿@using System.Threading
 
 <MudAutocomplete T="string"
-Variant="Variant.Outlined"
-Value="@_value"
-Label="Values"
-SearchFunc="SearchValues"
-ResetValueOnEmptyText="true"
-Adornment="Adornment.End"
-AdornmentIcon="@Icons.Material.Filled.Add"
-OnAdornmentClick="OpenDialog" />
+                 Variant="Variant.Outlined"
+                 Value="@_value"
+                 Label="Values"
+                 SearchFunc="SearchValues"
+                 ResetValueOnEmptyText="true"
+                 Adornment="Adornment.End"
+                 AdornmentIcon="@Icons.Material.Filled.Add"
+                 OnAdornmentClick="OpenDialog" />
 
 <MudDialog @bind-Visible="_dialogVisible">
     <TitleContent>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -998,7 +998,7 @@ namespace MudBlazor
         {
             if (OnAdornmentClick.HasDelegate)
             {
-                await FocusAsync();
+
                 await OnAdornmentClick.InvokeAsync();
             }
             else


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #10817 
AdornmentClickHandler was triggering focus when the adornment has a delegate. Now it does not, the delegate can decide whether to open the menu using the public methods inside the click handler.
This is a regression from a previous PR.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
all existing unit tests still complete, visually checked all viewer tests as well as docs.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
