### PR TITLE
DataGrid: GroupingByOrder / Style Fix / Expansion StateHasChanged

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnGroupingTest.razor
@@ -1,16 +1,25 @@
 ﻿<MudPopoverProvider />
 <MudDataGrid T="Model" ShowMenuIcon="true" Items="@_items" Groupable="true">
     <Columns>
-        <PropertyColumn Property="x => x.Name" Title="Name" Grouping="@IsNameGrouped" HeaderClass="name" />
-        <PropertyColumn Property="x => x.Age" Title="Age" Grouping="@IsAgeGrouped" HeaderClass="age" />
+        <PropertyColumn Property="x => x.Name" Title="Name" @bind-Grouping="@IsNameGrouped" HeaderClass="name" />
+        <PropertyColumn Property="x => x.Age" Title="Age" @bind-Grouping="@IsAgeGrouped" HeaderClass="age" />
         <PropertyColumn Property="x => x.Gender" Title="Gender" @bind-Grouping="@IsGenderGrouped" HeaderClass="gender"/>
         <PropertyColumn Property="x => x.Profession" Title="Profession" @bind-Grouping="@IsProfessionGrouped" GroupBy="_groupByProfession" HeaderClass="profession" />
     </Columns>
 </MudDataGrid>
 
-<MudButton Class="GroupByGender" @onclick="GroupByGender">Group By Gender</MudButton>
-<MudButton Class="GroupByAge" @onclick="GroupByAge">Group By Age</MudButton>
-<MudButton Class="GroupByProfession" @onclick="GroupByProfession">Group By Profession</MudButton>
+<MudButton Class="@($"GroupByName {(IsNameGrouped ? "test-grouped" : "")}")" @onclick="GroupByName">Group By Name</MudButton>
+<MudButton Class="@($"GroupByGender {(IsGenderGrouped ? "test-grouped" : "")}")" @onclick="GroupByGender">Group By Gender</MudButton>
+<MudButton Class="@($"GroupByAge {(IsAgeGrouped ? "test-grouped" : "")}")" @onclick="GroupByAge">Group By Age</MudButton>
+<MudButton Class="@($"GroupByProfession {(IsProfessionGrouped ? "test-grouped" : "")}")" @onclick="GroupByProfession">Group By Profession</MudButton>
+<MudButton Class="UnGroupAll" @onclick="UnGroupAll">UnGroup All</MudButton>
+
+<style>
+    .test-grouped {
+        border: 1px dotted red;
+    }
+</style>
+
 @code {
 
     private readonly Func<Model, object> _groupByProfession = x => string.IsNullOrEmpty(x.Profession)
@@ -32,6 +41,14 @@
         new("Steve", 32, "Male", null),
         new("Alice", 32, "Female", "Cook")
     ];
+
+    private void GroupByName(MouseEventArgs args)
+    {
+        IsNameGrouped = true;
+        IsProfessionGrouped = false;
+        IsAgeGrouped = false;
+        IsGenderGrouped = false;
+    }
 
     private void GroupByGender(MouseEventArgs args)
     {
@@ -55,7 +72,15 @@
         IsProfessionGrouped = true;
         IsAgeGrouped = false;
         IsGenderGrouped = false;
-    }    
+    }
+
+    private void UnGroupAll(MouseEventArgs args)
+    {
+        IsNameGrouped = false;
+        IsProfessionGrouped = false;
+        IsAgeGrouped = false;
+        IsGenderGrouped = false;
+    }
 
     public record Model(string Name, int Age, string Gender, string? Profession);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupByNullTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupByNullTest.razor
