### PR TITLE
MudProgressLinear: Use MudGlobal.Rounded as default.

### DIFF
--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -84,7 +84,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
-        public bool Rounded { get; set; }
+        public bool Rounded { get; set; } = MudGlobal.Rounded == true;
 
         /// <summary>
         /// Displays animated stripes for the value portion of this progress bar.


### PR DESCRIPTION
## Description

The `Rounded` property of the `MudProgressLinear` should use the `MudGlobal.Rounded` property. The documentation already says it does, but it was not actually included in the implementation.

## How Has This Been Tested?

- Tested manually using the `MudBlazor.Docs.Server` by doing this in `Program.cs`:
```csharp
var builder = WebApplication.CreateBuilder(args);

MudGlobal.Rounded = true;

// Add services to the container.
builder.Services.AddControllersWithViews();
builder.Services.AddRazorPages();
builder.Services.AddServerSideBlazor();
builder.Services.AddHttpClient<GitHubApiClient>();
builder.Services.TryAddDocsViewServices();
builder.Services.AddHttpContextAccessor();
```
- No unittest added; It uses a static property and I found out that there aren't any unittests for the properties that are used there. I assume this is to prevent clashing unittests which make use of the same static properties which might cause race conditions in parallel unittests.

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
~- [ ] I've added relevant tests.~
