### PR TITLE
Docs: Add XML Documentation for MudThemeProvider-MudTimePicker

### DIFF
--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor.State;
@@ -11,6 +9,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
+
+/// <summary>
+/// Provides a standard set of colors, shapes, sizes and shadows to a layout.
+/// </summary>
+/// <seealso cref="MudTheme"/>
 partial class MudThemeProvider : ComponentBaseWithState, IDisposable
 {
     // private const string Breakpoint = "mud-breakpoint";
@@ -40,26 +43,37 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     public MudTheme? Theme { get; set; }
 
     /// <summary>
-    ///  If true, will not apply MudBlazor styled scrollbar and use browser default. 
+    /// Uses the browser default scrollbar instead of the MudBlazor scrollbar. 
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
     [Parameter]
     public bool DefaultScrollbar { get; set; }
 
     /// <summary>
-    /// Sets a value indicating whether to observe changes in the system theme preference.
-    /// Default is <c>true</c>.
+    /// Detects when the system theme has changed between Light Mode and Dark Mode.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.<br />
+    /// When <c>true</c>, the theme will automatically change to Light Mode or Dark Mode as the system theme changes.
+    /// </remarks>
     [Parameter]
     public bool ObserveSystemThemeChange { get; set; } = true;
 
     /// <summary>
-    /// The active palette of the theme.
+    /// Uses darker colors for all MudBlazor components.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>. When this value changes, <see cref="IsDarkModeChanged"/> occurs.<br />  
+    /// When <c>true</c>, the <see cref="MudTheme.PaletteDark"/> colors will be used.<br />  
+    /// When <c>false</c>, the <see cref="MudTheme.PaletteLight"/> colors will be used.<br />  
+    /// </remarks>
     [Parameter]
     public bool IsDarkMode { get; set; }
 
     /// <summary>
-    /// Invoked when the dark mode changes.
+    /// Occurs when <see cref="IsDarkMode"/> has changed.
     /// </summary>
     [Parameter]
     public EventCallback<bool> IsDarkModeChanged { get; set; }
@@ -79,9 +93,12 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     }
 
     /// <summary>
-    /// Returns the dark mode preference of the user. True if dark mode is preferred.
+    /// Gets whether the system is using Dark Mode.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>
+    /// When <c>true</c>, the system is using Dark Mode.<br />
+    /// When <c>false</c>, the system is using Light Mode.
+    /// </returns>
     public async Task<bool> GetSystemPreference()
     {
         var (_, value) = await JsRuntime.InvokeAsyncWithErrorHandling(false, "darkModeChange");
@@ -89,6 +106,13 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         return value;
     }
 
+    /// <summary>
+    /// Calls a function when the system theme has changed.
+    /// </summary>
+    /// <param name="functionOnChange">The function to call when the system theme has changed.</param>
+    /// <remarks>
+    /// A value of <c>true</c> is passed if the system is now in Dark Mode.  Otherwise, the system is now in Light Mode.
+    /// </remarks>
     public Task WatchSystemPreference(Func<bool, Task> functionOnChange)
     {
         _darkLightModeChanged += functionOnChange;
@@ -96,6 +120,10 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Occurs when the system theme has changed.
+    /// </summary>
+    /// <param name="isDarkMode">When <c>true</c>, the system is in Dark Mode.</param>
     [JSInvokable]
     public async Task SystemPreferenceChanged(bool isDarkMode)
     {
@@ -107,6 +135,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         }
     }
 
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -121,12 +150,14 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         await base.OnAfterRenderAsync(firstRender);
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         _theme = Theme ?? new MudTheme();
         base.OnInitialized();
     }
 
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
         if (Theme is not null)
@@ -140,6 +171,10 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         base.OnParametersSet();
     }
 
+    /// <summary>
+    /// Gets the CSS styles for this provider.
+    /// </summary>
+    /// <returns>A <c>style</c> HTML element containing this theme's styles.</returns>
     protected string BuildTheme()
     {
         _theme = Theme ?? new MudTheme();
@@ -154,6 +189,10 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         return theme.ToString();
     }
 
+    /// <summary>
+    /// Gets the CSS styles for the browser scrollbar.
+    /// </summary>
+    /// <returns>A <c>style</c> HTML element containing the scrollbar's styles.</returns>
     protected static string BuildMudBlazorScrollbar()
     {
         var scrollbar = new StringBuilder();
@@ -169,6 +208,13 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         return scrollbar.ToString();
     }
 
