### PR TITLE
MudOverlay: Prevent unnecessary LockScroll changes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -301,4 +301,101 @@ public class OverlayTests : BunitTest
         elementId.Should().NotBeNullOrWhiteSpace();
         overlayDiv.Id.Should().Be(elementId);
     }
+
+    [Test]
+    [TestCase(true, true)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(false, false)]
+    public async Task Overlay_HandleLockScrollChanges(bool absolute, bool lockscroll)
+    {
+        var scrollManagerMock = new Mock<IScrollManager>();
+        Context.Services.AddSingleton(scrollManagerMock.Object);
+        var providerComp = Context.RenderComponent<MudPopoverProvider>();
+
+        var visible = true;
+
+        // === Initial: Visible = true, should lock scroll if conditions match ===
+        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+            .Add(p => p.Absolute, absolute)
+            .Bind(p => p.Visible, visible, p => visible = p)
+            .Add(p => p.LockScroll, lockscroll)
+        );
+
+        var mudOverlay = comp.Instance;
+
+        // Initial unlock state
+        scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+        if (!absolute && lockscroll)
+        {
+            scrollManagerMock.Verify(s => s.LockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
+            mudOverlay._lockCount.Should().Be(1);
+        }
+        else
+        {
+            scrollManagerMock.Verify(s => s.LockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            mudOverlay._lockCount.Should().Be(0);
+        }
+
+        // === Manually re-trigger HandleLockScrollChange (should not change counts) ===
+        await mudOverlay.HandleLockScrollChange();
+
+        if (!absolute && lockscroll)
+        {
+            scrollManagerMock.Verify(s => s.LockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
+            mudOverlay._lockCount.Should().Be(1);
+        }
+        else
+        {
+            scrollManagerMock.Verify(s => s.LockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            mudOverlay._lockCount.Should().Be(0);
+        }
+
+        // === Toggle visible to false, expect unlock ===
+        visible = false;
+        comp.SetParametersAndRender(p => p.Add(p => p.Visible, visible));
+
+        if (!absolute && lockscroll)
+        {
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
+            mudOverlay._lockCount.Should().Be(0);
+        }
+        else
+        {
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            mudOverlay._lockCount.Should().Be(0);
+        }
+
+        // === Close overlay manually, expect another unlock ===
+        // raise counter so it will force and unlock
+        mudOverlay._lockCount++;
+        await mudOverlay.CloseOverlayAsync();
+
+        if (!absolute && lockscroll)
+        {
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Exactly(2));
+            mudOverlay._lockCount.Should().Be(0);
+        }
+        else
+        {
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            mudOverlay._lockCount.Should().Be(1);
+            mudOverlay._lockCount--;
+        }
+
+        // === Dispose component, expect final unlock since we are raising counter ===
+        mudOverlay._lockCount++;
+        await mudOverlay.DisposeAsync();
+
+        if (!absolute && lockscroll)
+        {
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Exactly(3));
+        }
+        else
+        {
+            // we added a lockCount to force the unlock
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
+        }
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -330,12 +330,10 @@ public class OverlayTests : BunitTest
         if (!absolute && lockscroll)
         {
             scrollManagerMock.Verify(s => s.LockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
-            mudOverlay._lockCount.Should().Be(1);
         }
         else
         {
             scrollManagerMock.Verify(s => s.LockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-            mudOverlay._lockCount.Should().Be(0);
         }
 
         // === Manually re-trigger HandleLockScrollChange (should not change counts) ===
@@ -344,12 +342,10 @@ public class OverlayTests : BunitTest
         if (!absolute && lockscroll)
         {
             scrollManagerMock.Verify(s => s.LockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
-            mudOverlay._lockCount.Should().Be(1);
         }
         else
         {
             scrollManagerMock.Verify(s => s.LockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-            mudOverlay._lockCount.Should().Be(0);
         }
 
         // === Toggle visible to false, expect unlock ===
@@ -359,43 +355,38 @@ public class OverlayTests : BunitTest
         if (!absolute && lockscroll)
         {
             scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Once());
-            mudOverlay._lockCount.Should().Be(0);
         }
         else
         {
             scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-            mudOverlay._lockCount.Should().Be(0);
         }
 
-        // === Close overlay manually, expect another unlock ===
-        // raise counter so it will force and unlock
-        mudOverlay._lockCount++;
+        // open it
+        visible = true;
+        comp.SetParametersAndRender(p => p.Add(p => p.Visible, visible));
+
+        // close it by method
         await mudOverlay.CloseOverlayAsync();
 
         if (!absolute && lockscroll)
         {
             scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Exactly(2));
-            mudOverlay._lockCount.Should().Be(0);
         }
         else
         {
             scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-            mudOverlay._lockCount.Should().Be(1);
-            mudOverlay._lockCount--;
         }
 
-        // === Dispose component, expect final unlock since we are raising counter ===
-        mudOverlay._lockCount++;
+        // === Dispose component ===
         await mudOverlay.DisposeAsync();
 
         if (!absolute && lockscroll)
         {
-            scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.Exactly(3));
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync("body", mudOverlay.LockScrollClass), Times.AtLeast(2));
         }
         else
         {
-            // we added a lockCount to force the unlock
-            scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
+            scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.AtMostOnce());
         }
     }
 }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -16,11 +16,11 @@ namespace MudBlazor;
 /// </summary>
 public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, IAsyncDisposable
 {
-    private readonly string _elementId = Identifier.Create("overlay");
+    private int _lockCount;
+    private bool _previousAbsolute;
+    private bool _previousLockScroll;
     private readonly ParameterState<bool> _visibleState;
-    private bool _previousLockScroll = false;
-    private bool _previousAbsolute = false;
-    private int _lockCount = 0;
+    private readonly string _elementId = Identifier.Create("overlay");
 
     protected string Classname =>
         new CssBuilder("mud-overlay")
@@ -287,7 +287,11 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     private ValueTask BlockScrollAsync()
     {
         // we only want to lock scroll once
-        if (_lockCount > 0) return ValueTask.CompletedTask;
+        if (_lockCount > 0)
+        {
+            return ValueTask.CompletedTask;
+        }
+
         _lockCount++;
         return ScrollManager.LockScrollAsync("body", LockScrollClass);
     }
@@ -334,7 +338,9 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
         }
 
         if (_lockCount > 0)
