### PR TITLE
Fix usages of MudGlobal.Rounded

### DIFF
--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -56,11 +56,12 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
         /// When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Avatar.Appearance)]
-        public bool Rounded { get; set; }
+        public bool Rounded { get; set; } = MudGlobal.Rounded == true;
 
         /// <summary>
         /// The color of the avatar.

--- a/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatarGroup.razor.cs
@@ -66,21 +66,25 @@ namespace MudBlazor
         /// Disables rounded corners when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> CSS style is set to <c>0</c>.
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
+        /// When <c>true</c>, the <c>border-radius</c> CSS style is set to <c>0</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
-        public bool MaxSquare { get; set; }
+        public bool MaxSquare { get; set; } = MudGlobal.Rounded == false;
 
         /// <summary>
         /// Shows rounded corners when the number of avatars exceeds <see cref="Max"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
+        /// When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.AvatarGroup.Appearance)]
-        public bool MaxRounded { get; set; }
+        public bool MaxRounded { get; set; } = MudGlobal.Rounded == true;
 
         /// <summary>
         /// The color of the avatar when the number of avatars exceeds <see cref="Max"/>.

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -53,7 +53,8 @@ namespace MudBlazor
         /// Shows a rounded border for all <see cref="MudNavLink" /> items.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c> in <see cref="MudGlobal.Rounded"/>.  
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
         /// When <c>true</c>, the theme <c>border-radius</c> value will be used. 
         /// Only takes affect if <see cref="Bordered"/> is <c>true</c>.
         /// </remarks>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -70,11 +70,13 @@ namespace MudBlazor
         /// Displays a rounded border.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  When <c>true</c>, the CSS <c>stroke-linecap</c> is set to <c>round</c>.
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
+        /// When <c>true</c>, the CSS <c>stroke-linecap</c> is set to <c>round</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ProgressLinear.Appearance)]
-        public bool Rounded { get; set; }
+        public bool Rounded { get; set; } = MudGlobal.Rounded == true;
 
         /// <summary>
         /// The lowest possible value.

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -79,7 +79,8 @@ namespace MudBlazor
         /// Displays a rounded border.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c> in <see cref="MudGlobal.Rounded"/>.
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
         /// When <c>true</c>, the CSS <c>border-radius</c> is set to the theme's default value.
         /// </remarks>
         [Parameter]

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -63,7 +63,8 @@ namespace MudBlazor
         /// Uses rounded corners on the tab's edges.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="MudGlobal.Rounded" />.
+        /// Defaults to <c>false</c>.
+        /// Can be overridden by <see cref="MudGlobal.Rounded"/>
         /// When <c>true</c>, the <c>border-radius</c> style is set to the theme's default value.
         /// </remarks>
         [Parameter]


### PR DESCRIPTION
## Description
Some components do not make use of the `MudGlobal.Rounded` property properly.
This is a follow-up for #10944 that was only targeted at the `MudProgressLinear`.

Added consistency for components:
- `MudAvatar` (+ `MudAvatarGroup`)
- `MudNavMenu` (documentation only)
- `MudProgressCircular`
- `MudProgressLinear` (documentation only)
- `MudTabs` (documentation only)

## How Has This Been Tested?
- Tested manually using the MudBlazor.Docs.Server by setting the `MudGlobal.Rounded` to `true`

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
~~- [ ] I've added relevant tests.~~
