### PR TITLE
MudCircularProgress: Add ChildContent to Show Centered Content in the Progress

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularInterminateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularInterminateExample.razor
@@ -4,7 +4,5 @@
 <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
 <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
 <MudProgressCircular Color="Color.Success" Indeterminate="true" />
-<div class="relative" style="height: 60px; width: 60px">
-    <MudProgressCircular Class="absolute" style="height: 60px; width: 60px" Color="Color.Info" Indeterminate="true" />
-    <div class="absolute" style="left: 50%; top: 50%; transform: translate(-50%, -50%)">Text</div>
-</div>
+<MudProgressCircular Color="Color.Info" Indeterminate="true" />
+

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularInterminateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularInterminateExample.razor
@@ -4,4 +4,7 @@
 <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
 <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
 <MudProgressCircular Color="Color.Success" Indeterminate="true" />
-<MudProgressCircular Color="Color.Info" Indeterminate="true" />
+<div class="relative" style="height: 60px; width: 60px">
+    <MudProgressCircular Class="absolute" style="height: 60px; width: 60px" Color="Color.Info" Indeterminate="true" />
+    <div class="absolute" style="left: 50%; top: 50%; transform: translate(-50%, -50%)">Text</div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
@@ -25,6 +25,9 @@
 <MudProgressCircular Style="height: 60px; width: 60px" Color="Color.Success" Value="@_doubleValue">
     <ChildContent>@_doubleValue.ToString("N2")</ChildContent>
 </MudProgressCircular>
