### PR TITLE
MudDataGrid: Hierarchy Column Header

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -182,7 +182,8 @@
                 <Description>
                     The <CodeInline>&lt;MudDataGrid></CodeInline> allows you to create hierarchical layouts. To do that the <CodeInline>HierarchyColumn</CodeInline> has to be added in the <CodeInline>Columns</CodeInline> definitions.
                     <br><br>
-                    You can customize the icon to toggle the RowDetail, disable the toggle button and also initially expand the RowDetail.
+                    You can customize the icon to toggle the RowDetail, disable the toggle button and also initially expand the RowDetail. In addition most customization options are available
+                    including <CodeInline>EnableHeaderToggle</CodeInline> that puts a Toggle Icon in the header row to Expand/Collapse all.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DataGridDetailRowExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -5,7 +5,7 @@
 
 <MudDataGrid @ref="_dataGrid" Items="@Elements" ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
     <Columns>
-        <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" InitiallyExpandedFunc="@(x => x.Sign == "Li")" />
+        <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" InitiallyExpandedFunc="@(x => x.Sign == "Li")" EnableHeaderToggle="@_enableHeaderToggle" />
         <PropertyColumn Property="x => x.Number" Title="Nr" />
         <PropertyColumn Property="x => x.Sign" />
         <PropertyColumn Property="x => x.Name" />
@@ -34,10 +34,14 @@
     <MudSwitch T="bool" @bind-Value="_isReadOnly" Color="@Color.Primary">Read Only</MudSwitch>
     <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
     <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
