### PR TITLE
MudCheckBox: Change disabled text color

### DIFF
--- a/src/MudBlazor/Styles/components/_checkbox.scss
+++ b/src/MudBlazor/Styles/components/_checkbox.scss
@@ -17,7 +17,7 @@
     }
   }
 
-  .mud-disabled:focus-visible, .mud-disabled:active {
+  &.mud-disabled, .mud-disabled:focus-visible, .mud-disabled:active {
     cursor: default;
     background-color: transparent !important;
 


### PR DESCRIPTION
## Description
When the ```MudCheckBox``` has the ```Disabled``` status, the text of the ```MudCheckBox``` has not the ```disabled``` text ```Color```. It is not consistent for example with the same type of style applied to ```MudRadio```.

## How Has This Been Tested?
This has only been tested visually. Only one css property has been modified.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Here's an example of the change in comparison with ```MudRadio```.

![Change](https://github.com/user-attachments/assets/f1ad1cfb-303c-4248-8d8f-62cb107546f2)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
