### PR TITLE
MudDialog: Allow actions to wrap in dialog component

### DIFF
--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -118,6 +118,7 @@
   & .mud-dialog-actions {
     flex: 0 0 auto;
     display: flex;
+    flex-wrap: wrap;
     padding: 8px;
     align-items: center;
     justify-content: flex-end;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Content in the `<DialogActions>` does not wrap, thus cause overflow or shrinking the children below min-content width.
This can be fixed by used `<MudStack Wrap="Wrap.Wrap">` but the wrapping of the <DialogActions> div should have wrapping by default, why not?

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested locally with adding the property to the class

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
before:
![Bildschirmfoto 2025-03-19 um 02 14 26](https://github.com/user-attachments/assets/0559189e-4f95-472d-b3ae-3c679d42240e)

after adding `flex-wrap: wrap;`
![Bildschirmfoto 2025-03-19 um 02 14 47](https://github.com/user-attachments/assets/4a52b0ca-f506-4c52-9bd3-9fb1d5d095cb)

yes i am using custom buttons - anyway, i think this could be improved even further by removing the margins of the children and use `gap: .5rem;` for example?  what do you think?
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