@@ -1,0 +1,50 @@
+﻿<MudDataGrid T="Fruit" @ref="_dataGrid" Items="@_fruits" Filterable="true" Hideable="true" Groupable="true"
+             GroupExpanded="true">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Fruits</MudText>
+        <MudSpacer />
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" Filterable="false" Groupable="false" />
+        <PropertyColumn Property="x => x.Count" />
+        <PropertyColumn Property="x => x.Category" Title="Category" Grouping="true" >
+            <GroupTemplate>
+                <span style="font-weight:bold">Category: @context.Grouping.Key</span>
+            </GroupTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+    <MudButton Class="addnull-button" OnClick="@AddNullFruit" Color="@Color.Primary">Add Null Fruit</MudButton>
+</div>
+
+@code {
+    private MudDataGrid<Fruit> _dataGrid = null!;
+    private readonly List<Fruit> _fruits =
+    [
+        new Fruit("Apple", 2, "Pome"),
+        new Fruit("Pear", 4, "Pome"),
+        new Fruit("Orange", 4, "Citrus")
+    ];
+
+    public void AddFruit()
+    {
+        _fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void AddNullFruit()
+    {
+        _fruits.Add(new Fruit("NullFruit", 3, null));
+    }
+
+    public class Fruit(string name, int count, string? category)
+    {
+        public string Name { get; set; } = name;
+
+        public int Count { get; set; } = count;
+
+        public string? Category { get; set; } = category;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
@@ -19,7 +19,6 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
     <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
     <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
     <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
-    <MudButton Class="addnull-button" OnClick="@AddNullFruit" Color="@Color.Primary">Add Null Fruit</MudButton>
 </div>
 
 @code {
@@ -30,18 +29,13 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
         new Fruit("Pear", 4, "Pome"),
         new Fruit("Orange", 4, "Citrus")
     ];
-    private readonly Func<Fruit, object> _groupBy = x => x.Category ?? "Unknown";
+    private readonly Func<Fruit, object> _groupBy = x => x.Category;
 
     public bool RowContextMenuClicked { get; set; }
 
     public void AddFruit()
     {
         _fruits.Add(new Fruit("Banana", 5, "Musa"));
-    }
-
-    public void AddNullFruit()
-    {
-        _fruits.Add(new Fruit("NullFruit", 3, null));
     }
 
     public Task ExpandAllGroups()
@@ -59,12 +53,12 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
         RowContextMenuClicked = true;
     }
 
-    public class Fruit(string name, int count, string? category)
+    public class Fruit(string name, int count, string category)
     {
         public string Name { get; set; } = name;
 
         public int Count { get; set; } = count;
 
-        public string? Category { get; set; } = category;
+        public string Category { get; set; } = category;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupExpandedTest.razor
@@ -19,6 +19,7 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
     <MudButton Class="expand-all" OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
     <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
     <MudButton Class="add-button" OnClick="@AddFruit" Color="@Color.Primary">Add Fruit</MudButton>
+    <MudButton Class="addnull-button" OnClick="@AddNullFruit" Color="@Color.Primary">Add Null Fruit</MudButton>
 </div>
 
 @code {
@@ -29,13 +30,18 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
         new Fruit("Pear", 4, "Pome"),
         new Fruit("Orange", 4, "Citrus")
     ];
-    private readonly Func<Fruit, object> _groupBy = x => x.Category;
+    private readonly Func<Fruit, object> _groupBy = x => x.Category ?? "Unknown";
 
     public bool RowContextMenuClicked { get; set; }
 
     public void AddFruit()
     {
         _fruits.Add(new Fruit("Banana", 5, "Musa"));
+    }
+
+    public void AddNullFruit()
+    {
+        _fruits.Add(new Fruit("NullFruit", 3, null));
     }
 
     public Task ExpandAllGroups()
@@ -53,12 +59,12 @@ GroupExpanded="true" RowContextMenuClick="@OnRowContextMenuClick">
         RowContextMenuClicked = true;
     }
 
-    public class Fruit(string name, int count, string category)
+    public class Fruit(string name, int count, string? category)
     {
         public string Name { get; set; } = name;
 
         public int Count { get; set; } = count;
 
-        public string Category { get; set; } = category;
+        public string? Category { get; set; } = category;
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -380,6 +380,68 @@ namespace MudBlazor.UnitTests.Components
             Rows().Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
         }
 
+        [Test]
+        public void DataGridGrouping_ManualGroupByOrderTest()
+        {
+            var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnGroupingTest.Model>>();
+            var popoverProvider = comp.FindComponent<MudPopoverProvider>();
+
+            var nameCol = dataGrid.Instance.RenderedColumns[0]; // Name col
+            nameCol.PropertyName.Should().Be("Name");
+            var ageCol = dataGrid.Instance.RenderedColumns[1]; // Age col
+            ageCol.PropertyName.Should().Be("Age");
+            var genderCol = dataGrid.Instance.RenderedColumns[2]; // Gender col
+            genderCol.PropertyName.Should().Be("Gender");
+
+            // Assert that initially, before any user interaction, groupbyorder on name is 0
+            // note that name starts grouped
+            nameCol._groupByOrderState.Value.Should().Be(0);
+
+            // add age grouping
+            var headerOption = comp.Find("th.age .mud-menu button");
+            headerOption.Click();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(2);
+            var clickablePopover = listItems[1].Find(".mud-menu-item");
+            clickablePopover.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(true);
+            // Assert that after user interaction, groupbyorder on age is 1 (+1)
+            ageCol._groupByOrderState.Value.Should().Be(1);
+
+            // add gender grouping
+            headerOption = comp.Find("th.gender .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(2);
+            clickablePopover = listItems[1].Find(".mud-menu-item");
+            clickablePopover.Click();
+            comp.Instance.IsGenderGrouped.Should().Be(true);
+            // Assert that after user interaction, groupbyorder on gender is 2 (+1 of max)
+            genderCol._groupByOrderState.Value.Should().Be(2);
+
+            // remove age grouping
+            headerOption = comp.Find("th.age .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(2);
+            clickablePopover = listItems[1].Find(".mud-menu-item");
+            clickablePopover.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(false);
+            // Assert that after user interaction, groupbyorder on age is 0
+            ageCol._groupByOrderState.Value.Should().Be(0);
+
+            // remove gender grouping
+            headerOption = comp.Find("th.gender .mud-menu button");
+            headerOption.Click();
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(2);
+            clickablePopover = listItems[1].Find(".mud-menu-item");
+            clickablePopover.Click();
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            // Assert that after user interaction, groupbyorder on gender is 0
+            genderCol._groupByOrderState.Value.Should().Be(0);
+        }
 
         [Test]
         public async Task DataGridGroupedWithServerDataPaginationTest()

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -548,7 +548,7 @@ namespace MudBlazor.UnitTests.Components
             void GetCount(bool currExpanded)
             {
                 // Whatever the expanded state is if it differs from the default it should be in the dictionary
-                dataGrid.Instance._groupExpansionsDict.Count.Should().Be(currExpanded != defaultExpanded ? 1 : 0);
+                dataGrid.Instance._groupExpansionsDict.Count.Should().BeGreaterThan(currExpanded != defaultExpanded ? 1 : 0);
             }
 
             // Test the UI
@@ -620,6 +620,30 @@ namespace MudBlazor.UnitTests.Components
             row = rows[7];
             row.Instance.Items.Should().NotBeNull();
             row.Instance.Items.Count().Should().Be(2);
+        }
+
+        // https://github.com/MudBlazor/MudBlazor/pull/10213 
+        // Allow grouping by null valus and toggle grouping keeps initial state on other groups
+        [Test]
+        public void DataGrid_Grouping_ByNull()
+        {
+            var comp = Context.RenderComponent<DataGridGroupByNullTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupByNullTest.Fruit>>();
+            // until a change happens this bool tracks whether GroupExpanded is applied.
+            dataGrid.Instance._groupInitialExpanded = true;
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(7);
+            var btn = comp.Find(".addnull-button");
+            btn.Should().NotBeNull();
+            btn.Click();
+            // group header, group row, and group footer so + 3
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(10);
+            // ensure toggling single expansion doesn't close all
+            var expanderButtons = comp.FindAll("button.mud-table-row-expander");
+            // nulled expander
+            var expander = expanderButtons[expanderButtons.Count - 1];
+            // clicking should close 2 rows, footer and group row. header should still exist
+            expander.Click();
+            comp.FindAll("tbody .mud-table-row").Count.Should().Be(8);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -314,6 +314,13 @@ namespace MudBlazor.UnitTests.Components
             professionCells[1].TextContent.Should().Be("Profession: (None)");
             Rows().Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
 
+            var ungroup = comp.Find(".UnGroupAll");
+            ungroup.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(false);
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            comp.Instance.IsProfessionGrouped.Should().Be(false);
+            comp.Instance.IsNameGrouped.Should().Be(false);
+
             //click age grouping in grid
             var headerOption = comp.Find("th.age .mud-menu button");
             headerOption.Click();
@@ -321,10 +328,14 @@ namespace MudBlazor.UnitTests.Components
             listItems.Count.Should().Be(2);
             var clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(true);
+            Rows().Count.Should().Be(5, because: "1 header row + 3 data rows + 1 footer row");
+
+            ungroup.Click();
             comp.Instance.IsAgeGrouped.Should().Be(false);
             comp.Instance.IsGenderGrouped.Should().Be(false);
-            comp.Instance.IsProfessionGrouped.Should().Be(true);
-            Rows().Count.Should().Be(5, because: "1 header row + 3 data rows + 1 footer row");
+            comp.Instance.IsProfessionGrouped.Should().Be(false);
+            comp.Instance.IsNameGrouped.Should().Be(false);
 
             //click gender grouping in grid
             headerOption = comp.Find("th.gender .mud-menu button");
@@ -334,9 +345,13 @@ namespace MudBlazor.UnitTests.Components
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
             comp.Instance.IsGenderGrouped.Should().Be(true);
+            Rows().Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
+
+            ungroup.Click();
             comp.Instance.IsAgeGrouped.Should().Be(false);
-            comp.Instance.IsProfessionGrouped.Should().Be(true);
-            Rows().Count.Should().Be(5, because: "1 header row + 3 data rows + 1 footer row");
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            comp.Instance.IsProfessionGrouped.Should().Be(false);
+            comp.Instance.IsNameGrouped.Should().Be(false);
 
             //click Name grouping in grid
             headerOption = comp.Find("th.name .mud-menu button");
@@ -345,10 +360,14 @@ namespace MudBlazor.UnitTests.Components
             listItems.Count.Should().Be(2);
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
-            comp.Instance.IsGenderGrouped.Should().Be(true);
-            comp.Instance.IsAgeGrouped.Should().Be(false);
-            comp.Instance.IsProfessionGrouped.Should().Be(true);
+            comp.Instance.IsNameGrouped.Should().Be(true);
             Rows().Count.Should().Be(6, because: "1 header row + 4 data rows + 1 footer row");
+
+            ungroup.Click();
+            comp.Instance.IsAgeGrouped.Should().Be(false);
+            comp.Instance.IsGenderGrouped.Should().Be(false);
+            comp.Instance.IsProfessionGrouped.Should().Be(false);
+            comp.Instance.IsNameGrouped.Should().Be(false);
 
             //click profession grouping in grid
             headerOption = comp.Find("th.profession .mud-menu button");
@@ -357,10 +376,8 @@ namespace MudBlazor.UnitTests.Components
             listItems.Count.Should().Be(2);
             clickablePopover = listItems[1].Find(".mud-menu-item");
             clickablePopover.Click();
-            comp.Instance.IsGenderGrouped.Should().Be(true);
-            comp.Instance.IsAgeGrouped.Should().Be(false);
-            comp.Instance.IsProfessionGrouped.Should().Be(false);
-            Rows().Count.Should().Be(6, because: "1 header row + 4 data rows + 1 footer row");
+            comp.Instance.IsProfessionGrouped.Should().Be(true);
+            Rows().Count.Should().Be(4, because: "1 header row + 2 data rows + 1 footer row");
         }
 
 
@@ -463,22 +480,24 @@ namespace MudBlazor.UnitTests.Components
             var row = rows[0];
             // Test the method
             // Act
+            var col = dataGrid.Instance.RenderedColumns[3]; // primary industry col
+            col.PropertyName.Should().Be("PrimaryIndustry");
+            var defaultExpanded = col._groupExpandedState.Value;
             void GetCount(bool currExpanded)
             {
-                var defaultExpanded = row.Instance.GroupDefinition.Expanded;
                 // Whatever the expanded state is if it differs from the default it should be in the dictionary
                 dataGrid.Instance._groupExpansionsDict.Count.Should().Be(currExpanded != defaultExpanded ? 1 : 0);
             }
 
             // Test the UI
-            var expandButton = () => row.Find(".mud-datagrid-group-button");
+            var expandButton = () => row.Find(".mud-table-row-expander");
             expandButton.Should().NotBeNull();
-            expandButton().Click();
 
+            expandButton().Click(); // collapse the group
             row.WaitForAssertion(() => row.Instance._expanded.Should().BeFalse());
             row.WaitForAssertion(() => GetCount(false));
-            expandButton().Click();
 
+            expandButton().Click(); // expand the group
             row.WaitForAssertion(() => row.Instance._expanded.Should().BeTrue());
             row.WaitForAssertion(() => GetCount(true));
         }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -24,7 +24,6 @@ namespace MudBlazor
         internal ParameterState<bool> GroupingState { get; }
         internal ParameterState<bool> _groupExpandedState;
         internal ParameterState<int> _groupByOrderState;
-        internal int _initialGroupByOrder = 0;
 
         /// <summary>
         /// The data grid which owns this column.
@@ -616,7 +615,6 @@ namespace MudBlazor
             base.OnInitialized();
 
             groupBy = GroupBy;
-            _initialGroupByOrder = _groupByOrderState.Value;
 
             DataGrid?.AddColumn(this);
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
         internal ParameterState<bool> GroupingState { get; }
         internal ParameterState<bool> _groupExpandedState;
         internal ParameterState<int> _groupByOrderState;
+        internal int _initialGroupByOrder = 0;
 
         /// <summary>
         /// The data grid which owns this column.
@@ -593,32 +594,11 @@ namespace MudBlazor
                 .WithChangeHandler(OnGroupByOrderChangedAsync);
         }
 
-        private async Task OnGroupingParameterChangedAsync()
-        {
-            // Regroup DataGrid           
-            if (DataGrid is not null)
-            {
-                await DataGrid.ChangedGrouping(this);
-            }
-        }
+        private void OnGroupingParameterChangedAsync() => DataGrid?.GroupItems();
 
-        private async Task OnGroupExpandedChangedAsync()
-        {
-            // Regroup DataGrid
-            if (DataGrid is not null)
-            {
-                await DataGrid.ChangedGrouping();
-            }
-        }
+        private void OnGroupByOrderChangedAsync() => DataGrid?.GroupItems();
 
-        private async Task OnGroupByOrderChangedAsync()
-        {
-            // Regroup DataGrid           
-            if (DataGrid is not null)
-            {
-                await DataGrid.ChangedGrouping();
-            }
-        }
+        private void OnGroupExpandedChangedAsync() => DataGrid?.GroupItems();
 
         protected override void OnInitialized()
         {
@@ -636,6 +616,7 @@ namespace MudBlazor
             base.OnInitialized();
 
             groupBy = GroupBy;
+            _initialGroupByOrder = _groupByOrderState.Value;
 
             DataGrid?.AddColumn(this);
 

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -5,7 +5,7 @@
 <tr class="mud-table-row">
     <td class="@GroupClassname" colspan="1000" style="@GroupStylename">
         <div style="display:flex; align-items:center;">
-            <MudIconButton Class="mud-datagrid-group-button" Icon="@(DataGrid.GetGroupIcon(_expanded))"
+            <MudIconButton Class="mud-table-row-expander" Icon="@(DataGrid.GetGroupIcon(_expanded))"
                            OnClick="@GroupExpandClick" />
             @if (GroupDefinition?.GroupTemplate == null)
             {

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
@@ -82,27 +82,8 @@ namespace MudBlazor
         internal void GroupExpandClick()
         {
             _expanded = !_expanded;
-            // update the expansion state for _groupExpansionsDict
-            // if it has a key we see if it differs from the definition Expanded State and update accordingly
-            // if it doesn't we add it if the new state doesn't match the definition
             if (Items != null)
-            {
-                var key = new { GroupDefinition.Title, Items.Key };
-                if (DataGrid._groupExpansionsDict.ContainsKey(key))
-                {
-                    if (_expanded == GroupDefinition.Expanded)
-                        DataGrid._groupExpansionsDict.Remove(key);
-                    else
-                        DataGrid._groupExpansionsDict[key] = _expanded;
-                }
-                else
-                {
-                    if (_expanded != GroupDefinition.Expanded)
-                        DataGrid._groupExpansionsDict.TryAdd(key, _expanded);
-                }
-            }
-            DataGrid._groupInitialExpanded = false;
-            ((Interfaces.IMudStateHasChanged)DataGrid).StateHasChanged();
+                DataGrid.ToggleGroupExpandAsync(GroupDefinition.Title, Items.Key, GroupDefinition, _expanded);
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
@@ -102,6 +102,7 @@ namespace MudBlazor
                 }
             }
             DataGrid._groupInitialExpanded = false;
+            ((Interfaces.IMudStateHasChanged)DataGrid).StateHasChanged();
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -538,12 +538,9 @@ namespace MudBlazor
             if (Column is not null)
             {
                 await Column.SetGroupingAsync(true);
-                await DataGrid.ChangedGrouping(Column);
+                await DataGrid.UpdateGroupingOrder(Column, true);
             }
-            else
-            {
-                await DataGrid.ChangedGrouping();
-            }
+            DataGrid.GroupItems();
             DataGrid.DropContainerHasChanged();
         }
 
@@ -552,8 +549,9 @@ namespace MudBlazor
             if (Column is not null)
             {
                 await Column.SetGroupingAsync(false);
+                await DataGrid.UpdateGroupingOrder(Column, false);
             }
-            await DataGrid.ChangedGrouping();
+            DataGrid.GroupItems();
             DataGrid.DropContainerHasChanged();
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2144,6 +2144,17 @@ namespace MudBlazor
             {
                 await column._groupByOrderState.SetValueAsync(default);
             }
+            // expand all but last grouped column when changed
+            await GroupExpansion();
+        }
+
+        private async Task GroupExpansion()
+        {
+            var groupedColumns = RenderedColumns.Where(x => x.GroupingState.Value).OrderBy(x => x._groupByOrderState.Value).SkipLast(1);
+            foreach (var col in groupedColumns.OrderBy(x => x._groupByOrderState.Value))
+            {
+                await col._groupExpandedState.SetValueAsync(true);
+            }
         }
 
         internal void ToggleGroupExpandAsync(string title, object? key, GroupDefinition<T> groupDef, bool expanded)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
