### PR TITLE
MudChart: Fix so chart type Line uses ChartOptions.YAxisRequireZeroPoint (#10832)

### DIFF
--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -72,6 +72,14 @@ namespace MudBlazor.Charts
             {
                 var minY = _series.SelectMany(series => series.Data).Min();
                 var maxY = _series.SelectMany(series => series.Data).Max();
+
+                var includeYAxisZeroPoint = MudChartParent?.ChartOptions.YAxisRequireZeroPoint ?? false;
+                if (includeYAxisZeroPoint)
+                {
+                    minY = Math.Min(minY, 0); // we want to include the 0 in the grid
+                    maxY = Math.Max(maxY, 0); // we want to include the 0 in the grid
+                }
+
                 lowestHorizontalLine = (int)Math.Floor(minY / gridYUnits);
                 var highestHorizontalLine = (int)Math.Ceiling(maxY / gridYUnits);
                 numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -53,6 +53,14 @@ namespace MudBlazor
         /// Defaults to <c>false</c>.
         /// </remarks>
         public bool XAxisLines { get; set; }
+
+        /// <summary>
+        /// Shows zero point on vertical axis.
+        /// Only takes effect when the <see cref="MudChart"/> type is <see cref="ChartType.Line"/> or <see cref="MudTimeSeriesChartBase" /> is used.
+        /// <remarks>
+        /// Defaults to <c>false</c>
+        /// </remarks>
+        /// </summary>
         public bool YAxisRequireZeroPoint { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fix so chart type Line uses ChartOptions.YAxisRequireZeroPoint (#10832)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This fix resolves bug #10832.
Having a MudChart of type ChartType.Line with all data points in ChartSeries between say 800-1000, the zero point on Y-axis is not displayed despite property YAxisRequireZeroPoint=true in the ChartOptions object.
Charts of type MudTimeSeriesChart (which also is a variant of a line chart) uses ChartOptions.YAxisRequireZeroPoint.
This fix will add same behaviour to line chart as MudTimeSeriesChart so the zero point of the Y-axis will be displayed when YAxisRequireZeroPoint=true. Same behaviour as previously when YAxisRequireZeroPoint=false.

## How Has This Been Tested?
Tested visually with MudBlazor.Docs project by adjusting the chart data and ChartOptions.YAxisRequireZeroPoint = true in an example line chart.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
