### PR TITLE
MudDataGrid: Enhance HierarchyColumn for RTL and Expand/Collapse All

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -3,8 +3,8 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid Items="@Elements"
-             ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
+<MudDataGrid @ref="_dataGrid" Items="@Elements"
+ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     <Columns>
         <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" InitiallyExpandedFunc="@(x => x.Sign == "Li")" />
         <PropertyColumn Property="x => x.Number" Title="Nr" />
@@ -33,16 +33,31 @@
 
 <div class="d-flex flex-wrap mt-4">
     <MudSwitch T="bool" @bind-Value="_isReadOnly" Color="@Color.Primary">Read Only</MudSwitch>
+    <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
+    <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
 </div>
 
 
-@code { 
+@code {
+
     private IEnumerable<Element> Elements = new List<Element>();
+
+    private MudDataGrid<Element> _dataGrid;
 
     protected override async Task OnInitializedAsync()
     {
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
     }
-    
+
+    private Task ExpandAll()
+    {
+        return _dataGrid.ExpandAllHierarchy();
+    }
+
+    private Task CollapseAll()
+    {
+        return _dataGrid.CollapseAllHierarchy();
+    }
+
     private bool _isReadOnly = true;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -3,8 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid @ref="_dataGrid" Items="@Elements"
-ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
+<MudDataGrid @ref="_dataGrid" Items="@Elements" ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     <Columns>
         <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" InitiallyExpandedFunc="@(x => x.Sign == "Li")" />
         <PropertyColumn Property="x => x.Number" Title="Nr" />
@@ -37,12 +36,10 @@ ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
 </div>
 
-
 @code {
-
+    private bool _isReadOnly = true;
+    private MudDataGrid<Element> _dataGrid = null!;
     private IEnumerable<Element> Elements = new List<Element>();
-
-    private MudDataGrid<Element> _dataGrid;
 
     protected override async Task OnInitializedAsync()
     {
@@ -58,6 +55,4 @@ ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     {
         return _dataGrid.CollapseAllHierarchy();
     }
-
-    private bool _isReadOnly = true;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,21 +1,27 @@
 ﻿
-
-<MudDataGrid Items="@_items" Filterable="true">
-    <Columns>
-        <HierarchyColumn ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
-        <PropertyColumn Property="x => x.Name" />
-        <PropertyColumn Property="x => x.Age" />
-        <PropertyColumn Property="x => x.Status" />
-    </Columns>
-    <ChildRowContent>
-        <tr>
-            <td colspan="3">@($"uid = {context.Item.Name}|{context.Item.Age}|{context.Item.Status}|{Guid.NewGuid()}")</td>
-        </tr>
-    </ChildRowContent>
-</MudDataGrid>
-
+<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
+    <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true">
+        <Columns>
+            <HierarchyColumn ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
+            <PropertyColumn Property="x => x.Name" />
+            <PropertyColumn Property="x => x.Age" />
+            <PropertyColumn Property="x => x.Status" />
+        </Columns>
+        <ChildRowContent>
+            <tr>
+                <td colspan="3">@($"uid = {context.Item.Name}|{context.Item.Age}|{context.Item.Status}|{Guid.NewGuid()}")</td>
+            </tr>
+        </ChildRowContent>
+    </MudDataGrid>
+</CascadingValue>
+<MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
+<MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
 @code {
-    private IEnumerable<Model> _items = new List<Model>()
+    [Parameter]
+    public bool RightToLeft { get; set; }
+
+    private MudDataGrid<Model> _dataGrid = default!;
+    private readonly IEnumerable<Model> _items = new List<Model>()
     {
         new Model("Sam", 56, Severity.Normal), 
         new Model("Alicia", 54, Severity.Info), 
@@ -25,4 +31,14 @@
     };
 
     public record Model (string Name, int Age, Severity Status);
+
+    private Task ExpandAll()
+    {
+        return _dataGrid.ExpandAllHierarchy();
+    }
+
+    private Task CollapseAll()
+    {
+        return _dataGrid.CollapseAllHierarchy();
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,5 +1,4 @@
-﻿
-<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
+﻿<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
     <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true">
         <Columns>
             <HierarchyColumn ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
@@ -20,7 +19,7 @@
     [Parameter]
     public bool RightToLeft { get; set; }
 
-    private MudDataGrid<Model> _dataGrid = default!;
+    private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>()
     {
         new Model("Sam", 56, Severity.Normal), 
@@ -29,8 +28,6 @@
         new Model("John", 32, Severity.Warning),
         new Model("Anders", 24, Severity.Error)
     };
-
-    public record Model (string Name, int Age, Severity Status);
 
     private Task ExpandAll()
     {
@@ -41,4 +38,6 @@
     {
         return _dataGrid.CollapseAllHierarchy();
     }
+
+    public record Model (string Name, int Age, Severity Status);
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2952,9 +2952,9 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(5));
         }
 
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
-        [Test]
         public void DataGrid_RowDetail_RTL_GroupIcon(bool rightToLeft)
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(param => param

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2940,6 +2940,44 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGrid_RowDetail_ExpandCollapseAllTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(2));
+            await dataGrid.InvokeAsync(() => dataGrid.Instance.CollapseAllHierarchy());
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(0));
+            await dataGrid.InvokeAsync(() => dataGrid.Instance.ExpandAllHierarchy());
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(5));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        [Test]
+        public void DataGrid_RowDetail_RTL_GroupIcon(bool rightToLeft)
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(param => param
+                .Add(p => p.RightToLeft, rightToLeft)
+            );
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+            var svg = dataGrid.Find(".mud-table-body .mud-table-row .mud-table-cell .mud-icon-root");
+
+            if (!rightToLeft)
+            {
+                // ChevronRight by Default
+                svg.InnerHtml.Should().Contain("<path d=\"M0 0h24v24H0z\"")
+                    .And.Contain("<path d=\"M10 6L8.59 7.41");
+            }
+            else
+            {
+                // ChevronLeft when RTL is true
+                svg.InnerHtml.Should().Contain("<path d=\"M0 0h24v24H0z\"")
+                    .And.Contain("<path d=\"M15.41 7.41L14 6l-6");
+            }
+        }
+
+        [Test]
         public void DataGridRowDetailButtonDisabledTest()
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -53,6 +53,7 @@ namespace MudBlazor
                 StartEditingItemAsync = () => dataGrid.SetEditingItemAsync(item),
                 CancelEditingItemAsync = () => dataGrid.CancelEditingItemAsync(),
                 ToggleHierarchyVisibilityForItemAsync = () => dataGrid.ToggleHierarchyVisibilityAsync(item),
+                GetGroupIcon = (expanded, rightToLeft) => dataGrid.GetGroupIcon(expanded, rightToLeft),
             };
         }
 
