### PR TITLE
MudButtonGroup: Fix some disabled styles not applying to buttons

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupDisabledStylesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ButtonGroup/ButtonGroupDisabledStylesTest.razor
@@ -1,0 +1,43 @@
+﻿<MudText Typo="Typo.h6">Buttons</MudText>
+
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Filled">One</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Filled">Two</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Filled">Three</MudButton>
+
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Text">One</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Text">Two</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Text">Three</MudButton>
+
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Outlined">One</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Outlined">Two</MudButton>
+<MudButton Disabled="_disabled" Color="Color.Primary" Variant="Variant.Outlined">Three</MudButton>
+
+<MudText Typo="Typo.h6">ButtonGroup</MudText>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" OverrideStyles="_overrideStyles">
+    <MudButton Disabled="_disabled">One</MudButton>
+    <MudButton Disabled="_disabled">Two</MudButton>
+    <MudButton Disabled="_disabled">Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Text" OverrideStyles="_overrideStyles">
+    <MudButton Disabled="_disabled">One</MudButton>
+    <MudButton Disabled="_disabled">Two</MudButton>
+    <MudButton Disabled="_disabled">Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" OverrideStyles="_overrideStyles">
+    <MudButton Disabled="_disabled">One</MudButton>
+    <MudButton Disabled="_disabled">Two</MudButton>
+    <MudButton Disabled="_disabled">Three</MudButton>
+</MudButtonGroup>
+
+<br />
+<br />
+<MudSwitch Label="Disabled" @bind-Value="_disabled" />
+<MudSwitch Label="Override Styles" @bind-Value="_overrideStyles" />
+
+@code {
+    private bool _disabled;
+    private bool _overrideStyles = true;
+}

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -28,6 +28,10 @@
       &:focus-visible, &:active {
         background-color: var(--mud-palette-action-default-hover);
       }
+
+      &:disabled {
+        border-color: var(--mud-palette-action-disabled-background) !important;
+      }
     }
   }
 
@@ -323,6 +327,10 @@
 
           &:focus-visible, &:active {
             background-color: var(--mud-palette-#{$color}-darken);
+          }
+
+          &:disabled {
+            background-color: var(--mud-palette-action-disabled-background);
           }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #10963 by making sure the disabled background and border styles take precedence.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->


## Default State

![1](https://github.com/user-attachments/assets/7352e63a-21cd-4f9c-abab-14eb38d5196f)

### Disabled: Before

![2](https://github.com/user-attachments/assets/e9841d7b-0400-4393-be55-23fe4d2fb6c0)

### Disabled: After

![2](https://github.com/user-attachments/assets/2d7b4b3d-df37-4d8d-8bc2-e791c95e93bf)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
