### PR TITLE
MudPopover: Fix positioning delay (partial revert of #10856)

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -639,11 +639,12 @@ class MudPopover {
 
             observer.observe(popoverContentNode, config);
 
-            // Optimize resize observer
-            const throttledResize = window.mudpopoverHelper.rafThrottle(entries => {
+            const resizeObserver = new ResizeObserver(entries => {
                 for (let entry of entries) {
                     const target = entry.target;
-                    for (let childNode of target.childNodes) {
+
+                    for (var i = 0; i < target.childNodes.length; i++) {
+                        const childNode = target.childNodes[i];
                         if (childNode.id && childNode.id.startsWith('popover-')) {
                             window.mudpopoverHelper.placePopover(childNode);
                         }
@@ -651,16 +652,15 @@ class MudPopover {
                 }
             });
 
-            const resizeObserver = new ResizeObserver(throttledResize);
             resizeObserver.observe(popoverNode.parentNode);
 
-            const throttledContent = window.mudpopoverHelper.rafThrottle(entries => {
+            const contentNodeObserver = new ResizeObserver(entries => {
                 for (let entry of entries) {
-                    window.mudpopoverHelper.placePopoverByNode(entry.target);
+                    var target = entry.target;
+                    window.mudpopoverHelper.placePopoverByNode(target);
                 }
             });
 
-            const contentNodeObserver = new ResizeObserver(throttledContent);
             contentNodeObserver.observe(popoverContentNode);
 
             this.map[id] = {

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -642,9 +642,7 @@ class MudPopover {
             const resizeObserver = new ResizeObserver(entries => {
                 for (let entry of entries) {
                     const target = entry.target;
-
-                    for (var i = 0; i < target.childNodes.length; i++) {
-                        const childNode = target.childNodes[i];
+                    for (const childNode of target.childNodes) {
                         if (childNode.id && childNode.id.startsWith('popover-')) {
                             window.mudpopoverHelper.placePopover(childNode);
                         }
@@ -656,8 +654,9 @@ class MudPopover {
 
             const contentNodeObserver = new ResizeObserver(entries => {
                 for (let entry of entries) {
-                    var target = entry.target;
-                    window.mudpopoverHelper.placePopoverByNode(target);
+                    const target = entry.target;
+                    if (target)
+                        window.mudpopoverHelper.placePopoverByNode(target);
                 }
             });
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #11044 
There were some instances of slow popover moving when latency was involved. The obvious culprit is the debounce/throttle used inside the connect method from #10856. Left debounce and throttle on resize/scroll since the popover is already positioned and this will avoid unnecessary js calls during one of those events.
- Only allow throttle and debounce on resize/scroll.
- revert #10856 changes inside the connect method

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested visually in Viewer project and Docs project.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