+        {
             await UnblockScrollAsync();
+        }
 
         await StopModelessAutoCloseTrackingAsync();
     }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -20,6 +20,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     private readonly ParameterState<bool> _visibleState;
     private bool _previousLockScroll = false;
     private bool _previousAbsolute = false;
+    internal int _lockCount = 0;
 
     protected string Classname =>
         new CssBuilder("mud-overlay")
@@ -245,7 +246,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
         }
     }
 
-    private async Task HandleLockScrollChange()
+    internal async Task HandleLockScrollChange()
     {
         if (LockScroll && !Absolute)
         {
@@ -273,10 +274,11 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
         await OnClick.InvokeAsync(ev);
     }
 
-    private async Task CloseOverlayAsync()
+    internal async Task CloseOverlayAsync()
     {
         await _visibleState.SetValueAsync(false);
         await OnClosed.InvokeAsync();
+        await HandleLockScrollChange();
     }
 
     /// <summary>
@@ -284,6 +286,9 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// </summary>
     private ValueTask BlockScrollAsync()
     {
+        // we only want to lock scroll once
+        if (_lockCount > 0) return ValueTask.CompletedTask;
+        _lockCount++;
         return ScrollManager.LockScrollAsync("body", LockScrollClass);
     }
 
@@ -292,6 +297,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// </summary>
     private ValueTask UnblockScrollAsync()
     {
+        _lockCount = Math.Max(0, _lockCount - 1);
         return ScrollManager.UnlockScrollAsync("body", LockScrollClass);
     }
 
@@ -327,7 +333,8 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
             return;
         }
 
-        await UnblockScrollAsync();
+        if (_lockCount > 0)
+            await UnblockScrollAsync();
 
         await StopModelessAutoCloseTrackingAsync();
     }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -18,6 +18,8 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
 {
     private readonly string _elementId = Identifier.Create("overlay");
     private readonly ParameterState<bool> _visibleState;
+    private bool _previousLockScroll = false;
+    private bool _previousAbsolute = false;
 
     protected string Classname =>
         new CssBuilder("mud-overlay")
@@ -204,23 +206,12 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
         using var registerScope = CreateRegisterScope();
         _visibleState = registerScope.RegisterParameter<bool>(nameof(Visible))
             .WithParameter(() => Visible)
-            .WithEventCallback(() => VisibleChanged);
+            .WithEventCallback(() => VisibleChanged)
+            .WithChangeHandler(HandleVisibleChanged);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstTime)
     {
-        if (LockScroll && !Absolute)
-        {
-            if (Visible)
-            {
-                await BlockScrollAsync();
-            }
-            else
-            {
-                await UnblockScrollAsync();
-            }
-        }
-
         // If the overlay is initially visible and modeless auto-close is enabled,
         // then start tracking pointer down events.
         if (firstTime && Visible && !Modal && AutoClose)
@@ -231,6 +222,14 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_previousLockScroll != LockScroll || _previousAbsolute != Absolute)
+        {
+            // handle lock scroll change when user changes LockScroll parameter
+            _previousLockScroll = LockScroll;
+            _previousAbsolute = Absolute;
+            await HandleLockScrollChange();
+        }
+
         if (Modal || !AutoClose)
         {
             return;
@@ -245,6 +244,24 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
             await StopModelessAutoCloseTrackingAsync();
         }
     }