+    <MudSwitch @bind-Value="@_enableHeaderToggle" Label="Enable Header Toggle" Color="@Color.Primary" />
 </div>
 
 @code {
+
     private bool _isReadOnly = true;
+
+    private bool _enableHeaderToggle = false;
     private MudDataGrid<Element> _dataGrid = null!;
     private IEnumerable<Element> Elements = new List<Element>();
 

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridDetailRowExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudDataGrid @ref="_dataGrid" Items="@Elements" ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell">
+<MudDataGrid @ref="_dataGrid" Items="@Elements" ReadOnly="@_isReadOnly" EditMode="@DataGridEditMode.Cell" ExpandSingleRow="_expandSingleRow">
     <Columns>
         <HierarchyColumn T="Element" ButtonDisabledFunc="@(x => x.Sign == "He")" InitiallyExpandedFunc="@(x => x.Sign == "Li")" EnableHeaderToggle="@_enableHeaderToggle" />
         <PropertyColumn Property="x => x.Number" Title="Nr" />
@@ -35,12 +35,13 @@
     <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
     <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
     <MudSwitch @bind-Value="@_enableHeaderToggle" Label="Enable Header Toggle" Color="@Color.Primary" />
+    <MudSwitch @bind-Value="@_expandSingleRow" Label="Expand Single Row" Color="@Color.Primary" />
 </div>
 
 @code {
 
     private bool _isReadOnly = true;
-
+    private bool _expandSingleRow = false;
     private bool _enableHeaderToggle = false;
     private MudDataGrid<Element> _dataGrid = null!;
     private IEnumerable<Element> Elements = new List<Element>();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -20,7 +20,7 @@
     [Parameter]
     public bool RightToLeft { get; set; }
 
-    private bool _enableHeaderToggle = true;
+    private bool _enableHeaderToggle = false;
 
     private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,5 +1,5 @@
 ﻿<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
-    <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true">
+    <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true" ExpandSingleRow="@ExpandSingleRow">
         <Columns>
             <HierarchyColumn EnableHeaderToggle="@EnableHeaderToggle" ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
             <PropertyColumn Property="x => x.Name" />
@@ -16,12 +16,15 @@
 <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
 <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
 <MudSwitch @bind-Value="EnableHeaderToggle" Label="Enable Header Toggle" />
+<MudSwitch @bind-Value="ExpandSingleRow" Label="Expand Single Row" />
 @code {
 
     [Parameter]
     public bool RightToLeft { get; set; }
     [Parameter]
     public bool EnableHeaderToggle { get; set;}
+    [Parameter]
+    public bool ExpandSingleRow { get; set; }
 
     private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,7 +1,7 @@
 ﻿<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
     <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true">
         <Columns>
-            <HierarchyColumn ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
+            <HierarchyColumn EnableHeaderToggle="@_enableHeaderToggle" ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
             <PropertyColumn Property="x => x.Name" />
             <PropertyColumn Property="x => x.Age" />
             <PropertyColumn Property="x => x.Status" />
@@ -15,9 +15,12 @@
 </CascadingValue>
 <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
 <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
+<MudSwitch @bind-Value="_enableHeaderToggle" Label="Enable Header Toggle" />
 @code {
     [Parameter]
     public bool RightToLeft { get; set; }
+
+    private bool _enableHeaderToggle = true;
 
     private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -18,16 +18,17 @@
 <MudSwitch @bind-Value="EnableHeaderToggle" Label="Enable Header Toggle" />
 <MudSwitch @bind-Value="ExpandSingleRow" Label="Expand Single Row" />
 @code {
-
     [Parameter]
     public bool RightToLeft { get; set; }
+
     [Parameter]
     public bool EnableHeaderToggle { get; set;}
+
     [Parameter]
     public bool ExpandSingleRow { get; set; }
 
     private MudDataGrid<Model> _dataGrid = null!;
-    private readonly IEnumerable<Model> _items = new List<Model>()
+    private readonly IEnumerable<Model> _items = new List<Model>
     {
         new Model("Sam", 56, Severity.Normal), 
         new Model("Alicia", 54, Severity.Info), 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,7 +1,7 @@
 ﻿<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
     <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true">
         <Columns>
-            <HierarchyColumn EnableHeaderToggle="@_enableHeaderToggle" ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
+            <HierarchyColumn EnableHeaderToggle="@EnableHeaderToggle" ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
             <PropertyColumn Property="x => x.Name" />
             <PropertyColumn Property="x => x.Age" />
             <PropertyColumn Property="x => x.Status" />
@@ -15,12 +15,13 @@
 </CascadingValue>
 <MudButton OnClick="@ExpandAll" Color="@Color.Primary">Expand All</MudButton>
 <MudButton OnClick="@CollapseAll" Color="@Color.Primary">Collapse All</MudButton>
-<MudSwitch @bind-Value="_enableHeaderToggle" Label="Enable Header Toggle" />
+<MudSwitch @bind-Value="EnableHeaderToggle" Label="Enable Header Toggle" />
 @code {
+
     [Parameter]
     public bool RightToLeft { get; set; }
-
-    private bool _enableHeaderToggle = false;
+    [Parameter]
+    public bool EnableHeaderToggle { get; set;}
 
     private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>()

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5315,7 +5315,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DataGridGetGroupIconTest()
+        public void DataGridGetHierarchyGroupIconTest()
         {
             // Create a test component
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
@@ -5340,6 +5340,24 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.RightToLeft, true));
             // When collapsed + RTL
             comp.WaitForAssertion(() => accessor.GetGroupIcon().Should().Be(Icons.Material.Filled.ChevronLeft));
+        }
+
+        [Test]
+        public void DataGrid_HierarchyExpandSingleRowTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters => parameters
+                .Add(p => p.ExpandSingleRow, false));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            dataGrid.Instance._openHierarchies.Count.Should().Be(2);
+            var item = dataGrid.Instance._openHierarchies.First();
+            item.Should().NotBeNull();
+
+            comp.SetParametersAndRender(p => p.Add(p => p.ExpandSingleRow, true));
+
+            dataGrid.Instance._openHierarchies.Count.Should().Be(1);
+
+            dataGrid.Instance._openHierarchies.First().Should().Be(item);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5228,7 +5228,7 @@ namespace MudBlazor.UnitTests.Components
 
             var headerElement = comp.Find("th.mud-header-togglehierarchy");
             headerElement.Should().NotBeNull("Header should have mud-header-togglehierarchy class when EnableHeaderToggle is true");
-            headerCell.Instance._includeHierarchyToggle.Should().BeTrue();
+            headerCell.Instance.IncludeHierarchyToggle.Should().BeTrue();
 
             // Check that the HierarchyToggle button exists in the header
             var toggleButton = headerElement.QuerySelector(".mud-hierarchy-toggle-button");
@@ -5292,7 +5292,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DataGridToggleHierarchyMethodTest()
+        public async Task DataGridToggleHierarchyMethodTest()
         {
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
@@ -5302,20 +5302,20 @@ namespace MudBlazor.UnitTests.Components
             // Initially, there should be 2 expanded items
             dataGrid.Instance._openHierarchies.Count.Should().Be(2);
             var accessor = headerCell.Instance;
-            accessor.ToggleHierarchy();
+            await accessor.ToggleHierarchyAsync();
 
             // After calling ToggleHierarchy when some hierarchies are open, all should be collapsed
             dataGrid.Instance._openHierarchies.Count.Should().Be(0);
 
             // Call ToggleHierarchy again
-            accessor.ToggleHierarchy();
+            await accessor.ToggleHierarchyAsync();
 
             // Now all hierarchies should be expanded
             dataGrid.Instance._openHierarchies.Count.Should().Be(5);
         }
 
         [Test]
-        public void DataGridGetHierarchyGroupIconTest()
+        public async Task DataGridGetHierarchyGroupIconTest()
         {
             // Create a test component
             var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
@@ -5331,7 +5331,7 @@ namespace MudBlazor.UnitTests.Components
             var expandedIcon = accessor.GetGroupIcon();
             expandedIcon.Should().Be(Icons.Material.Filled.ExpandMore);
 
-            accessor.ToggleHierarchy(); // collapse all
+            await accessor.ToggleHierarchyAsync(); // collapse all
 
             // When collapsed + LTR
             var collapsedIcon = accessor.GetGroupIcon();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5214,5 +5214,132 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.SelectedItemChanged = false;
             comp.Instance.SelectedItemsChanged = false;
         }
+
+        [Test]
+        public void DataGridHeaderToggleHierarchyTest()
+        {
+            // Render with EnableHeaderToggle = true to enable header toggle functionality
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters =>
+                parameters.Add(p => p.EnableHeaderToggle, true));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            // Find the header cell that should include hierarchy toggle
+            var headerCell = dataGrid.FindComponents<HeaderCell<DataGridHierarchyColumnTest.Model>>().First();
+
+            var headerElement = comp.Find("th.mud-header-togglehierarchy");
+            headerElement.Should().NotBeNull("Header should have mud-header-togglehierarchy class when EnableHeaderToggle is true");
+            headerCell.Instance._includeHierarchyToggle.Should().BeTrue();
+
+            // Check that the HierarchyToggle button exists in the header
+            var toggleButton = headerElement.QuerySelector(".mud-hierarchy-toggle-button");
+            toggleButton.Should().NotBeNull("HierarchyToggle button should be rendered in header");
+
+            // The initial state should be expanded (Anders and Ira items are initially expanded)
+            dataGrid.Instance._openHierarchies.Count.Should().Be(2);
+
+            // Click the toggle button to collapse all hierarchies
+            toggleButton.Click();
+            comp.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(0));
+
+            // Click again to expand all
+            toggleButton = headerElement.QuerySelector(".mud-hierarchy-toggle-button");
+            toggleButton.Click();
+            comp.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(5));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DataGridHeaderToggleIconTest(bool rightToLeft)
+        {
+            // Render with EnableHeaderToggle = true and set RTL mode
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters =>
+            {
+                parameters.Add(p => p.EnableHeaderToggle, true);
+                parameters.Add(p => p.RightToLeft, rightToLeft);
+            });
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            // Find the header with toggle
+            var headerElement = comp.Find("th.mud-header-togglehierarchy");
+
+            // Find the toggle button in header
+            var toggleButton = headerElement.QuerySelector(".mud-hierarchy-toggle-button");
+            var icon = toggleButton.QuerySelector(".mud-icon-root");
+
+            // Initial state should show expanded icon (ExpandMore)
+            var iconPath = icon.InnerHtml;
+            iconPath.Should().Contain("M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z",
+                "Icon should be ExpandMore when hierarchies are expanded");
+
+            // Click to collapse all
+            toggleButton.Click();
+
+            // Now the icon should change based on RTL mode
+            icon = headerElement.QuerySelector(".mud-hierarchy-toggle-button .mud-icon-root");
+            iconPath = icon.InnerHtml;
+
+            if (rightToLeft)
+            {
+                iconPath.Should().Contain("M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z",
+                    "Icon should be ChevronLeft in RTL mode when hierarchies are collapsed");
+            }
+            else
+            {
+                iconPath.Should().Contain("M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z",
+                    "Icon should be ChevronRight in LTR mode when hierarchies are collapsed");
+            }
+        }
+
+        [Test]
+        public void DataGridToggleHierarchyMethodTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            var headerCell = dataGrid.FindComponents<HeaderCell<DataGridHierarchyColumnTest.Model>>().First();
+
+            // Initially, there should be 2 expanded items
+            dataGrid.Instance._openHierarchies.Count.Should().Be(2);
+            var accessor = headerCell.Instance;
+            accessor.ToggleHierarchy();
+
+            // After calling ToggleHierarchy when some hierarchies are open, all should be collapsed
+            dataGrid.Instance._openHierarchies.Count.Should().Be(0);
+
+            // Call ToggleHierarchy again
+            accessor.ToggleHierarchy();
+
+            // Now all hierarchies should be expanded
+            dataGrid.Instance._openHierarchies.Count.Should().Be(5);
+        }
+
+        [Test]
+        public void DataGridGetGroupIconTest()
+        {
+            // Create a test component
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            // Get a reference to a HeaderCell to test GetGroupIcon method
+            var headerCell = dataGrid.FindComponents<HeaderCell<DataGridHierarchyColumnTest.Model>>().First();
+
+            // Create a PrivateAccessor to invoke the GetGroupIcon method
+            var accessor = headerCell.Instance;
+
+            // When expanded (RTL doesn't matter in this case)
+            var expandedIcon = accessor.GetGroupIcon();
+            expandedIcon.Should().Be(Icons.Material.Filled.ExpandMore);
+
+            accessor.ToggleHierarchy(); // collapse all
+
+            // When collapsed + LTR
+            var collapsedIcon = accessor.GetGroupIcon();
+            comp.WaitForAssertion(() => collapsedIcon.Should().Be(Icons.Material.Filled.ChevronRight));
+
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.RightToLeft, true));
+            // When collapsed + RTL
+            comp.WaitForAssertion(() => accessor.GetGroupIcon().Should().Be(Icons.Material.Filled.ChevronLeft));
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -169,7 +169,7 @@ else if (Column != null && !Column.HiddenState.Value)
         return
         @<text>
             <MudIconButton Icon=@GetGroupIcon() 