-using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Clone;
@@ -21,7 +20,7 @@ namespace MudBlazor
     /// </summary>
     /// <typeparam name="T">The type of data represented by each row in this grid.</typeparam>
     [CascadingTypeParameter(nameof(T))]
-    public partial class MudDataGrid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable, IMudStateHasChanged
+    public partial class MudDataGrid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
         private MudForm _editForm;
         internal int? _rowsPerPage;
@@ -2132,16 +2131,22 @@ namespace MudBlazor
             return result;
         }
 
-        internal async Task ChangedGrouping(Column<T>? col = null)
+        internal async Task UpdateGroupingOrder(Column<T> column, bool added)
         {
-            // If col is not null add GroupByOrder is not set set it to the end
-            if (col is { _groupByOrderState.Value: 0 })
+            // if added then add to the end if no _groupByOrderState.Value
+            if (added)
             {
-                var maxOrder = RenderedColumns.Max(x => x._groupByOrderState.Value);
-                await col._groupByOrderState.SetValueAsync(maxOrder + 1);
+                var groupableColumns = RenderedColumns.Where(x => x.groupable);
+                var newOrder = groupableColumns.Any() ? groupableColumns.Max(x => x._groupByOrderState.Value) + 1 : 0;
+                await column._groupByOrderState.SetValueAsync(newOrder);
             }
-            GroupItems();
+            // if removed then reset _groupByOrderState.Value 
+            else
+            {
+                await column._groupByOrderState.SetValueAsync(default);
+            }
         }