+<MudProgressCircular Size="Size.Large" Indeterminate="true" Color="Color.Primary">
+    <ChildContent>Mud</ChildContent>
+</MudProgressCircular>
 
 @code {
     private bool _disposed;

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
@@ -31,9 +31,8 @@
 
 @code {
     private bool _disposed;
-
-    int _value = 0;
-    double _doubleValue = 0;
+    private int _value;
+    private double _doubleValue;
 
     public async Task SimulateProgressAsync()
     {

--- a/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/Examples/ProgressCircularPercentageExample.razor
@@ -1,0 +1,63 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System;
+@using System.Threading;
+
+@implements IDisposable
+
+<MudProgressCircular Color="Color.Default" Value="@_value">
+    <ChildContent>
+        @_value
+    </ChildContent>
+</MudProgressCircular>
+<MudProgressCircular Color="Color.Primary" Value="@_value" Size="Size.Large">
+    <ChildContent>
+        @_value %
+    </ChildContent>
+</MudProgressCircular>
+<MudProgressCircular Style="height: 80px; width: 80px" Color="Color.Primary" Value="@_value">
+    <ChildContent>
+        <MudStack Spacing="0" AlignItems="AlignItems.Center" Justify="Justify.Center">
+            <MudText Typo="Typo.subtitle2">Value</MudText>
+            <MudText Typo="Typo.subtitle2">@_value</MudText>
+        </MudStack>
+    </ChildContent>
+</MudProgressCircular>
+<MudProgressCircular Style="height: 60px; width: 60px" Color="Color.Success" Value="@_doubleValue">
+    <ChildContent>@_doubleValue.ToString("N2")</ChildContent>
+</MudProgressCircular>
+
+@code {
+    private bool _disposed;
+
+    int _value = 0;
+    double _doubleValue = 0;
+
+    public async Task SimulateProgressAsync()
+    {
+        _value = 0;
+        _doubleValue = 0;
+        do
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _value += 4;
+            _doubleValue += 4.2d;
+            StateHasChanged();
+            await Task.Delay(500);
+
+        } while (_value < 100);
+
+        await SimulateProgressAsync();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        await SimulateProgressAsync();
+    }
+
+    public void Dispose() => _disposed = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -52,6 +52,15 @@
                 </DocsPageSection>
 
                 <DocsPageSection>
+                    <SectionHeader Title="Percentage Content">
+                        <Description></Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(ProgressCircularPercentageExample)" ShowCode="false">
+                        <ProgressCircularPercentageExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
                     <SectionHeader Title="Sizes">
                         <Description>You can change the size with the pre-defined <CodeInline>Size</CodeInline> prop or change the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> in css.</Description>
                     </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -52,8 +52,10 @@
                 </DocsPageSection>
 
                 <DocsPageSection>
-                    <SectionHeader Title="Percentage Content">
-                        <Description>The desired elements can be placed in the component with the <CodeInline>ChildContent</CodeInline> parameter.</Description>
+                    <SectionHeader Title="Custom Content">
+                        <Description>
+                            You can place any content in the middle of the circular progress using the <CodeInline>ChildContent</CodeInline> parameter.
+                        </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(ProgressCircularPercentageExample)" ShowCode="false">
                         <ProgressCircularPercentageExample />

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -53,7 +53,7 @@
 
                 <DocsPageSection>
                     <SectionHeader Title="Percentage Content">
-                        <Description></Description>
+                        <Description>The desired elements can be placed in the component with the <CodeInline>ChildContent</CodeInline> parameter.</Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(ProgressCircularPercentageExample)" ShowCode="false">
                         <ProgressCircularPercentageExample />

--- a/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
             container.GetAttribute("aria-live").Should().Be(
                 indeterminate ?
                  null : "polite");
-            container.ChildElementCount.Should().Be(1);
+            container.ChildElementCount.Should().Be(2);
 
             var circleContainer = container.Children[0];
             circleContainer.ClassList.Should().Contain("mud-progress-circular-svg");

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -15,6 +15,10 @@
         <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth"></circle>
         </svg>
+
+        <div class="mud-progress-circular-percentage mud-progress-circular-indeterminate-child">
+            @ChildContent
+        </div>
     }
     else
     {

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -10,14 +10,20 @@
      class="@Classname"
      style="@Style"
      @attributes="UserAttributes">
-    <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
-        @if (Indeterminate)
-        {
+    @if (Indeterminate)
+    {
+        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth"></circle>
-        }
-        else
-        {
+        </svg>
+    }
+    else
+    {
+        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @MagicNumber; stroke-dashoffset: @_svgValue;"></circle>
-        }
-    </svg>
+        </svg>
+
+        <div class="mud-progress-circular-percentage">
+            @ChildContent
+        </div>
+    }
 </div>

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -19,6 +19,7 @@ namespace MudBlazor
         private int _svgValue;
         private readonly ParameterState<double> _valueState;
         private const int MagicNumber = 126; // weird, but required for the SVG to work
+        private double _fraction;
 
         protected string Classname =>
             new CssBuilder("mud-progress-circular")
@@ -118,6 +119,13 @@ namespace MudBlazor
         [Category(CategoryTypes.ProgressCircular.Appearance)]
         public int StrokeWidth { get; set; } = 3;
 
+        /// <summary>
+        /// RenderFragment for rendering custom content
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.ProgressCircular.Appearance)]
+        public RenderFragment? ChildContent { get; set; }
+
         public MudProgressCircular()
         {
             using var registerScope = CreateRegisterScope();
@@ -144,9 +152,9 @@ namespace MudBlazor
         {
             var minValue = Math.Min(Math.Max(Min, value), Max);
             // calculate fraction, which is a value between 0 and 1
-            var fraction = (minValue - Min) / (Max - Min);
+            _fraction = (minValue - Min) / (Max - Min);
             // now project into the range of the SVG value (126 .. 0)
-            return (int)Math.Round(MagicNumber - (MagicNumber * fraction));
+            return (int)Math.Round(MagicNumber - (MagicNumber * _fraction));
         }
     }
 }

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -17,9 +17,9 @@ namespace MudBlazor
     public partial class MudProgressCircular : MudComponentBase
     {
         private int _svgValue;
+        private double _fraction;
         private readonly ParameterState<double> _valueState;
         private const int MagicNumber = 126; // weird, but required for the SVG to work
-        private double _fraction;
 
         protected string Classname =>
             new CssBuilder("mud-progress-circular")

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -17,7 +17,6 @@ namespace MudBlazor
     public partial class MudProgressCircular : MudComponentBase
     {
         private int _svgValue;
-        private double _fraction;
         private readonly ParameterState<double> _valueState;
         private const int MagicNumber = 126; // weird, but required for the SVG to work
 
@@ -152,9 +151,9 @@ namespace MudBlazor
         {
             var minValue = Math.Min(Math.Max(Min, value), Max);
             // calculate fraction, which is a value between 0 and 1
-            _fraction = (minValue - Min) / (Max - Min);
+            var fraction = (minValue - Min) / (Max - Min);
             // now project into the range of the SVG value (126 .. 0)
-            return (int)Math.Round(MagicNumber - (MagicNumber * _fraction));
+            return (int)Math.Round(MagicNumber - (MagicNumber * fraction));
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_progresscircular.scss
+++ b/src/MudBlazor/Styles/components/_progresscircular.scss
@@ -1,6 +1,7 @@
 
 .mud-progress-circular {
   display: inline-block;
+  position: relative;
   color: var(--mud-palette-text-secondary);
 
   &.mud-progress-indeterminate {
@@ -31,6 +32,17 @@
 .mud-progress-circular-svg {
   display: block;
   transform: rotate(-90deg);
+}
+
+.mud-progress-circular-percentage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .mud-progress-circular-circle {

--- a/src/MudBlazor/Styles/components/_progresscircular.scss
+++ b/src/MudBlazor/Styles/components/_progresscircular.scss
@@ -34,6 +34,10 @@
   transform: rotate(-90deg);
 }
 
+.mud-progress-circular-indeterminate-child {
+  animation: mud-progress-circular-keyframes-circular-rotate 1.4s linear reverse infinite;
+}
+
 .mud-progress-circular-percentage {
   position: absolute;
   top: 0;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This PR based on @fondraco 's PR #7419 .
Fixes #2520 , Fixes #6437 .

According to other PR, this PR is simplified. Changed `PercentageContent` name to `ChildContent` and delete math formulas. Users can use value directly inside of ChildContent. Also deleted `ShowPercentage` parameter, because it's unnecessary, if user doesn't describe ChildContent there will be no issue. And the old PR's formulas don't support double value's display, this PR supports maximum flexibility.


https://github.com/user-attachments/assets/664e1369-b249-4745-82e9-9e703d9c056b

As the same with other PR, there is a special situation with `Indetermine` circular progress, because it also rotates the child content. So we didn't touch indetermine state. It's always possible to center some other content via regular CSS. So we only show an example in the docs and guide users how to achieve centered content:

![Ekran görüntüsü 2025-05-01 181459](https://github.com/user-attachments/assets/d5519ef9-c4f5-4096-8367-12625a7ab3a2)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
