### PR TITLE
Micro Size for Icon Button and standard Buttons

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Button/Examples/ButtonSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/Examples/ButtonSizeExample.razor
@@ -1,5 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
+<MudButton StartIcon="@Icons.Custom.Uncategorized.Radioactive" Variant="Variant.Filled" Size="Size.Micro" Color="Color.Dark">Micro</MudButton>
+<MudButton Variant="Variant.Filled" Size="Size.Micro" Color="Color.Dark">Micro</MudButton>
+<MudButton StartIcon="@Icons.Custom.Uncategorized.Radioactive" Variant="Variant.Filled" Size="Size.Small" Color="Color.Primary">Small</MudButton>
 <MudButton Variant="Variant.Filled" Size="Size.Small"  Color="Color.Primary">Small</MudButton>
+<MudButton StartIcon="@Icons.Custom.Uncategorized.Radioactive" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Secondary">Medium</MudButton>
 <MudButton Variant="Variant.Filled" Size="Size.Medium" Color="Color.Secondary">Medium</MudButton>
+<MudButton StartIcon="@Icons.Custom.Uncategorized.Radioactive" Variant="Variant.Filled" Size="Size.Large" Color="Color.Tertiary">Large</MudButton>
 <MudButton Variant="Variant.Filled" Size="Size.Large"  Color="Color.Tertiary">Large</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/IconButton/Examples/IconButtonStyleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/IconButton/Examples/IconButtonStyleExample.razor
@@ -1,8 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
+<MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Micro" />
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small" />
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Medium"/>
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" />
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" />
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Medium" />
 <MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" />
+<MudIconButton Icon="@Icons.Material.Filled.Delete" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Micro" />

--- a/src/MudBlazor/Enums/Size.cs
+++ b/src/MudBlazor/Enums/Size.cs
@@ -8,6 +8,12 @@ namespace MudBlazor;
 public enum Size
 {
     /// <summary>
+    /// The smallest size for standard buttons and icon buttons.
+    /// </summary>
+    [Description("micro")]
+    Micro,
+
+    /// <summary>
     /// The smallest size.
     /// </summary>
     [Description("small")]

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -213,6 +213,11 @@
   border-color: currentColor;
 }
 
+.mud-button-text-size-micro {
+  padding: 2px 3px;
+  font-size: 0.75rem;
+}
+
 .mud-button-text-size-small {
   padding: 4px 5px;
   font-size: 0.8125rem;
@@ -221,6 +226,15 @@
 .mud-button-text-size-large {
   padding: 8px 11px;
   font-size: 0.9375rem;
+}
+
+.mud-button-outlined-size-micro {
+  padding: 1px 6px;
+  font-size: 0.75rem;
+
+  &.mud-icon-button {
+    padding: 4px;
+  }
 }
 
 .mud-button-outlined-size-small {
@@ -238,6 +252,15 @@
 
   &.mud-icon-button {
     padding: 4px;
+  }
+}
+
+.mud-button-filled-size-micro {
+  padding: 2px 8px;
+  font-size: 0.75rem;
+
+  &.mud-icon-button {
+    padding: 5px;
   }
 }
 
@@ -281,6 +304,12 @@
       margin-inline-start: -2px;
       margin-inline-end: 8px;
     }
+
+    &.mud-button-icon-size-micro {
+      margin-left: 0px;
+      margin-inline-start: 0px;
+      margin-inline-end: 8px;
+    }
   }
 
   .mud-button-icon-end {
@@ -300,7 +329,9 @@
 
 
 
-
+.mud-button-icon-size-micro > *:first-child {
+  font-size: 16px;
+}
 
 .mud-button-icon-size-small > *:first-child {
   font-size: 18px;

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -72,6 +72,23 @@
   margin-inline-start: unset;
 }
 
+.mud-icon-button-size-micro {
+  padding: 0;
+  font-size: 0.6875rem;
+
+  &.mud-icon-button-edge-start {
+    margin-left: 0px;
+    margin-inline-start: 0px;
+    margin-inline-end: unset;
+  }
+
+  &.mud-icon-button-edge-end {
+    margin-right: 0px;
+    margin-inline-end: 0px;
+    margin-inline-start: unset;
+  }
+}
+
 .mud-icon-button-size-small {
   padding: 3px;
   font-size: 1.125rem;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
It may be necessary to display a button in a restricted space. Particularly in the cells of a table or grid. However, the ```Small``` size of a button or icon can sometimes be too large. It doesn't allow for a more compact row in a table, or takes up too much space inside its container. A ```Micro``` size solves this type of scenario.

## How Has This Been Tested?
It has been tested visually. Only the _scss_ files with new classes and an ``enum`` have been modified for this implementation.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![One](https://github.com/user-attachments/assets/b7c682dc-6bfb-4974-ad40-ec6d67fe890e)
![Two](https://github.com/user-attachments/assets/9d807a67-7aab-4d16-a769-cca0b685bd31)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
