### PR TITLE
MudChart: Fix radius error in donut chart (#8780)

### DIFF
--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor
@@ -1,9 +1,10 @@
 ﻿@namespace MudBlazor.Charts
+@using System.Globalization
 @inherits MudCategoryChartBase
 
 <svg @attributes="UserAttributes" class="mud-chart-donut" width="@ParentWidth" height="@ParentHeight" viewBox="0 0 42 42">
     <Filters />
-    <circle class="mud-donut-ring" cx="21" cy="21" r="@(100 / (2 * Math.PI))"></circle>
+    <circle class="mud-donut-ring" cx="21" cy="21" r="@((100 / (2 * Math.PI)).ToString(CultureInfo.InvariantCulture))"></circle>
     @foreach (var item in _circles)
     {
         <circle class="mud-chart-serie mud-donut-segment" @onclick="() => SelectedIndex = item.Index" stroke="@MudChartParent?.ChartOptions.ChartPalette.GetValue(item.Index % MudChartParent.ChartOptions.ChartPalette.Length)"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
The error is a JavaScript error `Error: <circle> attribute r: Expected length, "15,9154943091895…".` It only occurs on a server/machine with culture settings where the decimal character is ",". Attribute r can only be a number with "." as decimal character.

The problem is solved by formatting the number with `.ToString(CultureInfo.InvariantCulture)`

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested and verified in browser. The error does not occur after modification.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
