### PR TITLE
MudMenu Nested Fix

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -3,13 +3,13 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes"
-class="@Classname"
-style="@Style"
-@onpointerenter="@PointerEnterAsync"
-@onpointerleave="@PointerLeaveAsync"
-@oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
-@oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
-@oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)">
+     class="@Classname"
+     style="@Style"
+     @onpointerenter="@PointerEnterAsync"
+     @onpointerleave="@PointerLeaveAsync"
+     @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
+     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
+     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)">
     @if (GetActivatorHidden())
     {
         @* No content was set so no need to render anything *@
@@ -27,29 +27,29 @@ style="@Style"
         if (ParentMenu is null)
         {
             <MudButton Class="mud-menu-button-activator"
-            StartIcon="@StartIcon"
-            EndIcon="@EndIcon"
-            IconColor="@IconColor"
-            Color="@Color"
-            Size="@Size"
-            Variant="@Variant"
-            Disabled="@Disabled"
-            Ripple="@Ripple"
-            DropShadow="@DropShadow"
-            OnClick="@ToggleMenuAsync"
-            aria-label="@AriaLabel">
+                       StartIcon="@StartIcon"
+                       EndIcon="@EndIcon"
+                       IconColor="@IconColor"
+                       Color="@Color"
+                       Size="@Size"
+                       Variant="@Variant"
+                       Disabled="@Disabled"
+                       Ripple="@Ripple"
+                       DropShadow="@DropShadow"
+                       OnClick="@ToggleMenuAsync"
+                       aria-label="@AriaLabel">
                 @Label
             </MudButton>
         }
         else
         {
             <MudMenuItem Class="mud-menu-sub-menu-activator"
-            Icon="@StartIcon"
-            IconColor="@IconColor"
-            Disabled="@Disabled"
-            OnClick="OpenSubMenuAsync"
-            AutoClose="false"
-            aria-label="@AriaLabel">
+                         Icon="@StartIcon"
+                         IconColor="@IconColor"
+                         Disabled="@Disabled"
+                         OnClick="OpenSubMenuAsync"
+                         AutoClose="false"
+                         aria-label="@AriaLabel">
                 @Label
             </MudMenuItem>
         }
@@ -57,35 +57,35 @@ style="@Style"
     else
     {
         <MudIconButton Class="mud-menu-icon-button-activator"
-        Variant="@Variant"
-        Icon="@Icon"
-        Color="@Color"
-        Size="@Size"
-        Disabled="@Disabled"
-        Ripple="@Ripple"
-        DropShadow="@DropShadow"
-        OnClick="@ToggleMenuAsync"
-        aria-label="@AriaLabel" />
+                       Variant="@Variant"
+                       Icon="@Icon"
+                       Color="@Color"
+                       Size="@Size"
+                       Disabled="@Disabled"
+                       Ripple="@Ripple"
+                       DropShadow="@DropShadow"
+                       OnClick="@ToggleMenuAsync"
+                       aria-label="@AriaLabel" />
     }
 
     @* The portal has to include the cascading values inside because it's not able to teletransport the cascade *@
     <MudPopover Open="@_openState.Value"
-    Class="@PopoverClassname"
-    Style="@Stylename"
-    MaxHeight="@MaxHeight"
-    AnchorOrigin="@GetAnchorOrigin()"
-    TransformOrigin="@TransformOrigin"
-    RelativeWidth="@RelativeWidth"
-    Fixed="@DropdownSettings.Fixed"
-    OverflowBehavior="@DropdownSettings.OverflowBehavior"
-    DropShadow="@DropShadow"
-    Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
+                Class="@PopoverClassname"
+                Style="@Stylename"
+                MaxHeight="@MaxHeight"
+                AnchorOrigin="@GetAnchorOrigin()"
+                TransformOrigin="@TransformOrigin"
+                RelativeWidth="@RelativeWidth"
+                Fixed="@DropdownSettings.Fixed"
+                OverflowBehavior="@DropdownSettings.OverflowBehavior"
+                DropShadow="@DropShadow"
+                Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
         <CascadingValue Value="@this">
             <MudList T="object"
-            Class="@ListClassname"
-            Dense="@Dense"
-            @onpointerenter="@PointerEnterAsync"
-            @onpointerleave="@PointerLeaveAsync">
+                     Class="@ListClassname"
+                     Dense="@Dense"
+                     @onpointerenter="@PointerEnterAsync"
+                     @onpointerleave="@PointerLeaveAsync">
                 @ChildContent
             </MudList>
         </CascadingValue>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -3,13 +3,13 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes"
-     class="@Classname"
-     style="@Style"
-     @onpointerenter="@PointerEnterAsync"
-     @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
-     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
-     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)">
+class="@Classname"
+style="@Style"
+@onpointerenter="@PointerEnterAsync"
+@onpointerleave="@PointerLeaveAsync"
+@oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
+@oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
+@oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)">
     @if (GetActivatorHidden())
     {
         @* No content was set so no need to render anything *@
@@ -27,29 +27,29 @@
         if (ParentMenu is null)
         {
             <MudButton Class="mud-menu-button-activator"
-                       StartIcon="@StartIcon"
-                       EndIcon="@EndIcon"
-                       IconColor="@IconColor"
-                       Color="@Color"
-                       Size="@Size"
-                       Variant="@Variant"
-                       Disabled="@Disabled"
-                       Ripple="@Ripple"
-                       DropShadow="@DropShadow"
-                       OnClick="@ToggleMenuAsync"
-                       aria-label="@AriaLabel">
+            StartIcon="@StartIcon"
+            EndIcon="@EndIcon"
+            IconColor="@IconColor"
+            Color="@Color"
+            Size="@Size"
+            Variant="@Variant"
+            Disabled="@Disabled"
+            Ripple="@Ripple"
+            DropShadow="@DropShadow"
+            OnClick="@ToggleMenuAsync"
+            aria-label="@AriaLabel">
                 @Label
             </MudButton>
         }
         else
         {
             <MudMenuItem Class="mud-menu-sub-menu-activator"
-                         Icon="@StartIcon"
-                         IconColor="@IconColor"
-                         Disabled="@Disabled"
-                         OnClick="OpenSubMenuAsync"
-                         AutoClose="false"
-                         aria-label="@AriaLabel">
+            Icon="@StartIcon"
+            IconColor="@IconColor"
+            Disabled="@Disabled"
+            OnClick="OpenSubMenuAsync"
+            AutoClose="false"
+            aria-label="@AriaLabel">
                 @Label
             </MudMenuItem>
         }
@@ -57,41 +57,41 @@
     else
     {
         <MudIconButton Class="mud-menu-icon-button-activator"
-                       Variant="@Variant"
-                       Icon="@Icon"
-                       Color="@Color"
-                       Size="@Size"
-                       Disabled="@Disabled"
-                       Ripple="@Ripple"
-                       DropShadow="@DropShadow"
-                       OnClick="@ToggleMenuAsync"
-                       aria-label="@AriaLabel" />
+        Variant="@Variant"
+        Icon="@Icon"
+        Color="@Color"
+        Size="@Size"
+        Disabled="@Disabled"
+        Ripple="@Ripple"
+        DropShadow="@DropShadow"
+        OnClick="@ToggleMenuAsync"
+        aria-label="@AriaLabel" />
     }
 
     @* The portal has to include the cascading values inside because it's not able to teletransport the cascade *@
-    @if (_openState.Value)
+    <MudPopover Open="@_openState.Value"
+    Class="@PopoverClassname"
+    Style="@Stylename"
+    MaxHeight="@MaxHeight"
+    AnchorOrigin="@GetAnchorOrigin()"
+    TransformOrigin="@TransformOrigin"
+    RelativeWidth="@RelativeWidth"
+    Fixed="@DropdownSettings.Fixed"
+    OverflowBehavior="@DropdownSettings.OverflowBehavior"
+    DropShadow="@DropShadow"
+    Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
+        <CascadingValue Value="@this">
+            <MudList T="object"
+            Class="@ListClassname"
+            Dense="@Dense"
+            @onpointerenter="@PointerEnterAsync"
+            @onpointerleave="@PointerLeaveAsync">
+                @ChildContent
+            </MudList>
+        </CascadingValue>
+    </MudPopover>
+    @if (ParentMenu is null)
     {
-        <MudPopover Open="@_openState.Value"
-                    Class="@PopoverClassname"
-                    Style="@Stylename"
-                    MaxHeight="@MaxHeight"
-                    AnchorOrigin="@GetAnchorOrigin()"
-                    TransformOrigin="@TransformOrigin"
-                    RelativeWidth="@RelativeWidth"
-                    Fixed="@DropdownSettings.Fixed"
-                    OverflowBehavior="@DropdownSettings.OverflowBehavior"
-                    DropShadow="@DropShadow"
-                    Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
-            <CascadingValue Value="@this">
-                <MudList T="object"
-                         Class="@ListClassname"
-                         Dense="@Dense"
-                         @onpointerenter="@PointerEnterAsync"
-                         @onpointerleave="@PointerLeaveAsync">
-                    @ChildContent
-                </MudList>
-            </CascadingValue>
-        </MudPopover>
-        <MudOverlay Visible="_openState.Value && !_isTransient" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />
-    }
+        <MudOverlay Class="mud-skip-overlay-positioning" Visible="_openState.Value && !_isTransient" AutoClose OnClosed="CloseMenuAsync" LockScroll="LockScroll" />        
+    }    
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
+using MudBlazor.Utilities.Debounce;
 
 namespace MudBlazor
 {
@@ -22,11 +23,15 @@ namespace MudBlazor
         private (double Top, double Left) _openPosition;
         private bool _isPointerOver;
         private bool _isTransient;
-        private CancellationTokenSource? _hoverCts;
-        private CancellationTokenSource? _leaveCts;
+        internal DebounceDispatcher _showDebouncer;
+        internal DebounceDispatcher _hideDebouncer;
 
         public MudMenu()
         {
+            _showDebouncer = new DebounceDispatcher(MudGlobal.MenuDefaults.HoverDelay);
+            // double the delay for hiding a menu
+            _hideDebouncer = new DebounceDispatcher(MudGlobal.MenuDefaults.HoverDelay * 2);
+
             using var registerScope = CreateRegisterScope();
             _openState = registerScope.RegisterParameter<bool>(nameof(Open))
                 .WithParameter(() => Open)
@@ -543,33 +548,22 @@ namespace MudBlazor
         {
             _isPointerOver = true;
 
-            CancelPendingActions();
-
             if (!IsHoverable(args))
             {
                 return;
             }
 
-            if (MudGlobal.MenuDefaults.HoverDelay > 0)
-            {
-                _hoverCts = new();
+            // Cancel any pending hide operation
+            _hideDebouncer.Cancel();
 
-                try
-                {
-                    // Wait a bit to allow the cursor to move over the activator if the user isn't trying to open it.
-                    await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _hoverCts.Token);
-                }
-                catch (TaskCanceledException)
-                {
-                    // Hover action was canceled.
-                    return;
-                }
-            }
-
-            if (!_openState.Value)
+            // Schedule the show operation with debouncing
+            await _showDebouncer.DebounceAsync(async () =>
             {
-                await OpenSubMenuAsync(args);
-            }
+                if (!_openState.Value)
+                {
+                    await OpenSubMenuAsync(args);
+                }
+            });
         }
 
         /// <summary>
