### PR TITLE
MudDateRangePicker: Fix error with MaxDays and IsDateDisabledFunc 

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DateRangePicker/DateRangePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DateRangePicker/DateRangePickerPage.razor
@@ -39,7 +39,9 @@
         <DocsPageSection>
             <SectionHeader Title="Min/Max Days">
                 <Description>
-                    Defines the smallest and largest number of days that a user can select
+                    Defines the smallest and largest number of days that a user can select.<br/><br/>
+                    For performance reasons, the component checks up to 50 years ahead, from the user-selected start date, to find valid dates that meet the <CodeInline>MaxDays</CodeInline> requirement. 
+                    To extend this limit, set the <CodeInline>MaxDate</CodeInline> property to a specific date.
                 </Description>    
             </SectionHeader>
             <SectionContent Code="@nameof(DateRangePickerMinMaxDaysExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1183,7 +1183,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.FindAll("button.mud-picker-calendar-day").Where(x => x.TrimmedText().Equals("24")).First().ClickAsync(new MouseEventArgs());
 
             comp.Instance.DateRange.Should().Be(new DateRange(new DateTime(2025, 1, 16).Date, new DateTime(2025, 1, 24).Date)); //max valid range 9 days
+        }
 
+        [Test]
+        public async Task DateRangePicker_MaxSelectableDateTest()
+        {
+            var comp = Context.RenderComponent<MudDateRangePicker>();
+
+            comp.SetParametersAndRender(parameters => parameters.Add(picker => picker.MaxDays, 30)
+                                                                .Add(picker => picker.PickerVariant, PickerVariant.Static)
+                                                                .Add(picker => picker.IsDateDisabledFunc, x => x.Date > DateTime.Today));
+
+            var today = DateTime.Today;
+
+            await comp.FindAll("button.mud-picker-calendar-day")
+                      .Where(x => x.TrimmedText().Equals(today.Day.ToString())).First().ClickAsync(new MouseEventArgs());
+            await comp.FindAll("button.mud-picker-calendar-day")
+                      .Where(x => x.TrimmedText().Equals(today.Day.ToString())).First().ClickAsync(new MouseEventArgs());
+
+            comp.Instance.DateRange.Start.Should().Be(comp.Instance.DateRange.End);
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -285,20 +285,30 @@ namespace MudBlazor
         private DateTime GetMaxSelectableDate(DateTime startDate, int maxDays)
         {
             var validDayCount = 1;
+            var lastValidDate = startDate;
             var maxDate = startDate.AddDays(1);
 
             while (validDayCount < maxDays)
             {
                 if (!IsDateDisabledFunc(maxDate))
+                {
                     validDayCount++;
+                    lastValidDate = maxDate;
+                }
 
                 if (validDayCount == maxDays)
+                    break;
+
+                if (maxDate.Date > MaxDate.GetValueOrDefault(startDate.AddYears(50)).Date)
+                    break;
+
+                if (maxDate.Date == DateTime.MaxValue.Date)
                     break;
 
                 maxDate = maxDate.AddDays(1);
             }
 
-            return maxDate;
+            return lastValidDate;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
When using `IsDateDisabledFunc` alongside `MaxDays`, there may be instances where the number of available dates is insufficient to meet the `MaxDays` requirement due to disabled dates. This can result in an `ArgumentOutOfRangeException`.

For example, if `MaxDays` is set to 10, but all future dates are disabled and the user selects today as the start date, the search for valid dates could theoretically extend up to `DateTime.MaxValue` without finding 10 selectable days (since all are disabled). To prevent an exhaustive search, the calculation is capped at 50 years from the selected start date. The user can remove this cap by setting the `MaxDate` property. 

Closes: #11031 

## How Has This Been Tested?
unit tests and visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
