### PR TITLE
Unit Tests: Fix selecting hidden dates

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -467,7 +467,7 @@ namespace MudBlazor.UnitTests.Components
 
             picker.Markup.Should().Contain("mud-selected"); //confirm selected date is shown
 
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("23")).Click();
+            comp.SelectDate("23");
 
             var date = DateTime.Today.Subtract(TimeSpan.FromDays(60));
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -7,7 +7,6 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -339,7 +338,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = OpenPicker();
             // clicking a day button to select a date and close
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("23")).Click();
+            comp.SelectDate("23");
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
         }
@@ -351,10 +350,7 @@ namespace MudBlazor.UnitTests.Components
             DateTime? returnDate = null;
             var comp = OpenPicker(EventCallback(nameof(MudDatePicker.DateChanged), (DateTime? date) => { eventCount++; returnDate = date; }));
             // clicking a day button to select a date and close
-            comp.FindAll("button.mud-picker-calendar-day")
-                .Where(x => !x.ClassList.Contains("mud-hidden") && x.TrimmedText().Equals("23"))
-                .First()
-                .Click();
+            comp.SelectDate("23");
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
             eventCount.Should().Be(1);
@@ -436,7 +432,7 @@ namespace MudBlazor.UnitTests.Components
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[2].Click();
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("2")).Click();
+            comp.SelectDate("2");
             comp.Instance.Date?.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
         }
 
@@ -455,7 +451,7 @@ namespace MudBlazor.UnitTests.Components
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[3].Click();
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("23")).Click();
+            comp.SelectDate("23");
             comp.Instance.Date?.Date.Should().Be(new DateTime(DateTime.Now.Year, 4, 23));
         }
 
@@ -536,7 +532,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[1].Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("1")).Click();
+            comp.SelectDate("1");
             comp.Instance.Date?.Date.Should().Be(new DateTime(2022, 2, 1));
         }
 
@@ -550,7 +546,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[1].Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("3")).Click();
+            comp.SelectDate("3");
             comp.Instance.Date?.Date.Should().Be(new DateTime(2021, 2, 3));
         }
 
@@ -576,7 +572,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container > div.mud-picker-year").First(x => x.TrimmedText().Contains("2022")).Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("3")).Click();
+            comp.SelectDate("3");
             comp.Instance.Date?.Date.Should().Be(new DateTime(2022, 1, 3));
         }
 
@@ -589,7 +585,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container").Count.Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count.Should().Be(0);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("3")).Click();
+            comp.SelectDate("3");
             comp.Instance.Date?.Date.Should().Be(new DateTime(2022, 1, 3));
         }
 
@@ -984,13 +980,11 @@ namespace MudBlazor.UnitTests.Components
             // So the test is working when the day is 20
             if (now.Day != 20)
             {
-                comp
-                    .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("20")).Click();
+                comp.SelectDate("20");
             }
             else
             {
-                comp
-                    .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("19")).Click();
+                comp.SelectDate("19");
             }
 
             // Check that the date should remain the same because autoclose is false
@@ -1017,11 +1011,11 @@ namespace MudBlazor.UnitTests.Components
             // Clicking a day button to select a date
             if (now.Day != 20)
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("20")).Click();
+                comp.SelectDate("20");
             }
             else
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("19")).Click();
+                comp.SelectDate("19");
             }
 
             // Check that the date should be equal to the new date 19 or 20
@@ -1059,11 +1053,11 @@ namespace MudBlazor.UnitTests.Components
             // So the test is working when the day is 20
             if (now.Day != 20)
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("20")).Click();
+                comp.SelectDate("20");
             }
             else
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("19")).Click();
+                comp.SelectDate("19");
             }
 
             // Close the datepicker
@@ -1094,11 +1088,11 @@ namespace MudBlazor.UnitTests.Components
             // Clicking a day button to select a date
             if (now.Day != 21)
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("22")).Click();
+                comp.SelectDate("22");
             }
             else
             {
-                comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("21")).Click();
+                comp.SelectDate("21");
             }
 
             // Close the datepicker
@@ -1120,7 +1114,7 @@ namespace MudBlazor.UnitTests.Components
 
             // An error should be raised if the datepicker could not be not opened and the days could not generated
             // It means that there would be an exception!
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("1")).Click();
+            comp.SelectDate("1");
         }
 
         /// <summary>
@@ -1363,7 +1357,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-input-adornment button").Click();
             comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
 
-            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("15")).Click();
+            comp.SelectDate("15");
 
             ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be(comp.Instance.Picker.Text);
         }


### PR DESCRIPTION
## Description
If the first day of a given month starts on any day other than a Sunday, the calendar will contain hidden dates from the end of the previous month. Some test cases select the first occurrence of a date by number. Sometimes that date may be a hidden date from the previous month. Unit tests should filter out these dates when selecting a date.

Fixes failing tests in the following PRs:
- #11262 
- #11263 

## How Has This Been Tested?
Retried failing test

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