+
+    private async Task HandleLockScrollChange()
+    {
+        if (LockScroll && !Absolute)
+        {
+            if (_visibleState.Value)
+            {
+                await BlockScrollAsync();
+            }
+            else
+            {
+                await UnblockScrollAsync();
+            }
+        }
+    }
+
+    // change lockscroll value when user toggles visible state
+    private Task HandleVisibleChanged(ParameterChangedEventArgs<bool> args) => HandleLockScrollChange();
 
     protected internal async Task OnClickHandlerAsync(MouseEventArgs ev)
     {
@@ -305,7 +322,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (IsJSRuntimeAvailable)
+        if (!IsJSRuntimeAvailable)
         {
             return;
         }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -20,7 +20,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     private readonly ParameterState<bool> _visibleState;
     private bool _previousLockScroll = false;
     private bool _previousAbsolute = false;
-    internal int _lockCount = 0;
+    private int _lockCount = 0;
 
     protected string Classname =>
         new CssBuilder("mud-overlay")

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -47,6 +47,8 @@ internal sealed class ScrollManager : IScrollManager
     public ValueTask ScrollToListItemAsync(string elementId) =>
         _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId);
 
+    // lockScroll and unlockScroll use a counter system in javascript so we can lock/unlock without limit
+    // and maintain the proper lock. IF YOU CHANGE THIS, CHANGE THE JAVASCRIPT AS WELL
     /// <inheritdoc />
     public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
         _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -54,15 +54,15 @@ class MudScrollManager {
 
     //locks the scroll of the selected element. Default is body
     lockScroll(selector, lockclass) {
-        let element = document.querySelector(selector) || document.body;
+        const element = document.querySelector(selector) || document.body;
 
         //if the body doesn't have a scroll bar, don't add the lock class with padding
-        let hasScrollBar = window.innerWidth > document.body.clientWidth;
+        const hasScrollBar = window.innerWidth > document.body.clientWidth;
+        const lockClassNoPadding = lockclass + "-no-padding";
 
-        if (hasScrollBar) {
+        if (hasScrollBar && !element.classList.contains(lockclass)) {
             element.classList.add(lockclass);
-        } else {
-            let lockClassNoPadding = lockclass + "-no-padding";
+        } else if (!element.classList.contains(lockClassNoPadding)) {            
             element.classList.add(lockClassNoPadding);
         }
 
@@ -70,7 +70,7 @@ class MudScrollManager {
 
     //unlocks the scroll. Default is body
     unlockScroll(selector, lockclass) {
-        let element = document.querySelector(selector) || document.body;
+        const element = document.querySelector(selector) || document.body;
 
         // remove both lock classes to be sure it's unlocked
         element.classList.remove(lockclass);

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -3,6 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 class MudScrollManager { 
+    constructor() {
+        this._lockCount = 0; // internal tracking for the # of overlay locks
+    }
+
     //scrolls to year in MudDatePicker
     scrollToYear(elementId, offset) {
         let element = document.getElementById(elementId);
@@ -54,27 +58,27 @@ class MudScrollManager {
 
     //locks the scroll of the selected element. Default is body
     lockScroll(selector, lockclass) {
-        const element = document.querySelector(selector) || document.body;
+        if (this._lockCount === 0) {
+            const element = document.querySelector(selector) || document.body;
 
-        //if the body doesn't have a scroll bar, don't add the lock class with padding
-        const hasScrollBar = window.innerWidth > document.body.clientWidth;
-        const lockClassNoPadding = lockclass + "-no-padding";
+            //if the body doesn't have a scroll bar, don't add the lock class with padding
+            const hasScrollBar = window.innerWidth > document.body.clientWidth;
+            const classToAdd = hasScrollBar ? lockclass : lockclass + "-no-padding";
 
-        if (hasScrollBar && !element.classList.contains(lockclass)) {
-            element.classList.add(lockclass);
-        } else if (!element.classList.contains(lockClassNoPadding)) {            
-            element.classList.add(lockClassNoPadding);
+            element.classList.add(classToAdd);
         }
-
+        this._lockCount++;
     }
 
     //unlocks the scroll. Default is body
     unlockScroll(selector, lockclass) {
-        const element = document.querySelector(selector) || document.body;
-
-        // remove both lock classes to be sure it's unlocked
-        element.classList.remove(lockclass);
-        element.classList.remove(lockclass + "-no-padding");
+        this._lockCount = Math.max(0, this._lockCount - 1); // subtract 1 or stop at 0
+        if (this._lockCount === 0) {
+            const element = document.querySelector(selector) || document.body;
+            // remove both lock classes to be sure it's unlocked
+            element.classList.remove(lockclass);
+            element.classList.remove(lockclass + "-no-padding");
+        }        
     }
 };
 window.mudScrollManager = new MudScrollManager();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Separated HandeLockScroll into it's own method to ensure it always fires at the appropriate time instead of every refresh. Added tracking to only trigger it on Visible state change by adding a ChangeHandler and modifying the code in CloseOverlayAsync, and only fires the respective javascript methods when necessary. Also fixed a bug in DisposeAsync preventing it from turning off LockScroll on dispose.

Since there can be more than one overlay added javascript logic to handle multiple overlays without flashing the class on and off, this should prevent blinking of scrollbars.

Thanks to @lafsar for bringing this to my attention with #11082 
Resolves #11245 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added extensive unit test with mocks as well as visual testing in BSS Docs and WASM Viewer

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
