### PR TITLE
Added Elevation Dark Mode Styling

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -240,14 +240,14 @@
             Type = "String[]",
             Default = "System.String[]"
         });
-        for (int i = 0; i < mudTheme.Shadows.Elevation.Length; i++)
+        for (int i = 0; i < mudTheme.Shadows.ElevationLight.Length; i++)
         {
             int a = i;
             ApiShadow.Add(new ApiDefaultTheme()
             {
                 Name = $"Elevation[{a}]",
                 Type = "String",
-                Default = mudTheme.Shadows.Elevation.GetValue(a),
+                Default = mudTheme.Shadows.ElevationLight.GetValue(a),
                 CSSVariable = $"--mud-elevation-{a}",
                 CSSClass = $"mud-elevation-{a}"
             });

--- a/src/MudBlazor.Docs/Theme/Theme.cs
+++ b/src/MudBlazor.Docs/Theme/Theme.cs
@@ -178,7 +178,7 @@ namespace MudBlazor.Docs
 
         private static readonly Shadow LandingPageShadows = new()
         {
-            Elevation = new string[]
+            ElevationLight = new string[]
             {
             "none",
             "0 2px 4px -1px rgba(6, 24, 44, 0.2)",

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -340,32 +340,10 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
         theme.AppendLine($"--{Ripple}-opacity-secondary: {_theme.PaletteLight.RippleOpacitySecondary.ToString(CultureInfo.InvariantCulture)};");
 
         //Elevations
-        theme.AppendLine($"--{Elevation}-0: {_theme.Shadows.Elevation.GetValue(0)};");
-        theme.AppendLine($"--{Elevation}-1: {_theme.Shadows.Elevation.GetValue(1)};");
-        theme.AppendLine($"--{Elevation}-2: {_theme.Shadows.Elevation.GetValue(2)};");
-        theme.AppendLine($"--{Elevation}-3: {_theme.Shadows.Elevation.GetValue(3)};");
-        theme.AppendLine($"--{Elevation}-4: {_theme.Shadows.Elevation.GetValue(4)};");
-        theme.AppendLine($"--{Elevation}-5: {_theme.Shadows.Elevation.GetValue(5)};");
-        theme.AppendLine($"--{Elevation}-6: {_theme.Shadows.Elevation.GetValue(6)};");
-        theme.AppendLine($"--{Elevation}-7: {_theme.Shadows.Elevation.GetValue(7)};");
-        theme.AppendLine($"--{Elevation}-8: {_theme.Shadows.Elevation.GetValue(8)};");
-        theme.AppendLine($"--{Elevation}-9: {_theme.Shadows.Elevation.GetValue(9)};");
-        theme.AppendLine($"--{Elevation}-10: {_theme.Shadows.Elevation.GetValue(10)};");
-        theme.AppendLine($"--{Elevation}-11: {_theme.Shadows.Elevation.GetValue(11)};");
-        theme.AppendLine($"--{Elevation}-12: {_theme.Shadows.Elevation.GetValue(12)};");
-        theme.AppendLine($"--{Elevation}-13: {_theme.Shadows.Elevation.GetValue(13)};");
-        theme.AppendLine($"--{Elevation}-14: {_theme.Shadows.Elevation.GetValue(14)};");
-        theme.AppendLine($"--{Elevation}-15: {_theme.Shadows.Elevation.GetValue(15)};");
-        theme.AppendLine($"--{Elevation}-16: {_theme.Shadows.Elevation.GetValue(16)};");
-        theme.AppendLine($"--{Elevation}-17: {_theme.Shadows.Elevation.GetValue(17)};");
-        theme.AppendLine($"--{Elevation}-18: {_theme.Shadows.Elevation.GetValue(18)};");
-        theme.AppendLine($"--{Elevation}-19: {_theme.Shadows.Elevation.GetValue(19)};");
-        theme.AppendLine($"--{Elevation}-20: {_theme.Shadows.Elevation.GetValue(20)};");
-        theme.AppendLine($"--{Elevation}-21: {_theme.Shadows.Elevation.GetValue(21)};");
-        theme.AppendLine($"--{Elevation}-22: {_theme.Shadows.Elevation.GetValue(22)};");
-        theme.AppendLine($"--{Elevation}-23: {_theme.Shadows.Elevation.GetValue(23)};");
-        theme.AppendLine($"--{Elevation}-24: {_theme.Shadows.Elevation.GetValue(24)};");
-        theme.AppendLine($"--{Elevation}-25: {_theme.Shadows.Elevation.GetValue(25)};");
+        for (int i = 0; i <= 25; i++)
+        {
+            theme.AppendLine($"--{Elevation}-{i}: {(IsDarkMode ? _theme.Shadows.ElevationDark.GetValue(i) : _theme.Shadows.ElevationLight.GetValue(i))};");
+        }
 
         //Layout Properties
         theme.AppendLine(

--- a/src/MudBlazor/Themes/Models/Shadow.cs
+++ b/src/MudBlazor/Themes/Models/Shadow.cs
@@ -7,9 +7,9 @@
     public class Shadow
     {
         /// <summary>
-        /// Gets or sets the elevation levels for the shadow.
+        /// Gets or sets the elevation levels for the shadow in light mode.
         /// </summary>
-        public string[] Elevation { get; set; } =
+        public string[] ElevationLight { get; set; } =
         {
             "none",
             "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
@@ -36,6 +36,39 @@
             "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
             "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
             "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+            "0 5px 5px -3px rgba(0,0,0,.06), 0 8px 10px 1px rgba(0,0,0,.042), 0 3px 14px 2px rgba(0,0,0,.036)"
+        };
+
+        /// <summary>
+        /// Gets or sets the elevation levels for the shadow in dark mode.
+        /// </summary>
+        public string[] ElevationDark { get; set; } =
+        {
+            "none",
+            "0px 2px 1px -1px rgba(0,0,0,0.8),0px 1px 1px 0px rgba(0,0,0,0.56),0px 1px 3px 0px rgba(0,0,0,0.48)",
+            "0px 3px 1px -2px rgba(0,0,0,0.8),0px 2px 2px 0px rgba(0,0,0,0.56),0px 1px 5px 0px rgba(0,0,0,0.48)",
+            "0px 3px 3px -2px rgba(0,0,0,0.8),0px 3px 4px 0px rgba(0,0,0,0.56),0px 1px 8px 0px rgba(0,0,0,0.48)",
+            "0px 2px 4px -1px rgba(0,0,0,0.8),0px 4px 5px 0px rgba(0,0,0,0.56),0px 1px 10px 0px rgba(0,0,0,0.48)",
+            "0px 3px 5px -1px rgba(0,0,0,0.8),0px 5px 8px 0px rgba(0,0,0,0.56),0px 1px 14px 0px rgba(0,0,0,0.48)",
+            "0px 3px 5px -1px rgba(0,0,0,0.8),0px 6px 10px 0px rgba(0,0,0,0.56),0px 1px 18px 0px rgba(0,0,0,0.48)",
+            "0px 4px 5px -2px rgba(0,0,0,0.8),0px 7px 10px 1px rgba(0,0,0,0.56),0px 2px 16px 1px rgba(0,0,0,0.48)",
+            "0px 5px 5px -3px rgba(0,0,0,0.8),0px 8px 10px 1px rgba(0,0,0,0.56),0px 3px 14px 2px rgba(0,0,0,0.48)",
+            "0px 5px 6px -3px rgba(0,0,0,0.8),0px 9px 12px 1px rgba(0,0,0,0.56),0px 3px 16px 2px rgba(0,0,0,0.48)",
+            "0px 6px 6px -3px rgba(0,0,0,0.8),0px 10px 14px 1px rgba(0,0,0,0.56),0px 4px 18px 3px rgba(0,0,0,0.48)",
+            "0px 6px 7px -4px rgba(0,0,0,0.8),0px 11px 15px 1px rgba(0,0,0,0.56),0px 4px 20px 3px rgba(0,0,0,0.48)",
+            "0px 7px 8px -4px rgba(0,0,0,0.8),0px 12px 17px 2px rgba(0,0,0,0.56),0px 5px 22px 4px rgba(0,0,0,0.48)",
+            "0px 7px 8px -4px rgba(0,0,0,0.8),0px 13px 19px 2px rgba(0,0,0,0.56),0px 5px 24px 4px rgba(0,0,0,0.48)",
+            "0px 7px 9px -4px rgba(0,0,0,0.8),0px 14px 21px 2px rgba(0,0,0,0.56),0px 5px 26px 4px rgba(0,0,0,0.48)",
+            "0px 8px 9px -5px rgba(0,0,0,0.8),0px 15px 22px 2px rgba(0,0,0,0.56),0px 6px 28px 5px rgba(0,0,0,0.48)",
+            "0px 8px 10px -5px rgba(0,0,0,0.8),0px 16px 24px 2px rgba(0,0,0,0.56),0px 6px 30px 5px rgba(0,0,0,0.48)",
+            "0px 8px 11px -5px rgba(0,0,0,0.8),0px 17px 26px 2px rgba(0,0,0,0.56),0px 6px 32px 5px rgba(0,0,0,0.48)",
+            "0px 9px 11px -5px rgba(0,0,0,0.8),0px 18px 28px 2px rgba(0,0,0,0.56),0px 7px 34px 6px rgba(0,0,0,0.48)",
+            "0px 9px 12px -6px rgba(0,0,0,0.8),0px 19px 29px 2px rgba(0,0,0,0.56),0px 7px 36px 6px rgba(0,0,0,0.48)",
+            "0px 10px 13px -6px rgba(0,0,0,0.8),0px 20px 31px 3px rgba(0,0,0,0.56),0px 8px 38px 7px rgba(0,0,0,0.48)",
+            "0px 10px 13px -6px rgba(0,0,0,0.8),0px 21px 33px 3px rgba(0,0,0,0.56),0px 8px 40px 7px rgba(0,0,0,0.48)",
+            "0px 10px 14px -6px rgba(0,0,0,0.8),0px 22px 35px 3px rgba(0,0,0,0.56),0px 8px 42px 7px rgba(0,0,0,0.48)",
+            "0px 11px 14px -7px rgba(0,0,0,0.8),0px 23px 36px 3px rgba(0,0,0,0.56),0px 9px 44px 8px rgba(0,0,0,0.48)",
+            "0px 11px 15px -7px rgba(0,0,0,0.8),0px 24px 38px 3px rgba(0,0,0,0.56),0px 9px 46px 8px rgba(0,0,0,0.48)",
             "0 5px 5px -3px rgba(0,0,0,.06), 0 8px 10px 1px rgba(0,0,0,.042), 0 3px 14px 2px rgba(0,0,0,.036)"
         };
     }


### PR DESCRIPTION
## Description
The elevation shadows in dark mode were hard to see/distinguish from the other dark colors. Added the ability to change elevation for both light and dark mode and made the dark variant the same color as the light but adjusted the opacity to make them more visible.

## How Has This Been Tested?
Visually tested, and existing tests passing.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

### _Could be a breaking change if code references `Elevation` as that is now called `ElevationLight`_
- `ElevationLight` could remain just `Elevation` if wanted.
- Technically a visually breaking change but it only made the shadows darker in dark mode (see pictures below) so I think that is fine.

**Updated dark elevation on the left, and before on the right**
![elevationBeforeAfter](https://github.com/user-attachments/assets/b9901de2-e828-4d64-bb8a-73f8757cccad)

**Updated dark elevation on the left, and current light mode on the right**
![elevationChangeAndLight](https://github.com/user-attachments/assets/c84f5155-6c59-435f-8891-df1b29da92e2)

**With this PR you can now separately adjust light/dark, so if you wanted white elevation in dark mode only you could do:**
```razor
private static readonly Shadow WhiteShadows = new()
{
    ElevationDark = new string[]
    {
        "none",
        "0px 2px 1px -1px rgba(255,255,255,0.2),0px 1px 1px 0px rgba(255,255,255,0.14),0px 1px 3px 0px rgba(255,255,255,0.12)",
        "0px 3px 1px -2px rgba(255,255,255,0.2),0px 2px 2px 0px rgba(255,255,255,0.14),0px 1px 5px 0px rgba(255,255,255,0.12)",
        "0px 3px 3px -2px rgba(255,255,255,0.2),0px 3px 4px 0px rgba(255,255,255,0.14),0px 1px 8px 0px rgba(255,255,255,0.12)",
        "0px 2px 4px -1px rgba(255,255,255,0.2),0px 4px 5px 0px rgba(255,255,255,0.14),0px 1px 10px 0px rgba(255,255,255,0.12)",
        "0px 3px 5px -1px rgba(255,255,255,0.2),0px 5px 8px 0px rgba(255,255,255,0.14),0px 1px 14px 0px rgba(255,255,255,0.12)",
        "0px 3px 5px -1px rgba(255,255,255,0.2),0px 6px 10px 0px rgba(255,255,255,0.14),0px 1px 18px 0px rgba(255,255,255,0.12)",
        "0px 4px 5px -2px rgba(255,255,255,0.2),0px 7px 10px 1px rgba(255,255,255,0.14),0px 2px 16px 1px rgba(255,255,255,0.12)",
        "0px 5px 5px -3px rgba(255,255,255,0.2),0px 8px 10px 1px rgba(255,255,255,0.14),0px 3px 14px 2px rgba(255,255,255,0.12)",
        "0px 5px 6px -3px rgba(255,255,255,0.2),0px 9px 12px 1px rgba(255,255,255,0.14),0px 3px 16px 2px rgba(255,255,255,0.12)",
        "0px 6px 6px -3px rgba(255,255,255,0.2),0px 10px 14px 1px rgba(255,255,255,0.14),0px 4px 18px 3px rgba(255,255,255,0.12)",
        "0px 6px 7px -4px rgba(255,255,255,0.2),0px 11px 15px 1px rgba(255,255,255,0.14),0px 4px 20px 3px rgba(255,255,255,0.12)",
        "0px 7px 8px -4px rgba(255,255,255,0.2),0px 12px 17px 2px rgba(255,255,255,0.14),0px 5px 22px 4px rgba(255,255,255,0.12)",
        "0px 7px 8px -4px rgba(255,255,255,0.2),0px 13px 19px 2px rgba(255,255,255,0.14),0px 5px 24px 4px rgba(255,255,255,0.12)",
        "0px 7px 9px -4px rgba(255,255,255,0.2),0px 14px 21px 2px rgba(255,255,255,0.14),0px 5px 26px 4px rgba(255,255,255,0.12)",
        "0px 8px 9px -5px rgba(255,255,255,0.2),0px 15px 22px 2px rgba(255,255,255,0.14),0px 6px 28px 5px rgba(255,255,255,0.12)",
        "0px 8px 10px -5px rgba(255,255,255,0.2),0px 16px 24px 2px rgba(255,255,255,0.14),0px 6px 30px 5px rgba(255,255,255,0.12)",
        "0px 8px 11px -5px rgba(255,255,255,0.2),0px 17px 26px 2px rgba(255,255,255,0.14),0px 6px 32px 5px rgba(255,255,255,0.12)",
        "0px 9px 11px -5px rgba(255,255,255,0.2),0px 18px 28px 2px rgba(255,255,255,0.14),0px 7px 34px 6px rgba(255,255,255,0.12)",
        "0px 9px 12px -6px rgba(255,255,255,0.2),0px 19px 29px 2px rgba(255,255,255,0.14),0px 7px 36px 6px rgba(255,255,255,0.12)",
        "0px 10px 13px -6px rgba(255,255,255,0.2),0px 20px 31px 3px rgba(255,255,255,0.14),0px 8px 38px 7px rgba(255,255,255,0.12)",
        "0px 10px 13px -6px rgba(255,255,255,0.2),0px 21px 33px 3px rgba(255,255,255,0.14),0px 8px 40px 7px rgba(255,255,255,0.12)",
        "0px 10px 14px -6px rgba(255,255,255,0.2),0px 22px 35px 3px rgba(255,255,255,0.14),0px 8px 42px 7px rgba(255,255,255,0.12)",
        "0px 11px 14px -7px rgba(255,255,255,0.2),0px 23px 36px 3px rgba(255,255,255,0.14),0px 9px 44px 8px rgba(255,255,255,0.12)",
        "0px 11px 15px -7px rgba(255,255,255,0.2),0px 24px 38px 3px rgba(255,255,255,0.14),0px 9px 46px 8px rgba(255,255,255,0.12)",
        "0 5px 5px -3px rgba(255,255,255,.06), 0 8px 10px 1px rgba(255,255,255,.042), 0 3px 14px 2px rgba(255,255,255,.036)"
    }
};

var theme = new MudTheme()
{
    Shadows = WhiteShadows
};
```
![image](https://github.com/user-attachments/assets/e3be7372-eaef-4eb5-8d10-90fc6cd8ed8f)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
