### PR TITLE
MudDrawer: Fix stall when loading

### DIFF
--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -288,7 +288,7 @@ namespace MudBlazor
                 await UpdateHeightAsync();
                 if (!_disposed)
                 {
-                    await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
+                    _ = BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
                 }
 
                 _isRendered = true;


### PR DESCRIPTION
Prevents stall when loading the drawer by no longer awaiting viewport subscription.

## Description
Currently the Drawer waits for the viewport subscription to complete which can take several seconds (due to javascript calls).
This seems unnecessary as the callback invokes on the main thread anyway. 

## How Has This Been Tested?
All tests pass

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
