### PR TITLE
MudCarousel: Utilize ParameterState

### DIFF
--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -207,20 +207,20 @@ namespace MudBlazor
 
         }
 
-        private Task OnAutoCycleChangedAsync(ParameterChangedEventArgs<bool> args)
+        private async Task OnAutoCycleChangedAsync(ParameterChangedEventArgs<bool> args)
         {
             if (args.Value)
-                return ResetTimerAsync();
+                await ResetTimerAsync();
             else
-                return StopTimerAsync();
+                await StopTimerAsync();
         }
 
-        private Task OnAutoCycleTimeChangedAsync(ParameterChangedEventArgs<TimeSpan> args)
+        private async Task OnAutoCycleTimeChangedAsync(ParameterChangedEventArgs<TimeSpan> args)
         {
             if (_autoCycleState.Value)
-                return ResetTimerAsync();
+                await ResetTimerAsync();
             else
-                return StopTimerAsync();
+                await StopTimerAsync();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -207,20 +207,20 @@ namespace MudBlazor
 
         }
 
-        private async Task OnAutoCycleChangedAsync(ParameterChangedEventArgs<bool> args)
+        private Task OnAutoCycleChangedAsync(ParameterChangedEventArgs<bool> args)
         {
             if (args.Value)
-                await ResetTimerAsync();
+                return ResetTimerAsync();
             else
-                await StopTimerAsync();
+                return StopTimerAsync();
         }
 
-        private async Task OnAutoCycleTimeChangedAsync(ParameterChangedEventArgs<TimeSpan> args)
+        private Task OnAutoCycleTimeChangedAsync(ParameterChangedEventArgs<TimeSpan> args)
         {
             if (_autoCycleState.Value)
-                await ResetTimerAsync();
+                return ResetTimerAsync();
             else
-                await StopTimerAsync();
+                return StopTimerAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Calling `StateHasChanged` on a parent component causes any `Carousel` `ChildComponent` to restart the `AutoCycle` timer due to the set logic included.

Closes #11320 

## How Has This Been Tested?
Visually

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
