### PR TITLE
MudDateRangePicker: Re-enable selecting end date before start date (fix regression)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1232,7 +1232,5 @@ namespace MudBlazor.UnitTests.Components
 
             return selectedDate;
         }
-
-        
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -255,10 +255,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
-            comp.FindAll("button.mud-picker-calendar-day")
-                .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("button.mud-picker-calendar-day")
-                .Where(x => x.TrimmedText().Equals("8")).First().Click();
+            comp.SelectDate("10");
+            comp.SelectDate("8");
             comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
@@ -1203,5 +1201,38 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.DateRange.Start.Should().Be(comp.Instance.DateRange.End);
         }
+    }
+
+    public static class DatePickerRenderedFragmentExtensions
+    {
+        public static void SelectDate(this IRenderedFragment comp, string day, bool firstOccurrence = true)
+        {
+            comp.ValidateSelection(day, firstOccurrence).Click();
+        }
+
+        public static async Task SelectDateAsync(this IRenderedFragment comp, string day, bool firstOccurrence = true)
+        {
+            await comp.ValidateSelection(day, firstOccurrence).ClickAsync(new MouseEventArgs());
+        }
+
+        private static IElement ValidateSelection(this IRenderedFragment comp, string day, bool firstOccurrence)
+        {
+            var matchingDays = comp.FindAll("button.mud-picker-calendar-day")
+                       .Where(x => !x.ClassList.Contains("mud-hidden") && x.TrimmedText().Equals(day))
+                       .ToList();
+
+            Assert.That(matchingDays.Count != 0, $"Invalid day ({day}) selected");
+
+            if (!firstOccurrence)
+                Assert.That(matchingDays.Count == 2, $"Only one instance of date ({day}) found");
+
+            var selectedDate = matchingDays[firstOccurrence ? 0 : 1];
+
+            Assert.That(!selectedDate.IsDisabled(), $"Selected date ({day}) is disabled");
+
+            return selectedDate;
+        }
+
+        
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -259,14 +259,14 @@ namespace MudBlazor
         {
             var start = MinDays switch
             {
-                null => selectedDate,
+                null => MinDate ?? DateTime.MinValue,
                 _ when _allowDisabledDatesInCountState.Value => selectedDate.Date.AddDays(MinDays.Value - 1),
                 _ => _minValidDate
             };
 
             var end = MaxDays switch
             {
-                null => DateTime.MaxValue,
+                null => MaxDate ?? DateTime.MaxValue,
                 _ when _allowDisabledDatesInCountState.Value => selectedDate.Date.AddDays(MaxDays.Value - 1),
                 _ => _maxValidDate
             };


### PR DESCRIPTION
## Description
The introduction of Min/Max days constraint inadvertently prevented selecting an end date before a start date when Min/Max days **is not** being used. This change corrects this regression.

Fixes #11121 

## How Has This Been Tested?
- corrected unit test 
- tested visually 
- re-ran unit tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
