### PR TITLE
MudAutocomplete: Fix duplicate search calls when opened on click

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
         private int _elementKey = 0;
         private int _returnedItemsCount;
         private bool _open;
+        private bool _opening;
         private MudInput<string> _elementReference = null!;
         private CancellationTokenSource? _cancellationTokenSrc;
         private Task? _currentSearchTask;
@@ -676,6 +677,8 @@ namespace MudBlazor
                 return;
             }
 
+            _opening = true;
+
             var searchedItems = Array.Empty<T>();
             CancelToken();
 
@@ -741,6 +744,7 @@ namespace MudBlazor
                 Open = true;
             }
 
+            _opening = false;
             StateHasChanged();
         }
 
@@ -959,21 +963,14 @@ namespace MudBlazor
 
         private async Task OnInputActivationAsync(bool openMenu)
         {
-            var wasFocused = _isFocused;
             _isFocused = true;
 
-            if (Open || GetDisabledState() || GetReadOnlyState())
-            {
-                return;
-            }
-
-            if (SelectOnActivation)
+            if (SelectOnActivation && !GetDisabledState() && !GetReadOnlyState())
             {
                 await SelectAsync();
             }
 
-            // The click and focus events can be called together and we only want to open the menu once.
-            if (openMenu && !wasFocused)
+            if (openMenu && !Open && !_opening)
             {
                 await OpenMenuAsync();
             }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -665,11 +665,8 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Opens the drop-down of items.
+        /// Opens the drop-down of items, or refreshes the list if it is already open.
         /// </summary>
-        /// <remarks>
-        /// Will have no effect if the autocomplete is disabled or read-only.
-        /// </remarks>
         public async Task OpenMenuAsync()
         {
             if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
@@ -962,6 +959,7 @@ namespace MudBlazor
 
         private async Task OnInputActivationAsync(bool openMenu)
         {
+            var wasFocused = _isFocused;
             _isFocused = true;
 
             if (Open || GetDisabledState() || GetReadOnlyState())
@@ -974,7 +972,8 @@ namespace MudBlazor
                 await SelectAsync();
             }
 
-            if (openMenu)
+            // The click and focus events can be called together and we only want to open the menu once.
+            if (openMenu && !wasFocused)
             {
                 await OpenMenuAsync();
             }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #10864

The click event comes with a focus event, causing two calls to `OpenMenuAsync` meaning two search calls. Now they won't try to open the menu if it's already in the process of opening.

An idea to explore is a throttle to avoid spam calls, like if the user held down their tab key.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually on firefox and edge for windows

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before:

https://github.com/user-attachments/assets/4c32252d-2f07-4c6b-931e-000c0ae119e5

After:

https://github.com/user-attachments/assets/01334f58-989a-45b2-8321-1ca935c88e67


From:

```razor
<MudPopoverProvider />

<MudText>Search Count: @(_searchCount)</MudText>

<MudAutocomplete T="string" Label="US States" @bind-Value="_value1" SearchFunc="@Search1" OpenOnFocus />

@code {
    public static string __description__ = "The number of search calls should be one per click";
    private string _value1 = "California";
    private int _searchCount;

    private readonly string[] _states =
    {
        "Alabama", "Alaska", "American Samoa", "Arizona",
        "Arkansas", "California", "Colorado", "Connecticut",
        "Delaware", "District of Columbia", "Federated States of Micronesia",
        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
        "Louisiana", "Maine", "Marshall Islands", "Maryland",
        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
        "Missouri", "Montana", "Nebraska", "Nevada",
        "New Hampshire", "New Jersey", "New Mexico", "New York",
        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
        "Washington", "West Virginia", "Wisconsin", "Wyoming",
    };

    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
    {
        _searchCount++;
        StateHasChanged();

        // In real life use an asynchronous function for fetching data from an api.
        await Task.Delay(50, token);

        // if text is null or empty, show complete list
        if (string.IsNullOrEmpty(value))
            return _states;

        return _states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
    }
}
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