-                           Class="mud-table-row-expander"
+                           Class="ma-n3 pa-1"
                            OnClick=@ToggleHierarchy
                            aria-label="@(_expanded ? @Localizer[LanguageResource.MudDataGrid_CollapseAllGroups] : @Localizer[LanguageResource.MudDataGrid_ExpandAllGroups])" />
         </text>;

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -46,9 +46,9 @@ else if (Column != null && !Column.HiddenState.Value)
                     {
                         @Column.HeaderTemplate(Column.headerContext)
                     }
-                    else if (_includeHierarchyToggle)
+                    else if (IncludeHierarchyToggle)
                     {
-                        @HierarchyToggle()
+                        @HierarchyToggle
                     }
                     else 
                     {
@@ -62,9 +62,9 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     @Column.HeaderTemplate(Column.headerContext)
                 }
-                else if (_includeHierarchyToggle)
+                else if (IncludeHierarchyToggle)
                 {
-                    @HierarchyToggle()
+                    @HierarchyToggle
                 }
                 else 
                 {
@@ -164,14 +164,12 @@ else if (Column != null && !Column.HiddenState.Value)
         </text>;
     }
 
-    internal RenderFragment HierarchyToggle()
-    {
-        return
+    private RenderFragment HierarchyToggle =>
         @<text>
-            <MudIconButton Icon=@GetGroupIcon() 
-                           Class="ma-n3 pa-1 mud-hierarchy-toggle-button"
-                           OnClick=@ToggleHierarchy
-                           aria-label="@(_expanded ? @Localizer[LanguageResource.MudDataGrid_CollapseAllGroups] : @Localizer[LanguageResource.MudDataGrid_ExpandAllGroups])" />
-        </text>;
-    }
+             <MudIconButton Icon="@GetGroupIcon()"
+                            Class="ma-n3 pa-1 mud-hierarchy-toggle-button"
+                            OnClick="@ToggleHierarchyAsync"
+                            aria-label="@(Expanded ? @Localizer[LanguageResource.MudDataGrid_CollapseAllGroups] : @Localizer[LanguageResource.MudDataGrid_ExpandAllGroups])"/>
+         </text>;
+
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -32,7 +32,7 @@ else if (Column != null && !Column.HiddenState.Value)
     </th>
 }
 
