### PR TITLE
[Docs] Fix color preview getting cut off

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -28,7 +28,7 @@
                                     <td>@Row.Name</td>
                                     <td>@Row.Type</td>
                                     <td>
-                                        <div class="d-flex align-center">
+                                        <div class="d-inline-flex align-center">
                                             <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Default}")"/>
                                             @Row.Default
                                         </div>
@@ -37,7 +37,7 @@
                                     <td>
                                         @if (!Row.Default.Equals(Row.Dark))
                                         {
-                                            <div class="d-flex align-center">
+                                            <div class="d-inline-flex align-center">
                                                 <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Dark}")"/>
                                                 @Row.Dark
                                             </div>


### PR DESCRIPTION
The color in the preview was not visible for longer values due to the style.

## Description
`d-flex` to `d-inline-flex`

## How Has This Been Tested?
Visually tested

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

**Before:**
![image](https://github.com/user-attachments/assets/de5f8306-4114-439f-8a33-26425cbbe492)
**After:**
![image](https://github.com/user-attachments/assets/2eaea642-1a41-4efe-b383-5b52ac307677)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
