### PR TITLE
MudStepper: Fix final step completed color

### DIFF
--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -806,6 +806,25 @@ namespace MudBlazor.UnitTests.Components
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
         }
 
+        [Test]
+        public void HasCompletedClassIfLinear()
+        {
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.CompletedStepColor, Color.Success);
+                self.Add(x => x.CurrentStepColor, Color.Secondary);
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Completed, true);
+                });
+            });
+
+            var stepIcon = stepper.Find(".mud-step-label-icon");
+
+            stepIcon.ClassList.Should().Contain("mud-success");
+            stepIcon.ClassList.Should().NotContain("mud-secondary");
+        }
+
         [TestCase(true, true)]
         [TestCase(false, false)]
         public void HasRippleClass(bool ripple, bool hasClass)

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -48,7 +48,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
         new CssBuilder("mud-step-label-icon")
             .AddClass($"mud-{(CompletedStepColor.HasValue ? CompletedStepColor.Value.ToDescriptionString() : Parent?.CompletedStepColor.ToDescriptionString())}", CompletedState && !HasErrorState && Parent?.CompletedStepColor != Color.Default && (Parent?.ActiveStep != this || (Parent?.IsCompleted == true && Parent?.NonLinear == false)))
             .AddClass($"mud-{(ErrorStepColor.HasValue ? ErrorStepColor.Value.ToDescriptionString() : Parent?.ErrorStepColor.ToDescriptionString())}", HasErrorState)
-            .AddClass($"mud-{Parent?.CurrentStepColor.ToDescriptionString()}", Parent?.ActiveStep == this)
+            .AddClass($"mud-{Parent?.CurrentStepColor.ToDescriptionString()}", Parent?.ActiveStep == this && !(Parent?.IsCompleted == true && Parent?.NonLinear == false))
             .Build();
 
     internal string LabelContentClassname =>

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -46,7 +46,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
 
     internal string LabelIconClassname =>
         new CssBuilder("mud-step-label-icon")
-            .AddClass($"mud-{(CompletedStepColor.HasValue ? CompletedStepColor.Value.ToDescriptionString() : Parent?.CompletedStepColor.ToDescriptionString())}", CompletedState && !HasErrorState && Parent?.CompletedStepColor != Color.Default && Parent?.ActiveStep != this)
+            .AddClass($"mud-{(CompletedStepColor.HasValue ? CompletedStepColor.Value.ToDescriptionString() : Parent?.CompletedStepColor.ToDescriptionString())}", CompletedState && !HasErrorState && Parent?.CompletedStepColor != Color.Default && (Parent?.ActiveStep != this || (Parent?.IsCompleted == true && Parent?.NonLinear == false)))
             .AddClass($"mud-{(ErrorStepColor.HasValue ? ErrorStepColor.Value.ToDescriptionString() : Parent?.ErrorStepColor.ToDescriptionString())}", HasErrorState)
             .AddClass($"mud-{Parent?.CurrentStepColor.ToDescriptionString()}", Parent?.ActiveStep == this)
             .Build();

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -22,9 +22,18 @@ public partial class MudStepper : MudComponentBase
             .WithParameter(() => ActiveIndex)
             .WithEventCallback(() => ActiveIndexChanged)
             .WithChangeHandler(async args => await SetActiveIndexAsync(args.Value));
+
+        _currentStepColor = registerScope.RegisterParameter<Color>(nameof(CurrentStepColor))
+            .WithParameter(() => CurrentStepColor)
+            .WithEventCallback(() => CurrentStepColorChanged)
+            .WithChangeHandler(async args => await SetCurrentStepColorAsync(args.Value));
+
+        _originalCurrentStepColor = CurrentStepColor;
     }
 
     private readonly ParameterState<int> _activeIndex;
+    private readonly ParameterState<Color> _currentStepColor;
+    private readonly Color _originalCurrentStepColor;
     private List<MudStep> _steps = [];
     private HashSet<MudStep> _skippedSteps = [];
 
@@ -70,6 +79,13 @@ public partial class MudStepper : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<int> ActiveIndexChanged { get; set; }
+
+    /// <summary>
+    /// Occurs when <see cref="CurrentStepColor"/> has changed.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.List.Behavior)]
+    public EventCallback<Color> CurrentStepColorChanged { get; set; }
 
     /// <summary>
     /// The color of completed steps.
@@ -431,6 +447,8 @@ public partial class MudStepper : MudComponentBase
                     var nextStep = GetNextStep(index);
                     if (nextStep is not null)
                         index = _steps.IndexOf(nextStep);
+                    else
+                        await SetCurrentStepColorAsync(CompletedStepColor);
                     await SetActiveIndexAsync(index);
                     break;
                 }
