### PR TITLE
Popover: Initial Show When Open="true"

### DIFF
--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -18,7 +18,7 @@ public class PopoverOptions
 
     /// <summary>
     /// Gets or sets the CSS class of the popover container.
-    /// The default value is <c>mudblazor-main-content</c>.
+    /// The default value is <c>mud-popover-provider</c>.
     /// </summary>
     public string ContainerClass { get; set; } = "mud-popover-provider";
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -892,6 +892,7 @@ class MudPopover {
             isOpened: startOpened
         };
 
+        window.mudpopoverHelper.placePopover(popoverContentNode);
         // queue a resize event so we ensure if this popover started opened or nested it will be positioned correctly
         // needs to be after setup in the map
         window.mudpopoverHelper.debouncedResize();

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -807,8 +807,7 @@ class MudPopover {
             const tickAttribute = target.getAttribute('data-ticks');            
             // data ticks is not 0 so let's reposition the popover and overlay
 
-            if (tickAttribute > 0 && target.parentNode && this.map[id] && this.map[id].isOpened &&
-                target.parentNode.classList.contains(window.mudpopoverHelper.mainContainerClass)) {
+            if (tickAttribute > 0 && target.parentNode && this.map[id] && this.map[id].isOpened) {
                 // reposition popover individually
                 window.mudpopoverHelper.placePopoverByNode(target);           
             }
@@ -817,6 +816,7 @@ class MudPopover {
 
     initialize(containerClass, flipMargin, overflowPadding) {
         // only happens when the PopoverService is created which happens on application start and anytime the service might crash
+        // "mud-popover-provider" is the default name.
         const mainContent = document.getElementsByClassName(containerClass);
         if (mainContent.length == 0) {
             console.error(`No Popover Container found with class ${containerClass}`);
@@ -882,17 +882,19 @@ class MudPopover {
 
         // this is the content node in the provider regardless of the RenderFragment that exists when the popover is active
         const popoverContentNode = document.getElementById('popovercontent-' + id);
-
-        // queue a resize event so we ensure if this popover started opened or nested it will be positioned correctly
-        window.mudpopoverHelper.debouncedResize();
+        const startOpened = popoverContentNode.classList.contains('mud-popover-open');
 
         // Store all references needed for later cleanup
         this.map[id] = {
             popoverContentNode: popoverContentNode,
             scrollableElements: null,
             parentResizeObserver: null,
-            isOpened: false
+            isOpened: startOpened
         };
+
+        // queue a resize event so we ensure if this popover started opened or nested it will be positioned correctly
+        // needs to be after setup in the map
+        window.mudpopoverHelper.debouncedResize();
     }
 
     /**


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Resolves #11259 
Popovers that start open weren't receiving a reflow due to the isOpened flag only being set on mutation "mud-popover-open". Now it properly checks on connect if a popover should be open. Most popovers force a reflow due to changes as it's rendered but some don't is why it was not a widespread problem.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually in WASM and BSS.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