+    /// <summary>
+    /// Generates the CSS styles for the specified theme.
+    /// </summary>
+    /// <param name="theme">The theme to append to.</param>
+    /// <remarks>
+    /// Several CSS values for color, opacity, and elevation are appended based on the value of <see cref="IsDarkMode"/>.
+    /// </remarks>
     protected virtual void GenerateTheme(StringBuilder theme)
     {
         if (_theme is null)
@@ -479,6 +525,9 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         theme.AppendLine($"--mud-native-html-color-scheme: {(IsDarkMode ? "dark" : "light")};");
     }
 
+    /// <summary>
+    /// Releases resources used by this component.
+    /// </summary>
     public void Dispose()
     {
         if (!_disposed)

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -111,7 +111,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     /// </summary>
     /// <param name="functionOnChange">The function to call when the system theme has changed.</param>
     /// <remarks>
-    /// A value of <c>true</c> is passed if the system is now in Dark Mode.  Otherwise, the system is now in Light Mode.
+    /// A value of <c>true</c> is passed if the system is now in Dark Mode. Otherwise, the system is now in Light Mode.
     /// </remarks>
     public Task WatchSystemPreference(Func<bool, Task> functionOnChange)
     {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -114,7 +114,7 @@ namespace MudBlazor
         /// The amount of time, in milliseconds, to wait before closing the picker.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>200</c>.  The delay gives users a moment to see the selected time before the popover disappears.
+        /// Defaults to <c>200</c>. The delay gives users a moment to see the selected time before the popover disappears.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -124,7 +124,7 @@ namespace MudBlazor
         /// Closes this picker when the value is set or cleared.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  When <c>true</c> and <c>PickerActions</c> are defined, 
+        /// Defaults to <c>false</c>. When <c>true</c> and <c>PickerActions</c> are defined, 
         /// the hour and the minutes can be selected and the drop-down will close without having to 
         /// click any of the action buttons.
         /// </remarks>
@@ -136,7 +136,7 @@ namespace MudBlazor
         /// The step interval when selecting minutes.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>1</c>.  For example: a value of <c>15</c> would only let minutes of <c>0</c>, <c>15</c>, 
+        /// Defaults to <c>1</c>. For example: a value of <c>15</c> would allow minutes <c>0</c>, <c>15</c>, 
         /// <c>30</c>, and <c>45</c> be selected.
         /// </remarks>
         [Parameter]

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -13,6 +13,11 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+    /// <summary>
+    /// A component for selecting time values.
+    /// </summary>
+    /// <seealso cref="MudDatePicker"/>
+    /// <seealso cref="MudDateRangePicker"/>
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
         private const string Format24Hours = "HH:mm";
@@ -86,46 +91,66 @@ namespace MudBlazor
         internal TimeSpan? TimeIntermediate { get; private set; }
 
         /// <summary>
-        /// First view to show in the MudDatePicker.
+        /// The initial view for this picker.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="OpenTo.Hours"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public OpenTo OpenTo { get; set; } = OpenTo.Hours;
 
         /// <summary>
-        /// Selects the edit mode. By default, you can edit hours and minutes.
+        /// Controls which values can be edited.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimeEditMode.Normal"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public TimeEditMode TimeEditMode { get; set; } = TimeEditMode.Normal;
 
         /// <summary>
-        /// Sets the amount of time in milliseconds to wait before closing the picker.
+        /// The amount of time, in milliseconds, to wait before closing the picker.
         /// </summary>
         /// <remarks>
-        /// This helps the user see that the time was selected before the popover disappears.
+        /// Defaults to <c>200</c>.  The delay gives users a moment to see the selected time before the popover disappears.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int ClosingDelay { get; set; } = 200;
 
         /// <summary>
-        /// If true and PickerActions are defined, the hour and the minutes can be defined without any action.
+        /// Closes this picker when the value is set or cleared.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c> and <c>PickerActions</c> are defined, 
+        /// the hour and the minutes can be selected and the drop-down will close without having to 
+        /// click any of the action buttons.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public bool AutoClose { get; set; }
 
         /// <summary>
-        /// Sets the number interval for minutes.
+        /// The step interval when selecting minutes.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>1</c>.  For example: a value of <c>15</c> would only let minutes of <c>0</c>, <c>15</c>, 
+        /// <c>30</c>, and <c>45</c> be selected.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int MinuteSelectionStep { get; set; } = 1;
 
         /// <summary>
-        /// If true, enables 12 hour selection clock.
+        /// Shows a 12-hour selection clock.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.<br />
+        /// When <c>true</c>, hours 1-12 are displayed with an AM or PM marker.<br />
+        /// When <c>false</c>, hours 0-23 are displayed.<br />
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool AmPm
@@ -151,8 +176,17 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// String format for selected time view.
+        /// The format applied to time values.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>hh:mm tt</c> when <see cref="AmPm"/> is <c>true</c>, otherwise <c>HH:mm</c>.<br />
+        /// Format strings are typically a combination of these characters:<br />
+        /// * <c>h</c> (lowercase) for hours in 12-hour time, <br />
+        /// * <c>H</c> (uppercase) for hours in 24-hour time, <br />
+        /// * <c>m</c> for minutes,<br />
+        /// * <c>tt</c> for AM/PM markers.<br />
+        /// For example: <c>h:mm tt</c> would display <c>6:32 PM</c>, and <c>HH:mm</c> would display <c>18:32</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string TimeFormat
@@ -177,8 +211,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The currently selected time (two-way bindable). If <c>null</c>, nothing was selected.
+        /// The currently selected time.
         /// </summary>
+        /// <remarks>
+        /// When this value changes, <see cref="TimeChanged"/> occurs.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Data)]
         public TimeSpan? Time
@@ -187,6 +224,11 @@ namespace MudBlazor
             set => SetTimeAsync(value, true).CatchAndLog();
         }
 
+        /// <summary>
+        /// Sets the selected time value.
+        /// </summary>
+        /// <param name="time">The new value to set.</param>
+        /// <param name="updateValue">When <c>true</c>, the <c>Text</c> will also be updated.</param>
         protected async Task SetTimeAsync(TimeSpan? time, bool updateValue)
         {
             if (_value != time)
@@ -207,10 +249,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Fired when the date changes.
+        /// Occurs when <see cref="Time"/> has changed.
         /// </summary>
         [Parameter] public EventCallback<TimeSpan?> TimeChanged { get; set; }
 
+        /// <inheritdoc />
         protected override Task StringValueChangedAsync(string value)
         {
             Touched = true;
@@ -219,8 +262,8 @@ namespace MudBlazor
             return SetTimeAsync(Converter.Get(value), false);
         }
 
-        // The last line cannot be tested.
-        [ExcludeFromCodeCoverage]
+        /// <inheritdoc />
+        [ExcludeFromCodeCoverage] // The last line cannot be tested.
         protected override async Task OnPickerOpenedAsync()
         {
             await base.OnPickerOpenedAsync();
@@ -233,6 +276,7 @@ namespace MudBlazor
             };
         }
 
+        /// <inheritdoc />
         protected internal override Task SubmitAsync()
         {
             if (GetReadOnlyState())
@@ -245,6 +289,7 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
+        /// <inheritdoc />
         public override async Task ClearAsync(bool close = true)
         {
             TimeIntermediate = null;
@@ -256,6 +301,10 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// Gets the hour portion of the selected time.
+        /// </summary>
+        /// <returns>A two-character string depending on whether <see cref="AmPm"/> is set, or <c>--</c> if no value is set.</returns>
         private string GetHourString()
         {
             if (TimeIntermediate == null)
@@ -267,6 +316,10 @@ namespace MudBlazor
             return $"{Math.Min(23, Math.Max(0, h)):D2}";
         }
 
+        /// <summary>
+        /// Gets the minute portion of the selected time.
+        /// </summary>
+        /// <returns>A two-digit string for minutes, or <c>--</c> if no value is set.</returns>
         private string GetMinuteString()
         {
             if (TimeIntermediate == null)
@@ -506,6 +559,7 @@ namespace MudBlazor
 
         protected ElementReference ClockElementReference { get; private set; }
 
+        /// <inheritdoc />
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
@@ -546,19 +600,21 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// <c>true</c> while the main pointer button is held down and moving.
+        /// Whether the pointer button is held down and moving.
         /// </summary>
         /// <remarks>
-        /// Disables clock animations.
+        /// When <c>true</c>, clock animations are disabled.
         /// </remarks>
         public bool PointerMoving { get; set; }
 
         /// <summary>
         /// Updates the position of the hands on the clock.
-        /// This method is called by the JavaScript events.
         /// </summary>
         /// <param name="value">The minute or hour.</param>
         /// <param name="pointerMoving">Is the pointer being moved?</param>
+        /// <remarks>
+        /// This method is invoked via JavaScript.
+        /// </remarks>
         [JSInvokable]
         public async Task SelectTimeFromStick(int value, bool pointerMoving)
         {
@@ -589,9 +645,11 @@ namespace MudBlazor
 
         /// <summary>
         /// Performs the click action for the sticks.
-        /// This method is called by the JavaScript events.
         /// </summary>
         /// <param name="value">The minute or hour.</param>
+        /// <remarks>
+        /// This method is invoked via JavaScript.
+        /// </remarks>
         [JSInvokable]
         public async Task OnStickClick(int value)
         {

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -8,6 +8,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// Displays items in chronological order.
+    /// </summary>
+    /// <seealso cref="MudTimelineItem"/>
     public partial class MudTimeline : MudBaseItemsControl<MudTimelineItem>
     {
         protected string Classnames =>
@@ -25,36 +30,55 @@ namespace MudBlazor
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Sets the orientation of the timeline and its timeline items.
+        /// The orientation of the timeline and its items.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimelineOrientation.Vertical"/>.<br />
+        /// When set to <see cref="TimelineOrientation.Vertical"/>, <see cref="TimelinePosition"/> can be set to <c>Left</c>, <c>Right</c>, <c>Alternate</c>, <c>Start</c>, or <c>End</c>.<br />
+        /// When set to <see cref="TimelineOrientation.Horizontal"/>, <see cref="TimelinePosition"/> can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c>.<br />
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public TimelineOrientation TimelineOrientation { get; set; } = TimelineOrientation.Vertical;
 
         /// <summary>
-        /// The position the timeline itself and how the timeline items should be displayed.
+        /// The position the timeline and how its items are displayed.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimelinePosition.Alternate"/>.<br />
+        /// Can be set to <c>Left</c>, <c>Right</c>, <c>Alternate</c>, <c>Start</c>, or <c>End</c> when <see cref="TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
+        /// Can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c> when <see cref="TimelineOrientation"/> is <see cref="TimelineOrientation.Horizontal"/>.<br />
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public TimelinePosition TimelinePosition { get; set; } = TimelinePosition.Alternate;
 
         /// <summary>
-        /// Aligns the dot and any item modifiers is changed, in default mode they are centered to the item.
+        /// The position of each item's dot relative to its text.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimelineAlign.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public TimelineAlign TimelineAlign { get; set; } = TimelineAlign.Default;
 
         /// <summary>
-        /// Reverse the order of TimelineItems when TimelinePosition is set to Alternate.
+        /// Reverses the order of items when <see cref="TimelinePosition"/> is <see cref="TimelinePosition.Alternate"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public bool Reverse { get; set; } = false;
 
         /// <summary>
-        /// If true, enables all TimelineItem modifiers, like adding a caret to a MudCard. Enabled by default.
+        /// Enables modifiers for items, such as adding a caret for a <see cref="MudCard"/>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public bool Modifiers { get; set; } = true;

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="TimelineOrientation.Vertical"/>.<br />
         /// When set to <see cref="TimelineOrientation.Vertical"/>, <see cref="TimelinePosition"/> can be set to <c>Left</c>, <c>Right</c>, <c>Alternate</c>, <c>Start</c>, or <c>End</c>.<br />
-        /// When set to <see cref="TimelineOrientation.Horizontal"/>, <see cref="TimelinePosition"/> can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c>.<br />
+        /// When set to <see cref="TimelineOrientation.Horizontal"/>, <see cref="TimelinePosition"/> can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -47,7 +47,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="TimelinePosition.Alternate"/>.<br />
         /// Can be set to <c>Left</c>, <c>Right</c>, <c>Alternate</c>, <c>Start</c>, or <c>End</c> when <see cref="TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
-        /// Can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c> when <see cref="TimelineOrientation"/> is <see cref="TimelineOrientation.Horizontal"/>.<br />
+        /// Can be set to <c>Top</c>, <c>Bottom</c>, or <c>Alternate</c> when <see cref="TimelineOrientation"/> is <see cref="TimelineOrientation.Horizontal"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]

--- a/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
@@ -2,14 +2,17 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
 #nullable enable
+
+    /// <summary>
+    /// A chronological item displayed as part of a <see cref="MudTimeline"/>
+    /// </summary>
+    /// <seealso cref="MudTimeline"/>
     public partial class MudTimelineItem : MudComponentBase, IDisposable
     {
         protected string Classnames =>
@@ -34,89 +37,123 @@ namespace MudBlazor
         protected internal MudBaseItemsControl<MudTimelineItem>? Parent { get; set; }
 
         /// <summary>
-        /// Dot Icon
+        /// (Obsolete)  The icon displayed for the dot.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public string? Icon { get; set; }
 
         /// <summary>
-        /// Variant of the dot.
+        /// The display variant for the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Variant.Outlined"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public Variant Variant { get; set; } = Variant.Outlined;
 
         /// <summary>
-        /// User styles, applied to the lineItem dot.
+        /// The CSS styles applied to the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Styles such as <c>background-color</c> can be applied (e.g. <c>background-color:red;</c>).
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public string? DotStyle { get; set; }
 
         /// <summary>
-        /// Color of the dot.
+        /// The color of the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// Size of the dot.
+        /// The size of the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Small"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public Size Size { get; set; } = Size.Small;
 
         /// <summary>
-        /// Elevation of the dot. The higher the number, the heavier the drop-shadow.
+        /// The size of the dot's drop shadow.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>1</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public int Elevation { set; get; } = 1;
 
         /// <summary>
-        /// Overrides Timeline Parents default sorting method in Default and Reverse mode.
+        /// Overrides <see cref="MudTimeline.TimelineAlign"/> with a custom value.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimelineAlign.Default"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public TimelineAlign TimelineAlign { get; set; }
 
         /// <summary>
-        /// If true, dot will not be displayed.
+        /// Hides the dot for this item.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public bool HideDot { get; set; }
 
         /// <summary>
-        /// If used renders child content of the ItemOpposite.
+        /// The custom content for the opposite side of this item.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public RenderFragment? ItemOpposite { get; set; }
 
         /// <summary>
-        /// If used renders child content of the ItemContent.
+        /// The custom content for this item.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Only applies if <see cref="ChildContent"/> is <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public RenderFragment? ItemContent { get; set; }
 
         /// <summary>
-        /// If used renders child content of the ItemDot.
+        /// The custom content for the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public RenderFragment? ItemDot { get; set; }
 
         /// <summary>
-        /// Optional child content if no other RenderFragments is used.
+        /// The custom content for the entire item.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  When set, <see cref="ItemContent"/> will not be displayed.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
+        /// <inheritdoc />
         protected override Task OnInitializedAsync()
         {
             Parent?.Items.Add(this);
@@ -130,6 +167,9 @@ namespace MudBlazor
             Parent?.MoveTo(myIndex ?? 0);
         }
 
+        /// <summary>
+        /// Releases resources used by this component.
+        /// </summary>
         public void Dispose()
         {
             Parent?.Items.Remove(this);

--- a/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
@@ -37,7 +37,7 @@ namespace MudBlazor
         protected internal MudBaseItemsControl<MudTimelineItem>? Parent { get; set; }
 
         /// <summary>
-        /// (Obsolete)  The icon displayed for the dot.
+        /// (Obsolete) The icon displayed for the dot.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
@@ -57,7 +57,7 @@ namespace MudBlazor
         /// The CSS styles applied to the dot.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>null</c>.  Styles such as <c>background-color</c> can be applied (e.g. <c>background-color:red;</c>).
+        /// Defaults to <c>null</c>. Styles such as <c>background-color</c> can be applied (e.g. <c>background-color:red;</c>).
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
@@ -87,7 +87,7 @@ namespace MudBlazor
         /// The size of the dot's drop shadow.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>1</c>.  A higher number creates a heavier drop shadow.  Use a value of <c>0</c> for no shadow.
+        /// Defaults to <c>1</c>. A higher number creates a heavier drop shadow. Use a value of <c>0</c> for no shadow.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
@@ -127,7 +127,7 @@ namespace MudBlazor
         /// The custom content for this item.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>null</c>.  Only applies if <see cref="ChildContent"/> is <c>null</c>.
+        /// Defaults to <c>null</c>. Only applies if <see cref="ChildContent"/> is <c>null</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]
@@ -147,7 +147,7 @@ namespace MudBlazor
         /// The custom content for the entire item.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>null</c>.  When set, <see cref="ItemContent"/> will not be displayed.
+        /// Defaults to <c>null</c>. When set, <see cref="ItemContent"/> will not be displayed.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Behavior)]

--- a/src/MudBlazor/Enums/TimeEditMode.cs
+++ b/src/MudBlazor/Enums/TimeEditMode.cs
@@ -1,9 +1,26 @@
-﻿namespace MudBlazor
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+/// <summary>
+/// Indicates the editable values of a <see cref="MudTimePicker"/>.
+/// </summary>
+public enum TimeEditMode
 {
-    public enum TimeEditMode
-    {
-        Normal,
-        OnlyMinutes,
-        OnlyHours
-    }
+    /// <summary>
+    /// Hours and minutes can be edited.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// Only minutes can be edited.
+    /// </summary>
+    OnlyMinutes,
+
+    /// <summary>
+    /// Only hours can be edited.
+    /// </summary>
+    OnlyHours
 }

--- a/src/MudBlazor/Enums/TimelineAlign.cs
+++ b/src/MudBlazor/Enums/TimelineAlign.cs
@@ -1,14 +1,27 @@
 ﻿using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Specifies the alignment of each item's dot relative to its text in a <see cref="MudTimeline"/>.
+/// </summary>
+public enum TimelineAlign
 {
-    public enum TimelineAlign
-    {
-        [Description("default")]
-        Default,
-        [Description("start")]
-        Start,
-        [Description("end")]
-        End
-    }
+    /// <summary>
+    /// The dot is centered relative to its text.
+    /// </summary>
+    [Description("default")]
+    Default,
+
+    /// <summary>
+    /// The dot is aligned with the start of the text.
+    /// </summary>
+    [Description("start")]
+    Start,
+
+    /// <summary>
+    /// The dot is aligned with the end of the text.
+    /// </summary>
+    [Description("end")]
+    End
 }

--- a/src/MudBlazor/Enums/TimelineOrientation.cs
+++ b/src/MudBlazor/Enums/TimelineOrientation.cs
@@ -1,12 +1,21 @@
 ﻿using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Specifies the orientation of items in a <see cref="MudTimeline"/>
+/// </summary>
+public enum TimelineOrientation
 {
-    public enum TimelineOrientation
-    {
-        [Description("vertical")]
-        Vertical,
-        [Description("horizontal")]
-        Horizontal
-    }
+    /// <summary>
+    /// Items are displayed vertically.
+    /// </summary>
+    [Description("vertical")]
+    Vertical,
+
+    /// <summary>
+    /// Items are displayed horizontally.
+    /// </summary>
+    [Description("horizontal")]
+    Horizontal
 }

--- a/src/MudBlazor/Enums/TimelinePosition.cs
+++ b/src/MudBlazor/Enums/TimelinePosition.cs
@@ -1,22 +1,73 @@
 ﻿using System.ComponentModel;
 
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// Specifies how items are drawn in a <see cref="MudTimeline" />.
+/// </summary>
+public enum TimelinePosition
 {
-    public enum TimelinePosition
-    {
-        [Description("alternate")]
-        Alternate,
-        [Description("top")]
-        Top,
-        [Description("bottom")]
-        Bottom,
-        [Description("left")]
-        Left,
-        [Description("right")]
-        Right,
-        [Description("start")]
-        Start,
-        [Description("end")]
-        End
-    }
+    /// <summary>
+    /// Items alternate on either side of centered dots.
+    /// </summary>
+    [Description("alternate")]
+    Alternate,
+
+    /// <summary>
+    /// Dots are displayed above the text of each timeline item.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Horizontal"/>.
+    /// </remarks>
+    [Description("top")]
+    Top,
+
+    /// <summary>
+    /// Dots are displayed below the text of each timeline item.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.
+    /// </remarks>
+    [Description("bottom")]
+    Bottom,
+
+    /// <summary>
+    /// Dots are displayed to the left of text for each timeline item.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.
+    /// </remarks>
+    [Description("left")]
+    Left,
+
+    /// <summary>
+    /// Dots are displayed to the right of text for each timeline item.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.
+    /// </remarks>
+    [Description("right")]
+    Right,
+
+    /// <summary>
+    /// Dots are displayed at the start based on the Right-to-Left setting of the <see cref="MudRTLProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
+    /// When Right-to-Left is enabled, the dots are displayed on the right of each item's text.<br />
+    /// When Right-to-Left is disabled, the dots are displayed on the left of each item's text.<br />
+    /// </remarks>
+    [Description("start")]
+    Start,
+
+    /// <summary>
+    /// Dots are displayed at the end based on the Right-to-Left setting of the <see cref="MudRTLProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
+    /// When Right-to-Left is enabled, the dots are displayed on the left of each item's text.<br />
+    /// When Right-to-Left is disabled, the dots are displayed on the right of each item's text.<br />
+    /// </remarks>
+    [Description("end")]
+    End
 }

--- a/src/MudBlazor/Enums/TimelinePosition.cs
+++ b/src/MudBlazor/Enums/TimelinePosition.cs
@@ -55,7 +55,7 @@ public enum TimelinePosition
     /// <remarks>
     /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
     /// When Right-to-Left is enabled, the dots are displayed on the right of each item's text.<br />
-    /// When Right-to-Left is disabled, the dots are displayed on the left of each item's text.<br />
+    /// When Right-to-Left is disabled, the dots are displayed on the left of each item's text.
     /// </remarks>
     [Description("start")]
     Start,
@@ -66,7 +66,7 @@ public enum TimelinePosition
     /// <remarks>
     /// Only applies if <see cref="MudTimeline.TimelineOrientation"/> is <see cref="TimelineOrientation.Vertical"/>.<br />
     /// When Right-to-Left is enabled, the dots are displayed on the left of each item's text.<br />
-    /// When Right-to-Left is disabled, the dots are displayed on the right of each item's text.<br />
+    /// When Right-to-Left is disabled, the dots are displayed on the right of each item's text.
     /// </remarks>
     [Description("end")]
     End


### PR DESCRIPTION
## Description

This update adds XML documentation for the following types:

* MudThemeProvider
* MudTimeline
  * MudTimelineItem
  * TimelinePosition
  * TimelineOrientation
  * TimelineAlign
* MudTimePicker
  * TimeEditMode
 
> [!TIP]  
> The parameter **MudTimelineItem.Icon** is unused.  Consider removing it as a breaking change for MudBlazor 9.

> [!TIP]  
> The parameter **MudTimelineItem.HideDot** is a negative property name.  Consider changing to **ShowDot** and reversing logic depending on it, as a breaking change for MudBlazor 9.

## How Has This Been Tested?

This was tested by examining the example Razor code for all affected components:

#### MudThemeProvider

![image](https://github.com/user-attachments/assets/cba134af-59cc-4af6-8603-76a83d960a9a)
![image](https://github.com/user-attachments/assets/86d87c55-a6a3-4b5b-8a65-f9dcc3a92fd7)
![image](https://github.com/user-attachments/assets/b531f490-0908-4e65-8b24-d946a34f8ae3)
![image](https://github.com/user-attachments/assets/9e6162c9-2e4c-40fb-8342-264a1f31bc7a)

#### MudTimeline

![image](https://github.com/user-attachments/assets/f442d9a3-3586-4da6-8c54-f55c19468d4d)
![image](https://github.com/user-attachments/assets/cd5fcc8b-a7a1-4a0f-bc5f-e41c7747991c)
![image](https://github.com/user-attachments/assets/f65fa6d0-5af5-4615-9025-0abd9a1e6f0f)
![image](https://github.com/user-attachments/assets/7d326680-0a06-4f66-8edc-bc6c8a5717d3)
![image](https://github.com/user-attachments/assets/c3c6aaa4-76d4-487f-870f-8764ae98c7b5)
![image](https://github.com/user-attachments/assets/45a81ce7-c73d-4553-a312-1c4c3ee3b632)

#### MudTimePicker

![image](https://github.com/user-attachments/assets/de3b8142-7f07-48ea-8b89-74db7b600b12)
![image](https://github.com/user-attachments/assets/3b39d2f2-d0b1-4d17-8b7f-5e1fdc3062a5)
![image](https://github.com/user-attachments/assets/352bdbfe-9142-434a-b9d0-f7ccc9674f87)

#### TimelineAlign

![image](https://github.com/user-attachments/assets/4f165a52-998f-4c6a-bd88-0e84a9d6b9ae)
![image](https://github.com/user-attachments/assets/b1e6e91b-7805-4f66-b3c0-b8e821eedcba)
![image](https://github.com/user-attachments/assets/b39da350-1d66-44ce-b9a2-3c223be91d1e)

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

## Checklist

- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