@@ -80,6 +81,11 @@ namespace MudBlazor
             /// The function which toggles hierarchy visibility.
             /// </summary>
             public required Func<Task> ToggleHierarchyVisibilityForItemAsync { get; init; }
+
+            /// <summary>
+            /// The function which retrieves the GroupIcon.
+            /// </summary>
+            public required Func<bool, bool, string> GetGroupIcon { get; init; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -85,7 +85,7 @@ namespace MudBlazor
             /// <summary>
             /// The function which retrieves the GroupIcon.
             /// </summary>
-            public required Func<bool, bool, string> GetGroupIcon { get; init; }
+            public Func<bool, bool, string>? GetGroupIcon { get; init; }
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -12,7 +12,7 @@
         }
         <MudIconButton 
             Class="ma-n3 pa-1"
-            Icon="@(context.OpenHierarchies.Contains(context.Item) ?  OpenIcon : ClosedIcon)" 
+            Icon="@GetGroupIcon(context)" 
             OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
             Size="@IconSize"
             Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
@@ -20,13 +19,19 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     private readonly HashSet<CellContext<T>> _initiallyExpandedItems = [];
 
     /// <summary>
+    /// Whether the display should be right to left
+    /// </summary>
+    [CascadingParameter(Name = "RightToLeft")]
+    public bool RightToLeft { get; set; }
+
+    /// <summary>
     /// The icon to display for the close button.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Icons.Material.Filled.ChevronRight"/>.
+    /// Defaults to <see cref="Icons.Material.Filled.ChevronRight"/> or <see cref="Icons.Material.Filled.ChevronLeft"/> if RightToLeft.
     /// </remarks>
     [Parameter]
-    public string ClosedIcon { get; set; } = Icons.Material.Filled.ChevronRight;
+    public string ClosedIcon { get; set; }
 
     /// <summary>
     /// The icon to display for the open button.
@@ -35,7 +40,7 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     /// Defaults to <see cref="Icons.Material.Filled.ExpandMore"/>.
     /// </remarks>
     [Parameter]
-    public string OpenIcon { get; set; } = Icons.Material.Filled.ExpandMore;
+    public string OpenIcon { get; set; }
 
     /// <summary>
     /// The size of the open and close icons.
@@ -107,5 +112,16 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
                 await context.Actions.ToggleHierarchyVisibilityForItemAsync.Invoke();
             }
         }
