### PR TITLE
MudInput - Heap Locked When Disabled

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
@@ -4,7 +4,7 @@
               Variant="Variant.Text"
               Immediate="true"
               OnKeyDown="@HandleKeyDown"
-              OnKeyUp="@(async (args) => await SendMessage(args))"
+              OnKeyUp="@SendMessage"
               Disabled="@IsLoading"
               MaxLength="5000"
               Lines="10"
@@ -14,20 +14,16 @@
               AutoGrow="true"
               MaxLines="10"
               Underline="true"
-              UserAttributes="@(new Dictionary<string, object> { { "autocomplete", "off" },  { "data-textfieldref", "ChatbotMessageTextField" } })" />
+              UserAttributes="@_userAttributes" />
 
 @code {
-    public string Text { get; set; } = "????";
-    public string ButtonText { get; set; } = "Click Me";
-    public int ButtonClicked { get; set; }
     bool IsLoading = false;
 
-    void ButtonOnClick()
+    private readonly Dictionary<string, object> _userAttributes = new Dictionary<string, object>
     {
-        ButtonClicked += 1;
-        Text = $"Awesome x {ButtonClicked}";
-        ButtonText = "Click Me Again";
-    }
+        { "autocomplete", "off" },
+        { "data-textfieldref", "ChatbotMessageTextField" }
+    };
 
     private async Task SendMessage(KeyboardEventArgs e)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
@@ -1,0 +1,52 @@
+﻿<br />
+<MudTextField T="string"
+              Placeholder="Test"
+              Variant="Variant.Text"
+              Immediate="true"
+              OnKeyDown="@HandleKeyDown"
+              OnKeyUp="@(async (args) => await SendMessage(args))"
+              Disabled="@IsLoading"
+              MaxLength="5000"
+              Lines="10"
+              AutoFocus="true"
+              Class="chat-input"
+              TextUpdateSuppression="true"
+              AutoGrow="true"
+              MaxLines="10"
+              Underline="true"
+              UserAttributes="@(new Dictionary<string, object> { { "autocomplete", "off" },  { "data-textfieldref", "ChatbotMessageTextField" } })" />
+
+@code {
+    public string Text { get; set; } = "????";
+    public string ButtonText { get; set; } = "Click Me";
+    public int ButtonClicked { get; set; }
+    bool IsLoading = false;
+
+    void ButtonOnClick()
+    {
+        ButtonClicked += 1;
+        Text = $"Awesome x {ButtonClicked}";
+        ButtonText = "Click Me Again";
+    }
+
+    private async Task SendMessage(KeyboardEventArgs e)
+    {
+        await Task.CompletedTask;
+    }
+
+    private void HandleKeyDown(KeyboardEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case "Enter":
+                IsLoading = true;
+                break;
+            default:
+                if (e.Key.Length == 1) // Single character
+                {
+                    StateHasChanged();
+                }
+                break;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputHeapLockedTest.razor
@@ -5,7 +5,7 @@
               Immediate="true"
               OnKeyDown="@HandleKeyDown"
               OnKeyUp="@SendMessage"
-              Disabled="@IsLoading"
+              Disabled="@_isLoading"
               MaxLength="5000"
               Lines="10"
               AutoFocus="true"
@@ -17,7 +17,7 @@
               UserAttributes="@_userAttributes" />
 
 @code {
-    bool IsLoading = false;
+    private bool _isLoading = false;
 
     private readonly Dictionary<string, object> _userAttributes = new Dictionary<string, object>
     {
@@ -25,17 +25,14 @@
         { "data-textfieldref", "ChatbotMessageTextField" }
     };
 
-    private async Task SendMessage(KeyboardEventArgs e)
-    {
-        await Task.CompletedTask;
-    }
+    private Task SendMessage(KeyboardEventArgs e) => Task.CompletedTask;
 
     private void HandleKeyDown(KeyboardEventArgs e)
     {
         switch (e.Key)
         {
             case "Enter":
-                IsLoading = true;
+                _isLoading = true;
                 break;
             default:
                 if (e.Key.Length == 1) // Single character

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -155,7 +155,10 @@ class MudElementReference {
             e.preventDefault();
             element.blur();
             if (dotNetReference) {
-                dotNetReference.invokeMethodAsync('CallOnBlurredAsync');
+                // make sure blur events only happen when heap is unlocked
+                requestAnimationFrame(() => {
+                    dotNetReference.invokeMethodAsync('CallOnBlurredAsync');
+                });                
             }
             else {
                 console.error("No dotNetReference found for iosKeyboardFocus");


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Events in javascript depend on the element being drawn, in some refreshes/redraws the manual blur event is attempting to fire during a redraw (or heap lock). Simply waiting until the Dom is done fixes the issue.
- Modified `mudElementReference.js` to invoke `dotNetReference` after heap unlock using `requestAnimationFrame`.
- Added a new `MudTextField` component in `InputHeapLockedTest.razor` with attributes for user input for testing.
Resolves #11034 (again)

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visual Testing, minimal changes

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
