### PR TITLE
MudCheckBox: Allow custom indicator

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -66,6 +66,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Custom Content">
+                <Description>You can place custom content via <CodeInline>IndicatorContent</CodeInline> renderfragment.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(CheckboxCustomContentExample)">
+                <CheckboxCustomContentExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Indeterminate State">
                 <Description>
                     When you use <CodeInline>T="bool?"</CodeInline> or bind the checkbox against a nullable bool it can have an indeterminate state when the value is <CodeInline>null</CodeInline>.

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxCustomContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxCustomContentExample.razor
@@ -1,0 +1,69 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudStack AlignItems="AlignItems.Center">
+    <MudCheckBox T="bool" Color="Color.Primary" Size="@_size">
+        <IndicatorContent>
+            @if(context == true)
+            {
+                <div class="mud-width-full mud-height-full mud-theme-primary d-flex align-center justify-center checkbox-scale">
+                    <MudIcon Icon="@Icons.Material.Filled.Check" />
+                </div>
+            }
+            else
+            {
+                @* Show nothing *@
+            }
+        </IndicatorContent>
+    </MudCheckBox>
+
+    <MudCheckBox T="bool?" Color="Color.Primary" TriState="true" Size="@_size" IndicatorClass="smooth">
+        <IndicatorContent>
+            @if(context == true)
+            {
+                <div class="mud-width-full mud-height-full mud-theme-primary d-flex align-center justify-center checkbox-scale rounded-0">
+                    <MudIcon Icon="@Icons.Material.Filled.Check" />
+                </div>
+            }
+            else if (context == false)
+            {
+                <div class="mud-width-full mud-height-full mud-theme-primary d-flex align-center justify-center checkbox-rotate rounded-0">
+                    <MudIcon Icon="@Icons.Material.Filled.Close" />
+                </div>
+            }
+            else if (context == null)
+            {
+                <div class="dimension-80 mud-theme-primary d-flex align-center justify-center rounded-circle" />
+            }
+        </IndicatorContent>
+    </MudCheckBox>
+
+    <MudSelect @bind-Value="_size" Variant="Variant.Outlined" Label="Size" Margin="Margin.Dense" Dense>
+        <MudSelectItem Value="Size.Small">Small</MudSelectItem>
+        <MudSelectItem Value="Size.Medium">Medium</MudSelectItem>
+        <MudSelectItem Value="Size.Large">Large</MudSelectItem>
+    </MudSelect>
+</MudStack>
+
+
+@code {
+    private Size _size = Size.Medium;
+}
+
+<style>
+    .checkbox-scale {
+        animation: mud-scale-up-center 0.3s ease;
+    }
+
+    .checkbox-rotate {
+        animation: mud-progress-circular-keyframes-circular-rotate 0.3s;
+    }
+
+    .smooth {
+        transition: all 0.3s;
+    }
+
+    .dimension-80 {
+        width: 80%;
+        height: 80%;
+    }
+</style>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -8,7 +8,16 @@
             <span tabindex="0" class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
                 <input tabindex="-1" @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" aria-checked="@(BoolValue.ToString().ToLower())" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" aria-required="@Required.ToString().ToLowerInvariant()" />
-                <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
+                <div class="@IndicatorClassname">
+                    @if (IndicatorContent != null)
+                    {
+                        @IndicatorContent(BoolValue)
+                    }
+                    else
+                    {
+                        <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
+                    }   
+                </div>
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -31,6 +31,15 @@ namespace MudBlazor
             .AddClass($"mud-input-content-placement-{ConvertPlacement(LabelPlacement).ToDescriptionString()}")
             .Build();
 
+        protected string IndicatorClassname => new CssBuilder("mud-checkbox-indicator")
+            .AddClass("border-2 border-solid", IndicatorContent != null)
+            .AddClass($"mud-border-{Color.ToDescriptionString()}", IndicatorContent != null && HasErrors == false)
+            .AddClass($"mud-border-error", HasErrors == true)
+            .AddClass($"mud-checkbox-{Size.ToDescriptionString()}")
+            .AddClass("d-flex align-center justify-center")
+            .AddClass(IndicatorClass)
+            .Build();
+
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
             .AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor == null || (UncheckedColor != null && BoolValue == true))
             .AddClass($"mud-{UncheckedColor?.ToDescriptionString()}-text hover:mud-{UncheckedColor?.ToDescriptionString()}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
@@ -42,6 +51,20 @@ namespace MudBlazor
             .AddClass($"mud-checkbox-false", BoolValue == false)
             .AddClass($"mud-checkbox-null", BoolValue is null)
             .Build();
+
+        /// <summary>
+        /// A RenderFragment for designing custom checkbox indicator.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public RenderFragment<bool?>? IndicatorContent { get; set; }
+
+        /// <summary>
+        /// CSS classes for the indicator renderfragment root.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string? IndicatorClass { get; set; }
 
         /// <summary>
         /// The color of the checkbox when its <c>Value</c> is <c>false</c> or <c>null</c>.

--- a/src/MudBlazor/Styles/components/_checkbox.scss
+++ b/src/MudBlazor/Styles/components/_checkbox.scss
@@ -56,6 +56,21 @@
   cursor: pointer;
 }
 
+.mud-checkbox-small {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.mud-checkbox-medium {
+  width: 1.50rem;
+  height: 1.50rem;
+}
+
+.mud-checkbox-large {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
 .mud-chart-legend-checkbox .mud-checkbox svg path:last-child {
   fill: var(--checkbox-color) !important;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
With current CheckBox design, we only can switch between icons and it limits the checkbox ability.
Added a RenderFragment named `IndicatorContent` with bool? parameter that users can freely create their own checkbox design and easily reuse on their whole application.

It's not a breaking change, the old behavior is the same while `IndicatorContent` is null. But i think we should also change the default behavior. We should discuss what we can do about it and i want to argue with this PR as an enhanced and flexible pattern.

Added an example on docs as shown:


https://github.com/user-attachments/assets/37a86af0-626d-4274-b99d-10002fd0c8c1



## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
