### PR TITLE
MudDataGrid: Use key row item instead of row index.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridUniqueRowKeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridUniqueRowKeyTest.razor
@@ -1,0 +1,22 @@
+﻿
+@* The input element will be tested to see if it gets recreated when row order changes. *@
+<MudDataGrid Items="@_items" ReadOnly="false" EditMode="DataGridEditMode.Cell">
+    <Columns>
+        <PropertyColumn Property="x => x" Grouping="Group">
+            <EditTemplate>
+                <MudInput T="string"></MudInput>
+            </EditTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    [Parameter]
+    public bool Group { get; set; }
+
+    private readonly IEnumerable<string> _items = new List<string>
+    {
+        "Item1", 
+        "Item2",
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5029,5 +5029,37 @@ namespace MudBlazor.UnitTests.Components
             else
                 test.GetGroupIcon(isExpanded, isRightToLeft).Should().Be(isRightToLeft ? Icons.Material.Filled.ChevronLeft : Icons.Material.Filled.ChevronRight);
         }
+
+        /// <summary>
+        /// Verifies data grid does not reuse row child components for different items (the @key for the row is set to the user supplied item).
+        /// </summary>
+        [Test]
+        public async Task DataGridUniqueRowKey()
+        {
+            //Test the normal case
+            var comp = Context.RenderComponent<DataGridUniqueRowKeyTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<string>>();
+
+            var sortByColumnName = dataGrid.Instance.RenderedColumns.FirstOrDefault().PropertyName;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync(sortByColumnName, SortDirection.Ascending, x => { return x; }));
+            var before = dataGrid.FindComponent<MudInput<string>>();
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync(sortByColumnName, SortDirection.Descending, x => { return x; }));
+            var after = dataGrid.FindComponent<MudInput<string>>();
+
+            before.Should().NotBeSameAs(after, because: "If the @key is correctly set to the row item, child components will be recreated on row reordering.");
+
+
+            //Test the expanded group case
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.Group, true));
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllGroups());
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync(sortByColumnName, SortDirection.Ascending, x => { return x; }));
+            before = dataGrid.FindComponent<MudInput<string>>();
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync(sortByColumnName, SortDirection.Descending, x => { return x; }));
+            after = dataGrid.FindComponent<MudInput<string>>();
+
+            before.Should().NotBeSameAs(after, because: "If the @key is correctly set to the row item, child components will be recreated on row reordering.");
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -269,7 +269,7 @@
                                             <ChildContent>
                                                 @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(itemBag.Item, itemBag.Index)).Build(); }
                                                 @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(itemBag.Item, itemBag.Index)).Build(); }
-                                                <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Index"
+                                                <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Item"
                                                     @onclick="@((args) => OnRowClickedAsync(args, itemBag.Item, itemBag.Index))"
                                                     @oncontextmenu="@((args) => OnContextMenuClickedAsync(args, itemBag.Item, itemBag.Index))"
                                                     @oncontextmenu:preventDefault="@(RowContextMenuClick.HasDelegate)">
@@ -330,7 +330,7 @@
                                     <ChildContent>
                                         @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(itemBag.Item, itemBag.Index)).Build(); }
                                         @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(itemBag.Item, itemBag.Index)).Build(); }
-                                        <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Index" 
+                                        <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Item" 
                                             @onclick="@((args) => OnRowClickedAsync(args, itemBag.Item, itemBag.Index))" 
                                             @oncontextmenu="@((args) => OnContextMenuClickedAsync(args, itemBag.Item, itemBag.Index))"
                                             @oncontextmenu:preventDefault="@(RowContextMenuClick.HasDelegate ? true : false)">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
This is reverting a change made for .net 8 version of MudBlazor that causes issues (not sure exactly when it was done).

MudDataGrid was changed such that the `<tr>` elements were given a `@key` equal to the row index of the `<tr>` instead of the user supplied item. This does not match the purpose of `@key` which is to help maintain the relationship between Blazor components in a sequence and their corresponding models. This can cause odd and subtle issues. See bug report for details.

fixes #10802

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually confirmed using code referenced in Reproduction link of #10802.
Also added bUnit test that verifies child components of rows are recreated - indicating the row's key is using the row item. Verified the test fails with the old MudDataGrid code (which keys off row index) and passes with new code (keys off row item).

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
