### PR TITLE
mudElementReference.js: Fix null exception

### DIFF
--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -164,7 +164,7 @@ class MudElementReference {
                 console.error("No dotNetReference found for iosKeyboardFocus");
             }
         }
-        element.addEventListener('blur', element._mudBlurHandler);
+        if (element) element.addEventListener('blur', element._mudBlurHandler);
     }
     // dispose event
     removeOnBlurEvent(element, dotnetRef) {


### PR DESCRIPTION
## Description
Check null before call any function.
Fix: #11221

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Just setup a page like image bellow. The error should not be occur.
If there is a condition to show/hide MudTextField immediately during initializing, we will get the error `Cannot read properties of null (reading 'addEventListener')`.  

![image](https://github.com/user-attachments/assets/d93c74e4-22ae-48c7-9937-09f5d8d61d91)


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
