### PR TITLE
MudDataGrid - Preserve Selection with ParameterState

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventCallbacksTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventCallbacksTest.razor
@@ -1,29 +1,33 @@
-
+﻿
 
 <MudDataGrid T="Item" Items="@_items" EditMode="@DataGridEditMode.Cell"
-    RowClick="@OnRowClick"
-    RowContextMenuClick="@OnRowContextMenuClick"
-    SelectedItemChanged="@OnSelectedItemChanged"
-    CommittedItemChanges="@OnCommittedItemChanges" 
-    StartedEditingItem="@OnStartedEditingItem" 
-    CanceledEditingItem="@OnCanceledEditingItem"
-    ReadOnly="false">
+             RowClick="@OnRowClick"
+             RowContextMenuClick="@OnRowContextMenuClick"
+             SelectedItemChanged="@OnSelectedItemChanged"
+             SelectedItemsChanged="@OnSelectedItemsChanged"
+             CommittedItemChanges="@OnCommittedItemChanges"
+             StartedEditingItem="@OnStartedEditingItem"
+             CanceledEditingItem="@OnCanceledEditingItem"
+             ReadOnly="false">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
     </Columns>
 </MudDataGrid>
 
 @code {
+    public static string __description__ = "Used for Unit Tests to verify SelectedItem/SelectedItems Changed";
+
     private IEnumerable<Item> _items = new List<Item>()
     {
-        new Item("A"), 
-        new Item("B"), 
+        new Item("A"),
+        new Item("B"),
         new Item("C")
     };
 
     public bool RowClicked { get; set; }
     public bool RowContextMenuClicked { get; set; }
     public bool SelectedItemChanged { get; set; }
+    public bool SelectedItemsChanged { get; set; }
     public bool CommittedItemChanges { get; set; }
     public bool StartedEditingItem { get; set; }
     public bool CanceledEditingItem { get; set; }
@@ -32,7 +36,7 @@
     {
         RowClicked = true;
     }
-    
+
     private void OnRowContextMenuClick(DataGridRowClickEventArgs<Item> args)
     {
         RowContextMenuClicked = true;
@@ -41,6 +45,11 @@
     private void OnSelectedItemChanged(Item item)
     {
         SelectedItemChanged = true;
+    }
+
+    private void OnSelectedItemsChanged(HashSet<Item> items)
+    {
+        SelectedItemsChanged = true;
     }
 
     private void OnCommittedItemChanges(Item item)

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
@@ -1,0 +1,45 @@
+﻿<MudDataGrid T="DocumentChecklistItem" ServerData="ServerReload" Bordered="true" Dense="true"
+MultiSelection="true" SelectedItemsChanged="@((e) => OnSelectedItemsChanged(e))"
+RowsPerPage="25"
+@ref="_dataGrid">
+    <Columns>
+        <SelectColumn T="DocumentChecklistItem"></SelectColumn>
+        <PropertyColumn Property="c=>c.Id" Title="Id"></PropertyColumn>
+        <PropertyColumn Property="c=>c.Name" Title="Name"></PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+<MudText>
+    @_message
+</MudText>
+
+@code {
+    #nullable enable
+    public static string __description__ = "A test viewer for visibility testing of row Selection";
+    private List<DocumentChecklistItem> _selectedDocuments = [];
+    private MudDataGrid<DocumentChecklistItem>? _dataGrid;
+    private string _message = "Click select column to select the item";
+
+    private void OnSelectedItemsChanged(HashSet<DocumentChecklistItem> documents)
+    {
+        _selectedDocuments = documents.ToList();
+        _message = "OnSelectedItemsChanged was called. " + _selectedDocuments.Count() + " items selected";
+
+    }
+
+    private async Task<GridData<DocumentChecklistItem>> ServerReload(GridState<DocumentChecklistItem> state)
+    {
+        List<DocumentChecklistItem> items = new List<DocumentChecklistItem>(){
+                new DocumentChecklistItem {Id="1", Name="Test"},
+                new DocumentChecklistItem {Id="2",Name="Test2"}
+            };
+
+        return await Task.FromResult(new GridData<DocumentChecklistItem>() { Items = items, TotalItems = 1 });
+    }
+
+    public class DocumentChecklistItem
+    {
+        public string Id { get; set; } = default!;
+        public string Name { get; set; } = default!;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
@@ -1,7 +1,6 @@
 ﻿<MudDataGrid T="DocumentChecklistItem" ServerData="ServerReload" Bordered="true" Dense="true"
              MultiSelection="true" SelectedItemsChanged="@((e) => OnSelectedItemsChanged(e))"
-             RowsPerPage="25"
-             @ref="_dataGrid">
+             RowsPerPage="25">
     <Columns>
         <SelectColumn T="DocumentChecklistItem"></SelectColumn>
         <PropertyColumn Property="c=>c.Id" Title="Id"></PropertyColumn>
@@ -17,7 +16,6 @@
 #nullable enable
     public static string __description__ = "A test viewer for visibility testing of row Selection";
     private List<DocumentChecklistItem> _selectedDocuments = [];
-    private MudDataGrid<DocumentChecklistItem>? _dataGrid;
     private string _message = "Click select column to select the item";
 
     private void OnSelectedItemsChanged(HashSet<DocumentChecklistItem> documents)
@@ -26,20 +24,16 @@
         _message = "OnSelectedItemsChanged was called. " + _selectedDocuments.Count() + " items selected";
     }
 
-    private async Task<GridData<DocumentChecklistItem>> ServerReload(GridState<DocumentChecklistItem> state)
+    private static Task<GridData<DocumentChecklistItem>> ServerReload(GridState<DocumentChecklistItem> state)
     {
-        List<DocumentChecklistItem> items = new()
-            {
-                new DocumentChecklistItem {Id="1", Name="Test"},
-                new DocumentChecklistItem {Id="2",Name="Test2"}
-            };
+        List<DocumentChecklistItem> items =
+        [
+            new("1", "Test"),
+            new("2", "Test2")
+        ];
 
-        return await Task.FromResult(new GridData<DocumentChecklistItem>() { Items = items, TotalItems = items.Count });
+        return Task.FromResult(new GridData<DocumentChecklistItem> { Items = items, TotalItems = items.Count });
     }
 
-    public class DocumentChecklistItem
-    {
-        public string Id { get; set; } = default!;
-        public string Name { get; set; } = default!;
-    }
+    public record DocumentChecklistItem(string Id, string Name);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEventSelectionTest.razor
@@ -1,7 +1,7 @@
 ﻿<MudDataGrid T="DocumentChecklistItem" ServerData="ServerReload" Bordered="true" Dense="true"
-MultiSelection="true" SelectedItemsChanged="@((e) => OnSelectedItemsChanged(e))"
-RowsPerPage="25"
-@ref="_dataGrid">
+             MultiSelection="true" SelectedItemsChanged="@((e) => OnSelectedItemsChanged(e))"
+             RowsPerPage="25"
+             @ref="_dataGrid">
     <Columns>
         <SelectColumn T="DocumentChecklistItem"></SelectColumn>
         <PropertyColumn Property="c=>c.Id" Title="Id"></PropertyColumn>
@@ -14,7 +14,7 @@ RowsPerPage="25"
 </MudText>
 
 @code {
-    #nullable enable
+#nullable enable
     public static string __description__ = "A test viewer for visibility testing of row Selection";
     private List<DocumentChecklistItem> _selectedDocuments = [];
     private MudDataGrid<DocumentChecklistItem>? _dataGrid;
@@ -24,17 +24,17 @@ RowsPerPage="25"
     {
         _selectedDocuments = documents.ToList();
         _message = "OnSelectedItemsChanged was called. " + _selectedDocuments.Count() + " items selected";
-
     }
 
     private async Task<GridData<DocumentChecklistItem>> ServerReload(GridState<DocumentChecklistItem> state)
     {
-        List<DocumentChecklistItem> items = new List<DocumentChecklistItem>(){
+        List<DocumentChecklistItem> items = new()
+            {
                 new DocumentChecklistItem {Id="1", Name="Test"},
                 new DocumentChecklistItem {Id="2",Name="Test2"}
             };
 
-        return await Task.FromResult(new GridData<DocumentChecklistItem>() { Items = items, TotalItems = 1 });
+        return await Task.FromResult(new GridData<DocumentChecklistItem>() { Items = items, TotalItems = items.Count });
     }
 
     public class DocumentChecklistItem

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/_README.txt
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/_README.txt
@@ -5,5 +5,5 @@ It is advised to name the test component exactly the same as the bUnit testcase 
 In order to have the test description show up, make sure the component implements a static field __description__ in the @code section:
 
 @code {
-    public static string __description__ = " ... ";
+    public static string __description__ = "...";
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5103,5 +5103,61 @@ namespace MudBlazor.UnitTests.Components
             selectedItems.Count().Should().Be(2);
             selectedItem.Should().Be(4);
         }
+
+        [Test]
+        public async Task DataGridSelectedItemEventsTest()
+        {
+            var comp = Context.RenderComponent<DataGridEventCallbacksTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridEventCallbacksTest.Item>>();
+
+            // Test single selection mode
+            dataGrid.SetParam(x => x.MultiSelection, false);
+            comp.Render();
+
+            // Select an item
+            var firstItem = dataGrid.Instance.Items.First();
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+
+            // Verify events
+            comp.Instance.SelectedItemChanged.Should().BeTrue();
+            comp.Instance.SelectedItemsChanged.Should().BeTrue();
+
+            // Reset event flags
+            comp.Instance.SelectedItemChanged = false;
+            comp.Instance.SelectedItemsChanged = false;
+
+            // Deselect the item
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetSelectedItemAsync(false, firstItem));
+
+            // Verify events for deselection
+            comp.Instance.SelectedItemChanged.Should().BeTrue();
+            comp.Instance.SelectedItemsChanged.Should().BeTrue();
+
+            // Reset event flags
+            comp.Instance.SelectedItemChanged = false;
+            comp.Instance.SelectedItemsChanged = false;
+
+            // Test multi-selection mode
+            dataGrid.SetParam(x => x.MultiSelection, true);
+            comp.Render();
+
+            // Select all items
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetSelectAllAsync(true));
+
+            // Verify events
+            comp.Instance.SelectedItemChanged.Should().BeFalse();
+            comp.Instance.SelectedItemsChanged.Should().BeTrue();
+
+            // Reset event flags
+            comp.Instance.SelectedItemChanged = false;
+            comp.Instance.SelectedItemsChanged = false;
+
+            // Deselect all items
+            await comp.InvokeAsync(async () => await dataGrid.Instance.SetSelectAllAsync(false));
+
+            // Verify events for deselection
+            comp.Instance.SelectedItemChanged.Should().BeFalse();
+            comp.Instance.SelectedItemsChanged.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5158,6 +5158,23 @@ namespace MudBlazor.UnitTests.Components
             // Verify events for deselection
             comp.Instance.SelectedItemChanged.Should().BeFalse();
             comp.Instance.SelectedItemsChanged.Should().BeTrue();
+
+            // Reset event flags
+            comp.Instance.SelectedItemChanged = false;
+            comp.Instance.SelectedItemsChanged = false;
+
+            // Test row click select
+            // find first mud-table-row and second mud-table-cell
+            var firstRow = dataGrid.FindAll(".mud-table-row")[1];
+            firstRow.Click();
+
+            // Verify events for row click
+            comp.WaitForAssertion(() => comp.Instance.SelectedItemChanged.Should().BeTrue());
+            comp.Instance.SelectedItemsChanged.Should().BeTrue();
+
+            // Reset event flags
+            comp.Instance.SelectedItemChanged = false;
+            comp.Instance.SelectedItemsChanged = false;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1547,7 +1547,7 @@ namespace MudBlazor
         /// </remarks>
         public async Task SetSelectedItemAsync(T item)
         {
-            if (!SelectOnRowClick || item == null)
+            if (!SelectOnRowClick)
                 return;
 
             var isSelected = Selection.Contains(item);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1538,6 +1538,22 @@ namespace MudBlazor
             await InvokeAsync(StateHasChanged);
         }
 
+        /// <summary>
+        /// Set the currently selected item in the data grid.
+        /// </summary>
+        /// <param name="item">The item to select.</param>
+        /// <remarks>
+        /// When <see cref="MultiSelection"/> is <c>true</c> and <see cref="SelectOnRowClick"/> is <c>true</c>, the <see cref="SelectedItems"/> are updated.  The <see cref="SelectedItem"/> is also updated.
+        /// </remarks>
+        public async Task SetSelectedItemAsync(T item)
+        {
+            if (!SelectOnRowClick || item == null)
+                return;
+
+            var isSelected = Selection.Contains(item);
+            await SetSelectedItemAsync(!isSelected, item);
+        }
+
         internal async Task SetSelectAllAsync(bool value)
         {
             // nothing should happen if multiselection is false
@@ -1836,29 +1852,6 @@ namespace MudBlazor
                     _serverData.Items.Select((item, index) => new IndexBag<T>(request.StartIndex + index, item)),
                     _serverData.TotalItems);
             };
-        }
-
-        /// <summary>
-        /// Set the currently selected item in the data grid.
-        /// </summary>
-        /// <param name="item">The item to select.</param>
-        /// <remarks>
-        /// When <see cref="MultiSelection"/> is <c>true</c> and <see cref="SelectOnRowClick"/> is <c>true</c>, the <see cref="SelectedItems"/> are updated.  The <see cref="SelectedItem"/> is also updated.
-        /// </remarks>
-        public async Task SetSelectedItemAsync(T item)
-        {
-            if (!SelectOnRowClick)
-                return;
-
-            // duplicate code from SetSelectedItemAsync(bool, T) but we need to call this method when SelectOnRowClick is false
-            if (Selection.Contains(item))
-            {
-                await SetSelectedItemAsync(false, item);
-            }
-            else
-            {
-                await SetSelectedItemAsync(true, item);
-            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1548,17 +1548,10 @@ namespace MudBlazor
                     ? ServerItems
                     : FilteredItems;
 
+            Selection.Clear();
             if (value)
             {
-                Selection.Clear();
-                foreach (var item in items)
-                {
-                    Selection.Add(item);
-                }
-            }
-            else
-            {
-                Selection.Clear();
+                Selection.UnionWith(items);
             }
 
             await InvokeAsync(async () => await _selectedItemsState.SetValueAsync(Selection));

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1499,6 +1499,7 @@ namespace MudBlazor
 
         internal async Task SetSelectedItemAsync(bool value, T item)
         {
+            Selection = new HashSet<T>(Comparer);
             if (value)
             {
                 if (!MultiSelection)
@@ -1528,7 +1529,7 @@ namespace MudBlazor
                 }
             }
 
-            await _selectedItemsState.SetValueAsync(Selection);
+            await InvokeAsync(async () => await _selectedItemsState.SetValueAsync(Selection));
             await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
 
             await InvokeAsync(StateHasChanged);
@@ -1547,7 +1548,7 @@ namespace MudBlazor
             if (value)
                 Selection = new HashSet<T>(items, Comparer);
             else
-                Selection.Clear();
+                Selection = new HashSet<T>(Comparer);
 
             await InvokeAsync(async () => await _selectedItemsState.SetValueAsync(Selection));
             await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1855,29 +1855,15 @@ namespace MudBlazor
             if (!SelectOnRowClick)
                 return;
 
-            // this is toggle logic (unselect if selected)
-            if (!Selection.Remove(item))
+            // duplicate code from SetSelectedItemAsync(bool, T) but we need to call this method when SelectOnRowClick is false
+            if (Selection.Contains(item))
             {
-                Selection.Add(item);
-            }
-            else if (!MultiSelection)
-            {
-                await _selectedItemState.SetValueAsync(default);
-                return;
-            }
-
-            if (MultiSelection)
-            {
-                await _selectedItemsState.SetValueAsync(Selection);
-                SelectedItemsChangedEvent?.Invoke(Selection);
+                await SetSelectedItemAsync(false, item);
             }
             else
             {
-                Selection.Remove(_selectedItemState.Value);
+                await SetSelectedItemAsync(true, item);
             }
-
-            await _selectedItemState.SetValueAsync(item);
-            await _selectedItemsState.SetValueAsync(Selection);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1545,13 +1545,15 @@ namespace MudBlazor
         /// <remarks>
         /// When <see cref="MultiSelection"/> is <c>true</c> and <see cref="SelectOnRowClick"/> is <c>true</c>, the <see cref="SelectedItems"/> are updated.  The <see cref="SelectedItem"/> is also updated.
         /// </remarks>
-        public async Task SetSelectedItemAsync(T item)
+        public Task SetSelectedItemAsync(T item)
         {
             if (!SelectOnRowClick)
-                return;
+            {
+                return Task.CompletedTask;
+            }
 
             var isSelected = Selection.Contains(item);
-            await SetSelectedItemAsync(!isSelected, item);
+            return SetSelectedItemAsync(!isSelected, item);
         }
 
         internal async Task SetSelectAllAsync(bool value)
@@ -1659,9 +1661,9 @@ namespace MudBlazor
             await SetSelectedItemAsync(item);
         }
 
-        internal async Task OnContextMenuClickedAsync(MouseEventArgs args, T item, int rowIndex)
+        internal Task OnContextMenuClickedAsync(MouseEventArgs args, T item, int rowIndex)
         {
-            await RowContextMenuClick.InvokeAsync(new DataGridRowClickEventArgs<T>(args, item, rowIndex));
+            return RowContextMenuClick.InvokeAsync(new DataGridRowClickEventArgs<T>(args, item, rowIndex));
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1499,14 +1499,19 @@ namespace MudBlazor
 
         internal async Task SetSelectedItemAsync(bool value, T item)
         {
-            Selection = new HashSet<T>(Comparer);
             if (value)
             {
+                if (!MultiSelection)
+                {
+                    Selection.Clear();
+                }
+
                 Selection.Add(item);
                 await _selectedItemState.SetValueAsync(item);
             }
             else
             {
+                Selection.Remove(item);
                 if (Comparer != null)
                 {
                     if (Comparer.Equals(item, _selectedItemState.Value))
@@ -1523,7 +1528,9 @@ namespace MudBlazor
                 }
             }
 
-            await InvokeAsync(async () => await _selectedItemsState.SetValueAsync(Selection));
+            await _selectedItemsState.SetValueAsync(Selection);
+            // manually invoke due to ParameterState not seeing state change with HashSet
+            await InvokeAsync(async () => await SelectedItemsChanged.InvokeAsync(Selection));
             await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
 
             await InvokeAsync(StateHasChanged);
@@ -1540,11 +1547,21 @@ namespace MudBlazor
                     : FilteredItems;
 
             if (value)
-                Selection = new HashSet<T>(items, Comparer);
+            {
+                Selection.Clear();
+                foreach (var item in items)
+                {
+                    Selection.Add(item);
+                }
+            }
             else
-                Selection = new HashSet<T>(Comparer);
+            {
+                Selection.Clear();
+            }
 
             await InvokeAsync(async () => await _selectedItemsState.SetValueAsync(Selection));
+            // manually invoke due to ParameterState not seeing state change with HashSet
+            await InvokeAsync(async () => await SelectedItemsChanged.InvokeAsync(Selection));
             await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
             await InvokeAsync(() => SelectedAllItemsChangedEvent?.Invoke(value));
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1502,17 +1502,11 @@ namespace MudBlazor
             Selection = new HashSet<T>(Comparer);
             if (value)
             {
-                if (!MultiSelection)
-                {
-                    Selection.Clear();
-                }
-
                 Selection.Add(item);
                 await _selectedItemState.SetValueAsync(item);
             }
             else
             {
-                Selection.Remove(item);
                 if (Comparer != null)
                 {
                     if (Comparer.Equals(item, _selectedItemState.Value))

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1269,6 +1269,8 @@ namespace MudBlazor
             }
 
             await _selectedItemsState.SetValueAsync(Selection);
+            // doesn't fire due to hashset reference not changing, so fire it manually
+            await SelectedItemsChanged.InvokeAsync(Selection);
         }
 
         private void OnSelectedItemsChanged(ParameterChangedEventArgs<HashSet<T>> args)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #11027 
SetSelectedItem was not updating reference to HashSet causing ParameterState to not recognize change. Updated SetSelected and SetAllSelected methods to match and added unit test.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added unit test, visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
