### PR TITLE
MudCarousel: Fix timer creation after component disposal

### DIFF
--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -293,7 +293,7 @@ namespace MudBlazor
         /// </summary>
         private ValueTask StartTimerAsync()
         {
-            if (AutoCycle)
+            if (AutoCycle && _disposing == false)
             {
                 _timer?.Change(AutoCycleTime, TimeSpan.Zero);
             }

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -15,10 +15,10 @@ namespace MudBlazor
     public partial class MudCarousel<TData> : MudBaseBindableItemsControl<MudCarouselItem, TData>, IAsyncDisposable
     {
         private Timer? _timer;
+        private bool _disposing;
         private bool _autoCycle = true;
         private Color _currentColor = Color.Inherit;
         private TimeSpan _cycleTimeout = TimeSpan.FromSeconds(5);
-        private bool _disposing;
 
         protected string Classname => new CssBuilder("mud-carousel")
             .AddClass($"mud-carousel-{(BulletsColor ?? _currentColor).ToDescriptionString()}")
@@ -293,7 +293,7 @@ namespace MudBlazor
         /// </summary>
         private ValueTask StartTimerAsync()
         {
-            if (AutoCycle && _disposing == false)
+            if (AutoCycle && !_disposing)
             {
                 _timer?.Change(AutoCycleTime, TimeSpan.Zero);
             }

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         private bool _autoCycle = true;
         private Color _currentColor = Color.Inherit;
         private TimeSpan _cycleTimeout = TimeSpan.FromSeconds(5);
+        private bool _disposing;
 
         protected string Classname => new CssBuilder("mud-carousel")
             .AddClass($"mud-carousel-{(BulletsColor ?? _currentColor).ToDescriptionString()}")
@@ -334,6 +335,8 @@ namespace MudBlazor
 
             if (firstRender)
             {
+                // Prevent timer creation after or while disposal, which would result in a memory leak.
+                if (_disposing) return;
                 _timer = new Timer(TimerElapsed, null, AutoCycle ? AutoCycleTime : Timeout.InfiniteTimeSpan, AutoCycleTime);
             }
         }
@@ -347,6 +350,10 @@ namespace MudBlazor
 
         protected virtual async ValueTask DisposeAsyncCore()
         {
+            // Immediately sets disposing to true,
+            // so that timer creation on OnAfterRenderAsync does not happen after disposal.
+            _disposing = true;
+
             await StopTimerAsync();
 
             var timer = _timer;


### PR DESCRIPTION
## Issue
Found memory issues:
![image](https://github.com/user-attachments/assets/aa00e607-0dfe-47b9-908e-c6485aa1997f)
![image](https://github.com/user-attachments/assets/fa9a447a-b615-4d17-835f-556560c29114)
![image](https://github.com/user-attachments/assets/384e31cc-e218-405e-974d-e06622d961bd)
See the FromSeconds 5 which is referenced in the graph
![image](https://github.com/user-attachments/assets/03d4ba0d-be92-4200-abee-255711924b66)
![image](https://github.com/user-attachments/assets/de1cbb9f-6d92-4b63-826e-555bc759e776)
Timer is sometimes created after dispose is called

## Changes
- added `_disposing` to keep track of disposed state
- not creating timer if disposing is set to true

## Reason
- If component is created, and then immediately destroyed, timer may still get created in OnAfterRenderAsync lifecycle hook, which would cause timer to be created after disposal, which in turn leads to memory leak

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->


## How Has This Been Tested?
Added Console.WriteLine when timer should be created or reset

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
