### PR TITLE
Possibility to set Snackbar position in config

### DIFF
--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor
@@ -10,9 +10,12 @@
     #nullable enable
 }
 
-<div @attributes="UserAttributes" id="mud-snackbar-container" class="@Classname" style="@Style">
-    @foreach (var snackbar in Snackbar)
-    {
-        <MudSnackbarElement @key="snackbar" Snackbar="@snackbar"></MudSnackbarElement>
-    }
-</div>
+@foreach(var position in Snackbar.Select(x => x.PositionClass).Distinct())
+{
+    <div @attributes="UserAttributes" id="mud-snackbar-container" class="@GetClassname(position)" style="@Style">
+        @foreach (var snackbar in Snackbar.Where(x => x.PositionClass == position))
+        {
+            <MudSnackbarElement @key="snackbar" Snackbar="@snackbar"></MudSnackbarElement>
+        }
+    </div>
+}

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
@@ -21,14 +21,14 @@ namespace MudBlazor
                 ? Snackbars.ShownSnackbars.Reverse()
                 : Snackbars.ShownSnackbars;
 
-        protected string Classname =>
+        protected string GetClassname(string? snackbarPositionClass) =>
             new CssBuilder(Class)
-                .AddClass(GetPositionClass())
+                .AddClass(GetPositionClass(snackbarPositionClass))
                 .Build();
 
-        private string GetPositionClass()
+        private string GetPositionClass(string? snackbarPositionClass)
         {
-            var positionClass = Snackbars.Configuration.PositionClass;
+            var positionClass = snackbarPositionClass ?? Snackbars.Configuration.PositionClass;
             return positionClass switch
             {
                 Defaults.Classes.Position.BottomStart => RightToLeft ? Defaults.Classes.Position.BottomRight : Defaults.Classes.Position.BottomLeft,

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -40,6 +40,8 @@ namespace MudBlazor
         /// </summary>
         public Severity Severity => State.Options.Severity;
 
+        public string? PositionClass => State.Options.PositionClass;
+
         internal Snackbar(SnackbarMessage message, SnackbarOptions options)
         {
             SnackbarMessage = message;

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -101,6 +101,14 @@ namespace MudBlazor
         public SnackbarDuplicatesBehavior DuplicatesBehavior { get; set; } = SnackbarDuplicatesBehavior.GlobalDefault;
 
         /// <summary>
+        /// The Position Class for the snackbar. When null the positon from <see cref="SnackbarConfiguration.PositionClass"/> is used.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
+        public string? PositionClass { get; set; }
+
+        /// <summary>
         /// Creates new options for a snackbar.
         /// </summary>
         /// <param name="severity">The severity of the snackbar to display.</param>


### PR DESCRIPTION
## Description
This adds the possibility to define the position of each snackbar. As the position of the snackbar is defined in the `mud-snackbar-container` multiple containers are shown for each position of the snackbars.
resolves #2863
There is still a glitch: if one snackbar disappears all other containers disappear for a short time (animation?) This may someone else have to have a look at.

## How Has This Been Tested?
visually
If the changes are accepted I could also try to add UnitTests if necessary

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