+
 #nullable disable
         /// <summary>
         /// Expands all groups async.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
+using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Clone;
@@ -20,7 +21,7 @@ namespace MudBlazor
     /// </summary>
     /// <typeparam name="T">The type of data represented by each row in this grid.</typeparam>
     [CascadingTypeParameter(nameof(T))]
-    public partial class MudDataGrid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
+    public partial class MudDataGrid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable, IMudStateHasChanged
     {
         private MudForm _editForm;
         internal int? _rowsPerPage;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2136,8 +2136,8 @@ namespace MudBlazor
             // if added then add to the end if no _groupByOrderState.Value
             if (added)
             {
-                var groupableColumns = RenderedColumns.Where(x => x.groupable);
-                var newOrder = groupableColumns.Any() ? groupableColumns.Max(x => x._groupByOrderState.Value) + 1 : 0;
+                var groupedColumns = RenderedColumns.Where(x => x.GroupingState.Value && x != column);
+                var newOrder = groupedColumns.Any() ? groupedColumns.Max(x => x._groupByOrderState.Value) + 1 : 0;
                 await column._groupByOrderState.SetValueAsync(newOrder);
             }
             // if removed then reset _groupByOrderState.Value 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2109,11 +2109,12 @@ namespace MudBlazor
             foreach (var group in groups)
             {
                 var expanded = false;
-                if (group is { Key: not null })
+                if (group is not null)
                 {
                     var key = new GroupKey(groupDef.Title, group.Key);
                     expanded = _groupExpansionsDict.TryGetValue(key, out var value) ? value :
                                    groupDef.Expanded;
+                    _groupExpansionsDict.TryAdd(key, expanded);
                 }
                 result.Add(new GroupDefinition<T>
                 {
@@ -2124,7 +2125,7 @@ namespace MudBlazor
                     Title = groupDef.Title,
                     Parent = groupDef.Parent,
                     InnerGroup = groupDef.InnerGroup,
-                    Grouping = group,
+                    Grouping = group ?? new EmptyGrouping<object?, T>(null)
                 });
             }
             return result;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -39,7 +39,7 @@ namespace MudBlazor
         private CancellationTokenSource _serverDataCancellationTokenSource;
         private IEnumerable<T> _currentRenderFilteredItemsCache = null;
         internal GroupDefinition<T> _groupDefinition;
-        internal Dictionary<NullableObject<object>, bool> _groupExpansionsDict = [];
+        internal Dictionary<GroupKey, bool> _groupExpansionsDict = [];
         private GridData<T> _serverData = new() { TotalItems = 0, Items = Array.Empty<T>() };
         private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
 
@@ -2111,9 +2111,8 @@ namespace MudBlazor
                 var expanded = false;
                 if (group is { Key: not null })
                 {
-                    var key = new { groupDef.Title, group.Key };
-                    expanded = _groupExpansionsDict.ContainsKey(key) ?
-                                   _groupExpansionsDict[key] :
+                    var key = new GroupKey(groupDef.Title, group.Key);
+                    expanded = _groupExpansionsDict.TryGetValue(key, out var value) ? value :
                                    groupDef.Expanded;
                 }
                 result.Add(new GroupDefinition<T>
@@ -2147,7 +2146,24 @@ namespace MudBlazor
             }
         }
 
