### PR TITLE
MudTextField: Check if user is trying to enter negative number

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1586,10 +1586,18 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.Value, 5));
 
             comp.Find("input").Input("");
+            comp.Find("input").Blur();
+
+            comp.Instance.Text.Should().Be("");
             comp.Instance.Value.Should().Be(0);
 
+            comp.Find("input").Input("5");
+            comp.Find("input").Blur();
             comp.Find("input").Input("0-");
+            comp.Find("input").Blur();
+
             comp.Instance.Text.Should().Be("-");
+            comp.Instance.Value.Should().Be(5);
         }
 
         [TestCase(Adornment.Start, false, false)]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1578,6 +1578,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#error-id").InnerHtml.Should().Be(comp.Instance.ConversionErrorMessage);
         }
 
+        [Test]
+        public void TextField_Should_AllowUserToEnterNegativeNumberWhenBoundToNumericTypeAndImmediate()
+        {
+            var comp = Context.RenderComponent<MudTextField<int>>(parameters => parameters
+                .Add(p => p.Immediate, true)
+                .Add(p => p.Value, 5));
+
+            comp.Find("input").Input("0-");
+
+            comp.Instance.Text.Should().Be("-");
+            comp.Instance.Text.Should().NotBe("0");
+            comp.Instance.Value.Should().Be(5);
+        }
+
         [TestCase(Adornment.Start, false, false)]
         [TestCase(Adornment.Start, false, true)]
         [TestCase(Adornment.Start, true, false)]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1586,16 +1586,11 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.Value, 5));
 
             comp.Find("input").Input("");
-            comp.Find("input").Blur();
-
             comp.Instance.Text.Should().Be("");
             comp.Instance.Value.Should().Be(0);
 
             comp.Find("input").Input("5");
-            comp.Find("input").Blur();
             comp.Find("input").Input("0-");
-            comp.Find("input").Blur();
-
             comp.Instance.Text.Should().Be("-");
             comp.Instance.Value.Should().Be(5);
         }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1593,6 +1593,10 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Input("0-");
             comp.Instance.Text.Should().Be("-");
             comp.Instance.Value.Should().Be(5);
+
+            comp.Find("input").Input("-7");
+            comp.Instance.Text.Should().Be("-7");
+            comp.Instance.Value.Should().Be(-7);
         }
 
         [TestCase(Adornment.Start, false, false)]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1585,11 +1585,11 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.Immediate, true)
                 .Add(p => p.Value, 5));
 
-            comp.Find("input").Input("0-");
+            comp.Find("input").Input("");
+            comp.Instance.Value.Should().Be(0);
 
+            comp.Find("input").Input("0-");
             comp.Instance.Text.Should().Be("-");
-            comp.Instance.Text.Should().NotBe("0");
-            comp.Instance.Value.Should().Be(5);
         }
 
         [TestCase(Adornment.Start, false, false)]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -437,7 +437,21 @@ namespace MudBlazor
         {
             if (Text != text)
             {
-                Text = text;
+                if (text == "0-")
+                {
+                    Text = "-";
+                    updateValue = true;
+                }
+                else if (text == "-")
+                {
+                    Text = "-";
+                    updateValue = false;
+                }
+                else
+                {
+                    Text = text;
+                }
+
                 _validated = false;
 
                 if (!string.IsNullOrEmpty(Text))

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -435,37 +435,20 @@ namespace MudBlazor
 
         protected virtual async Task SetTextAsync(string? text, bool updateValue = true)
         {
-            if (Text != text)
+            Text = text;
+            _validated = false;
+
+            if (!string.IsNullOrEmpty(Text))
             {
-                if (text == "0-")
-                {
-                    Text = "-";
-                    updateValue = true;
-                }
-                else if (text == "-")
-                {
-                    Text = "-";
-                    updateValue = false;
-                }
-                else
-                {
-                    Text = text;
-                }
-
-                _validated = false;
-
-                if (!string.IsNullOrEmpty(Text))
-                {
-                    Touched = true;
-                }
-
-                if (updateValue)
-                {
-                    await UpdateValuePropertyAsync(false);
-                }
-
-                await TextChanged.InvokeAsync(Text);
+                Touched = true;
             }
+
+            if (updateValue)
+            {
+                await UpdateValuePropertyAsync(false);
+            }
+
+            await TextChanged.InvokeAsync(Text);
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -435,20 +435,23 @@ namespace MudBlazor
 
         protected virtual async Task SetTextAsync(string? text, bool updateValue = true)
         {
-            Text = text;
-            _validated = false;
-
-            if (!string.IsNullOrEmpty(Text))
+            if (Text != text)
             {
-                Touched = true;
-            }
+                Text = text;
+                _validated = false;
 
-            if (updateValue)
-            {
-                await UpdateValuePropertyAsync(false);
-            }
+                if (!string.IsNullOrEmpty(Text))
+                {
+                    Touched = true;
+                }
 
-            await TextChanged.InvokeAsync(Text);
+                if (updateValue)
+                {
+                    await UpdateValuePropertyAsync(false);
+                }
+
+                await TextChanged.InvokeAsync(Text);
+            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -212,6 +212,15 @@ namespace MudBlazor
                 text = _mask.Text;
             }
 
+            if (text != null && (typeof(T) == typeof(int) || typeof(T) == typeof(float) || typeof(T) == typeof(decimal) || typeof(T) == typeof(double) || typeof(T) == typeof(short) || typeof(T) == typeof(long)))
+            {
+                if (text == "0-")
+                    text = "-";
+
+                if (text == "-")
+                    updateValue = false;
+            }
+
             return base.SetTextAsync(text, updateValue);
         }
 

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -212,7 +212,9 @@ namespace MudBlazor
                 text = _mask.Text;
             }
 
-            if (text != null && (typeof(T) == typeof(int) || typeof(T) == typeof(float) || typeof(T) == typeof(decimal) || typeof(T) == typeof(double) || typeof(T) == typeof(short) || typeof(T) == typeof(long)))
+            var valueType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+            if (text != null && (valueType == typeof(int) || valueType == typeof(float) || valueType == typeof(decimal) || valueType == typeof(double) || valueType == typeof(short) || valueType == typeof(long)))
             {
                 if (text == "0-")
                     text = "-";


### PR DESCRIPTION
## Description
Check if user is trying to enter negative number. If they are, modify the text so that it allows them to do so.
This seems like a hacky fix. May need guidance on an alternative fix
For issue #11055 

## How Has This Been Tested?
Visually

## Type of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Before:
https://github.com/user-attachments/assets/be2f42db-a9c4-4f5d-93bd-d68fb7f18289

After:
https://github.com/user-attachments/assets/21621dd6-ba74-4e99-b4f8-c2b0056671c1

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
