### PR TITLE
Tests: Filter out hidden dates

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -337,7 +337,10 @@ namespace MudBlazor.UnitTests.Components
             DateTime? returnDate = null;
             var comp = OpenPicker(EventCallback(nameof(MudDatePicker.DateChanged), (DateTime? date) => { eventCount++; returnDate = date; }));
             // clicking a day button to select a date and close
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("23")).Click();
+            comp.FindAll("button.mud-picker-calendar-day")
+                .Where(x => !x.ClassList.Contains("mud-hidden") && x.TrimmedText().Equals("23"))
+                .First()
+                .Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
             eventCount.Should().Be(1);


### PR DESCRIPTION
## Description
Tests are currently failing due to the following mismatched date error:

```
Failed Open_CloseBySelectingADate_CheckClosed_Check_DateChangedCount [117 ms]
  Error Message:
   Expected returnDate to be <2025-03-23>, but found <2025-02-23>.
  Stack Trace:
     at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Primitives.DateTimeAssertions`1.Be(DateTime expected, String because, Object[] becauseArgs)
   at MudBlazor.UnitTests.Components.DatePickerTests.Open_CloseBySelectingADate_CheckClosed_Check_DateChangedCount() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/DatePickerTests.cs:line 345
```
This is due to the unit test selecting what should be a hidden (unavailable) date as seen below
![duplicate 23](https://github.com/user-attachments/assets/bab89bd9-c150-41ba-9cf7-312bf712f5c5)


## How Has This Been Tested?
Execute the test with culture set to US

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