-@code{
+@code {
 
     internal RenderFragment TableHeader()
     {
@@ -46,6 +46,10 @@ else if (Column != null && !Column.HiddenState.Value)
                     {
                         @Column.HeaderTemplate(Column.headerContext)
                     }
+                    else if (_includeHierarchyToggle)
+                    {
+                        @HierarchyToggle()
+                    }
                     else 
                     {
                         @computedTitle
@@ -57,6 +61,10 @@ else if (Column != null && !Column.HiddenState.Value)
                 @if (Column.HeaderTemplate != null)
                 {
                     @Column.HeaderTemplate(Column.headerContext)
+                }
+                else if (_includeHierarchyToggle)
+                {
+                    @HierarchyToggle()
                 }
                 else 
                 {
@@ -153,6 +161,17 @@ else if (Column != null && !Column.HiddenState.Value)
                 }
             </MudPopover>
         }
+        </text>;
+    }
+
+    internal RenderFragment HierarchyToggle()
+    {
+        return
+        @<text>
+            <MudIconButton Icon=@GetGroupIcon() 
+                           Class="mud-table-row-expander"
+                           OnClick=@ToggleHierarchy
+                           aria-label="@(_expanded ? @Localizer[LanguageResource.MudDataGrid_CollapseAllGroups] : @Localizer[LanguageResource.MudDataGrid_ExpandAllGroups])" />
         </text>;
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -169,7 +169,7 @@ else if (Column != null && !Column.HiddenState.Value)
         return
         @<text>
             <MudIconButton Icon=@GetGroupIcon() 
-                           Class="ma-n3 pa-1"
+                           Class="ma-n3 pa-1 mud-hierarchy-toggle-button"
                            OnClick=@ToggleHierarchy
                            aria-label="@(_expanded ? @Localizer[LanguageResource.MudDataGrid_CollapseAllGroups] : @Localizer[LanguageResource.MudDataGrid_ExpandAllGroups])" />
         </text>;

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -31,6 +31,12 @@ namespace MudBlazor
         public MudDataGrid<T> DataGrid { get; set; }
 
         /// <summary>
+        /// Whether the display should be right to left
+        /// </summary>
+        [CascadingParameter(Name = "RightToLeft")]
+        public bool RightToLeft { get; set; }
+
+        /// <summary>
         /// Shows this cell only in the header area.
         /// </summary>
         /// <remarks>
@@ -109,6 +115,16 @@ namespace MudBlazor
 
 
         #region Computed Properties and Functions
+
+        private bool _expanded
+        {
+            get
+            {
+                return Column?.DataGrid._openHierarchies.Count > 1;
+            }
+        }
+
+        private bool _includeHierarchyToggle { get { return Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false; } }
 
         private string computedTitle
         {
@@ -242,6 +258,23 @@ namespace MudBlazor
         }
 
         #region Events
+
+        private void ToggleHierarchy()
+        {
+            if (_expanded)
+            {
+                DataGrid?.CollapseAllHierarchy();
+            }
+            else
+            {
+                DataGrid?.ExpandAllHierarchy();
+            }
+        }
+
+        private string GetGroupIcon()
+        {
+            return DataGrid?.GetGroupIcon(_expanded, RightToLeft) ?? string.Empty;
+        }
 
         /// <summary>
         /// This is triggered by the DataGrid when a sort is applied

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -124,7 +124,7 @@ namespace MudBlazor
             }
         }
 
-        private bool _includeHierarchyToggle { get { return Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false; } }
+        internal bool _includeHierarchyToggle { get { return Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false; } }
 
         private string computedTitle
         {
@@ -259,7 +259,7 @@ namespace MudBlazor
 
         #region Events
 
-        private void ToggleHierarchy()
+        internal void ToggleHierarchy()
         {
             if (_expanded)
             {
@@ -271,7 +271,7 @@ namespace MudBlazor
             }
         }
 
-        private string GetGroupIcon()
+        internal string GetGroupIcon()
         {
             return DataGrid?.GetGroupIcon(_expanded, RightToLeft) ?? string.Empty;
         }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -116,15 +116,9 @@ namespace MudBlazor
 
         #region Computed Properties and Functions
 
-        private bool _expanded
-        {
-            get
-            {
-                return Column?.DataGrid._openHierarchies.Count > 1;
-            }
-        }
+        private bool Expanded => Column?.DataGrid._openHierarchies.Count > 1;
 
-        internal bool _includeHierarchyToggle { get { return Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false; } }
+        internal bool IncludeHierarchyToggle => Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false;
 
         private string computedTitle
         {
@@ -259,21 +253,26 @@ namespace MudBlazor
 
         #region Events
 
-        internal void ToggleHierarchy()
+        internal async Task ToggleHierarchyAsync()
         {
-            if (_expanded)
+            if (DataGrid is null)
             {
-                DataGrid?.CollapseAllHierarchy();
+                return;
+            }
+
+            if (Expanded)
+            {
+                await DataGrid.CollapseAllHierarchy();
             }
             else
             {
-                DataGrid?.ExpandAllHierarchy();
+                await DataGrid.ExpandAllHierarchy();
             }
         }
 
         internal string GetGroupIcon()
         {
-            return DataGrid?.GetGroupIcon(_expanded, RightToLeft) ?? string.Empty;
+            return DataGrid?.GetGroupIcon(Expanded, RightToLeft) ?? string.Empty;
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -7,15 +7,22 @@
     Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" HeaderTemplate="@HeaderTemplate"
     HeaderStyle="@HeaderStyle" HeaderStyleFunc="@HeaderStyleFunc">
     <CellTemplate>
+        @if (CellTemplate != null)
+        {
+            @CellTemplate(context)            
+        }
+        else
+        {
+            <MudIconButton 
+                Class="ma-n3 pa-1"
+                Icon="@GetGroupIcon(context)" 
+                OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
+                Size="@IconSize"
+                Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>            
+        }
         @if (!_finishedInitialExpanded && InitiallyExpandedFunc.Invoke(context.Item))
         {
             _initiallyExpandedItems.Add(context);
         }
-        <MudIconButton 
-            Class="ma-n3 pa-1"
-            Icon="@GetGroupIcon(context)" 
-            OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
-            Size="@IconSize"
-            Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>
     </CellTemplate>
 </TemplateColumn>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -2,9 +2,10 @@
 @inherits MudComponentBase
 @typeparam T
 
-<TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-    Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged" HeaderClass="@(EnableHeaderToggle ? "mud-header-togglehierarchy" : "")"
-    Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled">
+<TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderClassFunc="@HeaderClassFunc"
+    Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged" HeaderClass="@(EnableHeaderToggle ? $"mud-header-togglehierarchy {HeaderClass}" : HeaderClass)"
+    Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" HeaderTemplate="@HeaderTemplate"
+    HeaderStyle="@HeaderStyle" HeaderStyleFunc="@HeaderStyleFunc">
     <CellTemplate>
         @if (!_finishedInitialExpanded && InitiallyExpandedFunc.Invoke(context.Item))
         {

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -7,7 +7,7 @@
     Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" HeaderTemplate="@HeaderTemplate"
     HeaderStyle="@HeaderStyle" HeaderStyleFunc="@HeaderStyleFunc">
     <CellTemplate>
-        @if (CellTemplate != null)
+        @if (CellTemplate is not null)
         {
             @CellTemplate(context)            
         }
@@ -18,7 +18,7 @@
                 Icon="@GetGroupIcon(context)" 
                 OnClick="context.Actions.ToggleHierarchyVisibilityForItemAsync"
                 Size="@IconSize"
-                Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>            
+                Disabled="ButtonDisabledFunc.Invoke(context.Item)"/>
         }
         @if (!_finishedInitialExpanded && InitiallyExpandedFunc.Invoke(context.Item))
         {

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
-    Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged"
+    Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged" HeaderClass="@(EnableHeaderToggle ? "mud-header-togglehierarchy" : "")"
     Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled">
     <CellTemplate>
         @if (!_finishedInitialExpanded && InitiallyExpandedFunc.Invoke(context.Item))

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -131,6 +131,12 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     public RenderFragment<HeaderContext<T>> HeaderTemplate { get; set; }
 
     /// <summary>
+    /// The template used to display this column's value cells.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<CellContext<T>> CellTemplate { get; set; }
+
+    /// <summary>
     /// The function which determines whether the row should be initially expanded.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -95,6 +95,42 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     public bool EnableHeaderToggle { get; set; } = false;
 
     /// <summary>
+    /// The CSS class applied to the header.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Separate multiple classes with spaces.
+    /// </remarks>
+    [Parameter]
+    public string HeaderClass { get; set; }
+
+    /// <summary>
+    /// The function which calculates CSS classes for the header.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  Separate multiple classes with spaces.
+    /// </remarks>
+    [Parameter]
+    public Func<IEnumerable<T>, string> HeaderClassFunc { get; set; }
+
+    /// <summary>
+    /// The CSS style applied to this column's header.
+    /// </summary>
+    [Parameter]
+    public string HeaderStyle { get; set; } = "width:0%;";
+
+    /// <summary>
+    /// The function which calculates CSS styles for the header.
+    /// </summary>
+    [Parameter]
+    public Func<IEnumerable<T>, string> HeaderStyleFunc { get; set; }
+
+    /// <summary>
+    /// The template used to display this column's header.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<HeaderContext<T>> HeaderTemplate { get; set; }
+
+    /// <summary>
     /// The function which determines whether the row should be initially expanded.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -88,6 +88,13 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     public EventCallback<bool> HiddenChanged { get; set; }
 
     /// <summary>
+    /// Whether or not to show a button in the header to expand/collapse all columns.
+    /// </summary>
+    /// <remarks>Defaults to <c>false</c>.</remarks>
+    [Parameter]
+    public bool EnableHeaderToggle { get; set; } = false;
+
+    /// <summary>
     /// The function which determines whether the row should be initially expanded.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -452,6 +452,11 @@
                     <MudMenuItem OnClick="@dataGrid.ExpandAllGroups">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudMenuItem>
                     <MudMenuItem OnClick="@dataGrid.CollapseAllGroups">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudMenuItem>
                 }
+                @if (dataGrid.HasHierarchyColumn)
+                {
+                    <MudMenuItem OnClick="@dataGrid.ExpandAllHierarchy">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudMenuItem>
+                    <MudMenuItem OnClick="@dataGrid.CollapseAllHierarchy">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudMenuItem>
+                }
                 @if (dataGrid.HasServerData)
                 {
                     <MudMenuItem OnClick="@dataGrid.InvokeServerLoadFunc">@Localizer[LanguageResource.MudDataGrid_RefreshData]</MudMenuItem>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1299,7 +1299,7 @@ namespace MudBlazor
 
         private async Task OnExpandSingleRowChangedAsync(ParameterChangedEventArgs<bool> args)
         {
-            // If user changes the ExpandSingleRow parameter, clear all open hierarchies except the first;
+            // If user changes the ExpandSingleRow parameter, clear all open hierarchies except the first
             if (_openHierarchies.Count > 0)
             {
                 var first = _openHierarchies.First();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -30,7 +30,6 @@ namespace MudBlazor
         private bool _isFirstRendered = false;
         private bool _filtersMenuVisible = false;
         private bool _columnsPanelVisible = false;
-        private bool _expandSingleRow = false;
         internal HashSet<T> _openHierarchies = [];
         private string _columnsPanelSearch = string.Empty;
         private MudDropContainer<Column<T>> _dropContainer;
@@ -46,6 +45,7 @@ namespace MudBlazor
 
         private readonly ParameterState<T> _selectedItemState;
         private readonly ParameterState<HashSet<T>> _selectedItemsState;
+        private readonly ParameterState<bool> _expandSingleRowState;
 
         public MudDataGrid()
         {
@@ -61,6 +61,10 @@ namespace MudBlazor
                 .WithParameter(() => SelectedItems)
                 .WithEventCallback(() => SelectedItemsChanged)
                 .WithChangeHandler(OnSelectedItemsChanged);
+
+            _expandSingleRowState = registerScope.RegisterParameter<bool>(nameof(ExpandSingleRow))
+                .WithParameter(() => ExpandSingleRow)
+                .WithChangeHandler(OnExpandSingleRowChanged);
         }
 
         protected string Classname =>
@@ -1071,24 +1075,7 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>Defaults to <c>false</c>.</remarks>
         [Parameter]
-        public bool ExpandSingleRow
-        {
-            get => _expandSingleRow;
-            set
-            {
-                if (_expandSingleRow == value) return;
-                // if users changes the value this will update the open hierarchies to only include one
-                _expandSingleRow = value;
-
-                if (_openHierarchies.Count > 0)
-                {
-                    var item = _openHierarchies.First();
-                    _openHierarchies.Clear();
-                    _openHierarchies.Add(item);
-                    InvokeAsync(StateHasChanged);
-                }
-            }
-        }
+        public bool ExpandSingleRow { get; set; }
 
         /// <summary>
         /// The comparer used to determine row selection.
@@ -1307,6 +1294,18 @@ namespace MudBlazor
             else
             {
                 Selection = args.Value;
+            }
+        }
+
+        private void OnExpandSingleRowChanged(ParameterChangedEventArgs<bool> args)
+        {
+            // If user changes the ExpandSingleRow parameter, clear all open hierarchies except the first;
+            if (_openHierarchies.Count > 0)
+            {
+                var item = _openHierarchies.First();
+                _openHierarchies.Clear();
+                _openHierarchies.Add(item);
+                InvokeAsync(StateHasChanged);
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -64,7 +64,7 @@ namespace MudBlazor
 
             _expandSingleRowState = registerScope.RegisterParameter<bool>(nameof(ExpandSingleRow))
                 .WithParameter(() => ExpandSingleRow)
-                .WithChangeHandler(OnExpandSingleRowChanged);
+                .WithChangeHandler(OnExpandSingleRowChangedAsync);
         }
 
         protected string Classname =>
@@ -1297,15 +1297,15 @@ namespace MudBlazor
             }
         }
 
-        private void OnExpandSingleRowChanged(ParameterChangedEventArgs<bool> args)
+        private async Task OnExpandSingleRowChangedAsync(ParameterChangedEventArgs<bool> args)
         {
             // If user changes the ExpandSingleRow parameter, clear all open hierarchies except the first;
             if (_openHierarchies.Count > 0)
             {
-                var item = _openHierarchies.First();
+                var first = _openHierarchies.First();
                 _openHierarchies.Clear();
-                _openHierarchies.Add(item);
-                InvokeAsync(StateHasChanged);
+                _openHierarchies.Add(first);
+                await InvokeAsync(StateHasChanged);
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2138,9 +2138,11 @@ namespace MudBlazor
 
         public async Task ToggleHierarchyVisibilityAsync(T item)
         {
-            // if ExpandSingleRow is true, clear all open hierarchies which will immediate add the item clicked
-            if (ExpandSingleRow)
+            // if ExpandSingleRow is true, clear all open hierarchies, which will immediately add the item that was clicked.
+            if (_expandSingleRowState.Value)
+            {
                 _openHierarchies.Clear();
+            }
 
             // if item doesn't exist remove will return false and add the item
             if (!_openHierarchies.Remove(item))

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -30,6 +30,7 @@ namespace MudBlazor
         private bool _isFirstRendered = false;
         private bool _filtersMenuVisible = false;
         private bool _columnsPanelVisible = false;
+        private bool _expandSingleRow = false;
         internal HashSet<T> _openHierarchies = [];
         private string _columnsPanelSearch = string.Empty;
         private MudDropContainer<Column<T>> _dropContainer;
@@ -1064,6 +1065,30 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         public bool ShowMenuIcon { get; set; } = false;
+
+        /// <summary>
+        /// Ensures the user can only expand one Hierarchy row at a time. This only has an effect if you are using a Hierarchy column.
+        /// </summary>
+        /// <remarks>Defaults to <c>false</c>.</remarks>
+        [Parameter]
+        public bool ExpandSingleRow
+        {
+            get => _expandSingleRow;
+            set
+            {
+                if (_expandSingleRow == value) return;
+                // if users changes the value this will update the open hierarchies to only include one
+                _expandSingleRow = value;
+
+                if (_openHierarchies.Count > 0)
+                {
+                    var item = _openHierarchies.First();
+                    _openHierarchies.Clear();
+                    _openHierarchies.Add(item);
+                    InvokeAsync(StateHasChanged);
+                }
+            }
+        }
 
         /// <summary>
         /// The comparer used to determine row selection.
@@ -2112,13 +2137,14 @@ namespace MudBlazor
             await InvokeAsync(StateHasChanged);
         }
 
-        internal async Task ToggleHierarchyVisibilityAsync(T item)
+        public async Task ToggleHierarchyVisibilityAsync(T item)
         {
-            if (_openHierarchies.Contains(item))
-            {
-                _openHierarchies.Remove(item);
-            }
-            else
+            // if ExpandSingleRow is true, clear all open hierarchies which will immediate add the item clicked
+            if (ExpandSingleRow)
+                _openHierarchies.Clear();
+
+            // if item doesn't exist remove will return false and add the item
+            if (!_openHierarchies.Remove(item))
             {
                 _openHierarchies.Add(item);
             }

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -522,6 +522,10 @@
   }
 }
 
+.mud-header-togglehierarchy .mud-table-row-expander {
+    padding: 6px;
+}
+
 .mud-table-row-expander {
   margin-top: -12px;
   margin-bottom: -12px;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #11106 by adding the field EnableHeaderToggle (Defaults to false) which activates a toggle button at header row area to toggle expand all/collapse all. Also added HeaderClass, HeaderClassFunc, HeaderStyle, HeaderStyleFunc, HeaderTemplate, and CellTemplate to allow customization and be a little closer aligned for a Column since Hierarchy doesn't inherit from Column. Those new fields are passed to the TemplateColumn inside Hierarchy.

Resolves #11145 by making ToggleHierarchyAsync public so users can toggle a single row
Resolves #6926 by creating a property EnableSingleRow that sets Hierarchy to only allow 1 row to expand at a time
Resolves #11157 by cleaning up the Toggle logic

![Screenshot 2025-04-11 090212](https://github.com/user-attachments/assets/1fc2101f-5782-4e12-8838-e410d6622e84)
![Screenshot 2025-04-11 090221](https://github.com/user-attachments/assets/c4858285-3716-4598-a784-858e66c8de74)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually in Viewer (WASM) and BSS (Docs)
Unit Testing

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
