### PR TITLE
MudDateRangePicker: BlurAsync() MudRangeInput can now blur both inputs at once

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1203,5 +1203,24 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.DateRange.Start.Should().Be(comp.Instance.DateRange.End);
         }
+
+        [Test]
+        public async Task DateRangePicker_BlurAsync()
+        {
+            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+                    .Add(picker => picker.ReadOnly, false)
+                    .Add(picker => picker.Editable, true));
+
+            var input = comp.Find("input");
+
+            await comp.Instance.FocusStartAsync();
+
+            // the input is actually never focused because the test is run in a headless browser
+            //comp.Find("input").IsFocused.Should().BeTrue();
+
+            await comp.Instance.BlurAsync();
+
+            comp.Find("input").IsFocused.Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -212,6 +212,8 @@ namespace MudBlazor
         /// </summary>
         public ValueTask SelectEndAsync() => _rangeInput.SelectEndAsync();
 
+        public override ValueTask BlurAsync() => _rangeInput.BlurAsync();
+
         /// <summary>
         /// Selects a portion of the end input text.
         /// </summary>

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -101,6 +101,12 @@ namespace MudBlazor
         /// </summary>
         public ValueTask FocusStartAsync() => _elementReferenceStart.FocusAsync();
 
+        public override async ValueTask BlurAsync()
+        {
+            await _elementReferenceStart.MudBlurAsync();
+            await _elementReferenceEnd.MudBlurAsync();
+        }
+
         /// <summary>
         /// Selects the text in the starting input.
         /// </summary>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
The `BlurAsync()` method on the `MudDateRangePicker` wasn't implemented for the range picker before even though the documentation states it exists. It was implemented in a way that blurs both the start and the end input from the component, as the `MudBaseInput.BlurAsync()` initially doesn't do anything.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tests weren't written as checking the `IsFocused` doesn't work for the inputs.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
