### PR TITLE
MudAutocomplete: Fix various activation issues

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1854,6 +1854,75 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Ensure selecting an option does not reopen the list.
+        /// </summary>
+        [Test]
+        public void Autocomplete_SelectingOption_ShouldNot_ReopenList()
+        {
+            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+
+            // Open the menu
+            autocompleteComponent.Find("div.mud-input-control").Focus();
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            // Select an option
+            comp.Find("div.mud-list-item").Click();
+
+            // Assert: Menu should remain closed
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+        }
+
+        /// <summary>
+        /// Ensure the menu does not open in read-only mode.
+        /// </summary>
+        [Test]
+        public void Autocomplete_User_ShouldNot_OpenMenu_InReadOnlyMode()
+        {
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+                .Add(p => p.ReadOnly, true)
+                .Add(p => p.OpenOnFocus, true));
+            var autocomplete = comp.Instance;
+
+            // Attempt to open the menu via focus
+            comp.Find("div.mud-input-control").Focus();
+
+            // Assert: Menu should not open
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
+
+            // Attempt to open the menu via click
+            comp.Find("div.mud-input-control").MouseDown();
+
+            // Assert: Menu should not open
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
+        }
+
+        /// <summary>
+        /// Ensure the menu does not open in disabled mode.
+        /// </summary>
+        [Test]
+        public void Autocomplete_User_ShouldNot_OpenMenu_InDisabledMode()
+        {
+            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+                .Add(p => p.Disabled, true)
+                .Add(p => p.OpenOnFocus, true));
+            var autocomplete = comp.Instance;
+
+            // Attempt to open the menu via focus
+            comp.Find("div.mud-input-control").Focus();
+
+            // Assert: Menu should not open
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
+
+            // Attempt to open the menu via click
+            comp.Find("div.mud-input-control").MouseDown();
+
+            // Assert: Menu should not open
+            comp.WaitForAssertion(() => autocomplete.Open.Should().BeFalse());
+        }
+
+        /// <summary>
         /// Ensure that the ItemDisabledTemplate and ItemSelectedTemplate both can display when ItemTemplate isn't provided (null)
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2103,5 +2103,34 @@ namespace MudBlazor.UnitTests.Components
 
             comp.WaitForAssertion(() => comp.Instance.Open.Should().Be(openOnFocus, $"OpenOnFocus should set Open to {openOnFocus} after input Focus"));
         }
+
+        [Test]
+        public async Task DebounceShouldNotOpenMenuIfAutocompleteIsDisabledDuringThatTime()
+        {
+            var valueChangedCount = 0;
+            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            {
+                parameters.Add(p => p.DebounceInterval, 500);
+                parameters.Add(p => p.CoerceText, false);
+                parameters.Add(p => p.CoerceValue, true);
+                parameters.Add(p => p.Immediate, true);
+                parameters.Add(p => p.ValueChanged, v => valueChangedCount++);
+            });
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+
+            autocomplete.Disabled.Should().BeFalse();
+            autocomplete.Open.Should().BeFalse();
+            comp.Markup.Should().NotContain("mud-popover-open");
+
+            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+
+            autocomplete.Disabled = true;
+
+            // Wait until after the debounce should have elapsed and ensure the menu is still closed.
+            await Task.Delay(1000);
+            autocomplete.Open.Should().BeFalse();
+            comp.Markup.Should().NotContain("mud-popover-open");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2103,34 +2103,5 @@ namespace MudBlazor.UnitTests.Components
 
             comp.WaitForAssertion(() => comp.Instance.Open.Should().Be(openOnFocus, $"OpenOnFocus should set Open to {openOnFocus} after input Focus"));
         }
-
-        [Test]
-        public async Task DebounceShouldNotOpenMenuIfAutocompleteIsDisabledDuringThatTime()
-        {
-            var valueChangedCount = 0;
-            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
-            {
-                parameters.Add(p => p.DebounceInterval, 500);
-                parameters.Add(p => p.CoerceText, false);
-                parameters.Add(p => p.CoerceValue, true);
-                parameters.Add(p => p.Immediate, true);
-                parameters.Add(p => p.ValueChanged, v => valueChangedCount++);
-            });
-            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
-            var autocomplete = autocompletecomp.Instance;
-
-            autocomplete.Disabled.Should().BeFalse();
-            autocomplete.Open.Should().BeFalse();
-            comp.Markup.Should().NotContain("mud-popover-open");
-
-            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
-
-            autocomplete.Disabled = true;
-
-            // Wait until after the debounce should have elapsed and ensure the menu is still closed.
-            await Task.Delay(1000);
-            autocomplete.Open.Should().BeFalse();
-            comp.Markup.Should().NotContain("mud-popover-open");
-        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -20,6 +20,7 @@
                          Required="@Required"
                          @onmousedown="@OnInputClickedAsync"
                          @onfocus="@OnInputFocusedAsync"
