### PR TITLE
MudMenu: Autocomplete/Select adornment click no longer causes menu to close

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Overlay/OverlayNestedFreezeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Overlay/OverlayNestedFreezeTest.razor
@@ -6,7 +6,7 @@
     <MudSpacer />
     <MudMenu Label="Open AutoComplete Menu">
         <ActivatorContent>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary">I am a button</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary">AutoComplete button</MudButton>
         </ActivatorContent>
         <ChildContent>
             <MudMenuItem AutoClose="false">
@@ -18,7 +18,7 @@
     </MudMenu>
     <MudMenu Label="Open AutoComplete Menu">
         <ActivatorContent>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary">I am a button</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary">Select button</MudButton>
         </ActivatorContent>
         <ChildContent>
             <MudMenuItem AutoClose="false">
@@ -37,7 +37,7 @@
 
 <MudMenu Label="Open AutoComplete Menu">
     <ActivatorContent>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary">I am a button</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary">Autocomplete button</MudButton>
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem AutoClose="false">
@@ -50,7 +50,7 @@
 
 <MudMenu Label="Open Select Menu">
     <ActivatorContent>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary">I am a button</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary">Select button</MudButton>
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem AutoClose="false">
@@ -70,8 +70,8 @@
 
 @code {
     public static string __description__ = "Testing MudOverlay impact on MudAutoComplete when by itself, nested in mudmenu and nested in mudmenu in mudappbar";
-    string _value = string.Empty;
-    private string[] _states =
+    private string _value = string.Empty;
+    private readonly string[] _states =
     {
         "Alabama", "Alaska", "Arizona", "Arkansas", "California",
         "Colorado", "Connecticut", "Delaware", "Florida", "Georgia",

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -583,5 +583,39 @@ namespace MudBlazor.UnitTests.Components
             // Ensure all popovers are closed.
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
+
+        [Test]
+        public void Menu_ButtonActivator()
+        {
+            var provider = Context.RenderComponent<MudPopoverProvider>();
+            var comp = Context.RenderComponent<MudMenu>(parameters => parameters
+                .Add(p => p.ActivatorContent, builder =>
+                {
+                    builder.OpenComponent<MudButton>(0);
+                    builder.CloseComponent();
+                }));
+
+            provider.FindAll("div.mud-popover-open").Count.Should().Be(0);
+
+            // Click the MudButton inside the ActivatorContent
+            var button = comp.Find("button.mud-button-root");
+            button.Click();
+            provider.FindAll("div.mud-popover-open").Count.Should().Be(1);
+            button.Click();
+            // Render component with MudIconButton inside ActivatorContent
+            comp = Context.RenderComponent<MudMenu>(parameters => parameters
+                .Add(p => p.ActivatorContent, builder =>
+                {
+                    builder.OpenComponent<MudIconButton>(0);
+                    builder.AddAttribute(1, "Class", "mud-icon-button-activator");
+                    builder.CloseComponent();
+                }));
+
+            provider.FindAll("div.mud-popover-open").Count.Should().Be(0);
+
+            // Click the MudIconButton inside the ActivatorContent
+            comp.Find("button.mud-icon-button-activator").Click();
+            provider.FindAll("div.mud-popover-open").Count.Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -592,7 +592,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.ActivatorContent, builder =>
                 {
                     builder.OpenComponent<MudIconButton>(0);
-                    builder.AddAttribute(1, "Class", "mud-input-adornment-icon-button");
+                    builder.AddAttribute(1, "Class", "mud-no-activator");
                     builder.CloseComponent();
                 }));
             var menu = comp.Instance;
@@ -606,10 +606,15 @@ namespace MudBlazor.UnitTests.Components
             activatable.Activate(new object(), new MouseEventArgs());
             comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should be closed after calling Activate again"));
 
-            // Special case with input adornment icon button
-            var iconButton = comp.FindComponent<MudIconButton>().Instance;
-            activatable.Activate(iconButton, new MouseEventArgs());
-            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an input adornment icon button"));
+            // Special case with icon button
+            var classButton = comp.FindComponent<MudIconButton>().Instance;
+            activatable.Activate(classButton, new MouseEventArgs());
+            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an mud-no-activator selector"));
+
+            // Special case with regular button
+            var compButton = Context.RenderComponent<MudButton>(p => p.Add(p => p.Class, "mud-no-activator")).Instance;
+            activatable.Activate(compButton, new MouseEventArgs());
+            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an mud-no-activator selector"));
 
             // Clean up
             await menu.CloseMenuAsync();

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -585,6 +585,37 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task IActivatable_Activate_Should_ToggleMenu_Except_For_InputAdornmentIconButton()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudMenu>(parameters => parameters
+                .Add(p => p.ActivatorContent, builder =>
+                {
+                    builder.OpenComponent<MudIconButton>(0);
+                    builder.AddAttribute(1, "Class", "mud-input-adornment-icon-button");
+                    builder.CloseComponent();
+                }));
+            var menu = comp.Instance;
+            var activatable = (Interfaces.IActivatable)menu;
+
+            // Normal case
+            activatable.Activate(new object(), new MouseEventArgs());
+            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeTrue("Menu should open when Activate is called with a regular object"));
+
+            // Close Menu
+            activatable.Activate(new object(), new MouseEventArgs());
+            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should be closed after calling Activate again"));
+
+            // Special case with input adornment icon button
+            var iconButton = comp.FindComponent<MudIconButton>().Instance;
+            activatable.Activate(iconButton, new MouseEventArgs());
+            comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an input adornment icon button"));
+
+            // Clean up
+            await menu.CloseMenuAsync();
+        }
+
+        [Test]
         public void Menu_ButtonActivator()
         {
             var provider = Context.RenderComponent<MudPopoverProvider>();

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using static System.String;
@@ -128,7 +127,8 @@ namespace MudBlazor
             if (GetDisabledState())
                 return;
             await OnClick.InvokeAsync(ev);
-            Activatable?.Activate(this, ev);
+            if (!Class?.Contains("mud-input-adornment-icon-button") ?? true)
+                Activatable?.Activate(this, ev);
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -127,8 +127,7 @@ namespace MudBlazor
             if (GetDisabledState())
                 return;
             await OnClick.InvokeAsync(ev);
-            if (!Class?.Contains("mud-input-adornment-icon-button") ?? true)
-                Activatable?.Activate(this, ev);
+            Activatable?.Activate(this, ev);
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
-    <div class="@AutocompleteClassname">
+    <div class="@AutocompleteClassname" @onclick:stopPropagation @onmousedown:stopPropagation>
         <MudInputControl Label="@Label"
                          Variant="@Variant"
                          HelperId="@GetHelperId()"

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -44,6 +44,7 @@ namespace MudBlazor
                 .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
                 .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
                 .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
+                .AddClass("mud-no-activator")
                 .Build();
 
         internal override InputType GetInputType() => InputType;

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -14,7 +14,7 @@
     {
         @if (AdornmentClick.HasDelegate)
         {
-            <MudIconButton Class="mud-input-adornment-icon-button"
+            <MudIconButton Class="mud-input-adornment-icon-button mud-no-activator"
                            Icon="@Icon"
                            OnClick="@AdornmentClick"
                            Edge="@(Placement.ToEdge())"

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -633,8 +633,14 @@ namespace MudBlazor
         /// </summary>
         void IActivatable.Activate(object activator, MouseEventArgs args)
         {
-            _ = ToggleMenuAsync(args);
+            if (activator is MudIconButton activatorButton &&
+                (activatorButton.Class?.Contains("mud-input-adornment-icon-button") ?? false))
+            {
+                return;
+            }
+            ToggleMenuAsync(args).CatchAndLog();
         }
+
 
         /// <summary>
         /// Disposes managed and unmanaged resources.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -633,8 +633,8 @@ namespace MudBlazor
         /// </summary>
         void IActivatable.Activate(object activator, MouseEventArgs args)
         {
-            if (activator is MudIconButton activatorButton &&
-                (activatorButton.Class?.Contains("mud-input-adornment-icon-button") ?? false))
+            if (activator is MudBaseButton activatorButton &&
+                (activatorButton.Class?.Contains("mud-no-activator") ?? false))
             {
                 return;
             }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -3,7 +3,7 @@
 @inherits MudBaseInput<T>
 
 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
-    <div class="@OuterClassname" id="@_elementId" @onfocusout="@OnFocusOutAsync">
+    <div class="@OuterClassname" id="@_elementId" @onfocusout="@OnFocusOutAsync" @onclick:stopPropagation @onmousedown:stopPropagation>
         <MudInputControl Label="@Label"
                          Variant="@Variant"
                          HelperId="@GetHelperId()"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Added barriers at the outermostlevel for mousedown and click on MudSelect and MudAutocomplete. 
IActivator was catching the click event anytime an Adornment is Interactive. I added an exception clause for MudInputAdornments not to trigger IActivator. 

Exception class is `mud-no-activator`

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Existing Unit Tests, Visually, New Unit Tests for new method

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