+    }
+
+    private string GetGroupIcon(CellContext<T> context)
+    {
+        return context.OpenHierarchies.Contains(context.Item)
+                ? (string.IsNullOrWhiteSpace(OpenIcon)
+                    ? context.Actions.GetGroupIcon(true, RightToLeft)
+                    : OpenIcon)
+                : (string.IsNullOrWhiteSpace(ClosedIcon)
+                    ? context.Actions.GetGroupIcon(false, RightToLeft)
+                    : ClosedIcon);
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -116,12 +116,21 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
 
     private string GetGroupIcon(CellContext<T> context)
     {
-        return context.OpenHierarchies.Contains(context.Item)
-                ? (string.IsNullOrWhiteSpace(OpenIcon)
-                    ? context.Actions.GetGroupIcon(true, RightToLeft)
-                    : OpenIcon)
-                : (string.IsNullOrWhiteSpace(ClosedIcon)
-                    ? context.Actions.GetGroupIcon(false, RightToLeft)
-                    : ClosedIcon);
+        bool isItemOpen = context.OpenHierarchies.Contains(context.Item);
+        bool isOpenIconEmpty = string.IsNullOrWhiteSpace(OpenIcon);
+        bool isClosedIconEmpty = string.IsNullOrWhiteSpace(ClosedIcon);
+
+        if (isItemOpen)
+        {
+            return isOpenIconEmpty
+                ? context.Actions.GetGroupIcon(true, RightToLeft)
+                : OpenIcon;
+        }
+        else
+        {
+            return isClosedIconEmpty
+                ? context.Actions.GetGroupIcon(false, RightToLeft)
+                : ClosedIcon;
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -119,16 +119,17 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
         var isItemOpen = context.OpenHierarchies.Contains(context.Item);
         var isOpenIconEmpty = string.IsNullOrEmpty(OpenIcon);
         var isClosedIconEmpty = string.IsNullOrEmpty(ClosedIcon);
+        var isGetGroupDefined = context.Actions.GetGroupIcon != null;
 
         if (isItemOpen)
         {
-            return isOpenIconEmpty
+            return isOpenIconEmpty && isGetGroupDefined
                 ? context.Actions.GetGroupIcon(true, RightToLeft)
                 : OpenIcon;
         }
         else
         {
-            return isClosedIconEmpty
+            return isClosedIconEmpty && isGetGroupDefined
                 ? context.Actions.GetGroupIcon(false, RightToLeft)
                 : ClosedIcon;
         }

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -116,9 +116,9 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
 
     private string GetGroupIcon(CellContext<T> context)
     {
-        bool isItemOpen = context.OpenHierarchies.Contains(context.Item);
-        bool isOpenIconEmpty = string.IsNullOrWhiteSpace(OpenIcon);
-        bool isClosedIconEmpty = string.IsNullOrWhiteSpace(ClosedIcon);
+        var isItemOpen = context.OpenHierarchies.Contains(context.Item);
+        var isOpenIconEmpty = string.IsNullOrEmpty(OpenIcon);
+        var isClosedIconEmpty = string.IsNullOrEmpty(ClosedIcon);
 
         if (isItemOpen)
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1283,8 +1283,6 @@ namespace MudBlazor
             }
         }
 
-        #region Methods
-
         /// <summary>
         /// Check if a specific Footer cell is displayable
         /// </summary>
@@ -2107,14 +2105,20 @@ namespace MudBlazor
             GroupItems();
         }
 
-        internal async Task ExpandAllHierarchy()
+        /// <summary>
+        /// Expands all Hierarchy columns
+        /// </summary>
+        public async Task ExpandAllHierarchy()
         {
             _openHierarchies.Clear();
             _openHierarchies.UnionWith(FilteredItems);
             await InvokeAsync(StateHasChanged);
         }
 
-        internal async Task CollapseAllHierarchy()
+        /// <summary>
+        /// Collapses all Hierarchy columns
+        /// </summary>
+        public async Task CollapseAllHierarchy()
         {
             _openHierarchies.Clear();
             await InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2107,7 +2107,18 @@ namespace MudBlazor
             GroupItems();
         }
 
-        #endregion
+        internal async Task ExpandAllHierarchy()
+        {
+            _openHierarchies.Clear();
+            _openHierarchies.UnionWith(FilteredItems);
+            await InvokeAsync(StateHasChanged);
+        }
+
+        internal async Task CollapseAllHierarchy()
+        {
+            _openHierarchies.Clear();
+            await InvokeAsync(StateHasChanged);
+        }
 
         internal async Task ToggleHierarchyVisibilityAsync(T item)
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Add ExpandAllHierarchy and CollapseAllHierarchy to public methods on MudDataGrid
Updated Doc Example to include A Collapse and Expand all button.
Resolves #9047 
Add RTL Support in HierarchyColumn GroupIcon without requiring user to manually put in icons. Left that ability in.
Resolves #6965 

https://github.com/user-attachments/assets/a0b50309-2213-4def-8db7-3e71d51a0614

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Add multiple unit tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
