### PR TITLE
MudDataGrid: Add XML comment to ToggleHierarchyVisibilityAsync

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2112,7 +2112,11 @@ namespace MudBlazor
             await InvokeAsync(StateHasChanged);
         }
 
-        internal async Task ToggleHierarchyVisibilityAsync(T item)
+        /// <summary>
+        /// Collapses or expands the hierarchy of the specified item.
+        /// </summary>
+        /// <param name="item">The item whose hierarchy visibility is to be toggled.</param>
+        public async Task ToggleHierarchyVisibilityAsync(T item)
         {
             if (_openHierarchies.Contains(item))
             {


### PR DESCRIPTION
## Description
Fixes: #11145
Exposed the `MudDataGrid<T>.ToggleHierarchyVisibilityAsync` method by changing its access modifier from `internal` to `public`, enabling external use and improving the component's flexibility.

## Motivation
While integrating `MudDataGrid` into my application, I needed to toggle the hierarchy visibility in response to a `RowClick` event. Since there was no public method available, I resorted to using reflection to access `ToggleHierarchyVisibilityAsync`. This workaround functions correctly, but the method serves a clear purpose externally and would be more appropriately marked as `public`.

## How Has This Been Tested?
The method's functionality is already covered by existing tests. No new test cases were required as this change only exposes existing behavior.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. 
