### PR TITLE
MudSwitch: Decouple label font size from Size property

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -51,7 +51,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "Classname" protected property should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">");
     }
@@ -68,7 +68,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "Classname" protected property should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">");
     }
@@ -85,7 +85,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "BeginValidateAsync" protected method should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
@@ -102,7 +102,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "BeginValidateAsync" protected method should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
@@ -119,7 +119,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "CurrentView" protected field should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">");
     }
@@ -136,7 +136,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a message saying no members are found  (since the protected field was the ONLY field)
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-switch-label-small mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
         // The "CurrentView" protected field should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">");
     }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -97,32 +97,6 @@ namespace MudBlazor.UnitTests.Components
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
 
-        [Test]
-        public void SwitchLabelTextSizeTest()
-        {
-            var comp = Context.RenderComponent<MudSwitchTest>();
-
-            comp.FindAll("label.mud-switch", true)[3].Children[1].ClassList.Should().Contain("mud-switch-label-medium"); //4th switch doesn't have size set, it should be at default values
-            comp.FindAll("label.mud-switch", true)[3].Children[0].ClassList.Should().Contain("mud-switch-span-medium");
-
-            comp.FindAll("label.mud-switch", true)[4].Children[1].ClassList.Should().Contain("mud-switch-label-small"); //5th switch is a small switch with corresponding label text size
-            comp.FindAll("label.mud-switch", true)[4].Children[0].ClassList.Should().Contain("mud-switch-span-small");
-
-            comp.FindAll("label.mud-switch", true)[5].Children[1].ClassList.Should().Contain("mud-switch-label-medium"); //6th switch is a medium switch with corresponding label text size
-            comp.FindAll("label.mud-switch", true)[5].Children[0].ClassList.Should().Contain("mud-switch-span-medium");
-
-            comp.FindAll("label.mud-switch", true)[6].Children[1].ClassList.Should().Contain("mud-switch-label-large"); //7th switch is a large switch with corresponding label text size
-            comp.FindAll("label.mud-switch", true)[6].Children[0].ClassList.Should().Contain("mud-switch-span-large");
-
-            comp.FindAll("label.mud-switch", true)[7].Children[1].ClassList.Should().Contain("mud-switch-label-small"); //8th switch is a small switch that changes to large when unchecked
-            comp.FindAll("label.mud-switch", true)[7].Children[0].ClassList.Should().Contain("mud-switch-span-small");
-
-            // 8th switch Size is tied to the Label_Switch2 bool, if it's false, it should become large
-            comp.FindAll("input")[7].Change(false);
-            comp.FindAll("label.mud-switch", true)[7].Children[1].ClassList.Should().Contain("mud-switch-label-large");
-            comp.FindAll("label.mud-switch", true)[7].Children[0].ClassList.Should().Contain("mud-switch-span-large");
-        }
-
         /// <summary>
         /// Optional Switch should not have required attribute and aria-required should be false.
         /// </summary>

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -25,7 +25,6 @@ namespace MudBlazor
         protected override string LabelClassname => new CssBuilder("mud-switch")
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())
-            .AddClass($"mud-switch-label-{Size.ToDescriptionString()}")
             .AddClass($"mud-input-content-placement-{ConvertPlacement(LabelPlacement).ToDescriptionString()}")
             .Build();
 

--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -175,15 +175,3 @@
     height: 52px;
   }
 }
-
-.mud-switch-label-small {
-  font-size: 0.8125rem !important;
-}
-
-.mud-switch-label-medium {
-  font-size: 1rem !important;
-}
-
-.mud-switch-label-large {
-  font-size: 1.1875rem !important;
-}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

See https://github.com/MudBlazor/MudBlazor/pull/11099#issuecomment-2770043963

The font size can now be handled by the theme engine by switching from a hardcoded style to `body1` as seen in Material Design. Unlikely to negatively effect vast majority of apps and is easily worked around.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before

![image](https://github.com/user-attachments/assets/b3cd5372-6788-4273-9eb7-4ea844e0f247)

After

![image](https://github.com/user-attachments/assets/07c872d6-af45-4441-a9ec-5180002cf8d1)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