+        internal void ToggleGroupExpandAsync(string title, object? key, GroupDefinition<T> groupDef, bool expanded)
+        {
+            var groupKey = new GroupKey(title, key);
+
+            // update the expansion state for _groupExpansionsDict
+            // if it has a key we see if it differs from the definition Expanded State and update accordingly
+            // if it doesn't we add it if the new state doesn't match the definition
+            var col = RenderedColumns.FirstOrDefault(x => x.GroupBy == groupDef.Selector);
+            if (expanded == col?._groupExpandedState.Value)
+                _groupExpansionsDict.Remove(groupKey);
+            else
+                _groupExpansionsDict[groupKey] = expanded;
+
+            _groupInitialExpanded = false;
+            StateHasChanged();
+        }
 #nullable disable
+
         /// <summary>
         /// Expands all groups async.
         /// </summary>
@@ -2311,5 +2327,7 @@ namespace MudBlazor
 
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal record GroupKey(string Title, object ItemsKey);
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Moved Expansion logic to MudDataGrid since it needs to refresh grid and the logic needed to set the _groupExpansionsDict is in the grid. 
Setup a proper GroupByOrder when items are grouped manually. 
Fixed a class mismatch on Group Expander Icon
Resolves #11290 
Resolves #11300 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Updated two unit tests, one for my changes, and one was not testing the right thing highlighted by my changes
Added a unit test for GroupByOrder

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
