### PR TITLE
MudDataGrid Default GroupTemplate At Grid Level

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingExample.razor
@@ -9,6 +9,15 @@
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudSpacer />
     </ToolBarContent>
+    <GroupTemplate>
+        <span style="font-weight:bold">
+            @context.Title: @context.Grouping.Key Count: @context.Grouping.Count()
+            @if (context.DataGrid.FilteredItems.Count() != 0)
+            {
+                @string.Format(" Percentage: {0:P1}", context.Grouping.Count() / ((double)context.DataGrid.FilteredItems.Count()))
+            }
+            </span>
+    </GroupTemplate>
     <Columns>
         <PropertyColumn Property="x => x.Number" Title="Nr" Filterable="false" Groupable="false" />
         <PropertyColumn Property="x => x.Sign" />

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingMultiLevelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridGroupingMultiLevelExample.razor
@@ -17,9 +17,18 @@
                       @bind-Value="_searchString" @bind-Value:after="@(() => _dataGrid.ReloadServerData())" 
                       DebounceInterval="100" Variant="Variant.Outlined" Clearable />
     </ToolBarContent>
+    <GroupTemplate>
+        <span style="font-weight:bold">
+            @context.Title: @context.Grouping.Key Count: @context.Grouping.Count()
+            @if (context.DataGrid.FilteredItems.Count() != 0)
+            {
+                @string.Format(" Percentage: {0:P1}", context.Grouping.Count() / ((double)context.DataGrid.FilteredItems.Count()))
+            }
+            </span>
+    </GroupTemplate>
     <Columns>
         <PropertyColumn Property="x => x.State" Title="State" Groupable="false" />
-        <PropertyColumn Property="x => x.Counties" Groupable="false" />
+        <PropertyColumn Property="x => x.Counties" Groupable="true" />
         <PropertyColumn Property="x => x.Population" Groupable="false" Format="N0" />
         <PropertyColumn Property="x => x.PrimaryIndustry" Title="Primary Industry"
                         @bind-Grouping="_primaryIndustryGrouping" GroupBy="_groupBy1"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupingMultiLevelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupingMultiLevelTest.razor
@@ -15,9 +15,18 @@
                       @bind-Value="_searchString" @bind-Value:after="@(() => _dataGrid.ReloadServerData())" 
                       DebounceInterval="100" Variant="Variant.Outlined" Clearable />
     </ToolBarContent>
+    <GroupTemplate>
+        <span style="font-weight:bold">
+            @context.Title: @context.Grouping.Key Count: @context.Grouping.Count()
+            @if (context.DataGrid.FilteredItems.Count() != 0)
+            {
+                @string.Format(" Percentage: {0:P1}", context.Grouping.Count() / ((double)context.DataGrid.FilteredItems.Count()))
+            }
+            </span>
+    </GroupTemplate>
     <Columns>
         <PropertyColumn Property="x => x.State" Title="State" Groupable="false" />
-        <PropertyColumn Property="x => x.Counties" Groupable="false" />
+        <PropertyColumn Property="x => x.Counties" Groupable="true" />
         <PropertyColumn Property="x => x.Population" Groupable="false" Format="N0" />
         <PropertyColumn Property="x => x.PrimaryIndustry" Title="Primary Industry"
                         @bind-Grouping="_primaryIndustryGrouping" GroupBy="_groupBy1"

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -7,7 +7,7 @@
         <div style="display:flex; align-items:center;">
             <MudIconButton Class="mud-table-row-expander" Icon="@(DataGrid.GetGroupIcon(_expanded))"
                            OnClick="@GroupExpandClick" />
-            @if (GroupDefinition?.GroupTemplate is not null)
+            @if (GroupDefinition.GroupTemplate is not null)
             {
                 @GroupDefinition.GroupTemplate(GroupDefinition)
             }
@@ -17,7 +17,7 @@
             }
             else
             {
-                <span style="font-weight:bold">@GroupDefinition?.Title: @(Items?.Key ?? "null")</span>
+                <span style="font-weight:bold">@GroupDefinition.Title: @(Items?.Key ?? "null")</span>
             }
         </div>
     </td>

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -7,13 +7,17 @@
         <div style="display:flex; align-items:center;">
             <MudIconButton Class="mud-table-row-expander" Icon="@(DataGrid.GetGroupIcon(_expanded))"
                            OnClick="@GroupExpandClick" />
-            @if (GroupDefinition?.GroupTemplate == null)
+            @if (GroupDefinition?.GroupTemplate is not null)
             {
-                <span style="font-weight:bold">@GroupDefinition?.Title: @(Items?.Key ?? "null")</span>
+                @GroupDefinition.GroupTemplate(GroupDefinition)
+            }
+            else if (GroupDefinition.DataGrid.GroupTemplate is not null)
+            {
+                @GroupDefinition.DataGrid.GroupTemplate(GroupDefinition)
             }
             else
             {
-                @GroupDefinition.GroupTemplate(GroupDefinition)
+                <span style="font-weight:bold">@GroupDefinition?.Title: @(Items?.Key ?? "null")</span>
             }
         </div>
     </td>