@@ -578,34 +572,28 @@ namespace MudBlazor
         private async Task PointerLeaveAsync(PointerEventArgs args)
         {
             _isPointerOver = false;
-
-            CancelPendingActions();
+            var isSubmenu = ParentMenu is not null;
+            if (!isSubmenu && ActivationEvent != MouseEvent.MouseOver)
+            {
+                return; // main menu that doesn't use mopuseover
+            }
 
             if (!_isTransient || !IsHoverable(args))
             {
                 return;
             }
 
-            if (MudGlobal.MenuDefaults.HoverDelay > 0)
-            {
-                _leaveCts = new();
+            // Cancel any pending show operation
+            _showDebouncer.Cancel();
 
-                try
-                {
-                    // Wait a bit to allow the cursor to move from the activator to the items popover.
-                    await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _leaveCts.Token);
-                }
-                catch (TaskCanceledException)
-                {
-                    // Leave action was canceled.
-                    return;
-                }
-            }
-
-            if (!HasPointerOver(this))
+            // Schedule the hide operation with debouncing
+            await _hideDebouncer.DebounceAsync(async () =>
             {
-                await CloseMenuAsync();
-            }
+                if (!HasPointerOver(this))
+                {
+                    await CloseMenuAsync();
+                }
+            });
         }
 
         protected bool HasPointerOver(MudMenu menu)
