### PR TITLE
MudCollapse: Apply scroll to expanded content overflow

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpansionsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpansionsTest.razor
@@ -1,6 +1,14 @@
 ﻿<MudExpansionPanels>
-    <MudExpansionPanel Text="Panel One">
-        Panel One Content
+    <MudExpansionPanel Text="Panel One" MaxHeight="150">
+        Panel One Content - Lorem ipsum odor amet, consectetuer adipiscing elit. Euismod ullamcorper hendrerit ex aenean habitasse. Nostra duis ante penatibus donec duis fusce. Eget euismod quis morbi volutpat vehicula quis etiam arcu. At vivamus faucibus etiam vestibulum varius cursus. Placerat etiam fringilla imperdiet rutrum dictum finibus at. Taciti senectus primis lorem curabitur at ac. Rhoncus ridiculus tortor ridiculus pulvinar aliquet auctor habitasse penatibus. Enim leo consequat nascetur posuere tempor cras nulla augue donec.
+
+        Interdum ante proin montes ante class dis. Lacus porttitor in sollicitudin maecenas ornare non. Nullam lobortis id ut natoque sed. Nullam nulla ridiculus netus primis curae metus faucibus nec. Magna dolor sodales egestas montes cras. Neque sed aptent scelerisque maecenas mi eu. Laoreet congue convallis ligula ultrices himenaeos consectetur parturient sodales. Class sed tortor quisque tempor dictum enim nam enim. Taciti nullam nascetur vehicula justo sociosqu fusce phasellus sollicitudin magnis.
+
+        Neque parturient faucibus nisl, blandit class suscipit elit nibh. Venenatis hac eu facilisis nulla; velit sociosqu fermentum. In commodo lacinia lorem leo euismod magnis faucibus egestas. Parturient leo vehicula venenatis ex porta ultricies hendrerit. Fringilla natoque curabitur netus imperdiet luctus suscipit dolor. Laoreet bibendum dui ligula felis scelerisque consequat accumsan penatibus? Laoreet primis viverra ligula porta efficitur urna penatibus.
+
+        Fames iaculis turpis neque, hendrerit neque vulputate urna. Nulla donec neque congue montes aliquet morbi interdum quis vehicula. Odio adipiscing lacus aptent habitant integer euismod porttitor. Interdum quam lectus nunc purus dui turpis dolor. Nostra facilisi elementum rutrum blandit lacinia faucibus dignissim. Mollis vulputate diam et penatibus; consectetur cubilia ex. Mi etiam sit eleifend commodo sodales augue.
+
+        Facilisis magna lacinia imperdiet senectus consequat facilisi sapien malesuada. Accumsan penatibus hendrerit libero sed quam natoque. Sem iaculis lobortis odio habitasse eget nunc sagittis justo in. Semper convallis sollicitudin diam eu ex ex. Eget vehicula tellus posuere dis curae libero mauris euismod. Non porta in elit interdum aenean tempus. Dolor arcu pharetra aliquet hendrerit duis. Ante leo dignissim ad tincidunt rutrum, phasellus sollicitudin.
     </MudExpansionPanel>
     <MudExpansionPanel Text="Panel Two">
         Panel Two Content

--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -5,10 +5,8 @@
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Collapse;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -19,6 +17,10 @@ namespace MudBlazor.UnitTests.Components
         public void Collapse_TwoWayBinding_Test1()
         {
             var comp = Context.RenderComponent<CollapseBindingTest>();
+            var collapse = comp.FindComponent<MudCollapse>();
+
+            collapse.Markup.Should().Contain("mud-collapse-entered");
+
             IElement Button() => comp.Find("#outside_btn");
 
             IRenderedComponent<MudSwitch<bool>> MudSwitch() => comp.FindComponent<MudSwitch<bool>>();

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -81,7 +81,7 @@ namespace MudBlazor
         {
             base.OnAfterRender(firstRender);
 
-            if (firstRender && Expanded)
+            if (firstRender && _expandedState.Value)
             {
                 _state = CollapseState.Entered;
                 StateHasChanged();

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -77,6 +77,17 @@ namespace MudBlazor
                 .WithChangeHandler(OnExpandedParameterChangedAsync);
         }
 
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+
+            if (firstRender && Expanded)
+            {
+                _state = CollapseState.Entered;
+                StateHasChanged();
+            }
+        }
+
         private Task OnExpandedParameterChangedAsync(ParameterChangedEventArgs<bool> args)
         {
             _state = args.Value ? CollapseState.Entering : CollapseState.Exiting;

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -12,6 +12,10 @@
 .mud-collapse-entered {
   overflow: initial;
   grid-template-rows: minmax(0, 1fr);
+
+  & .mud-collapse-wrapper {
+      overflow-y: auto;
+  }
 }
 
 .mud-collapse-hidden {


### PR DESCRIPTION
## Description
Allow collapse content to scroll when it exceeds the max height of the container. 

In reviewing this I also found a bug where if a `MudCollapse` has `Expanded` set to `True` on initial load, the `mud-collapse-entered` class was not being applied. It instead remained at `mud-collapse-entering`, since the `_state` doesn't get updated due to [AnimationEndAsync](https://github.com/Anu6is/MudBlazor/blob/44cf632b62cc8a2af6178da84a7110ebd736e6c2/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs#L87) not being called.

Resolves: #10939 

## How Has This Been Tested?
visually & unit test updates

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