--- a/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor;
@@ -11,9 +12,14 @@ namespace MudBlazor;
 /// Represents the grouping information for columns in a <see cref="MudDataGrid{T}"/>.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class GroupDefinition<T>
+public class GroupDefinition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
 {
     private GroupDefinition<T>? _innerGroup;
+
+    /// <summary>
+    /// The <see cref="MudDataGrid{T}"/> which contains this group definition.
+    /// </summary>
+    public required MudDataGrid<T> DataGrid { get; init; }
 
     /// <summary>
     /// The LINQ definition of the grouping.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1082,11 +1082,14 @@ namespace MudBlazor
         [Parameter]
         public IEqualityComparer<T> Comparer { get; set; } = EqualityComparer<T>.Default;
 
+#nullable enable
         /// <summary>
-        /// The default template used to display column grouping for all columns.
+        /// The default template used to display column grouping for any column that is grouped. 
         /// </summary>
+        /// <remarks>Can be overridden by using the column level GroupTemplate, defaults to <c>null</c>.</remarks>
         [Parameter]
-        public RenderFragment<GroupDefinition<T>> GroupTemplate { get; set; }
+        public RenderFragment<GroupDefinition<T>>? GroupTemplate { get; set; }
+#nullable disable
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1082,6 +1082,12 @@ namespace MudBlazor
         [Parameter]
         public IEqualityComparer<T> Comparer { get; set; } = EqualityComparer<T>.Default;
 
+        /// <summary>
+        /// The default template used to display column grouping for all columns.
+        /// </summary>
+        [Parameter]
+        public RenderFragment<GroupDefinition<T>> GroupTemplate { get; set; }
+
         #endregion
 
         #region Properties
@@ -2094,6 +2100,7 @@ namespace MudBlazor
                             column._groupExpandedState.Value;
             return new()
             {
+                DataGrid = this,
                 Selector = column.groupBy,
                 Expanded = expanded,
                 GroupTemplate = column.GroupTemplate,
@@ -2118,6 +2125,7 @@ namespace MudBlazor
                 }
                 result.Add(new GroupDefinition<T>
                 {
+                    DataGrid = this,
                     Selector = groupDef.Selector,
                     Expanded = expanded,
                     GroupTemplate = groupDef.GroupTemplate,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
MudDataGrid provides a GroupTemplate on each column to control what information is presented when grouping by that column.

Its quite a common scenario to want to provide the same grouping information no matter which column is grouped. e.g. a count of the rows in the group or a percentage of the total rows. Providing the GroupTemplate on each column can be quite tedious for large grids.

This PR adds the GroupTemplate at grid level. Each column will use the most specific one in logical order: 
GroupTemplate Specified In Column -> Group Template Specified in Grid -> Default Group Template

Example usage added to docs:
```
<MudDataGrid @ref="dataGrid" MultiSelection="true" Items="@Elements" Filterable="true"
    Hideable="true" Groupable="true" GroupExpanded="false" GroupClassFunc="GroupClassFunc">
    <ToolBarContent>
        <MudText Typo="Typo.h6">Periodic Elements</MudText>
        <MudSpacer />
    </ToolBarContent>
    <GroupTemplate>
        <span style="font-weight:bold">
            @context.DataGrid.GroupedColumn.Title: @context.Grouping.Key Count: @context.Grouping.Count()
            @if (context.DataGrid.FilteredItems.Count() != 0)
            {
                @string.Format(" Percentage: {0:P1}", context.Grouping.Count() / ((double)context.DataGrid.FilteredItems.Count()))
            }
            </span>
    </GroupTemplate>
    <Columns>
        <PropertyColumn Property="x => x.Number" Title="Nr" Filterable="false" Groupable="false" />
        <PropertyColumn Property="x => x.Sign" />
        <PropertyColumn Property="x => x.Name" />
        <PropertyColumn Property="x => x.Position" />
        <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
        <PropertyColumn Property="x => x.Group" Title="Category" Grouping GroupBy="@_groupBy">
<!--overrides the grid level one -->
            <GroupTemplate>
                @if (_customizeGroupTemplate)
                {
                    <span style="font-weight:bold">Group: @context.Grouping.Key <MudChip Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small">total @context.Grouping.Count()</MudChip></span>
                }
                else
                {
                    <span style="font-weight:bold">Category: @context.Grouping.Key</span>
                }
            </GroupTemplate>
        </PropertyColumn>
    </Columns>
</MudDataGrid>
```

![img](https://peterthorpe81.github.io/Public/TempImages/Grouping.png)

Note the PR makes the GroupedColumn property public and DataGrid accessible via GroupDefinition to allow for more complex aggregates. I think these are ok as DataGrid can be accessed by referencing anyway and GroupedColumn is only a getter.

<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

## How Has This Been Tested?
Visually. I'm not sure there are any tests to implement.

<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