@@ -467,9 +485,20 @@ public partial class MudStepper : MudComponentBase
             step = _steps.SkipWhile(x => _steps.IndexOf(x) < index || x.DisabledState).FirstOrDefault();
             index = step is null ? -1 : _steps.IndexOf(step);
         }
+        if (NonLinear)
+        {
+            await SetCurrentStepColorAsync(_originalCurrentStepColor);
+        }
         ActiveStep = step;
         await _activeIndex.SetValueAsync(index);
         StateHasChanged(); // this is important !
+    }
+
+    private async Task SetCurrentStepColorAsync(Color color)
+    {
+        CurrentStepColor = color;
+        await _currentStepColor.SetValueAsync(color);
+        StateHasChanged();
     }
 
     // Keeps track of initialization
@@ -555,6 +584,8 @@ public partial class MudStepper : MudComponentBase
         {
             return;
         }
+
+        await SetCurrentStepColorAsync(_originalCurrentStepColor);
 
         foreach (var step in _steps)
         {

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -22,18 +22,9 @@ public partial class MudStepper : MudComponentBase
             .WithParameter(() => ActiveIndex)
             .WithEventCallback(() => ActiveIndexChanged)
             .WithChangeHandler(async args => await SetActiveIndexAsync(args.Value));
-
-        _currentStepColor = registerScope.RegisterParameter<Color>(nameof(CurrentStepColor))
-            .WithParameter(() => CurrentStepColor)
-            .WithEventCallback(() => CurrentStepColorChanged)
-            .WithChangeHandler(async args => await SetCurrentStepColorAsync(args.Value));
-
-        _originalCurrentStepColor = CurrentStepColor;
     }
 
     private readonly ParameterState<int> _activeIndex;
-    private readonly ParameterState<Color> _currentStepColor;
-    private readonly Color _originalCurrentStepColor;
     private List<MudStep> _steps = [];
     private HashSet<MudStep> _skippedSteps = [];
 
@@ -79,13 +70,6 @@ public partial class MudStepper : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<int> ActiveIndexChanged { get; set; }
-
-    /// <summary>
-    /// Occurs when <see cref="CurrentStepColor"/> has changed.
-    /// </summary>
-    [Parameter]
-    [Category(CategoryTypes.List.Behavior)]
-    public EventCallback<Color> CurrentStepColorChanged { get; set; }
 
     /// <summary>
     /// The color of completed steps.
@@ -447,8 +431,6 @@ public partial class MudStepper : MudComponentBase
                     var nextStep = GetNextStep(index);
                     if (nextStep is not null)
                         index = _steps.IndexOf(nextStep);
-                    else
-                        await SetCurrentStepColorAsync(CompletedStepColor);
                     await SetActiveIndexAsync(index);
                     break;
                 }
@@ -485,20 +467,9 @@ public partial class MudStepper : MudComponentBase
             step = _steps.SkipWhile(x => _steps.IndexOf(x) < index || x.DisabledState).FirstOrDefault();
             index = step is null ? -1 : _steps.IndexOf(step);
         }
-        if (NonLinear)
-        {
-            await SetCurrentStepColorAsync(_originalCurrentStepColor);
-        }
         ActiveStep = step;
         await _activeIndex.SetValueAsync(index);
         StateHasChanged(); // this is important !
-    }
-
-    private async Task SetCurrentStepColorAsync(Color color)
-    {
-        CurrentStepColor = color;
-        await _currentStepColor.SetValueAsync(color);
-        StateHasChanged();
     }
 
     // Keeps track of initialization
@@ -584,8 +555,6 @@ public partial class MudStepper : MudComponentBase
         {
             return;
         }
-
-        await SetCurrentStepColorAsync(_originalCurrentStepColor);
 
         foreach (var step in _steps)
         {


### PR DESCRIPTION
## Description
When the MudStepper is linear, the final step will now show the completed colour once completed.

Originally, it was impossible for the last step in a linear MudStepper to show the completed step color, as the last step was also the current step. This has been fixed so that if the MudStepper is linear and the last step has been completed, the current step color changes to the completed step color. The current step color is restored if the user resets the progress of the stepper. 

This behaviour doesn't happen in a non linear MudStepper, as these allow you to go back and view other steps when all steps have been completed, and so having a different colour representing the current step is necessary.

Resolves #10962 

## How Has This Been Tested?
No tests have been added.  The code does not alter existing code, and functions as expected on MudBlazor.Docs.Server

## Type of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![MudStepper_final_step_complete_color](https://github.com/user-attachments/assets/c0bab47b-c843-449f-b794-254457b8db8e)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