@@ -622,10 +610,8 @@ namespace MudBlazor
         /// </summary>
         private void CancelPendingActions()
         {
-            // ReSharper disable MethodHasAsyncOverload
-            _leaveCts?.Cancel();
-            _hoverCts?.Cancel();
-            // ReSharper restore MethodHasAsyncOverload
+            _showDebouncer.Cancel();
+            _hideDebouncer.Cancel();
         }
 
         /// <summary>
@@ -650,11 +636,7 @@ namespace MudBlazor
         {
             if (disposing)
             {
-                _hoverCts?.Cancel();
-                _hoverCts?.Dispose();
-
-                _leaveCts?.Cancel();
-                _leaveCts?.Dispose();
+                CancelPendingActions();
 
                 ParentMenu?.UnregisterChild(this);
             }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -544,7 +544,7 @@ namespace MudBlazor
         /// <summary>
         /// Handles the pointer entering either the activator or the menu list.
         /// </summary>
-        private async Task PointerEnterAsync(PointerEventArgs args)
+        internal async Task PointerEnterAsync(PointerEventArgs args)
         {
             _isPointerOver = true;
 
@@ -569,13 +569,13 @@ namespace MudBlazor
         /// <summary>
         /// Handles the pointer leaving either the activator or the menu list.
         /// </summary>
-        private async Task PointerLeaveAsync(PointerEventArgs args)
+        internal async Task PointerLeaveAsync(PointerEventArgs args)
         {
             _isPointerOver = false;
             var isSubmenu = ParentMenu is not null;
             if (!isSubmenu && ActivationEvent != MouseEvent.MouseOver)
             {
-                return; // main menu that doesn't use mopuseover
+                return; // main menu that doesn't use mouseover
             }
 
             if (!_isTransient || !IsHoverable(args))

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -78,7 +78,7 @@ public static class MudGlobal
     {
         /// <summary>
         /// The time in milliseconds before a <see cref="MudMenu"/> is activated by the cursor hovering over it
-        /// or before it is hidden after the cursor leaves the menu.
+        /// or 2x that time before it is hidden after the cursor leaves the menu.
         /// </summary>
         public static int HoverDelay { get; set; } = 300;
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Refactored the cancellation and Task.Delay logic into DebounceDispatcher
Made pointerleave 2x the hoverdelay as pointerenter for smoother transitions
Updated MudGlobal xml to read that behavior
Modified overlay to only have one overlay that is not repositioned allowing PointerEnter and PointerLeave to operate as intended
Added exception to PointerLeave for the Parent menu that does not activate by hover
Resolves #11115 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually tested in Viewer (WASM) and Docs (Server)
Added multiple unit tests to cover all scenarios and test the actual timing

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