+                         @onblur="OnInputBlurredAsync"
                          ForId="@InputElementId">
             <InputContent>
                 <MudInput @ref="_elementReference" @key="_elementKey" InputType="InputType.Text"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -20,7 +20,6 @@
                          Required="@Required"
                          @onmousedown="@OnInputClickedAsync"
                          @onfocus="@OnInputFocusedAsync"
-                         @onblur="OnInputBlurredAsync"
                          ForId="@InputElementId">
             <InputContent>
                 <MudInput @ref="_elementReference" @key="_elementKey" InputType="InputType.Text"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -674,17 +674,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Opens the drop-down of items, or refreshes the list if it is already open.
+        /// Opens the drop-down of items.
         /// </summary>
         public async Task OpenMenuAsync()
         {
-            if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
-            {
-                Open = false;
-                StateHasChanged();
-                return;
-            }
-
             _opening = true;
 
             var searchedItems = Array.Empty<T>();
@@ -764,8 +757,17 @@ namespace MudBlazor
         /// </returns>
         private async Task<bool> TryOpenMenuAsync()
         {
-            if (Open || GetDisabledState() || GetReadOnlyState())
+            // Close the menu if we don't have enough characters.
+            if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
             {
+                Open = false;
+                StateHasChanged();
+                return false;
+            }
+
+            if (GetDisabledState() || GetReadOnlyState())
+            {
+                await CloseMenuAsync();
                 return false;
             }
 
@@ -867,13 +869,9 @@ namespace MudBlazor
             {
                 case "Enter":
                 case "NumpadEnter":
-                    if (Open)
+                    if (!await TryOpenMenuAsync())
                     {
                         await OnEnterKeyAsync();
-                    }
-                    else
-                    {
-                        await TryOpenMenuAsync();
                     }
                     break;
                 case "Escape":

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -562,7 +562,10 @@ namespace MudBlazor
                     await _elementReference.SetText(optionText);
                 }
 
-                await CloseMenuAsync();
+                // We want focus with a closed popover	
+                Open = false;
+                // And update	
+                StateHasChanged();
             }
             finally
             {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -985,6 +985,7 @@ namespace MudBlazor
             var wasFocused = _isFocused;
             _isFocused = true;
 
+            // Skip features that are not meant for internal focus events.
             if (_handleNextFocus)
             {
                 _handleNextFocus = false;

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
         private T[]? _items;
         private List<int> _enabledItemIndices = [];
         private Func<T?, string?>? _toStringFunc;
-        private bool _isFocusBeingHandledInternally;
+        private bool _isNextFocusBeingHandledInternally;
 
         [Inject]
         private IScrollManager ScrollManager { get; set; } = null!;
@@ -976,13 +976,19 @@ namespace MudBlazor
 
         private async Task OnInputFocusedAsync()
         {
+            if (GetReadOnlyState())
+            {
+                // The readonly input doesn't trigger onblur and so we'll have to disable focus features for it.
+                return;
+            }
+
             var wasFocused = _isFocused;
             _isFocused = true;
 
             // Was focus NOT triggered by user interaction?
-            if (_isFocusBeingHandledInternally)
+            if (_isNextFocusBeingHandledInternally)
             {
-                _isFocusBeingHandledInternally = false;
+                _isNextFocusBeingHandledInternally = false;
                 return;
             }
 
@@ -1033,7 +1039,7 @@ namespace MudBlazor
         private Task OnInputBlurredAsync(FocusEventArgs args)
         {
             _isFocused = false;
-            _isFocusBeingHandledInternally = false;
+            _isNextFocusBeingHandledInternally = false;
 
             // When Immediate is enabled, then the CoerceValue is set by TextChanged
             // So only coerce the value on blur when Immediate is disabled
@@ -1118,7 +1124,7 @@ namespace MudBlazor
         /// </summary>
         public override ValueTask FocusAsync()
         {
-            _isFocusBeingHandledInternally = true; // The subsequent event that will be triggered will know it's not by the user.
+            _isNextFocusBeingHandledInternally = true; // The subsequent event that will be triggered will know it's not by the user.
             return _elementReference.FocusAsync();
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -674,10 +674,17 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Opens the drop-down of items.
+        /// Opens the drop-down of items, or refreshes the list if it is already open.
         /// </summary>
         public async Task OpenMenuAsync()
         {
+            if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
+            {
+                Open = false;
+                StateHasChanged();
+                return;
+            }
+
             _opening = true;
 
             var searchedItems = Array.Empty<T>();
@@ -757,17 +764,8 @@ namespace MudBlazor
         /// </returns>
         private async Task<bool> TryOpenMenuAsync()
         {
-            // Close the menu if we don't have enough characters.
-            if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
+            if (Open || GetDisabledState() || GetReadOnlyState())
             {
-                Open = false;
-                StateHasChanged();
-                return false;
-            }
-
-            if (GetDisabledState() || GetReadOnlyState())
-            {
-                await CloseMenuAsync();
                 return false;
             }
 
@@ -869,9 +867,13 @@ namespace MudBlazor
             {
                 case "Enter":
                 case "NumpadEnter":
-                    if (!await TryOpenMenuAsync())
+                    if (Open)
                     {
                         await OnEnterKeyAsync();
+                    }
+                    else
+                    {
+                        await TryOpenMenuAsync();
                     }
                     break;
                 case "Escape":

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -32,6 +32,7 @@ namespace MudBlazor
         private T[]? _items;
         private List<int> _enabledItemIndices = [];
         private Func<T?, string?>? _toStringFunc;
+        private bool _isFocusBeingHandledInternally;
 
         [Inject]
         private IScrollManager ScrollManager { get; set; } = null!;
@@ -561,13 +562,8 @@ namespace MudBlazor
                     await _elementReference.SetText(optionText);
                 }
 
-                _isFocused = true; // Prevent menu from reopening from the focus handler.
                 await FocusAsync();
-                // We want focus with a closed popover
-                Open = false;
-                // And update
-                StateHasChanged();
-
+                await CloseMenuAsync();
             }
             finally
             {
@@ -978,33 +974,33 @@ namespace MudBlazor
             return OnInputActivationAsync(true);
         }
 
-        private Task OnInputFocusedAsync() => OnInputActivationAsync(OpenOnFocus);
-
-        private async Task OnInputActivationAsync(bool openMenu)
+        private async Task OnInputFocusedAsync()
         {
-            int number = DateTime.Now.Millisecond;
+            var wasFocused = _isFocused;
+            _isFocused = true;
 
-            if (_isFocused)
+            // Was focus NOT triggered by user interaction?
+            if (_isFocusBeingHandledInternally)
             {
+                _isFocusBeingHandledInternally = false;
                 return;
             }
 
-            var wasFocused = _isFocused;
-            _isFocused = true;
-            Logger.LogInformation($"{number}: {wasFocused}");
-
-            if (SelectOnActivation)
+            // Select the input text unless we're already focused or it will interfere with mouse selection.
+            if (!wasFocused && SelectOnActivation)
             {
-                Logger.LogInformation($"{number}: before select");
                 await SelectAsync();
-                Logger.LogInformation($"{number}: after select");
             }
 
-            if (openMenu && !wasFocused && !Open && !_opening && !GetReadOnlyState())
+            await OnInputActivationAsync(OpenOnFocus);
+        }
+
+        private async Task OnInputActivationAsync(bool openMenu)
+        {
+            // The click event also triggers the focus event so we don't want to unnecessarily handle both.
+            if (openMenu && !Open && !_opening && !GetReadOnlyState())
             {
-                Logger.LogInformation($"{number}: before menu");
                 await OpenMenuAsync();
-                Logger.LogInformation($"{number}: after menu");
             }
         }
 
@@ -1012,12 +1008,12 @@ namespace MudBlazor
         {
             // clear button clicked, let's make sure text is cleared and the menu has focus
             Open = true;
-            _isFocused = true;
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedListItemIndex = default;
-            await CloseMenuAsync();
+            Open = false;
             StateHasChanged();
+            await FocusAsync();
             await OnClearButtonClick.InvokeAsync(e);
             await BeginValidateAsync();
         }
@@ -1026,7 +1022,6 @@ namespace MudBlazor
         {
             if (OnAdornmentClick.HasDelegate)
             {
-
                 await OnAdornmentClick.InvokeAsync();
             }
             else
@@ -1038,6 +1033,7 @@ namespace MudBlazor
         private Task OnInputBlurredAsync(FocusEventArgs args)
         {
             _isFocused = false;
+            _isFocusBeingHandledInternally = false;
 
             // When Immediate is enabled, then the CoerceValue is set by TextChanged
             // So only coerce the value on blur when Immediate is disabled
@@ -1122,6 +1118,7 @@ namespace MudBlazor
         /// </summary>
         public override ValueTask FocusAsync()
         {
+            _isFocusBeingHandledInternally = true; // The subsequent event that will be triggered will know it's not by the user.
             return _elementReference.FocusAsync();
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
         private T[]? _items;
         private List<int> _enabledItemIndices = [];
         private Func<T?, string?>? _toStringFunc;
-        private bool _isNextFocusBeingHandledInternally;
+        private bool _handleNextFocus;
 
         [Inject]
         private IScrollManager ScrollManager { get; set; } = null!;
@@ -985,9 +985,9 @@ namespace MudBlazor
             _isFocused = true;
 
             // Was focus NOT triggered by user interaction?
-            if (_isNextFocusBeingHandledInternally)
+            if (_handleNextFocus)
             {
-                _isNextFocusBeingHandledInternally = false;
+                _handleNextFocus = false;
                 return;
             }
 
@@ -1037,7 +1037,7 @@ namespace MudBlazor
         private Task OnInputBlurredAsync(FocusEventArgs args)
         {
             _isFocused = false;
-            _isNextFocusBeingHandledInternally = false;
+            _handleNextFocus = false;
 
             // When Immediate is enabled, then the CoerceValue is set by TextChanged
             // So only coerce the value on blur when Immediate is disabled
@@ -1122,7 +1122,7 @@ namespace MudBlazor
         /// </summary>
         public override ValueTask FocusAsync()
         {
-            _isNextFocusBeingHandledInternally = true; // The subsequent event that will be triggered will know it's not by the user.
+            _handleNextFocus = true; // The subsequent event that will be triggered will know it's not by the user.
             return _elementReference.FocusAsync();
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -970,37 +970,36 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            return OnInputActivationAsync(true);
+            return OnInputActivatedAsync(true);
         }
 
         private async Task OnInputFocusedAsync()
         {
             if (GetReadOnlyState())
             {
-                // The readonly input doesn't trigger onblur and so we'll have to disable focus features for it.
+                // A readonly input doesn't trigger onblur later correctly, so we have to disable focus features for it.
                 return;
             }
 
             var wasFocused = _isFocused;
             _isFocused = true;
 
-            // Was focus NOT triggered by user interaction?
             if (_handleNextFocus)
             {
                 _handleNextFocus = false;
                 return;
             }
 
-            // Select the input text unless we're already focused or it will interfere with mouse selection.
+            // Select the input text unless we're already focused or it will interfere with cursor selection.
             if (!wasFocused && SelectOnActivation)
             {
                 await SelectAsync();
             }
 
-            await OnInputActivationAsync(OpenOnFocus);
+            await OnInputActivatedAsync(OpenOnFocus);
         }
 
-        private async Task OnInputActivationAsync(bool openMenu)
+        private async Task OnInputActivatedAsync(bool openMenu)
         {
             // The click event also triggers the focus event so we don't want to unnecessarily handle both.
             if (openMenu && !Open && !_opening && !GetReadOnlyState())
@@ -1017,6 +1016,7 @@ namespace MudBlazor
             await SetTextAsync(default, false);
             _selectedListItemIndex = default;
             await CloseMenuAsync();
+            StateHasChanged();
             await OnClearButtonClick.InvokeAsync(e);
             await BeginValidateAsync();
         }
@@ -1025,6 +1025,7 @@ namespace MudBlazor
         {
             if (OnAdornmentClick.HasDelegate)
             {
+
                 await OnAdornmentClick.InvokeAsync();
             }
             else
@@ -1121,7 +1122,7 @@ namespace MudBlazor
         /// </summary>
         public override ValueTask FocusAsync()
         {
-            _handleNextFocus = true; // The subsequent event that will be triggered will know it's not by the user.
+            _handleNextFocus = true; // Let the event handler know it was not triggered by the user.
             return _elementReference.FocusAsync();
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -620,12 +620,12 @@ namespace MudBlazor
                 await CoerceValueToTextAsync();
 
             if (DebounceInterval <= 0)
-                await OpenMenuAsync();
+                await TryOpenMenuAsync();
             else
                 _debounceTimer = new Timer(OnDebounceComplete, null, DebounceInterval, Timeout.Infinite);
         }
 
-        private void OnDebounceComplete(object? stateInfo) => InvokeAsync(OpenMenuAsync);
+        private void OnDebounceComplete(object? stateInfo) => InvokeAsync(TryOpenMenuAsync);
 
         private void CancelToken()
         {
@@ -652,14 +652,12 @@ namespace MudBlazor
         /// <remarks>
         /// Will have no effect if the autocomplete is disabled or read-only.
         /// </remarks>
-        public Task ToggleMenuAsync()
+        public async Task ToggleMenuAsync()
         {
-            if (!Open && (GetDisabledState() || GetReadOnlyState()))
+            if (!await TryOpenMenuAsync())
             {
-                return Task.CompletedTask;
+                await CloseMenuAsync();
             }
-
-            return Open ? CloseMenuAsync() : OpenMenuAsync();
         }
 
         /// <summary>
@@ -759,6 +757,23 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Opens the drop-down of items if the UI is in a state where it's allowed to (e.g. not read-only or already open).
+        /// </summary>
+        /// <returns>
+        /// Returns <c>true</c> if the menu was opened; otherwise, <c>false</c>.
+        /// </returns>
+        private async Task<bool> TryOpenMenuAsync()
+        {
+            if (Open || GetDisabledState() || GetReadOnlyState())
+            {
+                return false;
+            }
+
+            await OpenMenuAsync();
+            return true;
+        }
+
+        /// <summary>
         /// Resets the Text and Value, and closes the drop-down if it is open.
         /// </summary>
         public async Task ClearAsync()
@@ -824,7 +839,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        await OpenMenuAsync();
+                        await TryOpenMenuAsync();
                     }
                     break;
                 case "ArrowUp":
@@ -834,7 +849,7 @@ namespace MudBlazor
                     }
                     else if (!Open)
                     {
-                        await OpenMenuAsync();
+                        await TryOpenMenuAsync();
                     }
                     else
                     {
@@ -858,7 +873,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        await OpenMenuAsync();
+                        await TryOpenMenuAsync();
                     }
                     break;
                 case "Escape":
@@ -982,7 +997,7 @@ namespace MudBlazor
 
             if (openMenu && !Open && !_opening)
             {
-                await OpenMenuAsync();
+                await TryOpenMenuAsync();
             }
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -562,9 +562,7 @@ namespace MudBlazor
                     await _elementReference.SetText(optionText);
                 }
 
-                // We want focus with a closed popover	
                 Open = false;
-                // And update	
                 StateHasChanged();
             }
             finally

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1017,7 +1017,6 @@ namespace MudBlazor
             await SetTextAsync(default, false);
             _selectedListItemIndex = default;
             await CloseMenuAsync();
-            await FocusAsync();
             await OnClearButtonClick.InvokeAsync(e);
             await BeginValidateAsync();
         }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -620,12 +620,12 @@ namespace MudBlazor
                 await CoerceValueToTextAsync();
 
             if (DebounceInterval <= 0)
-                await TryOpenMenuAsync();
+                await OpenMenuAsync();
             else
                 _debounceTimer = new Timer(OnDebounceComplete, null, DebounceInterval, Timeout.Infinite);
         }
 
-        private void OnDebounceComplete(object? stateInfo) => InvokeAsync(TryOpenMenuAsync);
+        private void OnDebounceComplete(object? stateInfo) => InvokeAsync(OpenMenuAsync);
 
         private void CancelToken()
         {
@@ -652,12 +652,14 @@ namespace MudBlazor
         /// <remarks>
         /// Will have no effect if the autocomplete is disabled or read-only.
         /// </remarks>
-        public async Task ToggleMenuAsync()
+        public Task ToggleMenuAsync()
         {
-            if (!await TryOpenMenuAsync())
+            if (!Open && (GetDisabledState() || GetReadOnlyState()))
             {
-                await CloseMenuAsync();
+                return Task.CompletedTask;
             }
+
+            return Open ? CloseMenuAsync() : OpenMenuAsync();
         }
 
         /// <summary>
@@ -757,23 +759,6 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Opens the drop-down of items if the UI is in a state where it's allowed to (e.g. not read-only or already open).
-        /// </summary>
-        /// <returns>
-        /// Returns <c>true</c> if the menu was opened; otherwise, <c>false</c>.
-        /// </returns>
-        private async Task<bool> TryOpenMenuAsync()
-        {
-            if (Open || GetDisabledState() || GetReadOnlyState())
-            {
-                return false;
-            }
-
-            await OpenMenuAsync();
-            return true;
-        }
-
-        /// <summary>
         /// Resets the Text and Value, and closes the drop-down if it is open.
         /// </summary>
         public async Task ClearAsync()
@@ -839,7 +824,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        await TryOpenMenuAsync();
+                        await OpenMenuAsync();
                     }
                     break;
                 case "ArrowUp":
@@ -849,7 +834,7 @@ namespace MudBlazor
                     }
                     else if (!Open)
                     {
-                        await TryOpenMenuAsync();
+                        await OpenMenuAsync();
                     }
                     else
                     {
@@ -873,7 +858,7 @@ namespace MudBlazor
                     }
                     else
                     {
-                        await TryOpenMenuAsync();
+                        await OpenMenuAsync();
                     }
                     break;
                 case "Escape":
@@ -997,7 +982,7 @@ namespace MudBlazor
 
             if (openMenu && !Open && !_opening)
             {
-                await TryOpenMenuAsync();
+                await OpenMenuAsync();
             }
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -976,6 +976,12 @@ namespace MudBlazor
 
         private async Task OnInputFocusedAsync()
         {
+            if (GetDisabledState())
+            {
+                // This shouldn't be possible through the UI, but could be triggered in code.
+                return;
+            }
+
             if (GetReadOnlyState())
             {
                 // A readonly input doesn't trigger onblur later correctly, so we have to disable focus features for it.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -562,7 +562,6 @@ namespace MudBlazor
                     await _elementReference.SetText(optionText);
                 }
 
-                await FocusAsync();
                 await CloseMenuAsync();
             }
             finally
@@ -1164,6 +1163,10 @@ namespace MudBlazor
             await SetTextAsync(text, true);
         }
 
-        private Task ListItemOnClickAsync(T item) => SelectOptionAsync(item);
+        private async Task ListItemOnClickAsync(T item)
+        {
+            await SelectOptionAsync(item);
+            await FocusAsync();
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -561,6 +561,7 @@ namespace MudBlazor
                     await _elementReference.SetText(optionText);
                 }
 
+                _isFocused = true; // Prevent menu from reopening from the focus handler.
                 await FocusAsync();
                 // We want focus with a closed popover
                 Open = false;
@@ -967,22 +968,43 @@ namespace MudBlazor
             }
         }
 
-        private Task OnInputClickedAsync() => OnInputActivationAsync(true);
+        private Task OnInputClickedAsync()
+        {
+            if (GetDisabledState())
+            {
+                return Task.CompletedTask;
+            }
+
+            return OnInputActivationAsync(true);
+        }
 
         private Task OnInputFocusedAsync() => OnInputActivationAsync(OpenOnFocus);
 
         private async Task OnInputActivationAsync(bool openMenu)
         {
-            _isFocused = true;
+            int number = DateTime.Now.Millisecond;
 
-            if (SelectOnActivation && !GetDisabledState() && !GetReadOnlyState())
+            if (_isFocused)
             {
-                await SelectAsync();
+                return;
             }
 
-            if (openMenu && !Open && !_opening)
+            var wasFocused = _isFocused;
+            _isFocused = true;
+            Logger.LogInformation($"{number}: {wasFocused}");
+
+            if (SelectOnActivation)
             {
+                Logger.LogInformation($"{number}: before select");
+                await SelectAsync();
+                Logger.LogInformation($"{number}: after select");
+            }
+
+            if (openMenu && !wasFocused && !Open && !_opening && !GetReadOnlyState())
+            {
+                Logger.LogInformation($"{number}: before menu");
                 await OpenMenuAsync();
+                Logger.LogInformation($"{number}: after menu");
             }
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1017,8 +1017,7 @@ namespace MudBlazor
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
             _selectedListItemIndex = default;
-            Open = false;
-            StateHasChanged();
+            await CloseMenuAsync();
             await FocusAsync();
             await OnClearButtonClick.InvokeAsync(e);
             await BeginValidateAsync();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Resolves #11122 and resolves #11154 and others by establishing these behaviors:

- To improve stability the component now keeps track of focus events it causes (as in v7)
- Selecting an option does not open the list again (applies to server rendering)
- The menu does not open in read-only or disabled modes
- Enable cursor text selection by not selecting all the text if we already have focus

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
